### PR TITLE
feat: integrate pi as a fourth agent_kind

### DIFF
--- a/apps/parsar-daemon/internal/agent/pi/export_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/export_test.go
@@ -1,0 +1,36 @@
+package pi
+
+import (
+	"context"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+type SessionConfigForTest struct {
+	PiBinary    string
+	ExtraArgs   []string
+	KillTimeout time.Duration
+}
+
+func NewSessionForTest(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope, cfg SessionConfigForTest) (*Session, error) {
+	return newSession(ctx, req, out, sessionConfig{
+		piBinary:    cfg.PiBinary,
+		extraArgs:   cfg.ExtraArgs,
+		killTimeout: cfg.KillTimeout,
+	})
+}
+
+type Translator translator
+
+type Translation = translation
+
+func NewTranslatorForTest(runID string) *Translator { return (*Translator)(newTranslator(runID)) }
+
+func (t *Translator) Translate(line []byte) (Translation, error) {
+	return (*translator)(t).Translate(line)
+}
+
+func (t *Translator) TerminalEnvelopes(waitErr error, stderr string, cancelled bool) []proto.Envelope {
+	return (*translator)(t).terminalEnvelopes(waitErr, stderr, cancelled)
+}

--- a/apps/parsar-daemon/internal/agent/pi/options.go
+++ b/apps/parsar-daemon/internal/agent/pi/options.go
@@ -1,0 +1,188 @@
+package pi
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// BuildResult is the pi CLI launch plan for one prompt. Cleanup is
+// always non-nil so callers can defer it blindly.
+type BuildResult struct {
+	Args    []string
+	Env     []string
+	WorkDir string
+	Cleanup func()
+}
+
+// BuildArgs translates the daemon prompt_request into a `pi --mode json`
+// invocation. resumeSessionID, if non-empty, takes precedence over any
+// "resume_session_id" key in opts. pi has no working-directory flag, so
+// WorkDir is resolved here and the caller sets cmd.Dir.
+func BuildArgs(runID, prompt, workDir string, opts map[string]any, resumeSessionID string) (BuildResult, error) {
+	_ = runID
+	result := BuildResult{Cleanup: func() {}}
+
+	resolvedWorkDir, err := resolveWorkDir(workDir)
+	if err != nil {
+		return result, err
+	}
+
+	promptText, err := buildPrompt(prompt)
+	if err != nil {
+		return result, err
+	}
+
+	// --no-approve forces project trust = false: a headless run must never
+	// block on the interactive trust prompt, and Parsar injects its own
+	// managed model/skills rather than loading untrusted project config.
+	args := []string{"--mode", "json", "--no-approve"}
+
+	if model := stringOpt(opts, "model"); model != "" {
+		args = append(args, "--model", model)
+	}
+	if provider := stringOpt(opts, "provider"); provider != "" {
+		args = append(args, "--provider", provider)
+	}
+	if apiKey := stringOpt(opts, "api_key"); apiKey != "" {
+		args = append(args, "--api-key", apiKey)
+	}
+
+	// override replaces the base system prompt and wins over append.
+	if override := stringOpt(opts, "override_system_prompt"); override != "" {
+		args = append(args, "--system-prompt", override)
+	} else if sys := stringOpt(opts, "system_prompt"); sys != "" {
+		args = append(args, "--append-system-prompt", sys)
+	}
+
+	resume := strings.TrimSpace(resumeSessionID)
+	if resume == "" {
+		resume = stringOpt(opts, "resume_session_id")
+	}
+	if resume != "" {
+		args = append(args, "--session", resume)
+	}
+
+	skillDirs, err := stringSlice(opts["skill_dirs"])
+	if err != nil {
+		return result, fmt.Errorf("pi.BuildArgs: skill_dirs: %w", err)
+	}
+	for _, d := range skillDirs {
+		if d = strings.TrimSpace(d); d != "" {
+			args = append(args, "--skill", d)
+		}
+	}
+
+	// pi's -p consumes the immediately-following arg as the prompt, so it
+	// must be appended last, after every other flag.
+	args = append(args, "-p", promptText)
+
+	env, err := buildEnv(opts)
+	if err != nil {
+		return result, err
+	}
+
+	result.Args = args
+	result.Env = env
+	result.WorkDir = resolvedWorkDir
+	return result, nil
+}
+
+func resolveWorkDir(input string) (string, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return "", nil
+	}
+	var abs string
+	switch {
+	case strings.HasPrefix(trimmed, "~/"):
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("pi: resolve home dir: %w", err)
+		}
+		abs = filepath.Join(home, strings.TrimPrefix(trimmed, "~/"))
+	case filepath.IsAbs(trimmed):
+		abs = trimmed
+	default:
+		return "", fmt.Errorf("pi: work_dir must be absolute or start with ~/, got %q", trimmed)
+	}
+	if err := os.MkdirAll(abs, 0o755); err != nil {
+		return "", fmt.Errorf("pi: mkdir work_dir %s: %w", abs, err)
+	}
+	return abs, nil
+}
+
+func buildPrompt(prompt string) (string, error) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return "", fmt.Errorf("pi: empty prompt")
+	}
+	return prompt, nil
+}
+
+func buildEnv(opts map[string]any) ([]string, error) {
+	// PI_TELEMETRY=0 force-disables pi's opt-in install telemetry for
+	// unattended daemon runs (pi reads PI_TELEMETRY, not DISABLE_TELEMETRY).
+	env := []string{"PI_TELEMETRY=0"}
+	raw, ok := opts["env"]
+	if !ok || raw == nil {
+		return env, nil
+	}
+	envMap, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("pi.BuildArgs: env must be object, got %T", raw)
+	}
+	keys := make([]string, 0, len(envMap))
+	for k := range envMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		s, ok := envMap[k].(string)
+		if !ok {
+			return nil, fmt.Errorf("pi.BuildArgs: env[%q] must be string, got %T", k, envMap[k])
+		}
+		env = append(env, k+"="+s)
+	}
+	return env, nil
+}
+
+func stringOpt(opts map[string]any, key string) string {
+	if opts == nil {
+		return ""
+	}
+	v, ok := opts[key]
+	if !ok || v == nil {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(s)
+}
+
+// stringSlice coerces a value to []string, accepting a typed []string or
+// the []any json.Unmarshal produces for a JSON array. nil yields nil.
+func stringSlice(v any) ([]string, error) {
+	switch x := v.(type) {
+	case nil:
+		return nil, nil
+	case []string:
+		return x, nil
+	case []any:
+		out := make([]string, 0, len(x))
+		for i, el := range x {
+			s, ok := el.(string)
+			if !ok {
+				return nil, fmt.Errorf("element %d must be string, got %T", i, el)
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("must be array of strings, got %T", v)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/pi/options.go
+++ b/apps/parsar-daemon/internal/agent/pi/options.go
@@ -46,9 +46,10 @@ func BuildArgs(runID, prompt, workDir string, opts map[string]any, resumeSession
 	if provider := stringOpt(opts, "provider"); provider != "" {
 		args = append(args, "--provider", provider)
 	}
-	if apiKey := stringOpt(opts, "api_key"); apiKey != "" {
-		args = append(args, "--api-key", apiKey)
-	}
+	// A managed api_key is deliberately NOT forwarded as --api-key: secrets
+	// ride the environment (PARSAR_PI_API_KEY, referenced from the
+	// materialised models.json) so they never land on the pi child's argv,
+	// where `ps` would leak them. See server injectPiManagedModel.
 
 	// override replaces the base system prompt and wins over append.
 	if override := stringOpt(opts, "override_system_prompt"); override != "" {

--- a/apps/parsar-daemon/internal/agent/pi/options_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/options_test.go
@@ -1,0 +1,207 @@
+package pi_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/pi"
+)
+
+func TestBuildArgsUsesModeJsonNoApproveAndPromptLast(t *testing.T) {
+	res, err := pi.BuildArgs("run-1", "hello", os.TempDir(), map[string]any{
+		"model":    "anthropic/claude-opus-4-7",
+		"api_key":  "sk-test",
+		"provider": "anthropic",
+	}, "")
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	defer res.Cleanup()
+
+	if !containsPair(res.Args, "--mode", "json") {
+		t.Fatalf("args missing --mode json: %v", res.Args)
+	}
+	if !slices.Contains(res.Args, "--no-approve") {
+		t.Fatalf("args missing --no-approve: %v", res.Args)
+	}
+	if !containsPair(res.Args, "--model", "anthropic/claude-opus-4-7") {
+		t.Fatalf("args missing --model: %v", res.Args)
+	}
+	if !containsPair(res.Args, "--api-key", "sk-test") {
+		t.Fatalf("args missing --api-key: %v", res.Args)
+	}
+	if !containsPair(res.Args, "--provider", "anthropic") {
+		t.Fatalf("args missing --provider: %v", res.Args)
+	}
+	// pi's -p consumes the immediately-following arg as the prompt, so the
+	// prompt MUST be the final arg, preceded by -p.
+	n := len(res.Args)
+	if n < 2 || res.Args[n-2] != "-p" || res.Args[n-1] != "hello" {
+		t.Fatalf("expected args to end with -p hello, got %v", res.Args)
+	}
+	if res.WorkDir != os.TempDir() {
+		t.Fatalf("WorkDir = %q, want %q", res.WorkDir, os.TempDir())
+	}
+}
+
+func TestBuildArgsRejectsRelativeWorkdir(t *testing.T) {
+	_, err := pi.BuildArgs("run-1", "hello", "./relative", nil, "")
+	if err == nil || !strings.Contains(err.Error(), "absolute") {
+		t.Fatalf("BuildArgs relative err = %v, want absolute-path error", err)
+	}
+}
+
+func TestBuildArgsCreatesMissingWorkdir(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "missing", "parents", "leaf")
+	res, err := pi.BuildArgs("run-1", "hello", target, nil, "")
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	defer res.Cleanup()
+	if res.WorkDir != target {
+		t.Fatalf("WorkDir = %q, want %q", res.WorkDir, target)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("stat target: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("target %q is not a directory", target)
+	}
+}
+
+func TestBuildArgsSystemPromptAppends(t *testing.T) {
+	res, err := pi.BuildArgs("run-1", "hello", "", map[string]any{
+		"system_prompt": "be terse",
+	}, "")
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	defer res.Cleanup()
+	if !containsPair(res.Args, "--append-system-prompt", "be terse") {
+		t.Fatalf("args missing --append-system-prompt: %v", res.Args)
+	}
+	if slices.Contains(res.Args, "--system-prompt") {
+		t.Fatalf("system_prompt must map to append, not override: %v", res.Args)
+	}
+}
+
+func TestBuildArgsOverrideSystemPromptReplaces(t *testing.T) {
+	res, err := pi.BuildArgs("run-1", "hello", "", map[string]any{
+		"system_prompt":          "be terse",
+		"override_system_prompt": "you are root",
+	}, "")
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	defer res.Cleanup()
+	if !containsPair(res.Args, "--system-prompt", "you are root") {
+		t.Fatalf("args missing --system-prompt override: %v", res.Args)
+	}
+	// Override wins: the append we tentatively added must be stripped.
+	if slices.Contains(res.Args, "--append-system-prompt") {
+		t.Fatalf("override must strip the append: %v", res.Args)
+	}
+}
+
+func TestBuildArgsResumeSessionExplicitWins(t *testing.T) {
+	res, err := pi.BuildArgs("run-1", "hello", "", map[string]any{
+		"resume_session_id": "from-opts",
+	}, "from-param")
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	defer res.Cleanup()
+	if !containsPair(res.Args, "--session", "from-param") {
+		t.Fatalf("explicit resume id must win: %v", res.Args)
+	}
+}
+
+func TestBuildArgsResumeSessionFromOpts(t *testing.T) {
+	res, err := pi.BuildArgs("run-1", "hello", "", map[string]any{
+		"resume_session_id": "sess-42",
+	}, "")
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	defer res.Cleanup()
+	if !containsPair(res.Args, "--session", "sess-42") {
+		t.Fatalf("opts resume id missing: %v", res.Args)
+	}
+}
+
+func TestBuildArgsSkillDirsRepeatFlag(t *testing.T) {
+	res, err := pi.BuildArgs("run-1", "hello", "", map[string]any{
+		"skill_dirs": []any{"/skills/a", "/skills/b"},
+	}, "")
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	defer res.Cleanup()
+	if !containsPair(res.Args, "--skill", "/skills/a") {
+		t.Fatalf("args missing first --skill: %v", res.Args)
+	}
+	if !containsPair(res.Args, "--skill", "/skills/b") {
+		t.Fatalf("args missing second --skill: %v", res.Args)
+	}
+}
+
+func TestBuildArgsTelemetryOptOutEnv(t *testing.T) {
+	res, err := pi.BuildArgs("run-1", "hello", "", nil, "")
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	defer res.Cleanup()
+	if envValue(res.Env, "PI_TELEMETRY") != "0" {
+		t.Fatalf("expected PI_TELEMETRY=0 opt-out, env=%v", res.Env)
+	}
+}
+
+func TestBuildArgsPassesThroughEnvSorted(t *testing.T) {
+	res, err := pi.BuildArgs("run-1", "hello", "", map[string]any{
+		"env": map[string]any{"BBB": "2", "AAA": "1"},
+	}, "")
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	defer res.Cleanup()
+	if envValue(res.Env, "AAA") != "1" || envValue(res.Env, "BBB") != "2" {
+		t.Fatalf("env passthrough missing: %v", res.Env)
+	}
+}
+
+func TestBuildArgsRejectsBadEnvShape(t *testing.T) {
+	_, err := pi.BuildArgs("run-1", "hello", "", map[string]any{"env": map[string]any{"K": 1}}, "")
+	if err == nil || !strings.Contains(err.Error(), "env") {
+		t.Fatalf("BuildArgs env err = %v, want env shape error", err)
+	}
+}
+
+func TestBuildArgsRejectsEmptyPrompt(t *testing.T) {
+	_, err := pi.BuildArgs("run-1", "   ", "", nil, "")
+	if err == nil || !strings.Contains(err.Error(), "prompt") {
+		t.Fatalf("BuildArgs empty prompt err = %v, want prompt error", err)
+	}
+}
+
+func containsPair(args []string, flag, value string) bool {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, item := range env {
+		if v, ok := strings.CutPrefix(item, prefix); ok {
+			return v
+		}
+	}
+	return ""
+}

--- a/apps/parsar-daemon/internal/agent/pi/options_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/options_test.go
@@ -30,8 +30,11 @@ func TestBuildArgsUsesModeJsonNoApproveAndPromptLast(t *testing.T) {
 	if !containsPair(res.Args, "--model", "anthropic/claude-opus-4-7") {
 		t.Fatalf("args missing --model: %v", res.Args)
 	}
-	if !containsPair(res.Args, "--api-key", "sk-test") {
-		t.Fatalf("args missing --api-key: %v", res.Args)
+	// Secrets must never ride on argv (ps would leak them): a provided
+	// api_key is intentionally dropped here and delivered via env instead
+	// (see server injectPiManagedModel / PARSAR_PI_API_KEY).
+	if slices.Contains(res.Args, "--api-key") || slices.Contains(res.Args, "sk-test") {
+		t.Fatalf("api_key must not leak onto argv: %v", res.Args)
 	}
 	if !containsPair(res.Args, "--provider", "anthropic") {
 		t.Fatalf("args missing --provider: %v", res.Args)

--- a/apps/parsar-daemon/internal/agent/pi/parser.go
+++ b/apps/parsar-daemon/internal/agent/pi/parser.go
@@ -244,26 +244,31 @@ func (t *translator) mergeUsage(u piUsage, provider, model string) {
 	if model != "" {
 		t.usage.Model = model
 	}
-	if u.CacheRead != 0 || u.CacheWrite != 0 || u.CacheWrite1h != 0 || u.Reasoning != 0 || u.TotalTokens != 0 {
-		if t.usage.Raw == nil {
-			t.usage.Raw = map[string]any{}
-		}
-		if u.CacheRead != 0 {
-			t.usage.Raw["cache_read_tokens"] = u.CacheRead
-		}
-		if u.CacheWrite != 0 {
-			t.usage.Raw["cache_write_tokens"] = u.CacheWrite
-		}
-		if u.CacheWrite1h != 0 {
-			t.usage.Raw["cache_write_1h_tokens"] = u.CacheWrite1h
-		}
-		if u.Reasoning != 0 {
-			t.usage.Raw["reasoning_tokens"] = u.Reasoning
-		}
-		if u.TotalTokens != 0 {
-			t.usage.Raw["total_tokens"] = u.TotalTokens
-		}
+	// pi reports usage per assistant message; a tool loop yields several
+	// message_end frames, so accumulate cache/reasoning/total the same way as
+	// input/output above — overwriting would leave Raw showing only the last
+	// frame while the summed token counts reflect all of them.
+	t.addRawTokens("cache_read_tokens", u.CacheRead)
+	t.addRawTokens("cache_write_tokens", u.CacheWrite)
+	t.addRawTokens("cache_write_1h_tokens", u.CacheWrite1h)
+	t.addRawTokens("reasoning_tokens", u.Reasoning)
+	t.addRawTokens("total_tokens", u.TotalTokens)
+}
+
+// addRawTokens sums one counter into usage.Raw. In-process the values stay
+// int32 (matching piUsage); they only become float64 once the envelope is
+// JSON-encoded downstream, which is why the lookup asserts int32.
+func (t *translator) addRawTokens(key string, v int32) {
+	if v == 0 {
+		return
 	}
+	if t.usage.Raw == nil {
+		t.usage.Raw = map[string]any{}
+	}
+	if existing, ok := t.usage.Raw[key].(int32); ok {
+		v += existing
+	}
+	t.usage.Raw[key] = v
 }
 
 func (t *translator) terminalEnvelopes(waitErr error, stderr string, cancelled bool) []proto.Envelope {

--- a/apps/parsar-daemon/internal/agent/pi/parser.go
+++ b/apps/parsar-daemon/internal/agent/pi/parser.go
@@ -1,0 +1,332 @@
+package pi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+// translator converts one NDJSON line from pi's `--mode json` stdout
+// into zero or more proto.Envelope frames. One translator lives per
+// session. pi has no explicit terminal frame: the stream ends at process
+// EOF, so the session pump calls terminalEnvelopes after cmd.Wait.
+type translator struct {
+	runID string
+	seq   atomic.Uint64
+
+	deltaBuf  strings.Builder
+	finalText string
+	rawLines  []string
+	usage     proto.Usage
+	usageSet  bool
+	sessionID string
+}
+
+type translation struct {
+	Envelopes []proto.Envelope
+	// SessionID is surfaced from the session header line so session.go
+	// can write it into binding metadata for --session resume.
+	SessionID string
+}
+
+func newTranslator(runID string) *translator { return &translator{runID: runID} }
+
+func (t *translator) Translate(line []byte) (translation, error) {
+	line = bytes.TrimSpace(line)
+	if len(line) == 0 {
+		return translation{}, nil
+	}
+	t.rawLines = append(t.rawLines, string(line))
+
+	var head struct {
+		Type string `json:"type"`
+	}
+	// pi emits strict JSON per line; a non-JSON line is a stray log, not
+	// a fatal error — skip it to keep one bad line from killing the run.
+	if err := json.Unmarshal(line, &head); err != nil || head.Type == "" {
+		return translation{}, nil
+	}
+
+	switch head.Type {
+	case "session":
+		return t.translateSessionHeader(line)
+	case "message_update":
+		return t.translateMessageUpdate(line)
+	case "tool_execution_start":
+		return t.translateToolStart(line)
+	case "tool_execution_end":
+		return t.translateToolEnd(line)
+	case "message_end":
+		return t.translateMessageEnd(line)
+	default:
+		return translation{}, nil
+	}
+}
+
+func (t *translator) translateSessionHeader(line []byte) (translation, error) {
+	var msg struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(line, &msg)
+	if msg.ID != "" {
+		t.sessionID = msg.ID
+	}
+	return translation{SessionID: msg.ID}, nil
+}
+
+func (t *translator) translateMessageUpdate(line []byte) (translation, error) {
+	var msg struct {
+		Event struct {
+			Type  string `json:"type"`
+			Delta string `json:"delta"`
+		} `json:"assistantMessageEvent"`
+	}
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return translation{}, fmt.Errorf("pi: parse message_update: %w", err)
+	}
+	switch msg.Event.Type {
+	case "text_delta":
+		if msg.Event.Delta == "" {
+			return translation{}, nil
+		}
+		t.deltaBuf.WriteString(msg.Event.Delta)
+		env, err := proto.NewEnvelope(proto.TypeDelta, t.runID, proto.DeltaPayload{
+			Delta:    msg.Event.Delta,
+			Sequence: t.seq.Add(1),
+		})
+		if err != nil {
+			return translation{}, err
+		}
+		return translation{Envelopes: []proto.Envelope{env}}, nil
+	case "thinking_delta":
+		if msg.Event.Delta == "" {
+			return translation{}, nil
+		}
+		env, err := proto.NewEnvelope(proto.TypeThinking, t.runID, proto.ThinkingPayload{
+			Text:     msg.Event.Delta,
+			Sequence: t.seq.Add(1),
+		})
+		if err != nil {
+			return translation{}, err
+		}
+		return translation{Envelopes: []proto.Envelope{env}}, nil
+	default:
+		return translation{}, nil
+	}
+}
+
+func (t *translator) translateToolStart(line []byte) (translation, error) {
+	var msg struct {
+		ToolCallID string         `json:"toolCallId"`
+		ToolName   string         `json:"toolName"`
+		Args       map[string]any `json:"args"`
+	}
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return translation{}, fmt.Errorf("pi: parse tool_execution_start: %w", err)
+	}
+	env, err := proto.NewEnvelope(proto.TypeToolCall, t.runID, proto.ToolCallPayload{
+		ID:    msg.ToolCallID,
+		Name:  msg.ToolName,
+		Stage: "before",
+		Args:  msg.Args,
+	})
+	if err != nil {
+		return translation{}, err
+	}
+	return translation{Envelopes: []proto.Envelope{env}}, nil
+}
+
+func (t *translator) translateToolEnd(line []byte) (translation, error) {
+	var msg struct {
+		ToolCallID string `json:"toolCallId"`
+		ToolName   string `json:"toolName"`
+		Result     any    `json:"result"`
+		IsError    bool   `json:"isError"`
+	}
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return translation{}, fmt.Errorf("pi: parse tool_execution_end: %w", err)
+	}
+	env, err := proto.NewEnvelope(proto.TypeToolCall, t.runID, proto.ToolCallPayload{
+		ID:    msg.ToolCallID,
+		Name:  msg.ToolName,
+		Stage: "after",
+		Result: map[string]any{
+			"content":  msg.Result,
+			"is_error": msg.IsError,
+		},
+	})
+	if err != nil {
+		return translation{}, err
+	}
+	return translation{Envelopes: []proto.Envelope{env}}, nil
+}
+
+type piUsage struct {
+	Input        int32 `json:"input"`
+	Output       int32 `json:"output"`
+	CacheRead    int32 `json:"cacheRead"`
+	CacheWrite   int32 `json:"cacheWrite"`
+	CacheWrite1h int32 `json:"cacheWrite1h"`
+	Reasoning    int32 `json:"reasoning"`
+	TotalTokens  int32 `json:"totalTokens"`
+	Cost         struct {
+		Total float64 `json:"total"`
+	} `json:"cost"`
+}
+
+func (t *translator) translateMessageEnd(line []byte) (translation, error) {
+	var msg struct {
+		Message struct {
+			Role         string `json:"role"`
+			Content      []json.RawMessage
+			Provider     string  `json:"provider"`
+			Model        string  `json:"model"`
+			Usage        piUsage `json:"usage"`
+			StopReason   string  `json:"stopReason"`
+			ErrorMessage string  `json:"errorMessage"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return translation{}, fmt.Errorf("pi: parse message_end: %w", err)
+	}
+	if msg.Message.Role != "assistant" {
+		return translation{}, nil
+	}
+
+	t.mergeUsage(msg.Message.Usage, msg.Message.Provider, msg.Message.Model)
+	if text := extractText(msg.Message.Content); text != "" {
+		t.finalText = text
+	}
+
+	if msg.Message.StopReason == "error" {
+		errMsg := msg.Message.ErrorMessage
+		if errMsg == "" {
+			errMsg = "pi: assistant message ended with error"
+		}
+		env, err := proto.NewEnvelope(proto.TypeError, t.runID, proto.ErrorPayload{Error: errMsg})
+		if err != nil {
+			return translation{}, err
+		}
+		return translation{Envelopes: []proto.Envelope{env}}, nil
+	}
+	return translation{}, nil
+}
+
+func extractText(content []json.RawMessage) string {
+	var b strings.Builder
+	for _, raw := range content {
+		var item struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}
+		if err := json.Unmarshal(raw, &item); err != nil {
+			continue
+		}
+		if item.Type == "text" {
+			b.WriteString(item.Text)
+		}
+	}
+	return b.String()
+}
+
+func (t *translator) mergeUsage(u piUsage, provider, model string) {
+	t.usageSet = true
+	t.usage.InputTokens += u.Input
+	t.usage.OutputTokens += u.Output
+	t.usage.CostUSD += u.Cost.Total
+	if provider != "" {
+		t.usage.Provider = provider
+	}
+	if model != "" {
+		t.usage.Model = model
+	}
+	if u.CacheRead != 0 || u.CacheWrite != 0 || u.CacheWrite1h != 0 || u.Reasoning != 0 || u.TotalTokens != 0 {
+		if t.usage.Raw == nil {
+			t.usage.Raw = map[string]any{}
+		}
+		if u.CacheRead != 0 {
+			t.usage.Raw["cache_read_tokens"] = u.CacheRead
+		}
+		if u.CacheWrite != 0 {
+			t.usage.Raw["cache_write_tokens"] = u.CacheWrite
+		}
+		if u.CacheWrite1h != 0 {
+			t.usage.Raw["cache_write_1h_tokens"] = u.CacheWrite1h
+		}
+		if u.Reasoning != 0 {
+			t.usage.Raw["reasoning_tokens"] = u.Reasoning
+		}
+		if u.TotalTokens != 0 {
+			t.usage.Raw["total_tokens"] = u.TotalTokens
+		}
+	}
+}
+
+func (t *translator) terminalEnvelopes(waitErr error, stderr string, cancelled bool) []proto.Envelope {
+	var envs []proto.Envelope
+
+	content := strings.TrimSpace(t.deltaBuf.String())
+	if content == "" && t.finalText != "" {
+		content = strings.TrimSpace(t.finalText)
+		if content != "" {
+			if env, err := proto.NewEnvelope(proto.TypeDelta, t.runID, proto.DeltaPayload{Delta: content, Sequence: t.seq.Add(1)}); err == nil {
+				envs = append(envs, env)
+			}
+		}
+	}
+
+	usage := t.usage
+	if usage.Provider == "" {
+		usage.Provider = "pi"
+	}
+	if t.usageSet {
+		if env, err := proto.NewEnvelope(proto.TypeUsage, t.runID, proto.UsagePayload{Usage: usage}); err == nil {
+			envs = append(envs, env)
+		}
+	}
+
+	if waitErr != nil || cancelled {
+		msg := "pi: subprocess exited without success"
+		if waitErr != nil {
+			msg = fmt.Sprintf("pi: subprocess exited: %v", waitErr)
+		}
+		if strings.TrimSpace(stderr) != "" {
+			msg += ": " + truncate(strings.TrimSpace(stderr), 400)
+		}
+		if cancelled {
+			msg = "pi: cancelled"
+		}
+		if env, err := proto.NewEnvelope(proto.TypeError, t.runID, proto.ErrorPayload{Error: msg}); err == nil {
+			envs = append(envs, env)
+		}
+	}
+
+	metadata := map[string]any{"connector_path": "pi_print"}
+	if t.sessionID != "" {
+		metadata["pi_session_id"] = t.sessionID
+		// claude_session_id is the canonical key the server's resume
+		// write-back reads (binder MetaClaudeSessionID); mirror pi's id
+		// into it so --session resume works, exactly as codex does.
+		metadata["claude_session_id"] = t.sessionID
+	}
+	if env, err := proto.NewEnvelope(proto.TypeDone, t.runID, proto.DonePayload{
+		Content:    content,
+		Transcript: strings.Join(t.rawLines, "\n"),
+		Usage:      usage,
+		Metadata:   metadata,
+	}); err == nil {
+		envs = append(envs, env)
+	}
+	return envs
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max]
+}

--- a/apps/parsar-daemon/internal/agent/pi/parser_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/parser_test.go
@@ -1,0 +1,203 @@
+package pi_test
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/pi"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestTranslateSessionHeaderSurfacesSessionID(t *testing.T) {
+	tr := pi.NewTranslatorForTest("run-1")
+	tx, err := tr.Translate([]byte(`{"type":"session","id":"sess-abc","cwd":"/x","timestamp":"t"}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	if tx.SessionID != "sess-abc" {
+		t.Fatalf("SessionID = %q, want sess-abc", tx.SessionID)
+	}
+	if len(tx.Envelopes) != 0 {
+		t.Fatalf("session header should emit no envelopes, got %#v", tx.Envelopes)
+	}
+}
+
+func TestTranslateTextDeltaEmitsDelta(t *testing.T) {
+	tr := pi.NewTranslatorForTest("run-1")
+	tx, err := tr.Translate([]byte(`{"type":"message_update","message":{"role":"assistant"},"assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"hello"}}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	if len(tx.Envelopes) != 1 || tx.Envelopes[0].Type != proto.TypeDelta {
+		t.Fatalf("delta envelopes = %#v", tx.Envelopes)
+	}
+	delta := decodePayload[proto.DeltaPayload](t, tx.Envelopes[0])
+	if delta.Delta != "hello" || delta.Sequence == 0 {
+		t.Fatalf("delta payload = %#v", delta)
+	}
+}
+
+func TestTranslateThinkingDeltaEmitsThinking(t *testing.T) {
+	tr := pi.NewTranslatorForTest("run-1")
+	tx, err := tr.Translate([]byte(`{"type":"message_update","message":{"role":"assistant"},"assistantMessageEvent":{"type":"thinking_delta","contentIndex":0,"delta":"pondering"}}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	if len(tx.Envelopes) != 1 || tx.Envelopes[0].Type != proto.TypeThinking {
+		t.Fatalf("thinking envelopes = %#v", tx.Envelopes)
+	}
+	think := decodePayload[proto.ThinkingPayload](t, tx.Envelopes[0])
+	if think.Text != "pondering" || think.Sequence == 0 {
+		t.Fatalf("thinking payload = %#v", think)
+	}
+}
+
+func TestTranslateToolExecutionStartEmitsBeforeToolCall(t *testing.T) {
+	tr := pi.NewTranslatorForTest("run-1")
+	tx, err := tr.Translate([]byte(`{"type":"tool_execution_start","toolCallId":"t1","toolName":"bash","args":{"cmd":"ls"}}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	if len(tx.Envelopes) != 1 || tx.Envelopes[0].Type != proto.TypeToolCall {
+		t.Fatalf("toolcall envelopes = %#v", tx.Envelopes)
+	}
+	tc := decodePayload[proto.ToolCallPayload](t, tx.Envelopes[0])
+	if tc.ID != "t1" || tc.Name != "bash" || tc.Stage != "before" {
+		t.Fatalf("toolcall payload = %#v", tc)
+	}
+	if tc.Args["cmd"] != "ls" {
+		t.Fatalf("toolcall args = %#v", tc.Args)
+	}
+}
+
+func TestTranslateToolExecutionEndEmitsAfterToolCall(t *testing.T) {
+	tr := pi.NewTranslatorForTest("run-1")
+	tx, err := tr.Translate([]byte(`{"type":"tool_execution_end","toolCallId":"t1","toolName":"bash","result":{"stdout":"x"},"isError":true}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	if len(tx.Envelopes) != 1 || tx.Envelopes[0].Type != proto.TypeToolCall {
+		t.Fatalf("toolcall envelopes = %#v", tx.Envelopes)
+	}
+	tc := decodePayload[proto.ToolCallPayload](t, tx.Envelopes[0])
+	if tc.ID != "t1" || tc.Stage != "after" {
+		t.Fatalf("toolcall payload = %#v", tc)
+	}
+	if tc.Result["is_error"] != true {
+		t.Fatalf("toolcall result = %#v", tc.Result)
+	}
+}
+
+func TestTranslateMessageEndCapturesUsage(t *testing.T) {
+	tr := pi.NewTranslatorForTest("run-u")
+	line := `{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"hi"}],"provider":"anthropic","model":"claude-x","usage":{"input":10,"output":7,"cacheRead":2,"cacheWrite":1,"reasoning":3,"totalTokens":23,"cost":{"input":0.1,"output":0.2,"cacheRead":0,"cacheWrite":0,"total":0.3}},"stopReason":"stop"}}`
+	if _, err := tr.Translate([]byte(line)); err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	envs := tr.TerminalEnvelopes(nil, "", false)
+	var got *proto.UsagePayload
+	for _, env := range envs {
+		if env.Type == proto.TypeUsage {
+			payload := decodePayload[proto.UsagePayload](t, env)
+			got = &payload
+		}
+	}
+	if got == nil {
+		t.Fatalf("usage env missing: %#v", envs)
+	}
+	if got.Provider != "anthropic" || got.Model != "claude-x" {
+		t.Fatalf("usage provider/model = %#v", got)
+	}
+	if got.InputTokens != 10 || got.OutputTokens != 7 || got.CostUSD != 0.3 {
+		t.Fatalf("usage tokens/cost = %#v", got)
+	}
+	if got.Raw["cache_read_tokens"] != float64(2) {
+		t.Fatalf("usage raw = %#v", got.Raw)
+	}
+}
+
+// pi exits 0 even when the model errors: it emits a message_end whose
+// assistant message carries stopReason "error". The parser MUST surface
+// that as TypeError despite the clean process exit.
+func TestTranslateMessageEndErrorStopReasonEmitsError(t *testing.T) {
+	tr := pi.NewTranslatorForTest("run-err")
+	line := `{"type":"message_end","message":{"role":"assistant","content":[],"provider":"anthropic","model":"m","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"error","errorMessage":"boom"}}`
+	tx, err := tr.Translate([]byte(line))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	var found bool
+	for _, env := range tx.Envelopes {
+		if env.Type == proto.TypeError {
+			ep := decodePayload[proto.ErrorPayload](t, env)
+			if strings.Contains(ep.Error, "boom") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected TypeError mentioning boom, got %#v", tx.Envelopes)
+	}
+}
+
+func TestTerminalAlwaysEmitsDoneWithSessionMetadata(t *testing.T) {
+	tr := pi.NewTranslatorForTest("run-1")
+	if _, err := tr.Translate([]byte(`{"type":"session","id":"sess-abc","cwd":"/x","timestamp":"t"}`)); err != nil {
+		t.Fatalf("Translate header: %v", err)
+	}
+	if _, err := tr.Translate([]byte(`{"type":"message_update","message":{"role":"assistant"},"assistantMessageEvent":{"type":"text_delta","contentIndex":0,"delta":"hello"}}`)); err != nil {
+		t.Fatalf("Translate delta: %v", err)
+	}
+	envs := tr.TerminalEnvelopes(nil, "", false)
+	last := envs[len(envs)-1]
+	if last.Type != proto.TypeDone {
+		t.Fatalf("last env = %q, want done", last.Type)
+	}
+	done := decodePayload[proto.DonePayload](t, last)
+	if done.Content != "hello" {
+		t.Fatalf("done content = %q, want hello", done.Content)
+	}
+	if done.Metadata["pi_session_id"] != "sess-abc" {
+		t.Fatalf("done metadata = %#v, want pi_session_id sess-abc", done.Metadata)
+	}
+	// Resume hinges on the canonical claude_session_id (see parser.go).
+	if done.Metadata["claude_session_id"] != "sess-abc" {
+		t.Fatalf("done metadata = %#v, want claude_session_id sess-abc", done.Metadata)
+	}
+}
+
+func TestTerminalErrorIncludesStderr(t *testing.T) {
+	tr := pi.NewTranslatorForTest("run-e")
+	envs := tr.TerminalEnvelopes(errors.New("exit status 2"), "bad auth", false)
+	if len(envs) < 2 || envs[0].Type != proto.TypeError || envs[len(envs)-1].Type != proto.TypeDone {
+		t.Fatalf("error terminal envs = %#v", envs)
+	}
+	errPayload := decodePayload[proto.ErrorPayload](t, envs[0])
+	if !strings.Contains(errPayload.Error, "bad auth") {
+		t.Fatalf("error payload = %#v", errPayload)
+	}
+}
+
+func TestMessageEndContentFallbackWhenNoDeltas(t *testing.T) {
+	tr := pi.NewTranslatorForTest("run-f")
+	line := `{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"final answer"}],"provider":"anthropic","model":"m","usage":{"input":1,"output":1,"cacheRead":0,"cacheWrite":0,"totalTokens":2,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"stop"}}`
+	if _, err := tr.Translate([]byte(line)); err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	envs := tr.TerminalEnvelopes(nil, "", false)
+	done := decodePayload[proto.DonePayload](t, envs[len(envs)-1])
+	if done.Content != "final answer" {
+		t.Fatalf("done content = %q, want final answer", done.Content)
+	}
+}
+
+func decodePayload[T any](t *testing.T, env proto.Envelope) T {
+	t.Helper()
+	var out T
+	if err := json.Unmarshal(env.Payload, &out); err != nil {
+		t.Fatalf("decode %s payload: %v", env.Type, err)
+	}
+	return out
+}

--- a/apps/parsar-daemon/internal/agent/pi/parser_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/parser_test.go
@@ -118,6 +118,48 @@ func TestTranslateMessageEndCapturesUsage(t *testing.T) {
 	}
 }
 
+// A tool loop makes pi emit one message_end per assistant turn. Every
+// counter — including the cache/reasoning/total ones parked in Raw — must
+// sum across frames, not get clobbered by the final frame.
+func TestTranslateMessageEndAccumulatesUsageAcrossFrames(t *testing.T) {
+	tr := pi.NewTranslatorForTest("run-multi")
+	first := `{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"a"}],"provider":"anthropic","model":"m","usage":{"input":10,"output":7,"cacheRead":2,"cacheWrite":1,"reasoning":3,"totalTokens":23,"cost":{"total":0.3}},"stopReason":"tool_use"}}`
+	second := `{"type":"message_end","message":{"role":"assistant","content":[{"type":"text","text":"b"}],"provider":"anthropic","model":"m","usage":{"input":5,"output":4,"cacheRead":6,"cacheWrite":2,"reasoning":1,"totalTokens":12,"cost":{"total":0.2}},"stopReason":"stop"}}`
+	for _, line := range []string{first, second} {
+		if _, err := tr.Translate([]byte(line)); err != nil {
+			t.Fatalf("Translate: %v", err)
+		}
+	}
+	envs := tr.TerminalEnvelopes(nil, "", false)
+	var got *proto.UsagePayload
+	for _, env := range envs {
+		if env.Type == proto.TypeUsage {
+			payload := decodePayload[proto.UsagePayload](t, env)
+			got = &payload
+		}
+	}
+	if got == nil {
+		t.Fatalf("usage env missing: %#v", envs)
+	}
+	if got.InputTokens != 15 || got.OutputTokens != 11 {
+		t.Fatalf("summed input/output = %d/%d, want 15/11", got.InputTokens, got.OutputTokens)
+	}
+	if got.CostUSD < 0.49 || got.CostUSD > 0.51 {
+		t.Fatalf("summed cost = %v, want ~0.5", got.CostUSD)
+	}
+	// Raw round-trips through JSON, so the counters decode back as float64.
+	for key, want := range map[string]float64{
+		"cache_read_tokens":  8,
+		"cache_write_tokens": 3,
+		"reasoning_tokens":   4,
+		"total_tokens":       35,
+	} {
+		if got.Raw[key] != want {
+			t.Fatalf("Raw[%q] = %#v, want %v (must sum across frames)", key, got.Raw[key], want)
+		}
+	}
+}
+
 // pi exits 0 even when the model errors: it emits a message_end whose
 // assistant message carries stopReason "error". The parser MUST surface
 // that as TypeError despite the clean process exit.

--- a/apps/parsar-daemon/internal/agent/pi/provider_config.go
+++ b/apps/parsar-daemon/internal/agent/pi/provider_config.go
@@ -1,0 +1,160 @@
+package pi
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// piManagedProviderSlug is the provider key the daemon always writes into
+// models.json, and the server pins opts["model"] to "parsar/<modelKey>" so
+// pi routes through this entry instead of a built-in provider.
+const piManagedProviderSlug = "parsar"
+
+// piAgentDirEnvVar is pi's sole override for its config directory
+// (config.ts ENV_AGENT_DIR); pi reads models.json from <dir>/models.json.
+const piAgentDirEnvVar = "PI_CODING_AGENT_DIR"
+
+type piProviderConfig struct {
+	Name       string
+	BaseURL    string
+	API        string
+	APIKeyEnv  string
+	Model      string
+	Headers    map[string]string
+	AuthHeader bool
+}
+
+func writePiModelsJSON(agentDir string, cfg piProviderConfig) error {
+	if strings.TrimSpace(cfg.BaseURL) == "" {
+		return fmt.Errorf("pi: provider base_url is required")
+	}
+	if strings.TrimSpace(cfg.API) == "" {
+		return fmt.Errorf("pi: provider api is required")
+	}
+	if strings.TrimSpace(cfg.APIKeyEnv) == "" {
+		return fmt.Errorf("pi: provider api_key_env is required")
+	}
+	if strings.TrimSpace(cfg.Model) == "" {
+		return fmt.Errorf("pi: provider model is required")
+	}
+	if err := os.MkdirAll(agentDir, 0o700); err != nil {
+		return fmt.Errorf("pi: mkdir agent dir %s: %w", agentDir, err)
+	}
+
+	provider := map[string]any{
+		"baseUrl": cfg.BaseURL,
+		"api":     cfg.API,
+		// pi reads a bare apiKey string as a LITERAL key; only "$NAME" is an
+		// env reference (resolve-config-value.ts:138-143). The secret rides
+		// the subprocess env as APIKeyEnv, so we emit the reference form.
+		"apiKey": "$" + cfg.APIKeyEnv,
+		"models": []map[string]any{{"id": cfg.Model}},
+	}
+	if cfg.Name != "" {
+		provider["name"] = cfg.Name
+	}
+	if len(cfg.Headers) > 0 {
+		provider["headers"] = cfg.Headers
+	}
+	if cfg.AuthHeader {
+		provider["authHeader"] = true
+	}
+
+	doc := map[string]any{"providers": map[string]any{piManagedProviderSlug: provider}}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("pi: marshal models.json: %w", err)
+	}
+	path := filepath.Join(agentDir, "models.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("pi: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// normalisePiProvider flattens agent_options["pi_provider"] (the string-keyed
+// map injectPiManagedModel emits) into a typed piProviderConfig. Returns
+// hasProvider=false when the key is absent so callers skip materialisation.
+// Required-field validation lives in writePiModelsJSON (single source).
+func normalisePiProvider(raw any) (piProviderConfig, bool, error) {
+	if raw == nil {
+		return piProviderConfig{}, false, nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return piProviderConfig{}, false, fmt.Errorf("pi: pi_provider must be object, got %T", raw)
+	}
+	cfg := piProviderConfig{
+		Name:      stringOpt(m, "name"),
+		BaseURL:   stringOpt(m, "base_url"),
+		API:       stringOpt(m, "api"),
+		APIKeyEnv: stringOpt(m, "api_key_env"),
+		Model:     stringOpt(m, "model"),
+	}
+	if v, ok := m["auth_header"].(bool); ok {
+		cfg.AuthHeader = v
+	}
+	if hdrs, ok := m["headers"].(map[string]any); ok {
+		cfg.Headers = make(map[string]string, len(hdrs))
+		for k, v := range hdrs {
+			if s, ok := v.(string); ok {
+				cfg.Headers[k] = s
+			}
+		}
+	}
+	return cfg, true, nil
+}
+
+// resolveAgentDir returns the directory set as PI_CODING_AGENT_DIR for this
+// prompt — pi reads models.json (and writes sessions) there. Scoped per
+// conversation as a sibling of resolveSkillsRoot so consecutive turns reuse
+// the same sessions/ tree (resume) without two conversations racing. runID
+// scopes the one-shot fallback when there is no conversation.
+func resolveAgentDir(conversationID, runID string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("pi: resolve home: %w", err)
+	}
+	base := filepath.Join(home, ".parsar", "runtime", "pi")
+	if id := strings.TrimSpace(conversationID); id != "" {
+		return filepath.Join(base, "conv-"+id, "agent"), nil
+	}
+	return filepath.Join(base, "run-"+strings.TrimSpace(runID), "agent"), nil
+}
+
+// applyPiManagedProvider materialises opts["pi_provider"] into a per-conversation
+// models.json and returns a clone of opts with PI_CODING_AGENT_DIR injected into
+// opts["env"] (so buildEnv forwards it). When no pi_provider is present it
+// returns opts unchanged. The caller's opts and env maps are never mutated.
+func applyPiManagedProvider(opts map[string]any, conversationID, runID string) (map[string]any, error) {
+	cfg, ok, err := normalisePiProvider(opts["pi_provider"])
+	if err != nil {
+		return opts, err
+	}
+	if !ok {
+		return opts, nil
+	}
+	agentDir, err := resolveAgentDir(conversationID, runID)
+	if err != nil {
+		return opts, err
+	}
+	if err := writePiModelsJSON(agentDir, cfg); err != nil {
+		return opts, err
+	}
+	out := cloneAgentOptions(opts)
+	out["env"] = withAgentDirEnv(opts["env"], agentDir)
+	return out, nil
+}
+
+func withAgentDirEnv(existing any, agentDir string) map[string]any {
+	out := map[string]any{}
+	if m, ok := existing.(map[string]any); ok {
+		maps.Copy(out, m)
+	}
+	out[piAgentDirEnvVar] = agentDir
+	return out
+}

--- a/apps/parsar-daemon/internal/agent/pi/provider_config_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/provider_config_test.go
@@ -1,0 +1,271 @@
+package pi
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// modelsFile mirrors the subset of pi's models.json schema this adapter
+// emits (packages/coding-agent/src/core/model-registry.ts ProviderConfigSchema).
+type modelsFile struct {
+	Providers map[string]struct {
+		Name       string            `json:"name"`
+		BaseURL    string            `json:"baseUrl"`
+		APIKey     string            `json:"apiKey"`
+		API        string            `json:"api"`
+		Headers    map[string]string `json:"headers"`
+		AuthHeader bool              `json:"authHeader"`
+		Models     []struct {
+			ID string `json:"id"`
+		} `json:"models"`
+	} `json:"providers"`
+}
+
+func readModelsJSON(t *testing.T, dir string) modelsFile {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, "models.json"))
+	if err != nil {
+		t.Fatalf("read models.json: %v", err)
+	}
+	var mf modelsFile
+	if err := json.Unmarshal(raw, &mf); err != nil {
+		t.Fatalf("models.json is not valid JSON: %v\n%s", err, raw)
+	}
+	return mf
+}
+
+func TestWritePiModelsJSON_AnthropicProvider(t *testing.T) {
+	dir := t.TempDir()
+	cfg := piProviderConfig{
+		Name:      "Parsar Anthropic",
+		BaseURL:   "https://platform-api.example.com",
+		API:       "anthropic-messages",
+		APIKeyEnv: "PARSAR_PI_API_KEY",
+		Model:     "claude-opus-4-6-thinking-max",
+		Headers:   map[string]string{"X-Sub-Module": "claude-code-internal"},
+	}
+	if err := writePiModelsJSON(dir, cfg); err != nil {
+		t.Fatalf("writePiModelsJSON: %v", err)
+	}
+
+	p, ok := readModelsJSON(t, dir).Providers[piManagedProviderSlug]
+	if !ok {
+		t.Fatalf("models.json missing provider %q", piManagedProviderSlug)
+	}
+	if p.BaseURL != cfg.BaseURL {
+		t.Errorf("baseUrl = %q, want %q", p.BaseURL, cfg.BaseURL)
+	}
+	if p.API != "anthropic-messages" {
+		t.Errorf("api = %q, want anthropic-messages", p.API)
+	}
+	// CRITICAL: pi treats a bare apiKey string as a LITERAL key, and only a
+	// "$NAME" string as an env reference (resolve-config-value.ts:138-143).
+	// Writing the bare env name would send the literal text as the key → 401.
+	if p.APIKey != "$PARSAR_PI_API_KEY" {
+		t.Errorf("apiKey = %q, want $PARSAR_PI_API_KEY (env reference, not literal)", p.APIKey)
+	}
+	if p.Headers["X-Sub-Module"] != "claude-code-internal" {
+		t.Errorf("headers[X-Sub-Module] = %q, want claude-code-internal", p.Headers["X-Sub-Module"])
+	}
+	if len(p.Models) != 1 || p.Models[0].ID != cfg.Model {
+		t.Errorf("models = %+v, want one model id %q", p.Models, cfg.Model)
+	}
+	if p.Name != cfg.Name {
+		t.Errorf("name = %q, want %q", p.Name, cfg.Name)
+	}
+	// anthropic-messages carries auth via x-api-key (the resolved apiKey),
+	// not an Authorization bearer header, so authHeader must stay false.
+	if p.AuthHeader {
+		t.Errorf("authHeader = true, want false for anthropic-messages")
+	}
+}
+
+func TestWritePiModelsJSON_OpenAIAuthHeader(t *testing.T) {
+	dir := t.TempDir()
+	cfg := piProviderConfig{
+		BaseURL:    "https://gw.example.com/v1",
+		API:        "openai-completions",
+		APIKeyEnv:  "PARSAR_PI_API_KEY",
+		Model:      "gpt-5.5",
+		AuthHeader: true,
+	}
+	if err := writePiModelsJSON(dir, cfg); err != nil {
+		t.Fatalf("writePiModelsJSON: %v", err)
+	}
+	p := readModelsJSON(t, dir).Providers[piManagedProviderSlug]
+	if p.API != "openai-completions" {
+		t.Errorf("api = %q, want openai-completions", p.API)
+	}
+	if !p.AuthHeader {
+		t.Errorf("authHeader = false, want true so pi sends Authorization: Bearer")
+	}
+}
+
+func TestWritePiModelsJSON_RejectsMissingFields(t *testing.T) {
+	base := piProviderConfig{
+		BaseURL:   "https://x/v1",
+		API:       "anthropic-messages",
+		APIKeyEnv: "PARSAR_PI_API_KEY",
+		Model:     "m",
+	}
+	cases := map[string]func(*piProviderConfig){
+		"missing base_url":    func(c *piProviderConfig) { c.BaseURL = "" },
+		"missing api":         func(c *piProviderConfig) { c.API = "" },
+		"missing api_key_env": func(c *piProviderConfig) { c.APIKeyEnv = "" },
+		"missing model":       func(c *piProviderConfig) { c.Model = "" },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg := base
+			mutate(&cfg)
+			dir := t.TempDir()
+			if err := writePiModelsJSON(dir, cfg); err == nil {
+				t.Fatalf("expected error for %s, got nil", name)
+			}
+			if _, err := os.Stat(filepath.Join(dir, "models.json")); err == nil {
+				t.Fatalf("%s: models.json must not be written on invalid config", name)
+			}
+		})
+	}
+}
+
+func TestNormalisePiProvider_FullRoundTrip(t *testing.T) {
+	raw := map[string]any{
+		"name":        "Parsar Anthropic",
+		"base_url":    "https://platform-api.example.com",
+		"api":         "openai-completions",
+		"api_key_env": "PARSAR_PI_API_KEY",
+		"model":       "gpt-5.5",
+		"auth_header": true,
+		// Headers cross the daemon boundary as JSON, so they arrive as
+		// map[string]any even though the server typed them map[string]string.
+		"headers": map[string]any{"X-Sub-Module": "codex-internal"},
+	}
+	cfg, ok, err := normalisePiProvider(raw)
+	if err != nil {
+		t.Fatalf("normalisePiProvider: %v", err)
+	}
+	if !ok {
+		t.Fatal("hasProvider must be true for non-nil raw")
+	}
+	if cfg.Name != "Parsar Anthropic" || cfg.BaseURL != "https://platform-api.example.com" {
+		t.Fatalf("scalar fields wrong: %+v", cfg)
+	}
+	if cfg.API != "openai-completions" || cfg.APIKeyEnv != "PARSAR_PI_API_KEY" || cfg.Model != "gpt-5.5" {
+		t.Fatalf("scalar fields wrong: %+v", cfg)
+	}
+	if !cfg.AuthHeader {
+		t.Fatalf("auth_header lost: %+v", cfg)
+	}
+	if cfg.Headers["X-Sub-Module"] != "codex-internal" {
+		t.Fatalf("headers lost: %+v", cfg.Headers)
+	}
+}
+
+func TestNormalisePiProvider_Nil(t *testing.T) {
+	cfg, ok, err := normalisePiProvider(nil)
+	if err != nil {
+		t.Fatalf("normalisePiProvider nil: %v", err)
+	}
+	if ok {
+		t.Fatal("hasProvider must be false for nil")
+	}
+	_ = cfg
+}
+
+func TestNormalisePiProvider_WrongType(t *testing.T) {
+	if _, _, err := normalisePiProvider("not-an-object"); err == nil {
+		t.Fatal("expected error for non-object pi_provider")
+	}
+}
+
+func TestResolveAgentDirConversationScoped(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	got, err := resolveAgentDir("conv-abc", "run-1")
+	if err != nil {
+		t.Fatalf("resolveAgentDir: %v", err)
+	}
+	// Sibling of resolveSkillsRoot's conv-<id>/skills so one conversation's
+	// pi runtime state (models.json, sessions) co-locates under one dir.
+	want := filepath.Join(tmp, ".parsar", "runtime", "pi", "conv-conv-abc", "agent")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveAgentDirRunScopedFallback(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	got, err := resolveAgentDir("", "run-9")
+	if err != nil {
+		t.Fatalf("resolveAgentDir: %v", err)
+	}
+	want := filepath.Join(tmp, ".parsar", "runtime", "pi", "run-run-9", "agent")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestApplyPiManagedProvider_WritesModelsAndSetsEnv(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	callerEnv := map[string]any{"PARSAR_PI_API_KEY": "sk-proxy", "OTHER": "x"}
+	opts := map[string]any{
+		"model": "parsar/claude-opus-4-6-thinking-max",
+		"env":   callerEnv,
+		"pi_provider": map[string]any{
+			"base_url":    "https://platform-api.example.com",
+			"api":         "anthropic-messages",
+			"api_key_env": "PARSAR_PI_API_KEY",
+			"model":       "claude-opus-4-6-thinking-max",
+			"headers":     map[string]any{"X-Sub-Module": "claude-code-internal"},
+		},
+	}
+
+	out, err := applyPiManagedProvider(opts, "conv-xyz", "run-1")
+	if err != nil {
+		t.Fatalf("applyPiManagedProvider: %v", err)
+	}
+
+	agentDir := filepath.Join(tmp, ".parsar", "runtime", "pi", "conv-conv-xyz", "agent")
+	env, ok := out["env"].(map[string]any)
+	if !ok {
+		t.Fatalf("out[env] not a map: %T", out["env"])
+	}
+	if env["PI_CODING_AGENT_DIR"] != agentDir {
+		t.Errorf("PI_CODING_AGENT_DIR = %v, want %q", env["PI_CODING_AGENT_DIR"], agentDir)
+	}
+	if env["PARSAR_PI_API_KEY"] != "sk-proxy" || env["OTHER"] != "x" {
+		t.Errorf("pre-existing env not preserved: %+v", env)
+	}
+
+	p := readModelsJSON(t, agentDir).Providers[piManagedProviderSlug]
+	if p.APIKey != "$PARSAR_PI_API_KEY" || p.BaseURL != "https://platform-api.example.com" {
+		t.Errorf("models.json not materialised correctly: %+v", p)
+	}
+
+	// The caller's env map must be untouched — buildEnv reads opts["env"]
+	// and a shared reference would leak PI_CODING_AGENT_DIR back to the
+	// server-owned options map across turns.
+	if _, leaked := callerEnv["PI_CODING_AGENT_DIR"]; leaked {
+		t.Error("applyPiManagedProvider mutated the caller's env map")
+	}
+}
+
+func TestApplyPiManagedProvider_NoProviderNoop(t *testing.T) {
+	opts := map[string]any{"model": "anthropic/x"}
+	out, err := applyPiManagedProvider(opts, "conv-1", "run-1")
+	if err != nil {
+		t.Fatalf("applyPiManagedProvider: %v", err)
+	}
+	if env, ok := out["env"].(map[string]any); ok {
+		if _, set := env["PI_CODING_AGENT_DIR"]; set {
+			t.Fatal("PI_CODING_AGENT_DIR must not be set when no pi_provider present")
+		}
+	}
+}
+
+

--- a/apps/parsar-daemon/internal/agent/pi/session.go
+++ b/apps/parsar-daemon/internal/agent/pi/session.go
@@ -99,6 +99,15 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		}
 	}
 
+	// Without this, pi never sees the proxy base_url + X-Sub-Module header and
+	// sends the managed key to api.anthropic.com → 401. Writes models.json and
+	// sets PI_CODING_AGENT_DIR in opts["env"] (buildEnv forwards it).
+	provOpts, provErr := applyPiManagedProvider(opts, req.ConversationID, req.RunID)
+	if provErr != nil {
+		return nil, fmt.Errorf("pi: apply managed provider: %w", provErr)
+	}
+	opts = provOpts
+
 	buildRes, err := BuildArgs(req.RunID, req.Prompt, req.WorkDir, opts, req.ResumeSessionID)
 	if err != nil {
 		return nil, fmt.Errorf("pi: build args: %w", err)

--- a/apps/parsar-daemon/internal/agent/pi/session.go
+++ b/apps/parsar-daemon/internal/agent/pi/session.go
@@ -1,0 +1,240 @@
+// Package pi is the agent_kind="pi" adapter. It drives the pi CLI via
+// `pi --mode json -p <prompt>`, translating pi's NDJSON event stream on
+// stdout into proto.Envelope frames for the dispatch router.
+package pi
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	obslog "github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+)
+
+type sessionConfig struct {
+	piBinary    string
+	extraArgs   []string
+	killTimeout time.Duration
+	logger      *slog.Logger
+}
+
+func defaultConfig() sessionConfig {
+	return sessionConfig{piBinary: defaultBinary, killTimeout: 3 * time.Second, logger: obslog.Bg()}
+}
+
+// Factory implements agent.Factory for agent_kind="pi".
+func Factory(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+	return newSession(ctx, req, out, defaultConfig())
+}
+
+// Session wraps a single `pi --mode json` subprocess.
+type Session struct {
+	runID string
+	cfg   sessionConfig
+
+	cmd *exec.Cmd
+	out chan<- proto.Envelope
+
+	cancelCtx context.Context
+	cancelFn  context.CancelFunc
+
+	cancelOnce   sync.Once
+	closeOutOnce sync.Once
+	waitDone     chan struct{}
+	cleanup      func()
+
+	stderrMu sync.Mutex
+	stderr   bytes.Buffer
+}
+
+var _ agent.Session = (*Session)(nil)
+
+func newSession(parent context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope, cfg sessionConfig) (*Session, error) {
+	if out == nil {
+		return nil, errors.New("pi: nil out channel")
+	}
+	if cfg.logger == nil {
+		cfg.logger = obslog.Bg()
+	}
+	if cfg.piBinary == "" {
+		cfg.piBinary = defaultBinary
+	}
+	if cfg.killTimeout <= 0 {
+		cfg.killTimeout = 3 * time.Second
+	}
+
+	// pi needs an explicit --skill flag per skill (unlike Claude Code's
+	// auto-scan), so installSkills returns dirs even on a cache hit.
+	opts := req.AgentOptions
+	if rawSkills, ok := opts["skills"]; ok {
+		descriptors, decodeWarns := decodeSkillDescriptors(rawSkills)
+		for _, w := range decodeWarns {
+			cfg.logger.Warn("pi: skill descriptor decode warning", "run_id", req.RunID, "msg", w)
+		}
+		root, rErr := resolveSkillsRoot(req.ConversationID, req.RunID)
+		if rErr != nil {
+			return nil, fmt.Errorf("pi: resolve skills root: %w", rErr)
+		}
+		installRes, iErr := installSkills(parent, cfg.logger, root, descriptors)
+		if iErr != nil {
+			return nil, fmt.Errorf("pi: install skills: %w", iErr)
+		}
+		for _, w := range installRes.Warnings {
+			cfg.logger.Warn("pi: skill install warning", "run_id", req.RunID, "msg", w)
+		}
+		if len(installRes.SkillDirs) > 0 {
+			opts = cloneAgentOptions(req.AgentOptions)
+			opts["skill_dirs"] = mergeSkillDirs(opts["skill_dirs"], installRes.SkillDirs)
+		}
+	}
+
+	buildRes, err := BuildArgs(req.RunID, req.Prompt, req.WorkDir, opts, req.ResumeSessionID)
+	if err != nil {
+		return nil, fmt.Errorf("pi: build args: %w", err)
+	}
+	cancelCtx, cancelFn := context.WithCancel(parent)
+
+	args := append([]string{}, buildRes.Args...)
+	args = append(args, cfg.extraArgs...)
+	cmd := exec.CommandContext(cancelCtx, cfg.piBinary, args...)
+	// pi has no working-directory flag, so the resolved WorkDir becomes
+	// the subprocess cwd.
+	if buildRes.WorkDir != "" {
+		cmd.Dir = buildRes.WorkDir
+	}
+	cmd.Env = append(os.Environ(), buildRes.Env...)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancelFn()
+		buildRes.Cleanup()
+		return nil, fmt.Errorf("pi: stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancelFn()
+		buildRes.Cleanup()
+		return nil, fmt.Errorf("pi: stderr pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		cancelFn()
+		buildRes.Cleanup()
+		return nil, fmt.Errorf("pi: start %q: %w", cfg.piBinary, err)
+	}
+
+	s := &Session{
+		runID:     req.RunID,
+		cfg:       cfg,
+		cmd:       cmd,
+		out:       out,
+		cancelCtx: cancelCtx,
+		cancelFn:  cancelFn,
+		waitDone:  make(chan struct{}),
+		cleanup:   buildRes.Cleanup,
+	}
+	go s.pumpStderr(stderr)
+	go s.run(stdout)
+	return s, nil
+}
+
+func (s *Session) Cancel(context.Context) error {
+	s.cancelOnce.Do(func() {
+		if s.cmd.Process == nil {
+			return
+		}
+		_ = s.cmd.Process.Signal(syscall.SIGTERM)
+		go func() {
+			select {
+			case <-s.waitDone:
+				return
+			case <-time.After(s.cfg.killTimeout):
+				_ = s.cmd.Process.Signal(syscall.SIGKILL)
+			}
+		}()
+		s.cancelFn()
+	})
+	return nil
+}
+
+func (s *Session) SubmitPermission(context.Context, string, proto.PermissionDecisionPayload) error {
+	return agent.ErrUnknownPermission
+}
+
+func (s *Session) SubmitPromptForUserChoice(context.Context, string, proto.PromptForUserChoiceDecisionPayload) error {
+	return agent.ErrUnknownAsk
+}
+
+func (s *Session) run(stdout io.Reader) {
+	defer close(s.waitDone)
+	defer s.cleanup()
+	defer s.closeOut()
+
+	tr := newTranslator(s.runID)
+	sc := bufio.NewScanner(stdout)
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for sc.Scan() {
+		tx, err := tr.Translate(sc.Bytes())
+		if err != nil {
+			s.cfg.logger.Warn("pi: translate line", "run_id", s.runID, "err", err)
+			continue
+		}
+		for _, env := range tx.Envelopes {
+			select {
+			case s.out <- env:
+			case <-s.cancelCtx.Done():
+				_ = s.cmd.Wait()
+				return
+			}
+		}
+	}
+	if err := sc.Err(); err != nil && !errors.Is(err, io.EOF) {
+		s.cfg.logger.Warn("pi: scan stdout", "run_id", s.runID, "err", err)
+	}
+
+	waitErr := s.cmd.Wait()
+	for _, env := range tr.terminalEnvelopes(waitErr, s.stderrString(), s.cancelCtx.Err() != nil) {
+		s.trySend(env)
+	}
+}
+
+func (s *Session) pumpStderr(stderr io.Reader) {
+	sc := bufio.NewScanner(stderr)
+	sc.Buffer(make([]byte, 0, 16*1024), 1<<20)
+	for sc.Scan() {
+		line := sc.Text()
+		s.stderrMu.Lock()
+		if s.stderr.Len() > 0 {
+			s.stderr.WriteByte('\n')
+		}
+		s.stderr.WriteString(line)
+		s.stderrMu.Unlock()
+		s.cfg.logger.Warn("pi stderr", "run_id", s.runID, "line", line)
+	}
+}
+
+func (s *Session) stderrString() string {
+	s.stderrMu.Lock()
+	defer s.stderrMu.Unlock()
+	return s.stderr.String()
+}
+
+func (s *Session) trySend(env proto.Envelope) {
+	select {
+	case s.out <- env:
+	case <-time.After(2 * time.Second):
+		s.cfg.logger.Warn("pi: terminal send timed out", "type", env.Type, "run_id", s.runID)
+	}
+}
+
+func (s *Session) closeOut() { s.closeOutOnce.Do(func() { close(s.out) }) }

--- a/apps/parsar-daemon/internal/agent/pi/session_provider_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/session_provider_test.go
@@ -1,0 +1,71 @@
+package pi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+// TestNewSessionMaterialisesPiProviderModelsJSON proves agent_options["pi_provider"]
+// flows through newSession → models.json on disk at the per-conversation agent
+// dir. The env-forwarding of PI_CODING_AGENT_DIR is covered by the
+// applyPiManagedProvider + buildEnv unit tests.
+func TestNewSessionMaterialisesPiProviderModelsJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	out := make(chan proto.Envelope, 64)
+	req := proto.PromptRequestPayload{
+		RunID:          "run_prov",
+		ConversationID: "conv-prov",
+		Prompt:         "hello",
+		AgentOptions: map[string]any{
+			"model": "parsar/claude-opus-4-6-thinking-max",
+			"pi_provider": map[string]any{
+				"base_url":    "https://platform-api.example.com",
+				"api":         "anthropic-messages",
+				"api_key_env": "PARSAR_PI_API_KEY",
+				"model":       "claude-opus-4-6-thinking-max",
+				"headers":     map[string]any{"X-Sub-Module": "claude-code-internal"},
+			},
+			"env": map[string]any{
+				"PI_TESTHELPER_ROLE": "json-success",
+				"PARSAR_PI_API_KEY":  "sk-proxy",
+			},
+		},
+	}
+	sess, err := newSession(context.Background(), req, out, sessionConfig{
+		piBinary:    os.Args[0],
+		extraArgs:   []string{"-test.run=^$"},
+		killTimeout: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("newSession: %v", err)
+	}
+	defer sess.Cancel(context.Background())
+
+	deadline := time.After(5 * time.Second)
+	for draining := true; draining; {
+		select {
+		case _, ok := <-out:
+			if !ok {
+				draining = false
+			}
+		case <-deadline:
+			t.Fatal("out did not close")
+		}
+	}
+
+	agentDir := filepath.Join(home, ".parsar", "runtime", "pi", "conv-conv-prov", "agent")
+	p := readModelsJSON(t, agentDir).Providers[piManagedProviderSlug]
+	if p.BaseURL != "https://platform-api.example.com" {
+		t.Fatalf("models.json baseUrl wrong: %+v", p)
+	}
+	if p.APIKey != "$PARSAR_PI_API_KEY" {
+		t.Fatalf("models.json apiKey = %q, want $PARSAR_PI_API_KEY", p.APIKey)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/pi/session_skills_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/session_skills_test.go
@@ -1,0 +1,86 @@
+package pi
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+// TestNewSessionInstallsSkillsAndInjectsSkillFlag is the end-to-end proof
+// that agent_options["skills"] flows download → disk → repeated --skill
+// argv on the pi subprocess. The fake pi records its argv into
+// PI_TESTHELPER_ARGS_FILE (see runFakePi).
+func TestNewSessionInstallsSkillsAndInjectsSkillFlag(t *testing.T) {
+	body := validSkillZip(t)
+	srv := startZipServer(t, body)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	argsFile := filepath.Join(t.TempDir(), "argv")
+	out := make(chan proto.Envelope, 64)
+	req := proto.PromptRequestPayload{
+		RunID:          "run_skill",
+		ConversationID: "conv-skill",
+		Prompt:         "hello",
+		AgentOptions: map[string]any{
+			"skills": []any{
+				map[string]any{
+					"name": "code-review", "version": "1.0.0",
+					"download_url": srv.URL, "sha256": sha256Hex(body),
+				},
+			},
+			"env": map[string]any{
+				"PI_TESTHELPER_ROLE":      "json-success",
+				"PI_TESTHELPER_ARGS_FILE": argsFile,
+			},
+		},
+	}
+	sess, err := newSession(context.Background(), req, out, sessionConfig{
+		piBinary:    os.Args[0],
+		extraArgs:   []string{"-test.run=^$"},
+		killTimeout: 200 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("newSession: %v", err)
+	}
+	defer sess.Cancel(context.Background())
+
+	deadline := time.After(5 * time.Second)
+	for draining := true; draining; {
+		select {
+		case _, ok := <-out:
+			if !ok {
+				draining = false
+			}
+		case <-deadline:
+			t.Fatal("out did not close")
+		}
+	}
+
+	wantDir := filepath.Join(home, ".parsar", "runtime", "pi", "conv-conv-skill", "skills", "code-review")
+	if _, err := os.Stat(filepath.Join(wantDir, "SKILL.md")); err != nil {
+		t.Fatalf("SKILL.md not installed at %s: %v", wantDir, err)
+	}
+	raw, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read args file: %v", err)
+	}
+	argv := strings.Split(string(raw), "\n")
+	if !containsArgPair(argv, "--skill", wantDir) {
+		t.Fatalf("argv missing --skill %s: %v", wantDir, argv)
+	}
+}
+
+func containsArgPair(argv []string, flag, val string) bool {
+	for i, a := range argv {
+		if a == flag && i+1 < len(argv) && argv[i+1] == val {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/parsar-daemon/internal/agent/pi/session_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/session_test.go
@@ -1,0 +1,334 @@
+package pi_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/pi"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+// TestMain re-execs the test binary as a fake `pi` when
+// PI_TESTHELPER_ROLE is set, bypassing m.Run so the framework's PASS
+// line doesn't pollute fake stdout.
+const piHelperEnvKey = "PI_TESTHELPER_ROLE"
+
+func TestMain(m *testing.M) {
+	if role := os.Getenv(piHelperEnvKey); role != "" {
+		runFakePi(role)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
+
+func runFakePi(role string) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetEscapeHTML(false)
+
+	// Record argv so the skill-injection test can assert --skill <dir>
+	// reached the subprocess.
+	if argsFile := os.Getenv("PI_TESTHELPER_ARGS_FILE"); argsFile != "" {
+		_ = os.WriteFile(argsFile, []byte(strings.Join(os.Args, "\n")), 0o644)
+	}
+
+	sawModeJSON := false
+	for i, arg := range os.Args {
+		if arg == "--mode" && i+1 < len(os.Args) && os.Args[i+1] == "json" {
+			sawModeJSON = true
+		}
+	}
+
+	header := map[string]any{"type": "session", "id": "sess-xyz", "cwd": "/", "timestamp": "t"}
+	delta := func(s string) map[string]any {
+		return map[string]any{
+			"type":                  "message_update",
+			"message":               map[string]any{"role": "assistant"},
+			"assistantMessageEvent": map[string]any{"type": "text_delta", "contentIndex": 0, "delta": s},
+		}
+	}
+
+	switch role {
+	case "json-success":
+		if !sawModeJSON {
+			_, _ = os.Stderr.WriteString("missing --mode json\n")
+			os.Exit(64)
+		}
+		_ = enc.Encode(header)
+		_ = enc.Encode(delta("hi "))
+		_ = enc.Encode(delta("there"))
+		_ = enc.Encode(map[string]any{
+			"type": "message_end",
+			"message": map[string]any{
+				"role":       "assistant",
+				"content":    []any{map[string]any{"type": "text", "text": "hi there"}},
+				"provider":   "anthropic",
+				"model":      "claude-x",
+				"stopReason": "stop",
+				"usage": map[string]any{
+					"input": 4, "output": 2, "cacheRead": 0, "cacheWrite": 0,
+					"totalTokens": 6,
+					"cost":        map[string]any{"input": 0.1, "output": 0.02, "cacheRead": 0, "cacheWrite": 0, "total": 0.12},
+				},
+			},
+		})
+
+	case "error-stop":
+		// pi exits 0 even when the model errors — it just emits a
+		// message_end with stopReason "error".
+		_ = enc.Encode(header)
+		_ = enc.Encode(map[string]any{
+			"type": "message_end",
+			"message": map[string]any{
+				"role":         "assistant",
+				"content":      []any{},
+				"provider":     "anthropic",
+				"model":        "claude-x",
+				"stopReason":   "error",
+				"errorMessage": "model boom",
+				"usage": map[string]any{
+					"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0, "totalTokens": 0,
+					"cost": map[string]any{"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0, "total": 0},
+				},
+			},
+		})
+
+	case "nonzero":
+		_, _ = os.Stderr.WriteString("bad auth from fake pi\n")
+		os.Exit(17)
+
+	case "hang":
+		_ = enc.Encode(header)
+		_ = enc.Encode(delta("started"))
+		time.Sleep(10 * time.Minute)
+	}
+}
+
+func piHelperConfig() pi.SessionConfigForTest {
+	return pi.SessionConfigForTest{
+		PiBinary:    os.Args[0],
+		ExtraArgs:   []string{"-test.run=^$"},
+		KillTimeout: 200 * time.Millisecond,
+	}
+}
+
+func piHelperReq(runID, prompt, role string) proto.PromptRequestPayload {
+	return proto.PromptRequestPayload{
+		RunID:  runID,
+		Prompt: prompt,
+		AgentOptions: map[string]any{
+			"env": map[string]any{
+				piHelperEnvKey: role,
+			},
+		},
+	}
+}
+
+func drainPi(t *testing.T, out <-chan proto.Envelope, dl time.Duration) ([]proto.Envelope, bool) {
+	t.Helper()
+	deadline := time.After(dl)
+	var got []proto.Envelope
+	for {
+		select {
+		case env, ok := <-out:
+			if !ok {
+				return got, true
+			}
+			got = append(got, env)
+		case <-deadline:
+			return got, false
+		}
+	}
+}
+
+func TestSessionJSONSuccessEmitsDeltaUsageAndDone(t *testing.T) {
+	out := make(chan proto.Envelope, 32)
+	sess, err := pi.NewSessionForTest(context.Background(),
+		piHelperReq("run_json", "hello", "json-success"), out, piHelperConfig())
+	if err != nil {
+		t.Fatalf("NewSessionForTest: %v", err)
+	}
+	defer sess.Cancel(context.Background())
+
+	got, closed := drainPi(t, out, 5*time.Second)
+	if !closed {
+		t.Fatalf("out did not close, drained %d envs", len(got))
+	}
+	types := piEnvTypes(got)
+	mustContainPi(t, types, proto.TypeDelta)
+	mustContainPi(t, types, proto.TypeUsage)
+	mustContainPi(t, types, proto.TypeDone)
+	if got[len(got)-1].Type != proto.TypeDone {
+		t.Fatalf("last env type = %q, want done; all=%v", got[len(got)-1].Type, types)
+	}
+	for _, env := range got {
+		if env.ID != "run_json" {
+			t.Errorf("env type=%s ID=%q, want run_json", env.Type, env.ID)
+		}
+	}
+	done := decodePayload[proto.DonePayload](t, got[len(got)-1])
+	if done.Content != "hi there" {
+		t.Fatalf("done content = %q, want hi there", done.Content)
+	}
+	if done.Usage.Provider != "anthropic" || done.Usage.InputTokens != 4 || done.Usage.OutputTokens != 2 {
+		t.Fatalf("done usage = %#v", done.Usage)
+	}
+	if done.Metadata["pi_session_id"] != "sess-xyz" {
+		t.Fatalf("done metadata = %#v, want pi_session_id sess-xyz", done.Metadata)
+	}
+}
+
+// pi exits 0 on a model error: the session must still surface TypeError
+// (from stopReason) and Done, and close out.
+func TestSessionModelErrorStopReasonStillEmitsErrorAndDone(t *testing.T) {
+	out := make(chan proto.Envelope, 16)
+	sess, err := pi.NewSessionForTest(context.Background(),
+		piHelperReq("run_mod_err", "hello", "error-stop"), out, piHelperConfig())
+	if err != nil {
+		t.Fatalf("NewSessionForTest: %v", err)
+	}
+	defer sess.Cancel(context.Background())
+
+	got, closed := drainPi(t, out, 5*time.Second)
+	if !closed {
+		t.Fatalf("out did not close, drained %d envs", len(got))
+	}
+	types := piEnvTypes(got)
+	mustContainPi(t, types, proto.TypeError)
+	mustContainPi(t, types, proto.TypeDone)
+	if got[len(got)-1].Type != proto.TypeDone {
+		t.Fatalf("last env type = %q, want done; all=%v", got[len(got)-1].Type, types)
+	}
+	var errPayload proto.ErrorPayload
+	for _, env := range got {
+		if env.Type == proto.TypeError {
+			errPayload = decodePayload[proto.ErrorPayload](t, env)
+		}
+	}
+	if !strings.Contains(errPayload.Error, "model boom") {
+		t.Fatalf("error payload = %#v, want model boom", errPayload)
+	}
+}
+
+func TestSessionNonZeroExitEmitsErrorAndDone(t *testing.T) {
+	out := make(chan proto.Envelope, 16)
+	sess, err := pi.NewSessionForTest(context.Background(),
+		piHelperReq("run_err", "hello", "nonzero"), out, piHelperConfig())
+	if err != nil {
+		t.Fatalf("NewSessionForTest: %v", err)
+	}
+	defer sess.Cancel(context.Background())
+
+	got, closed := drainPi(t, out, 5*time.Second)
+	if !closed {
+		t.Fatalf("out did not close, drained %d envs", len(got))
+	}
+	types := piEnvTypes(got)
+	mustContainPi(t, types, proto.TypeError)
+	mustContainPi(t, types, proto.TypeDone)
+	if got[len(got)-1].Type != proto.TypeDone {
+		t.Fatalf("last env type = %q, want done; all=%v", got[len(got)-1].Type, types)
+	}
+	var errPayload proto.ErrorPayload
+	for _, env := range got {
+		if env.Type == proto.TypeError {
+			errPayload = decodePayload[proto.ErrorPayload](t, env)
+		}
+	}
+	if !strings.Contains(errPayload.Error, "bad auth from fake pi") {
+		t.Fatalf("error payload = %#v", errPayload)
+	}
+}
+
+func TestSessionCancelClosesOutAndEmitsTerminalFrames(t *testing.T) {
+	out := make(chan proto.Envelope, 16)
+	sess, err := pi.NewSessionForTest(context.Background(),
+		piHelperReq("run_cancel", "hello", "hang"), out, piHelperConfig())
+	if err != nil {
+		t.Fatalf("NewSessionForTest: %v", err)
+	}
+
+	time.Sleep(150 * time.Millisecond)
+	if err := sess.Cancel(context.Background()); err != nil {
+		t.Errorf("Cancel: %v", err)
+	}
+
+	got, closed := drainPi(t, out, 5*time.Second)
+	if !closed {
+		t.Fatalf("out did not close after Cancel, drained %d envs", len(got))
+	}
+	types := piEnvTypes(got)
+	mustContainPi(t, types, proto.TypeDone)
+	if got[len(got)-1].Type != proto.TypeDone {
+		t.Fatalf("last env type = %q, want done; all=%v", got[len(got)-1].Type, types)
+	}
+}
+
+func TestSessionSubmitPermissionUnknownReturnsErrUnknown(t *testing.T) {
+	out := make(chan proto.Envelope, 16)
+	sess, err := pi.NewSessionForTest(context.Background(),
+		piHelperReq("run_perm", "hello", "hang"), out, piHelperConfig())
+	if err != nil {
+		t.Fatalf("NewSessionForTest: %v", err)
+	}
+	defer sess.Cancel(context.Background())
+
+	err = sess.SubmitPermission(context.Background(), "perm_nope", proto.PermissionDecisionPayload{Approved: true})
+	if !errors.Is(err, agent.ErrUnknownPermission) {
+		t.Fatalf("SubmitPermission err = %v, want ErrUnknownPermission", err)
+	}
+	err = sess.SubmitPromptForUserChoice(context.Background(), "ask_nope", proto.PromptForUserChoiceDecisionPayload{})
+	if !errors.Is(err, agent.ErrUnknownAsk) {
+		t.Fatalf("SubmitPromptForUserChoice err = %v, want ErrUnknownAsk", err)
+	}
+}
+
+func TestSessionRejectsNilOut(t *testing.T) {
+	_, err := pi.NewSessionForTest(context.Background(),
+		piHelperReq("run_nil", "hello", "json-success"), nil, piHelperConfig())
+	if err == nil {
+		t.Fatal("expected error on nil out")
+	}
+}
+
+func TestSessionRejectsEmptyPrompt(t *testing.T) {
+	out := make(chan proto.Envelope, 4)
+	_, err := pi.NewSessionForTest(context.Background(),
+		proto.PromptRequestPayload{RunID: "run_empty", Prompt: ""}, out, piHelperConfig())
+	if err == nil {
+		t.Fatal("expected error on empty prompt")
+	}
+}
+
+func TestSessionBadBinaryFailsToStart(t *testing.T) {
+	out := make(chan proto.Envelope, 4)
+	cfg := piHelperConfig()
+	cfg.PiBinary = "/nonexistent/binary/that/does/not/resolve"
+	cfg.ExtraArgs = nil
+	_, err := pi.NewSessionForTest(context.Background(),
+		piHelperReq("run_bad", "hello", "json-success"), out, cfg)
+	if err == nil {
+		t.Fatal("expected start error for bogus binary")
+	}
+}
+
+func piEnvTypes(envs []proto.Envelope) []string {
+	out := make([]string, len(envs))
+	for i, env := range envs {
+		out[i] = env.Type
+	}
+	return out
+}
+
+func mustContainPi(t *testing.T, haystack []string, needle string) {
+	t.Helper()
+	if !slices.Contains(haystack, needle) {
+		t.Fatalf("expected %q in %v", needle, haystack)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/pi/skills.go
+++ b/apps/parsar-daemon/internal/agent/pi/skills.go
@@ -1,0 +1,513 @@
+package pi
+
+import (
+	"archive/zip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"maps"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	obslog "github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+	"github.com/google/uuid"
+)
+
+// skillDescriptor is the daemon-side view of one server-sent skill entry
+// under agent_options["skills"]:
+//
+//	{ "name": "...", "version": "...", "download_url": "...", "sha256": "..." }
+type skillDescriptor struct {
+	Name        string
+	Version     string
+	DownloadURL string
+	SHA256      string
+}
+
+// SkillInstallResult carries the per-skill directories to feed into
+// repeated `--skill <dir>` flags plus warnings the session surfaces.
+// Unlike Claude Code (which auto-scans .claude/skills/), pi needs an
+// explicit flag per skill, so SkillDirs is populated even on a cache hit.
+type SkillInstallResult struct {
+	SkillDirs []string
+	Warnings  []string
+}
+
+const skillInstallTimeout = 60 * time.Second
+
+// maxSkillZipBytes mirrors the server-side cap. Defense in depth.
+const maxSkillZipBytes int64 = 32 * 1024 * 1024
+
+var skillsHTTPClient = &http.Client{Timeout: skillInstallTimeout + 10*time.Second}
+
+// installSkills materialises every skill under <root>/<name>/ and returns
+// the local paths. Per skill:
+//
+//  1. Cache hit (<dir>/.cache-key == name@sha256) returns the dir without
+//     a network round-trip — but still returns it, so --skill is injected
+//     on every turn.
+//  2. Fetch → verify SHA-256 → extract (single wrapping dir stripped,
+//     __MACOSX/ ignored) → stamp .cache-key.
+//
+// Errors during fetch/verify/extract demote one skill to a warning and
+// continue. A hard error means the root dir itself was uncreatable.
+func installSkills(
+	ctx context.Context,
+	logger *slog.Logger,
+	root string,
+	skills []skillDescriptor,
+) (SkillInstallResult, error) {
+	if logger == nil {
+		logger = obslog.Bg()
+	}
+	if len(skills) == 0 {
+		return SkillInstallResult{}, nil
+	}
+	if strings.TrimSpace(root) == "" {
+		return SkillInstallResult{}, errors.New("pi skills: root is required")
+	}
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return SkillInstallResult{}, fmt.Errorf("pi skills: mkdir %s: %w", root, err)
+	}
+
+	result := SkillInstallResult{}
+	for _, s := range skills {
+		if err := s.validate(); err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("skip skill (invalid descriptor): %v", err))
+			logger.Warn("pi skills: invalid descriptor", "err", err.Error())
+			continue
+		}
+
+		dir := filepath.Join(root, s.Name)
+		cacheKey := filepath.Join(dir, ".cache-key")
+		expectedKey := s.cacheKey()
+
+		if existing, err := os.ReadFile(cacheKey); err == nil && string(existing) == expectedKey {
+			logger.Info("pi skills: cache hit", "name", s.Name, "version", s.Version, "dir", dir)
+			result.SkillDirs = append(result.SkillDirs, dir)
+			continue
+		}
+
+		perCtx, cancel := context.WithTimeout(ctx, skillInstallTimeout)
+		err := installOneSkill(perCtx, logger, root, dir, cacheKey, expectedKey, s)
+		cancel()
+		if err != nil {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("skill %s@%s: %v", s.Name, s.Version, err))
+			logger.Warn("pi skills: install failed", "name", s.Name, "version", s.Version, "err", err.Error())
+			continue
+		}
+		result.SkillDirs = append(result.SkillDirs, dir)
+		logger.Info("pi skills: installed", "name", s.Name, "version", s.Version, "dir", dir)
+	}
+	return result, nil
+}
+
+func installOneSkill(
+	ctx context.Context,
+	logger *slog.Logger,
+	root, dir, cacheKey, expectedKey string,
+	s skillDescriptor,
+) error {
+	tmpDir := filepath.Join(root, ".tmp")
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir tmp: %w", err)
+	}
+
+	// Per-call uuid so concurrent installs of the same (name, version)
+	// don't truncate each other's bytes, and nothing on disk between
+	// verify and extract can be a different file than the one hashed.
+	zipPath := filepath.Join(tmpDir, fmt.Sprintf("%s-%s-%s.zip", s.Name, s.Version, uuid.NewString()))
+	defer func() { _ = os.Remove(zipPath) }()
+
+	fd, err := fetchSkillZip(ctx, s.DownloadURL, zipPath)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+
+	// Verify and extract BOTH read through the same FD (not the path):
+	// Unix file semantics pin the inode, so a swap on disk between
+	// hashing and extraction cannot change the bytes we use.
+	if err := verifySHA256FromFD(fd, s.SHA256); err != nil {
+		return err
+	}
+	if _, err := fd.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek: %w", err)
+	}
+	fi, err := fd.Stat()
+	if err != nil {
+		return fmt.Errorf("stat: %w", err)
+	}
+
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("rm old dir: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir target: %w", err)
+	}
+	if err := extractSkillZipFromFD(fd, fi.Size(), dir); err != nil {
+		_ = os.RemoveAll(dir)
+		return err
+	}
+
+	if err := os.WriteFile(cacheKey, []byte(expectedKey), 0o644); err != nil {
+		logger.Warn("pi skills: write cache key failed", "path", cacheKey, "err", err.Error())
+	}
+	return nil
+}
+
+// fetchSkillZip GETs url into dst, capping the body at maxSkillZipBytes.
+// Returns an OPEN file descriptor at offset 0; the caller closes it.
+// Holding the FD across verify + extract closes the TOCTOU between
+// hashing the on-disk bytes and reading them for extract.
+//
+// Only http/https are accepted to defend against a future download_url
+// reaching this code with file:// or http://internal-ip/... values.
+func fetchSkillZip(ctx context.Context, downloadURL, dst string) (*os.File, error) {
+	parsed, err := url.Parse(downloadURL)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return nil, errors.New("download_url must be http(s)")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return nil, errors.New("build request failed")
+	}
+	resp, err := skillsHTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("get failed: %s", sanitizeHTTPClientError(err))
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4*1024))
+		return nil, fmt.Errorf("get: status %d", resp.StatusCode)
+	}
+
+	f, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open dst: %w", err)
+	}
+
+	limited := io.LimitReader(resp.Body, maxSkillZipBytes+1)
+	written, err := io.Copy(f, limited)
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("copy body: %w", err)
+	}
+	if written > maxSkillZipBytes {
+		_ = f.Close()
+		return nil, fmt.Errorf("zip exceeds %d byte cap", maxSkillZipBytes)
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("seek after write: %w", err)
+	}
+	return f, nil
+}
+
+// sanitizeHTTPClientError strips the URL embedded by *url.Error so a
+// presigned download_url (OSSAccessKeyId + Signature) never lands in the
+// daemon log. Format is `<method> "<url>": <inner>`.
+func sanitizeHTTPClientError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	open := strings.Index(msg, `"`)
+	if open < 0 {
+		return msg
+	}
+	closeRel := strings.Index(msg[open+1:], `"`)
+	if closeRel < 0 {
+		return msg
+	}
+	closeAbs := open + 1 + closeRel
+	if closeAbs+2 > len(msg) {
+		return msg
+	}
+	return msg[:open] + "<redacted-url>" + msg[closeAbs+1:]
+}
+
+func verifySHA256FromFD(fd *os.File, want string) error {
+	want = strings.ToLower(strings.TrimSpace(want))
+	if want == "" {
+		return errors.New("verify: empty expected sha256")
+	}
+	if _, err := fd.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("verify: seek: %w", err)
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, fd); err != nil {
+		return fmt.Errorf("verify: hash: %w", err)
+	}
+	got := hex.EncodeToString(h.Sum(nil))
+	if got != want {
+		return fmt.Errorf("verify: sha256 mismatch (want=%s got=%s)", want, got)
+	}
+	return nil
+}
+
+// extractSkillZipFromFD reads via io.NewSectionReader rather than
+// re-opening the path so the byte stream stays identical to the verified
+// one (TOCTOU defense).
+func extractSkillZipFromFD(fd *os.File, size int64, dst string) error {
+	zr, err := zip.NewReader(io.NewSectionReader(fd, 0, size), size)
+	if err != nil {
+		return fmt.Errorf("extract: open zip: %w", err)
+	}
+
+	root := detectSingleZipRoot(zr.File)
+	absDst, err := filepath.Abs(dst)
+	if err != nil {
+		return fmt.Errorf("extract: abs dst: %w", err)
+	}
+
+	for _, f := range zr.File {
+		name := normaliseZipPath(f.Name)
+		if name == "" || strings.HasPrefix(name, "__MACOSX/") || name == "__MACOSX" {
+			continue
+		}
+		// Skip non-regular entries (symlinks, devices). A symlink entry
+		// would otherwise be written as a plain file holding the link
+		// target string — an exfil vector.
+		mode := f.Mode()
+		if !f.FileInfo().IsDir() && !mode.IsRegular() {
+			continue
+		}
+		if root != "" {
+			if !strings.HasPrefix(name, root) {
+				continue
+			}
+			name = strings.TrimPrefix(name, root)
+			if name == "" {
+				continue
+			}
+		}
+
+		target := filepath.Join(absDst, name)
+		rel, err := filepath.Rel(absDst, target)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("extract: entry %q escapes target", f.Name)
+		}
+
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("extract: mkdir %s: %w", target, err)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return fmt.Errorf("extract: mkdir parent of %s: %w", target, err)
+		}
+		if err := writeZipEntry(f, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeZipEntry(f *zip.File, target string) error {
+	rc, err := f.Open()
+	if err != nil {
+		return fmt.Errorf("extract: open entry %s: %w", f.Name, err)
+	}
+	defer rc.Close()
+
+	mode := f.Mode().Perm()
+	if mode == 0 {
+		mode = 0o644
+	}
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, mode)
+	if err != nil {
+		return fmt.Errorf("extract: open target %s: %w", target, err)
+	}
+	defer out.Close()
+	if _, err := io.Copy(out, rc); err != nil {
+		return fmt.Errorf("extract: copy %s: %w", target, err)
+	}
+	return nil
+}
+
+// detectSingleZipRoot returns the common wrapping directory (with
+// trailing slash) shared by every non-MACOSX entry, or "" when there is
+// none. Bare directory entries (no internal "/") are skipped when picking
+// the first candidate so `zip -r skill skill/` doesn't short-circuit on
+// its own leading directory entry. Hidden roots (".*") are NOT treated as
+// wrappers.
+func detectSingleZipRoot(files []*zip.File) string {
+	var first string
+	for _, f := range files {
+		name := normaliseZipPath(f.Name)
+		if name == "" || strings.HasPrefix(name, "__MACOSX/") || name == "__MACOSX" {
+			continue
+		}
+		if !strings.Contains(name, "/") {
+			continue
+		}
+		first = name
+		break
+	}
+	if first == "" {
+		return ""
+	}
+	idx := strings.Index(first, "/")
+	if idx <= 0 {
+		return ""
+	}
+	root := first[:idx+1]
+	if strings.HasPrefix(root, ".") {
+		return ""
+	}
+	for _, f := range files {
+		name := normaliseZipPath(f.Name)
+		if name == "" || strings.HasPrefix(name, "__MACOSX/") || name == "__MACOSX" {
+			continue
+		}
+		if name+"/" == root {
+			continue
+		}
+		if !strings.HasPrefix(name, root) {
+			return ""
+		}
+	}
+	return root
+}
+
+func normaliseZipPath(name string) string {
+	p := strings.ReplaceAll(name, "\\", "/")
+	return strings.TrimSuffix(p, "/")
+}
+
+// decodeSkillDescriptors converts agent_options["skills"] into typed
+// descriptors. Entries that fail to decode are dropped with a warning;
+// the rest may still be installable.
+func decodeSkillDescriptors(raw any) ([]skillDescriptor, []string) {
+	if raw == nil {
+		return nil, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, []string{fmt.Sprintf("agent_options[skills] must be array, got %T", raw)}
+	}
+	out := make([]skillDescriptor, 0, len(items))
+	warnings := make([]string, 0)
+	for i, item := range items {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			warnings = append(warnings, fmt.Sprintf("skills[%d]: not an object", i))
+			continue
+		}
+		s := skillDescriptor{
+			Name:        stringField(obj, "name"),
+			Version:     stringField(obj, "version"),
+			DownloadURL: stringField(obj, "download_url"),
+			SHA256:      stringField(obj, "sha256"),
+		}
+		if err := s.validate(); err != nil {
+			warnings = append(warnings, fmt.Sprintf("skills[%d] (%s): %v", i, s.Name, err))
+			continue
+		}
+		out = append(out, s)
+	}
+	return out, warnings
+}
+
+func stringField(m map[string]any, key string) string {
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func (s skillDescriptor) validate() error {
+	if strings.TrimSpace(s.Name) == "" {
+		return errors.New("name is required")
+	}
+	// Block path-traversal names before they hit filepath.Join.
+	if strings.ContainsAny(s.Name, "/\\") || s.Name == "." || s.Name == ".." {
+		return fmt.Errorf("name %q contains path separator or dot-ref", s.Name)
+	}
+	if strings.TrimSpace(s.DownloadURL) == "" {
+		return errors.New("download_url is required")
+	}
+	if len(s.SHA256) != 64 {
+		return fmt.Errorf("sha256 must be 64 hex chars (got %d)", len(s.SHA256))
+	}
+	return nil
+}
+
+func (s skillDescriptor) cacheKey() string {
+	return fmt.Sprintf("%s@%s", strings.TrimSpace(s.Name), strings.ToLower(s.SHA256))
+}
+
+// resolveSkillsRoot returns the absolute directory under which managed
+// skills install, one subdir per skill. Kept under ~/.parsar/ (runtime
+// state lives there, not the user's project tree) and scoped per
+// conversation so consecutive turns reuse .cache-key files without two
+// conversations racing the same skill dir. runID scopes the one-shot
+// fallback when there is no conversation.
+func resolveSkillsRoot(conversationID, runID string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("pi skills: resolve home: %w", err)
+	}
+	base := filepath.Join(home, ".parsar", "runtime", "pi")
+	if id := strings.TrimSpace(conversationID); id != "" {
+		return filepath.Join(base, "conv-"+id, "skills"), nil
+	}
+	return filepath.Join(base, "run-"+strings.TrimSpace(runID), "skills"), nil
+}
+
+// mergeSkillDirs combines a caller-supplied skill_dirs override (accepted
+// as []string OR []any) with the install-resolved list, preserving order
+// and deduplicating. Override wins on collision.
+func mergeSkillDirs(existing any, resolved []string) []string {
+	preset := coerceStringSlice(existing)
+	seen := make(map[string]bool, len(preset)+len(resolved))
+	out := make([]string, 0, len(preset)+len(resolved))
+	for _, d := range append(append([]string{}, preset...), resolved...) {
+		if d == "" || seen[d] {
+			continue
+		}
+		seen[d] = true
+		out = append(out, d)
+	}
+	return out
+}
+
+func coerceStringSlice(v any) []string {
+	switch t := v.(type) {
+	case nil:
+		return nil
+	case []string:
+		return t
+	case []any:
+		out := make([]string, 0, len(t))
+		for _, item := range t {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// cloneAgentOptions returns a shallow copy so we never mutate the
+// caller's map when overwriting the top-level "skill_dirs" key.
+func cloneAgentOptions(opts map[string]any) map[string]any {
+	if opts == nil {
+		return map[string]any{}
+	}
+	out := make(map[string]any, len(opts))
+	maps.Copy(out, opts)
+	return out
+}

--- a/apps/parsar-daemon/internal/agent/pi/skills_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/skills_test.go
@@ -1,0 +1,318 @@
+package pi
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type zipFile struct {
+	Name string
+	Body string
+}
+
+func buildZipBytes(t *testing.T, files []zipFile) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, f := range files {
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: f.Name, Method: zip.Deflate})
+		if err != nil {
+			t.Fatalf("zip header %q: %v", f.Name, err)
+		}
+		if _, err := w.Write([]byte(f.Body)); err != nil {
+			t.Fatalf("zip write %q: %v", f.Name, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func validSkillZip(t *testing.T) []byte {
+	return buildZipBytes(t, []zipFile{
+		{Name: "SKILL.md", Body: "---\nname: code-review\ndescription: Review code\n---\nBody"},
+	})
+}
+
+func sha256Hex(body []byte) string {
+	h := sha256.Sum256(body)
+	return hex.EncodeToString(h[:])
+}
+
+type zipServer struct {
+	*httptest.Server
+	hits *int
+	body []byte
+	stat int
+}
+
+func startZipServer(t *testing.T, body []byte) *zipServer {
+	t.Helper()
+	var hits int
+	zs := &zipServer{hits: &hits, body: body, stat: http.StatusOK}
+	zs.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(zs.stat)
+		_, _ = w.Write(zs.body)
+	}))
+	t.Cleanup(zs.Close)
+	return zs
+}
+
+func (s *zipServer) Hits() int { return *s.hits }
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestInstallSkillsHappyPathReturnsDirAndStampsCacheKey(t *testing.T) {
+	body := validSkillZip(t)
+	srv := startZipServer(t, body)
+	root := t.TempDir()
+
+	res, err := installSkills(context.Background(), discardLogger(), root, []skillDescriptor{
+		{Name: "code-review", Version: "1.0.0", DownloadURL: srv.URL, SHA256: sha256Hex(body)},
+	})
+	if err != nil {
+		t.Fatalf("installSkills: %v", err)
+	}
+	if len(res.Warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", res.Warnings)
+	}
+	if len(res.SkillDirs) != 1 {
+		t.Fatalf("SkillDirs = %v, want 1 entry", res.SkillDirs)
+	}
+	dir := res.SkillDirs[0]
+	if filepath.Base(dir) != "code-review" {
+		t.Fatalf("dir basename = %q, want code-review", filepath.Base(dir))
+	}
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err != nil {
+		t.Fatalf("SKILL.md missing: %v", err)
+	}
+	stamped, err := os.ReadFile(filepath.Join(dir, ".cache-key"))
+	if err != nil {
+		t.Fatalf("read cache-key: %v", err)
+	}
+	if want := "code-review@" + sha256Hex(body); string(stamped) != want {
+		t.Fatalf("cache-key = %q, want %q", stamped, want)
+	}
+}
+
+func TestInstallSkillsCacheHitSkipsDownloadButStillReturnsDir(t *testing.T) {
+	body := validSkillZip(t)
+	srv := startZipServer(t, body)
+	root := t.TempDir()
+	desc := []skillDescriptor{
+		{Name: "code-review", Version: "1.0.0", DownloadURL: srv.URL, SHA256: sha256Hex(body)},
+	}
+
+	first, err := installSkills(context.Background(), discardLogger(), root, desc)
+	if err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if len(first.SkillDirs) != 1 || srv.Hits() != 1 {
+		t.Fatalf("first install dirs=%v hits=%d", first.SkillDirs, srv.Hits())
+	}
+
+	second, err := installSkills(context.Background(), discardLogger(), root, desc)
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if srv.Hits() != 1 {
+		t.Fatalf("cache should prevent second download; hits=%d", srv.Hits())
+	}
+	// A cache hit must STILL surface the dir so --skill is injected on
+	// every turn, not just the first.
+	if len(second.SkillDirs) != 1 || second.SkillDirs[0] != first.SkillDirs[0] {
+		t.Fatalf("cache hit must still return the dir; got %v", second.SkillDirs)
+	}
+}
+
+func TestInstallSkillsSHA256MismatchDemotesToWarning(t *testing.T) {
+	body := validSkillZip(t)
+	srv := startZipServer(t, body)
+	root := t.TempDir()
+
+	res, err := installSkills(context.Background(), discardLogger(), root, []skillDescriptor{
+		{Name: "code-review", Version: "1.0.0", DownloadURL: srv.URL, SHA256: strings.Repeat("0", 64)},
+	})
+	if err != nil {
+		t.Fatalf("installSkills should not hard-error on sha mismatch: %v", err)
+	}
+	if len(res.SkillDirs) != 0 {
+		t.Fatalf("SkillDirs = %v, want empty after sha mismatch", res.SkillDirs)
+	}
+	if len(res.Warnings) != 1 || !strings.Contains(res.Warnings[0], "sha256 mismatch") {
+		t.Fatalf("want 1 sha-mismatch warning, got %v", res.Warnings)
+	}
+	if _, err := os.Stat(filepath.Join(root, "code-review", "SKILL.md")); err == nil {
+		t.Fatal("SKILL.md should not exist after sha mismatch")
+	}
+}
+
+func TestInstallSkillsEmptyListIsNoop(t *testing.T) {
+	res, err := installSkills(context.Background(), discardLogger(), t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("empty install: %v", err)
+	}
+	if len(res.SkillDirs) != 0 || len(res.Warnings) != 0 {
+		t.Fatalf("expected empty result; got %+v", res)
+	}
+}
+
+func TestInstallSkillsStripsWrappingRoot(t *testing.T) {
+	body := buildZipBytes(t, []zipFile{
+		{Name: "wrapper/SKILL.md", Body: "---\nname: x\n---\nbody"},
+		{Name: "wrapper/refs/note.md", Body: "note"},
+	})
+	srv := startZipServer(t, body)
+	root := t.TempDir()
+
+	res, err := installSkills(context.Background(), discardLogger(), root, []skillDescriptor{
+		{Name: "x", Version: "1", DownloadURL: srv.URL, SHA256: sha256Hex(body)},
+	})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if len(res.SkillDirs) != 1 {
+		t.Fatalf("SkillDirs = %v", res.SkillDirs)
+	}
+	dir := res.SkillDirs[0]
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err != nil {
+		t.Fatalf("SKILL.md at expected path missing (wrapper not stripped?): %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "wrapper")); err == nil {
+		t.Fatal("wrapper survived the strip")
+	}
+}
+
+func TestInstallSkillsPathTraversalRejected(t *testing.T) {
+	body := buildZipBytes(t, []zipFile{
+		{Name: "SKILL.md", Body: "---\nname: x\n---"},
+		{Name: "../../escape", Body: "should never land outside dir"},
+	})
+	srv := startZipServer(t, body)
+	root := t.TempDir()
+
+	res, _ := installSkills(context.Background(), discardLogger(), root, []skillDescriptor{
+		{Name: "x", Version: "1", DownloadURL: srv.URL, SHA256: sha256Hex(body)},
+	})
+	if len(res.SkillDirs) != 0 {
+		t.Fatalf("SkillDirs = %v, want empty on path-traversal", res.SkillDirs)
+	}
+	if len(res.Warnings) == 0 || !strings.Contains(res.Warnings[0], "escapes") {
+		t.Fatalf("want escape warning, got %v", res.Warnings)
+	}
+}
+
+func TestInstallSkillsPartialInstall(t *testing.T) {
+	bodyOK := validSkillZip(t)
+	srvOK := startZipServer(t, bodyOK)
+	srvBAD := startZipServer(t, bodyOK)
+	root := t.TempDir()
+
+	res, err := installSkills(context.Background(), discardLogger(), root, []skillDescriptor{
+		{Name: "good", Version: "1", DownloadURL: srvOK.URL, SHA256: sha256Hex(bodyOK)},
+		{Name: "bad", Version: "1", DownloadURL: srvBAD.URL, SHA256: strings.Repeat("0", 64)},
+	})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if len(res.SkillDirs) != 1 || filepath.Base(res.SkillDirs[0]) != "good" {
+		t.Fatalf("SkillDirs = %v, want only the good one", res.SkillDirs)
+	}
+	if len(res.Warnings) == 0 {
+		t.Fatal("expected warning for the bad skill")
+	}
+}
+
+func TestInstallSkillsDescriptorValidatorRejectsBadNames(t *testing.T) {
+	body := validSkillZip(t)
+	srv := startZipServer(t, body)
+	res, _ := installSkills(context.Background(), discardLogger(), t.TempDir(), []skillDescriptor{
+		{Name: "../escape", Version: "1", DownloadURL: srv.URL, SHA256: sha256Hex(body)},
+	})
+	if len(res.SkillDirs) != 0 {
+		t.Fatalf("SkillDirs = %v; bad name should be rejected", res.SkillDirs)
+	}
+	if len(res.Warnings) == 0 {
+		t.Fatal("expected warning")
+	}
+}
+
+func TestDecodeSkillDescriptorsArrayShape(t *testing.T) {
+	raw := []any{
+		map[string]any{"name": "a", "version": "1", "download_url": "https://x/a.zip", "sha256": strings.Repeat("a", 64)},
+		map[string]any{"name": "", "version": "1", "download_url": "https://x/b.zip", "sha256": strings.Repeat("b", 64)},
+		"not an object",
+	}
+	got, warns := decodeSkillDescriptors(raw)
+	if len(got) != 1 || got[0].Name != "a" {
+		t.Fatalf("got = %v, want 1 valid entry", got)
+	}
+	if len(warns) != 2 {
+		t.Fatalf("warns = %v, want 2", warns)
+	}
+}
+
+func TestDecodeSkillDescriptorsNilAndWrongType(t *testing.T) {
+	if got, warns := decodeSkillDescriptors(nil); got != nil || warns != nil {
+		t.Fatalf("nil raw should be (nil, nil), got (%v, %v)", got, warns)
+	}
+	if got, warns := decodeSkillDescriptors("not-array"); got != nil || len(warns) != 1 {
+		t.Fatalf("string raw should warn, got got=%v warns=%v", got, warns)
+	}
+}
+
+func TestMergeSkillDirsOverrideWinsAndDedupes(t *testing.T) {
+	got := mergeSkillDirs([]any{"/a", "/b"}, []string{"/b", "/c"})
+	want := []string{"/a", "/b", "/c"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestMergeSkillDirsNilExisting(t *testing.T) {
+	got := mergeSkillDirs(nil, []string{"/x"})
+	if len(got) != 1 || got[0] != "/x" {
+		t.Fatalf("got %v, want [/x]", got)
+	}
+}
+
+func TestResolveSkillsRootConversationScoped(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	got, err := resolveSkillsRoot("conv-abc", "run-1")
+	if err != nil {
+		t.Fatalf("resolveSkillsRoot: %v", err)
+	}
+	want := filepath.Join(tmp, ".parsar", "runtime", "pi", "conv-conv-abc", "skills")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveSkillsRootRunScopedFallback(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	got, err := resolveSkillsRoot("", "run-9")
+	if err != nil {
+		t.Fatalf("resolveSkillsRoot: %v", err)
+	}
+	want := filepath.Join(tmp, ".parsar", "runtime", "pi", "run-run-9", "skills")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/pi/version.go
+++ b/apps/parsar-daemon/internal/agent/pi/version.go
@@ -1,0 +1,52 @@
+package pi
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// InstallURL points operators at the pi documentation when the daemon
+// can see the adapter but not the CLI binary.
+const InstallURL = "https://github.com/earendil-works/pi"
+
+const defaultBinary = "pi"
+
+// ErrCLINotFound is returned by CheckCLIAvailable when the binary cannot
+// be located on PATH. Callers use errors.Is to distinguish an install
+// problem from a present-but-broken CLI.
+var ErrCLINotFound = errors.New("pi CLI not found")
+
+// CheckCLIAvailable runs `<binary> --version` and returns the trimmed
+// first line. The empty binary name defaults to "pi".
+func CheckCLIAvailable(ctx context.Context, binary string) (string, error) {
+	if strings.TrimSpace(binary) == "" {
+		binary = defaultBinary
+	}
+	if _, lookErr := exec.LookPath(binary); lookErr != nil {
+		return "", fmt.Errorf("%w: %s", ErrCLINotFound, binary)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, binary, "--version")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("pi --version failed: %s", msg)
+	}
+	out := strings.TrimSpace(stdout.String())
+	if i := strings.IndexByte(out, '\n'); i >= 0 {
+		out = out[:i]
+	}
+	if out == "" {
+		return "", fmt.Errorf("pi --version returned empty output")
+	}
+	return out, nil
+}

--- a/apps/parsar-daemon/internal/agent/pi/version_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/version_test.go
@@ -1,0 +1,78 @@
+package pi_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/pi"
+)
+
+func TestCheckCLIAvailableMissingBinaryWrapsErrCLINotFound(t *testing.T) {
+	_, err := pi.CheckCLIAvailable(context.Background(), "parsar-daemon-nonexistent-pi-stub")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, pi.ErrCLINotFound) {
+		t.Fatalf("error %v does not wrap ErrCLINotFound", err)
+	}
+}
+
+func TestCheckCLIAvailableDefaultsToPiBinary(t *testing.T) {
+	_, err := pi.CheckCLIAvailable(context.Background(), "")
+	if err == nil {
+		return
+	}
+	if !errors.Is(err, pi.ErrCLINotFound) && !strings.Contains(err.Error(), "pi") {
+		t.Fatalf("error %q does not mention default binary name", err.Error())
+	}
+}
+
+func TestCheckCLIAvailableReturnsTrimmedFirstLine(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix-only stub script; daemon doesn't target Windows")
+	}
+
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "fake-pi")
+	body := "#!/bin/sh\nprintf 'pi 9.9.9\\nextra line\\n'\n"
+	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	ver, err := pi.CheckCLIAvailable(context.Background(), stub)
+	if err != nil {
+		t.Fatalf("CheckCLIAvailable: %v", err)
+	}
+	if ver != "pi 9.9.9" {
+		t.Fatalf("version = %q, want pi 9.9.9", ver)
+	}
+}
+
+func TestCheckCLIAvailableSurfacesNonZeroExit(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix-only stub script; daemon doesn't target Windows")
+	}
+
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "broken-pi")
+	body := "#!/bin/sh\necho 'pi kaboom' 1>&2\nexit 17\n"
+	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+
+	_, err := pi.CheckCLIAvailable(context.Background(), stub)
+	if err == nil {
+		t.Fatal("expected non-nil error for broken stub")
+	}
+	if errors.Is(err, pi.ErrCLINotFound) {
+		t.Fatalf("broken-but-present binary should not wrap ErrCLINotFound: %v", err)
+	}
+	if !strings.Contains(err.Error(), "pi kaboom") {
+		t.Fatalf("expected stderr in error, got %v", err)
+	}
+}

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -15,6 +15,7 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/claudecode"
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/codex"
 	opencodeagent "github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/opencode"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/pi"
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/daemonize"
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/dispatch"
@@ -193,12 +194,14 @@ type agentCLIDiscovery struct {
 	ClaudeCode proto.SupportedAgentKind
 	OpenCode   proto.SupportedAgentKind
 	Codex      proto.SupportedAgentKind
+	Pi         proto.SupportedAgentKind
 }
 
 type agentCLIChecks struct {
 	ClaudeCode func(context.Context, string) (string, error)
 	OpenCode   func(context.Context, string) (string, error)
 	Codex      func(context.Context, string) (string, error)
+	Pi         func(context.Context, string) (string, error)
 }
 
 func defaultAgentCLIChecks() agentCLIChecks {
@@ -206,6 +209,7 @@ func defaultAgentCLIChecks() agentCLIChecks {
 		ClaudeCode: claudecode.CheckCLIAvailable,
 		OpenCode:   opencodeagent.CheckCLIAvailable,
 		Codex:      codex.CheckCLIAvailable,
+		Pi:         pi.CheckCLIAvailable,
 	}
 }
 
@@ -222,6 +226,9 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 	}
 	if checks.Codex == nil {
 		checks.Codex = codex.CheckCLIAvailable
+	}
+	if checks.Pi == nil {
+		checks.Pi = pi.CheckCLIAvailable
 	}
 	out := agentCLIDiscovery{
 		ClaudeCode: proto.SupportedAgentKind{
@@ -246,6 +253,16 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 				// First-cut adapter runs silent (no permission cards),
 				// but streaming + usage + resume are all wired via
 				// the JSON-RPC notification stream + thread/resume RPC.
+				Streaming: true,
+				Usage:     true,
+				Resume:    true,
+			},
+		},
+		Pi: proto.SupportedAgentKind{
+			Kind: "pi",
+			Capabilities: proto.AgentKindCapabilities{
+				// pi runs --no-approve, so no permission cards; streaming,
+				// usage, and --session resume are all wired.
 				Streaming: true,
 				Usage:     true,
 				Resume:    true,
@@ -298,8 +315,23 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 		fmt.Fprintf(rc.stderr, "  Re-install or upgrade: %s\n", codex.InstallURL)
 	}
 
-	if !out.ClaudeCode.Available && !out.OpenCode.Available && !out.Codex.Available {
-		return out, fmt.Errorf("connect: no supported agent CLI available (install Claude Code, OpenCode, or Codex)")
+	piCtx, cancelPi := context.WithTimeout(context.Background(), cliVersionTimeout)
+	piVersion, piErr := checks.Pi(piCtx, "")
+	cancelPi()
+	if piErr == nil {
+		out.Pi.Available = true
+		out.Pi.Version = piVersion
+		fmt.Fprintf(rc.stdout, "pi preflight ok (%s)\n", piVersion)
+	} else if errors.Is(piErr, pi.ErrCLINotFound) {
+		fmt.Fprintln(rc.stderr, "parsar-daemon: pi CLI not found on PATH; pi unavailable.")
+		fmt.Fprintf(rc.stderr, "  Install instructions: %s\n", pi.InstallURL)
+	} else {
+		fmt.Fprintf(rc.stderr, "parsar-daemon: `pi --version` failed; pi unavailable: %v\n", piErr)
+		fmt.Fprintf(rc.stderr, "  Re-install or upgrade: %s\n", pi.InstallURL)
+	}
+
+	if !out.ClaudeCode.Available && !out.OpenCode.Available && !out.Codex.Available && !out.Pi.Available {
+		return out, fmt.Errorf("connect: no supported agent CLI available (install Claude Code, OpenCode, Codex, or pi)")
 	}
 	return out, nil
 }
@@ -308,6 +340,7 @@ func registerAgentKinds(registry *agent.Registry, agentCLIs agentCLIDiscovery) {
 	registry.RegisterKind(agentCLIs.ClaudeCode, claudecode.Factory)
 	registry.RegisterKind(agentCLIs.OpenCode, opencodeagent.Factory)
 	registry.RegisterKind(agentCLIs.Codex, codex.Factory)
+	registry.RegisterKind(agentCLIs.Pi, pi.Factory)
 }
 
 // spawnBackground forks the daemon into the background. Parent

--- a/apps/parsar-daemon/internal/cli/connect_test.go
+++ b/apps/parsar-daemon/internal/cli/connect_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/claudecode"
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/codex"
 	opencodeagent "github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/opencode"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/pi"
 	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
 )
 
@@ -79,6 +80,9 @@ func TestDiscoverAgentCLIsAllowsOpenCodeWithoutClaude(t *testing.T) {
 		Codex: func(context.Context, string) (string, error) {
 			return "", codex.ErrCLINotFound
 		},
+		Pi: func(context.Context, string) (string, error) {
+			return "", pi.ErrCLINotFound
+		},
 	})
 	if err != nil {
 		t.Fatalf("discoverAgentCLIs: %v", err)
@@ -91,6 +95,9 @@ func TestDiscoverAgentCLIsAllowsOpenCodeWithoutClaude(t *testing.T) {
 	}
 	if got.Codex.Available {
 		t.Fatalf("Codex.Available = true, want false: %#v", got.Codex)
+	}
+	if got.Pi.Available {
+		t.Fatalf("Pi.Available = true, want false: %#v", got.Pi)
 	}
 	if !got.OpenCode.Capabilities.Streaming || !got.OpenCode.Capabilities.Usage || got.OpenCode.Capabilities.Permissions {
 		t.Fatalf("OpenCode capabilities = %#v", got.OpenCode.Capabilities)
@@ -116,6 +123,9 @@ func TestDiscoverAgentCLIsBothMissingFails(t *testing.T) {
 		Codex: func(context.Context, string) (string, error) {
 			return "", codex.ErrCLINotFound
 		},
+		Pi: func(context.Context, string) (string, error) {
+			return "", pi.ErrCLINotFound
+		},
 	})
 	if err == nil {
 		t.Fatalf("expected error when all CLIs missing, got descriptors %#v", got)
@@ -123,7 +133,7 @@ func TestDiscoverAgentCLIsBothMissingFails(t *testing.T) {
 	if !strings.Contains(err.Error(), "no supported agent CLI") {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got.ClaudeCode.Available || got.OpenCode.Available || got.Codex.Available {
+	if got.ClaudeCode.Available || got.OpenCode.Available || got.Codex.Available || got.Pi.Available {
 		t.Fatalf("available descriptors after missing CLIs: %#v", got)
 	}
 }
@@ -140,6 +150,9 @@ func TestDiscoverAgentCLIsBothAvailable(t *testing.T) {
 		},
 		Codex: func(context.Context, string) (string, error) {
 			return "codex 0.141.0", nil
+		},
+		Pi: func(context.Context, string) (string, error) {
+			return "pi 0.1.0", nil
 		},
 	})
 	if err != nil {
@@ -159,6 +172,12 @@ func TestDiscoverAgentCLIsBothAvailable(t *testing.T) {
 	}
 	if !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Resume || got.Codex.Capabilities.Permissions {
 		t.Fatalf("Codex capabilities = %#v (want Streaming+Resume, no Permissions)", got.Codex.Capabilities)
+	}
+	if !got.Pi.Available || got.Pi.Version != "pi 0.1.0" {
+		t.Fatalf("Pi descriptor = %#v", got.Pi)
+	}
+	if !got.Pi.Capabilities.Streaming || !got.Pi.Capabilities.Usage || !got.Pi.Capabilities.Resume || got.Pi.Capabilities.Permissions {
+		t.Fatalf("Pi capabilities = %#v (want Streaming+Usage+Resume, no Permissions)", got.Pi.Capabilities)
 	}
 	if stderr.Len() != 0 {
 		t.Fatalf("stderr = %q, want empty", stderr.String())
@@ -198,14 +217,24 @@ func TestRegisterAgentKindsPreservesDescriptors(t *testing.T) {
 				Resume:    true,
 			},
 		},
+		Pi: proto.SupportedAgentKind{
+			Kind:      "pi",
+			Available: true,
+			Version:   "pi 0.1.0",
+			Capabilities: proto.AgentKindCapabilities{
+				Streaming: true,
+				Usage:     true,
+				Resume:    true,
+			},
+		},
 	})
 
 	kinds := reg.SupportedAgentKinds()
-	if len(kinds) != 3 {
-		t.Fatalf("SupportedAgentKinds len = %d, want 3: %#v", len(kinds), kinds)
+	if len(kinds) != 4 {
+		t.Fatalf("SupportedAgentKinds len = %d, want 4: %#v", len(kinds), kinds)
 	}
-	// Sorted: claude_code, codex, opencode.
-	if kinds[0].Kind != "claude_code" || kinds[1].Kind != "codex" || kinds[2].Kind != "opencode" {
+	// Sorted: claude_code, codex, opencode, pi.
+	if kinds[0].Kind != "claude_code" || kinds[1].Kind != "codex" || kinds[2].Kind != "opencode" || kinds[3].Kind != "pi" {
 		t.Fatalf("SupportedAgentKinds sort = %#v", kinds)
 	}
 	if !kinds[0].Available || kinds[0].Version != "claude 2.0.0" || !kinds[0].Capabilities.Permissions {
@@ -217,10 +246,16 @@ func TestRegisterAgentKindsPreservesDescriptors(t *testing.T) {
 	if kinds[2].Available || kinds[2].Version != "missing" || !kinds[2].Capabilities.Streaming || !kinds[2].Capabilities.Usage {
 		t.Fatalf("opencode descriptor not preserved: %#v", kinds[2])
 	}
+	if !kinds[3].Available || kinds[3].Version != "pi 0.1.0" || !kinds[3].Capabilities.Resume || kinds[3].Capabilities.Permissions {
+		t.Fatalf("pi descriptor not preserved: %#v", kinds[3])
+	}
 	if _, err := reg.Resolve("opencode"); err != nil {
 		t.Fatalf("opencode factory not registered: %v", err)
 	}
 	if _, err := reg.Resolve("codex"); err != nil {
 		t.Fatalf("codex factory not registered: %v", err)
+	}
+	if _, err := reg.Resolve("pi"); err != nil {
+		t.Fatalf("pi factory not registered: %v", err)
 	}
 }

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1492,6 +1492,10 @@
         "title": "Codex",
         "description": "Run OpenAI Codex (codex-rs) via the app-server protocol."
       },
+      "pi": {
+        "title": "Pi",
+        "description": "Run the pi coding agent CLI through parsar-daemon."
+      },
       "opencode": {
         "title": "OpenCode",
         "description": "Run OpenCode CLI through parsar-daemon for local or sandbox daemon workflows."

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1492,6 +1492,10 @@
         "title": "Codex",
         "description": "通过 app-server 协议运行 OpenAI Codex（codex-rs）。"
       },
+      "pi": {
+        "title": "Pi",
+        "description": "通过 parsar-daemon 运行 pi coding agent CLI。"
+      },
       "opencode": {
         "title": "OpenCode",
         "description": "通过 parsar-daemon 运行 OpenCode CLI，适合本机或 sandbox daemon 的 OpenCode 工作流。"

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -1,7 +1,7 @@
 import { Fragment, forwardRef, useEffect, useId, useMemo, useRef, useState, type ChangeEvent, type KeyboardEvent, type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 import { useQueryClient } from "@tanstack/react-query"
-import { AlertTriangle, ArrowUpRight, Bot, Check, ChevronDown, Cloud, Cpu, Eye, EyeOff, Laptop, Network, Search, Server } from "lucide-react"
+import { AlertTriangle, ArrowUpRight, Bot, Check, ChevronDown, Cloud, Cpu, Eye, EyeOff, Laptop, Network, Search, Server, Sparkles } from "lucide-react"
 
 import { Badge } from "../../components/ui/badge"
 import { Button } from "../../components/ui/button"
@@ -39,7 +39,7 @@ import type {
 const DEFAULT_PROMPT = "You are a helpful AI assistant for this team. Be concise and accurate."
 
 type ExecutionMode = "sandbox" | "local_device" | "external"
-type AgentEngine = "claude_code" | "opencode" | "codex"
+type AgentEngine = "claude_code" | "opencode" | "codex" | "pi"
 type SandboxSize = "standard" | "xl"
 type RuntimeChoice = AgentRuntime
 
@@ -61,6 +61,7 @@ function agentEngineFromAgent(a?: ProjectAgent | null): AgentEngine {
   const v = String(projectAgentConfig(a).agent_kind ?? agentConfig(a).agent_kind ?? "claude_code")
   if (v === "opencode") return "opencode"
   if (v === "codex") return "codex"
+  if (v === "pi") return "pi"
   return "claude_code"
 }
 
@@ -583,7 +584,7 @@ export function CreateAgentDialog({
   const hasConnector = true
   const connector = mode === "edit" && agent ? agent.connector_type : connectorForExecutionMode(executionMode)
   const hasModel = activeModels.length > 0
-  const requiresModel = connector !== "agent_daemon" || agentEngine === "claude_code" || agentEngine === "codex"
+  const requiresModel = connector !== "agent_daemon" || agentEngine === "claude_code" || agentEngine === "codex" || agentEngine === "pi"
   const hasRequiredModel = !requiresModel || (hasModel && modelID !== "")
   const daemonExecutionEditable = connector === "agent_daemon"
   const showExecutionChoices = mode === "create" || daemonExecutionEditable
@@ -992,7 +993,7 @@ export function CreateAgentDialog({
                   </Field>
                   {connector === "agent_daemon" && (
                     <Field label={t("agents.form.fields.agentEngine")} required>
-                      <div className="grid gap-2 sm:grid-cols-3">
+                      <div className="grid gap-2 sm:grid-cols-2">
                         <ChoiceCard
                           icon={<Cpu className="h-4 w-4" />}
                           title={t("agents.engine.claudeCode.title")}
@@ -1004,6 +1005,12 @@ export function CreateAgentDialog({
                           title={t("agents.engine.codex.title")}
                           selected={agentEngine === "codex"}
                           onSelect={() => setAgentEngine("codex")}
+                        />
+                        <ChoiceCard
+                          icon={<Sparkles className="h-4 w-4" />}
+                          title={t("agents.engine.pi.title")}
+                          selected={agentEngine === "pi"}
+                          onSelect={() => setAgentEngine("pi")}
                         />
                         <ChoiceCard
                           icon={<Server className="h-4 w-4" />}

--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -749,7 +749,7 @@ function formatAgentKindLabel(kind: string): string {
       return "OpenCode"
     case "codex":
       return "Codex"
-    case "pi_agent":
+    case "pi":
       return "PI Agent"
     default:
       return kind

--- a/apps/web/src/pages/admin/runtimes/LocalDeviceRuntimesPanel.tsx
+++ b/apps/web/src/pages/admin/runtimes/LocalDeviceRuntimesPanel.tsx
@@ -251,7 +251,7 @@ function formatAgentKindLabel(kind: string): string {
       return "OpenCode"
     case "codex":
       return "Codex"
-    case "pi_agent":
+    case "pi":
       return "PI Agent"
     default:
       return kind

--- a/docs/integrations/pi-agent-kind.md
+++ b/docs/integrations/pi-agent-kind.md
@@ -1,0 +1,359 @@
+# 接入 `pi` 作为新的 agent_kind —— 接入手册
+
+> 目标：把 [`@earendil-works/pi-coding-agent`](https://github.com/earendil-works/pi)（Pi Agent Harness 的交互式 coding agent CLI）接进 Parsar，作为 `parsar-daemon` 下一个新的 **`agent_kind = "pi"`**。
+>
+> 适用读者：要动手实现 adapter 的工程师 / Agent。先读 [`AGENTS.md`](../../AGENTS.md) 与 [`docs/architecture.md`](../architecture.md)。
+
+---
+
+## 0. 结论先行
+
+| 判断项 | 结论 |
+|---|---|
+| pi 是什么 | 一个**交互式 coding agent CLI**，和 claude_code / opencode / codex 同类 |
+| 接入层级 | **场景 A：新增 `agent_kind`**，复用现有 `agent_daemon` 连接器。**不是**新 `connector_type` |
+| 是否能 headless 包装 | **能**。pi 有成熟的 `--mode json`（单发 NDJSON 流）和 `--mode rpc`（常驻）两种无 TUI 模式 |
+| MVP 改动范围 | **纯 daemon 侧**：新建一个 adapter 包 + `connect.go` 接 8 处线。**dispatch 路径零 server 改动**（BYO key 模式下） |
+| server / web 改动 | **可选**：仅当需要「Parsar 托管模型注入」「能力(skill/MCP)渲染」「Web 后台下拉创建 pi agent」时才改 |
+| DB migration | **不需要**。`agent_kind` 存在 `project_agents.config` 的 JSONB 里，无 CHECK 约束；心跳的 `supported_agent_kinds` 也是 JSONB |
+
+一句话：**pi 的接入是「克隆 opencode adapter → 改 CLI 拼参 → 改 stdout 解析」三件事**，外加 `connect.go` 注册。
+
+> **本次接入范围（已与负责人锁定）**
+>
+> | 维度 | 决策 |
+> |---|---|
+> | Daemon adapter（流式正文/思考/工具/用量/续聊） | ✅ 做 |
+> | 模型来源 | ✅ **Parsar 托管模型注入**（非 BYO env key） |
+> | 托管 skill | ✅ **纳入**（pi 原生 Agent Skills，经 `--skill` 注入，与 claude_code 同 `SKILL.md` 标准） |
+> | 托管 mcp / plugin | ❌ pi 不支持 → 标 `ErrUnsupported`（同 opencode/codex，用户见"该能力不支持"提示） |
+> | AskUserQuestion 人在环 | ❌ 不做（pi 无此能力，两个 Submit 返回 Unknown 哨兵） |
+> | Web 后台创建入口 | ✅ **纳入**（创建向导加第 4 张引擎卡，对齐 codex/claude_code） |
+> | DB migration | ❌ 不需要 |
+>
+> 因此 §4.2「可选」项里的 **托管模型注入 / 托管 skill / Web 后台** 三项本次均**转为必做**；详细排期见文末 **§9 落地 Plan**。
+
+---
+
+## 1. 抽象回顾（你要落在哪一层）
+
+```
+Server  ──(connector_type=agent_daemon)──> agent_daemon 连接器
+                                              │  WebSocket(proto.Envelope)
+                                              ▼
+parsar-daemon: dispatch.Router ──(agent_kind)──> agent.Factory ──> agent.Session
+                                                                     │
+                                            claudecode / opencode / codex / 【新增 pi】
+```
+
+你要实现的是下层 `agent.Factory` + `agent.Session`（`apps/parsar-daemon/internal/agent/registry.go:37` / `:41`）。契约：
+
+- **`Factory(ctx, req proto.PromptRequestPayload, out chan<- proto.Envelope) (Session, error)`**——一个 prompt 起一个 session。
+- **`Session` 三个方法**：
+  - `Cancel(ctx) error`——幂等、best-effort（SIGTERM→SIGKILL）。
+  - `SubmitPermission(ctx, permID, decision) error`——pi 无权限系统，**直接返回 `agent.ErrUnknownPermission`**。
+  - `SubmitPromptForUserChoice(ctx, askID, decision) error`——pi 无此能力，**直接返回 `agent.ErrUnknownAsk`**。
+- **channel 所有权**：adapter 拥有 `out` 的 close 权。**必须**在发完终态 `done` 或 `error` 帧之后 `close(out)` 恰好一次——router 用这个 close 当「会话结束」信号（`registry.go:5-15`）。
+
+---
+
+## 2. pi 侧事实速查（实现 adapter 前必须知道的）
+
+> 全部基于本地克隆 `pi/`（已 gitignore，见仓库根 `.gitignore` 的 `/pi/`）。版本 `0.80.2`。
+
+### 2.1 二进制与运行前提
+- 命令名 **`pi`**（`pi/packages/coding-agent/package.json:9-11`，`bin.pi = dist/cli.js`）。
+- npm 包 `@earendil-works/pi-coding-agent`；**Node ≥ 22.19.0**（`package.json:97-99`）。
+- 安装：`npm i -g @earendil-works/pi-coding-agent`（也支持 pnpm/yarn/bun，及 `bun build --compile` 出的独立二进制）。
+
+### 2.2 headless 单发模式（adapter 用这个）
+```bash
+pi --mode json -p "<prompt>"
+```
+- `--mode json` → stdout 输出 **NDJSON**（每行一个 JSON 对象），实时流式（`pi/packages/coding-agent/src/modes/print-mode.ts:104-108`）。
+- stdin 非 TTY 时自动进入 print 模式（`main.ts:762-768`）；prompt 可走 argv 或 stdin 管道。
+- **无 `--cwd` 标志**：工作目录取 `process.cwd()`（`main.ts:480`）。Parsar 用子进程 `cmd.Dir = req.WorkDir` 设定即可（opencode 已是这套）。
+
+### 2.3 NDJSON 事件流（你要解析的东西）
+- 第一行通常是 **session header**：`{"type":"session","version":3,"id":"<uuidv7>","cwd":"..."}`（`print-mode.ts:112-116`）。→ **抓 `id` 用于 resume**。
+- 之后是 `AgentEvent`（`pi/packages/agent/src/types.ts:413-428`）：
+
+| 事件 `type` | 含义 | 映射到 proto |
+|---|---|---|
+| `agent_start` / `turn_start` | 生命周期开始 | 忽略 |
+| `message_update` | 流式增量，**带 `assistantMessageEvent`** | 见下 |
+| `message_end` | 一条消息结束，`message.usage` 带 token | `proto.TypeUsage` |
+| `tool_execution_start` | 工具调用开始 | `proto.TypeToolCall`（stage=`before`，可选） |
+| `tool_execution_end` | 工具调用结束（`result`,`isError`） | `proto.TypeToolCall`（stage=`after`，可选） |
+| `agent_end` | 全部结束 | 触发 `proto.TypeDone` |
+
+- `message_update.assistantMessageEvent` 的形状（`pi/packages/ai/src/types.ts:453-457`）：
+  - `{type:"text_delta", delta:"...", partial:...}` → **增量正文** → 累加 + 发 `proto.TypeDelta`。
+  - `text_start` / `text_end` → 边界，可忽略正文（只取 delta）。
+  - ⚠️ 这个 union 还有 reasoning/thinking、tool 变体——实现前**完整读一遍 `types.ts:453` 起的 union**，把 thinking 类映射到 `proto.TypeThinking`。
+
+### 2.4 会话续聊（resume）
+- pi 默认把 session 持久化为 JSONL：`~/.pi/agent/sessions/--<cwd>--/<ts>_<id>.jsonl`（`session-manager.ts:439-444`）。
+- 续聊标志：
+  - `--session <id|path>`——按 id/路径打开（**推荐**）。
+  - `--session-id <id>`——用指定 id（不存在则创建）。
+  - `--continue` / `-c`——续当前 cwd 最近一次。
+  - `--no-session`——纯内存、不落盘。
+- **Parsar 续聊接法**（对齐 claude_code）：第一轮不带 resume → 从 header 抓 `id` → 在 `done` 帧 `Metadata` 里回带（如 `{"pi_session_id": id}`）→ server 落 `connector_session_bindings.metadata` → 下一轮经 `req.ResumeSessionID` 下发 → adapter 拼 `--session <id>`。
+- 能力位 `Resume: true`。
+
+### 2.5 权限 / 审批
+- **pi 没有工具级权限系统**，没有 `--yolo`/`--auto-approve`（README「Permissions & Containerization」，`project-trust.ts`）。
+- 唯一的「approve」是**项目信任**（是否加载仓库里的 `.pi/` 配置/扩展）：`--approve`/`-a` 信任、`--no-approve`/`-na` 不信任（`args.ts:180-182`）。
+- ✅ **headless 不会卡住、不会问用户**：`--mode json` 时 `hasUI=false`，遇到带 `.pi/` 的仓库会**静默判为不信任（false）→ 不加载该 `.pi/`**，绝不弹信任提示等输入（`project-trust.ts:86-88`；`package-manager-cli.ts:535` 设 `hasUI: appMode==="interactive"`）。pi 对内置 `read/bash/edit/write` **从来不做逐次审批**——没有 `--dangerously-skip-permissions`，因为它压根没有要跳过的权限系统。
+- **安全默认：仍显式传 `--no-approve`**——不是为了防卡住（headless 本就不会卡），而是把行为钉死：防止某台 runtime 的 `~/.pi/agent/settings.json` 设了 `defaultProjectTrust:"always"` 时被静默加载任意仓库的 `.pi/` 扩展（= 潜在任意代码执行）。需要主动加载项目级 skill/扩展时才用配置项打开 `--approve`（同样无提示）。
+- 能力位 `Permissions: false`。Parsar 的 permission_request / AskUserQuestion 拦截路径对 pi **不适用**。
+
+### 2.6 鉴权 / 选模型
+- Provider key 走环境变量：`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / …（`args.ts:335-377`）；或 `--api-key <key>`（需配合 `--model`，`main.ts:701-709`）。
+- 选模型：`--provider <name> --model <pattern>`，或合并写法 `--model openai/gpt-4o`、`--model sonnet:high`；默认 provider 是 `google`（`args.ts:238`）。
+- 配置文件：`~/.pi/agent/settings.json`（全局）、`<cwd>/.pi/settings.json`（项目，深合并）。
+- **MVP（BYO key）**：在 daemon 宿主/沙盒里配好 `*_API_KEY` 环境变量即可，**不碰 server 的托管模型注入**。
+
+### 2.7 其它
+- 系统提示：`--system-prompt <text>`（整体替换）/ `--append-system-prompt <text>`（追加、可重复）/ `<cwd>/.pi/SYSTEM.md`。
+- 工具开关：`--tools/-t`、`--exclude-tools/-xt`、`--no-tools`、`--no-builtin-tools`；内置 `read/bash/edit/write`（`grep/find/ls` 默认关）。
+- 思考档：`--thinking off|minimal|low|medium|high|xhigh`。
+- **不支持 MCP**（pi 用自有 extension 体系）。Parsar 的 MCP 能力渲染对 pi 无意义。
+- 版本：`pi --version` 打印版本并 exit 0（`main.ts:515-518`）——给 preflight 用。
+
+---
+
+## 3. 能力映射（心跳广播给 server 的 descriptor）
+
+`proto.AgentKindCapabilities`（`internal/agentdaemon/proto/inbound.go:194`）：
+
+```go
+proto.SupportedAgentKind{
+    Kind: "pi",
+    Capabilities: proto.AgentKindCapabilities{
+        Streaming:   true,  // --mode json 流式 NDJSON
+        Permissions: false, // 无工具级权限系统
+        Usage:       true,  // message_end 带 usage（provider 相关，可能不全）
+        Resume:      true,  // --session / --continue
+    },
+}
+```
+`Available` 由 preflight 探测 `pi --version` 的结果填。
+
+---
+
+## 4. 改动清单（一图看全）
+
+### 4.1 必改（daemon 侧，MVP 充分）
+
+| # | 文件 | 改动 |
+|---|---|---|
+| 1 | `apps/parsar-daemon/internal/agent/pi/`（新建包） | `session.go` / `options.go` / `parser.go` / `version.go` + 测试，**克隆 opencode** |
+| 2 | `apps/parsar-daemon/internal/cli/connect.go` | 8 处接线（见 §6 Step 2） |
+
+### 4.2 可选（按需）
+
+| 触发条件 | 文件 | 改动 |
+|---|---|---|
+| 要 Parsar **托管模型注入**（config 配 `model_id`） | `server/internal/connector/agentdaemon/model_injection.go:242` | `switch agentKind` 加 `case "pi":` + `injectPiManagedModel(...)`；否则 default 返回 `ErrUnsupportedAgentKind` |
+| 要给 pi agent 挂 Parsar **托管 skill/MCP/plugin/system_prompt** | `server/internal/connector/agentdaemon/capability_runtime.go:183` | `agentKindToRenderTarget` 加 `case "pi":`（+ `render.TargetPi`）。**不改也能跑**：未知 kind 落 `TargetClaudeCode` |
+| 要在 **Web 后台**下拉里创建 pi agent | `apps/web/src/pages/admin/CreateAgentDialog.tsx:42` 等 | `AgentEngine` union 加 `"pi"`、加一张 ChoiceCard、`requiresModel`/`agentEngineFromAgent` 同步 |
+
+> 为什么 BYO 模式零 server 改动：`injectManagedModel` 在没有 `model_id`/`default_model_id` 时**早返回 nil**（`model_injection.go:121-128`），根本走不到那个 `switch`；dispatch 路径上 `resolveAgentKind` 只从 config 读字符串、`validateAgentKindForSession` 纯靠心跳广播校验，都无硬编码 allowlist。
+
+### 4.3 不用动
+
+- `registry.go` / `dispatch/router.go`——通用，靠 `RegisterKind` + `Resolve(agent_kind)` 驱动。
+- `proto/outbound.go` / `proto/inbound.go`——wire schema 已通用。
+- DB / migrations——`agent_kind` 在 JSONB，无 CHECK。
+
+---
+
+## 5. 数据流走查（pi 一次 run）
+
+1. 运营在 `project_agents.config` 里设 `agent_kind="pi"` 并绑定 `runtime_id`（某台跑了 `parsar-daemon` 且 `pi` 可用的设备）。
+2. server `agent_daemon` 连接器 `resolveAgentKind` 读出 `"pi"`，对照该设备心跳的 `supported_agent_kinds` 校验 available。
+3. 连接器把 `PromptInput` 翻成 `proto.PromptRequestPayload`（`agent_kind="pi"`、`WorkDir`、`AgentOptions`、`ResumeSessionID`），WS 下发。
+4. daemon `dispatch.Router.handlePromptRequest` → `registry.Resolve("pi")` → `pi.Factory` 建 session，起 `pump`。
+5. session 跑 `pi --mode json -p ...` 子进程，逐行解析 NDJSON → 翻成 `delta/thinking/tool_call/usage/done` 上行帧写 `out`。
+6. 终态：发 `done`（`Content` = 累加正文，`Metadata` 带 `pi_session_id`）后 `close(out)` → 连接器落库、回灌飞书/Web。
+
+---
+
+## 6. 落地步骤（Step-by-step）
+
+### Step 0：前置
+- ⚠️ **按 `AGENTS.md`：所有代码改动必须在从 `origin/main` 切出的 worktree 里做，禁止直接在 `main` 提交。**
+  ```bash
+  git fetch origin main
+  git worktree add .worktrees/pi-agent-kind -b feature/pi-agent-kind origin/main
+  ```
+- 在目标 runtime 上装 pi：`npm i -g @earendil-works/pi-coding-agent`，`pi --version` 自检；配好 provider key 环境变量。
+
+### Step 1：新建 adapter 包 `apps/parsar-daemon/internal/agent/pi/`
+**直接 `cp` opencode 包改名**，逐文件改：
+
+- **`version.go`**（最简单，先做）——照 `opencode/version.go`：
+  - `defaultBinary = "pi"`、`InstallURL = "https://pi.dev/docs/latest"`、`ErrCLINotFound`。
+  - `CheckCLIAvailable(ctx, binary) (string, error)`：`LookPath` → 跑 `pi --version` → 返回 trim 后的版本串。
+
+- **`options.go`**——`BuildArgs(runID, prompt, workDir, opts map[string]any) (BuildResult, error)`，拼 pi 的 CLI：
+  - 基线 `args := []string{"--mode", "json", "-p"}`，外加 **`--no-approve`**（安全默认；可由 opts 翻成 `--approve`）。
+  - 续聊：`req.ResumeSessionID != ""` → `--session <id>`。
+  - 读 `opts` 键（沿用 Parsar 既有键名，未知键忽略）：
+
+    | opts 键 | 类型 | → pi 参数 |
+    |---|---|---|
+    | `model_selector` / `model` | string | `--model <v>`（前者优先；支持 `provider/model`） |
+    | `override_system_prompt` | string | `--system-prompt <v>`（整体替换） |
+    | `system_prompt` | string | `--append-system-prompt <v>`（追加，spec/memory 注入走这里） |
+    | `thinking` | string | `--thinking <v>` |
+    | `allowed_tools` / `tools` | []string/csv | `--tools <csv>` |
+    | `exclude_tools` | []string/csv | `--exclude-tools <csv>` |
+    | `approve_project_trust` | bool | true → `--approve`，false/缺省 → `--no-approve` |
+    | `env` | map[string]string | 注入子进程环境（provider key 等） |
+    | `api_key` | string | `--api-key <v>`（仅托管模型注入时才有；需同时有 `--model`） |
+  - `WorkDir` 解析照搬 opencode：必须绝对路径或 `~/` 开头，不存在则 `MkdirAll`；通过 `cmd.Dir` 传（pi 无 `--cwd`）。
+  - prompt 作为 `-p` 的实参（或走 stdin）。
+
+- **`parser.go`**——核心。`translator` 逐行 `json.Unmarshal` 后按 `type` 分发：
+  - `"session"` → 记 `header.id`（终态 `done.Metadata["pi_session_id"]` 回带）。
+  - `"message_update"` → 取 `assistantMessageEvent`：`text_delta` 累加 `delta` 并发 `proto.TypeDelta`；reasoning/thinking 变体发 `proto.TypeThinking`。
+  - `"message_end"` → 读 `message.usage` 发 `proto.TypeUsage`（`Provider="pi"` 或实际 provider）。
+  - `"tool_execution_start"`/`"_end"` →（可选）发 `proto.TypeToolCall`（stage before/after）。
+  - 非 JSON 行 → 进 plain buffer，兜底（同 opencode：全程无 delta 时把 plain 当一条 delta）。
+  - **终态**：stdout EOF 后 `cmd.Wait()`；`waitErr != nil`（且非 cancel）→ 发 `proto.TypeError`（带截断的 stderr）；最后**总是**发 `proto.TypeDone`（`Content` = 累加正文，`Metadata` 带 `pi_session_id` + `connector_path:"pi_run"`）。
+
+- **`session.go`**——照 `opencode/session.go`：
+  - `Factory` → `newSession`：`BuildArgs` → `exec.CommandContext(ctx, cfg.piBinary, args...)`，`cmd.Dir = workDir`，`cmd.Env = append(os.Environ(), buildRes.Env...)`，接 stdout/stderr，`Start`，起 `run(stdout)` + `pumpStderr(stderr)` 两个 goroutine。
+  - `run()` defer 链保证 `close(waitDone)`→`cleanup()`→`closeOut()`，**守住 close(out) 恰好一次**。
+  - `Cancel()`：`SIGTERM`，`killTimeout`（默认 3s）后升 `SIGKILL`。
+  - `SubmitPermission` 返回 `agent.ErrUnknownPermission`；`SubmitPromptForUserChoice` 返回 `agent.ErrUnknownAsk`。
+
+- **`export_test.go` + `*_test.go`**——照 opencode：用 `TestMain` 把测试二进制伪装成 fake `pi`（环境变量选 role：`json-success`/`plain`/`nonzero`/`hang`），断言 delta+usage+done 序列、plain 兜底、非零退出 error+done、cancel 关 out、空 prompt 拒绝、nil out 拒绝。
+
+### Step 2：`connect.go` 接 8 处线
+照 opencode（`apps/parsar-daemon/internal/cli/connect.go`）：
+
+1. import 加 `piagent ".../internal/agent/pi"`。
+2. `agentCLIDiscovery` 结构体加 `Pi proto.SupportedAgentKind`（`:192`）。
+3. `agentCLIChecks` 结构体加 `Pi func(context.Context, string) (string, error)`（`:198`）。
+4. `defaultAgentCLIChecks` 加 `Pi: piagent.CheckCLIAvailable`（`:204`）。
+5. `discoverAgentCLIs` 初始 descriptor 加 `Pi: proto.SupportedAgentKind{Kind:"pi", Capabilities: {Streaming,Usage,Resume:true}}`。
+6. `discoverAgentCLIs` 加 pi 版本探测块（仿 opencode `:271-284`）：成功置 `Available/Version`，`ErrCLINotFound` 打安装提示。
+7. 「无可用 CLI」兜底判断（`:301`）加 `&& !out.Pi.Available`。
+8. `registerAgentKinds`（`:307`）加 `registry.RegisterKind(agentCLIs.Pi, piagent.Factory)`。
+
+> 心跳 `supported_agent_kinds` 由 `registry.SupportedAgentKinds()` 自动带上，无需额外改。
+
+### Step 3（可选）：托管模型注入
+若要在 Parsar 里给 pi agent 配 `model_id`（而非 BYO env key）：
+- `server/internal/connector/agentdaemon/model_injection.go:242` 的 `switch` 加 `case "pi":`，新增 `injectPiManagedModel(opts, modelID, mr, apiKey)`：把解出的 `apiKey`/`provider`/`model` 写进 `opts`（adapter 再翻成 `--api-key` + `--model`）。
+
+### Step 4（可选）：Web 后台
+`apps/web/src/pages/admin/CreateAgentDialog.tsx`：`AgentEngine` 加 `"pi"`、加 ChoiceCard、同步 `requiresModel` / `agentEngineFromAgent`。**不做也行**——可先用 seed/SQL/API 直接写 `project_agents.config.agent_kind="pi"` 来创建/测试。
+
+### Step 5：创建一个 pi agent
+- 最快：在某条 `project_agents` 记录的 `config` JSONB 写 `{"agent_kind":"pi", ...}`，`runtime_id` 绑到装了 pi 的设备。
+- 该设备上 `parsar-daemon connect`，确认启动日志里 pi `preflight ok (<version>)`、心跳广播含 `pi`。
+
+### Step 6：验证
+```bash
+make check                      # AGENTS.md 必跑
+# 仅 daemon 包：
+go test ./apps/parsar-daemon/internal/agent/pi/...
+go test ./apps/parsar-daemon/internal/cli/...
+```
+- 手动冒烟：在装了 pi 的机器上 `pi --mode json -p "say hi"`，确认 NDJSON 形状和你解析的一致。
+- 端到端：飞书群里 @ 这个 pi agent 发一句，确认有流式回复 + 落库 + 续聊（第二句带上了 `--session`）。
+
+---
+
+## 7. 关键坑（提交前自查）
+
+1. **`close(out)` 恰好一次**：所有路径（正常结束 / 非零退出 / cancel / factory 后子进程起不来）都要先发终态帧再 close，否则 router 的 pump 永久阻塞。
+2. **headless 信任不会卡**：headless（`hasUI=false`）遇到带 `.pi/` 的仓库会**静默判为不信任并跳过加载**，不会弹提示等输入（`project-trust.ts:86-88`），用户**全程无需审批**。仍建议显式 `--no-approve` 把行为钉死（防止全局 `defaultProjectTrust:"always"` 静默加载仓库扩展）；要主动加载项目 skill/扩展才传 `--approve`。**不要**安装 `examples/extensions/permission-gate.ts` 这类扩展——那是唯一会重新引入审批提示的东西。
+3. **无 `--cwd`**：靠 `cmd.Dir` 设工作目录；sandbox 模式 `WorkDir` 为空时按 opencode 的 per-conversation scratch dir 兜底。
+4. **session 按 cwd 归档**：pi 的 `--continue` 依赖 cwd 稳定；Parsar 续聊请用**显式 `--session <id>`**（从 header 抓的 id），不要只靠 `--continue`。
+5. **usage 是 provider 相关的**：`message_end.usage` 可能字段不全或缺失，解析要容错；`Usage` 能力位标 true 但别假设一定有 cost。
+6. **不要映射不存在的能力**：pi 没有权限/AskUserQuestion/MCP——`Permissions=false`，两个 Submit 直接返回 Unknown 哨兵，别去拼不存在的 flag。
+7. **thinking union 要读全**：`assistantMessageEvent` 不止 text，reasoning/thinking 变体要正确归到 `proto.TypeThinking`，否则会把思考链拼进正文。
+8. **Node 版本**：runtime 需 Node ≥ 22.19；preflight `pi --version` 失败时给清楚的安装/升级提示（仿 opencode 的 `InstallURL`）。
+
+---
+
+## 8. 参考文件索引
+
+**Parsar 抽象层**
+- `apps/parsar-daemon/internal/agent/registry.go:37/41/86/93/108/132` —— Factory / Session / RegisterKind / Resolve
+- `internal/agentdaemon/proto/inbound.go:194/204/215` —— AgentKindCapabilities / SupportedAgentKind / Heartbeat
+- `internal/agentdaemon/proto/outbound.go:37` —— PromptRequestPayload
+
+**模板（opencode adapter）**
+- `apps/parsar-daemon/internal/agent/opencode/{session,options,parser,version}.go`
+- `apps/parsar-daemon/internal/cli/connect.go:192/198/204/216/271-284/301/307`
+
+**可选 server 改动点**
+- `server/internal/connector/agentdaemon/model_injection.go:119/121-128/242`
+- `server/internal/connector/agentdaemon/capability_runtime.go:183`
+- `apps/web/src/pages/admin/CreateAgentDialog.tsx:42`
+
+**pi 上游（本地克隆 `pi/`，已 gitignore）**
+- 入口 / 参数：`packages/coding-agent/src/cli.ts:20`、`src/cli/args.ts:63`、`src/main.ts:100-111/480/515-518/762-768`
+- headless 输出：`packages/coding-agent/src/modes/print-mode.ts:104-116`
+- 事件类型：`packages/agent/src/types.ts:413-428`、`packages/ai/src/types.ts:453-457`
+- 会话：`packages/coding-agent/src/core/session-manager.ts:439-444`
+- 信任：`packages/coding-agent/src/core/project-trust.ts`
+- 鉴权：`packages/coding-agent/src/cli/args.ts:335-377`
+
+---
+
+## 9. 落地 Plan（本次锁定 scope）
+
+> 范围见文首「本次接入范围」框。无 DB migration。所有改动按 `AGENTS.md` 在 worktree 内完成，提交前跑 `make check`。
+>
+> **依赖顺序**：Phase 1→2 是地基（daemon 能跑、心跳广播 pi）；Phase 3 / 4 / 5 相对独立，可并行。
+
+### Phase 0 — 前置
+- `git fetch origin main && git worktree add .worktrees/pi-agent-kind -b feature/pi-agent-kind origin/main`
+- 目标 runtime 装 pi：`npm i -g @earendil-works/pi-coding-agent`（Node ≥ 22.19），`pi --version` 自检
+- 冒烟：`pi --mode json -p "say hi"`，确认 NDJSON 形状与 §2.3 一致
+
+### Phase 1 — Daemon adapter（核心，纯 daemon，可独立测）⟶ 新建 `apps/parsar-daemon/internal/agent/pi/`
+克隆 opencode 包，逐文件改：
+1. **`version.go`**：`defaultBinary="pi"`、`InstallURL`、`ErrCLINotFound`、`CheckCLIAvailable`（跑 `pi --version`）。
+2. **`options.go`**：`BuildArgs` 基线 `--mode json -p` + `--no-approve`；opts→flags 映射见 §6 Step1 表，额外：
+   - 托管模型产物 `model`→`--model <provider/model>`、`api_key`→`--api-key`（pi 要求 `--api-key` 必配 `--model`）
+   - 托管 skill 产物 `skills`→逐个 `--skill <解压目录>`（解压见 #3）
+   - `WorkDir`→`cmd.Dir`（pi 无 `--cwd`）；resume→`--session <id>`
+3. **`skills.go`**（新增，参考 claude daemon 侧解压逻辑）：读 `opts["skills"]` 的 `{name,download_url,sha256}`→下载 zip→校验 sha256→解压到 scratch `<workDir>/.pi-skills/<name>/`→把目录路径回给 options 拼 `--skill`。
+4. **`parser.go`**：逐行 NDJSON 分发（见 §2.3）：`session`→记 id；`message_update.assistantMessageEvent` 的 `text_delta`→`TypeDelta`（累加）、reasoning/thinking 变体→`TypeThinking`；`message_end.usage`→`TypeUsage`（cost 容错）；`tool_execution_start/end`→`TypeToolCall`；EOF→`Wait()`，非 cancel 错→`TypeError`，**总是** `TypeDone`（Metadata 带 `pi_session_id`）；非 JSON 行→plain 兜底。
+5. **`session.go`**：Factory→newSession→`exec.CommandContext`+`cmd.Dir`+`cmd.Env`→run+pumpStderr；defer 链守 `close(out)` 恰好一次；Cancel SIGTERM→3s→SIGKILL；`SubmitPermission`→`ErrUnknownPermission`、`SubmitPromptForUserChoice`→`ErrUnknownAsk`。
+6. **`*_test.go` + `export_test.go`**：fake pi（json-success/plain/nonzero/hang），断言 delta+usage+done、plain 兜底、非零退出 error+done、cancel 关 out、空 prompt 拒绝、nil out 拒绝。
+- ✅ `go test ./apps/parsar-daemon/internal/agent/pi/...`
+
+### Phase 2 — connect.go 接线 ⟶ `apps/parsar-daemon/internal/cli/connect.go`
+照 opencode 接 8 处（见 §6 Step2）。Capabilities：`Streaming/Usage/Resume=true, Permissions=false`。
+- ✅ `go test ./apps/parsar-daemon/internal/cli/...`；`parsar-daemon connect` 日志见 `pi preflight ok (<ver>)`、心跳含 pi
+
+### Phase 3 — 托管模型注入 ⟶ `server/internal/connector/agentdaemon/model_injection.go:242`
+`switch agentKind` 加 `case "pi":`→新增 `injectPiManagedModel(opts, modelID, mr, apiKey)`：解 model_id→(provider, model_key, api_key)，写 `opts["model"]="<provider>/<model_key>"` + `opts["api_key"]`；补 Parsar provider 名→pi provider id 映射（anthropic/openai/google/…）。
+- ⚠️ 核对：create-agent **后端 API** 是否对 `agent_kind` 有 allowlist 校验（dispatch 路径无；admin 创建路径需确认，有则加 pi）。
+- ✅ server 单测 + 端到端确认子进程拿到正确 `--model`/`--api-key`
+
+### Phase 4 — 托管 skill render target ⟶ `server/internal/connector/agentdaemon/{render/*, capability_runtime.go}`
+1. `render` 包：加 `TargetPi` 常量 + `piRenderer`：`KindSkill`→复用 claude 的 `{name,version,oss_key,sha256}` descriptor（同 Agent Skills 标准）、`KindMCP`/`KindPlugin`→`ErrUnsupported`、`KindSystemPrompt`→共用 `renderSystemPrompt`；注册进 `render.For()`。
+2. `capability_runtime.go:183` `agentKindToRenderTarget` 加 `case "pi": return TargetPi`（消除未知 kind 错落 `TargetClaudeCode`）。
+- ⚠️ 首个 skill 实测确认 zip 内是标准 `SKILL.md` 布局（claude 与 pi 同标准，理论可直用）。
+- ✅ render 单测；绑 skill 的 pi agent 收到 `--skill` 生效；绑 mcp 见 unsupported 提示
+
+### Phase 5 — Web 创建卡 ⟶ `apps/web/src/pages/admin/CreateAgentDialog.tsx`
+`AgentEngine` union 加 `"pi"`（`:42`）、`agentEngineFromAgent` 加 pi（`:60`）、`requiresModel` 含 pi（`:586`）、Step2 加第 4 张 `<ChoiceCard>`（`:994`）+ i18n `agents.engine.pi.title`。`DevicePicker` 已按 `agentKind` 过滤设备，自动生效。
+- ✅ `npm run build`；后台能选 pi、要求选模型、提交后 `config.agent_kind="pi"`
+
+### Phase 6 — 验收 & PR
+- `make check`（AGENTS.md 必跑）
+- 飞书 @ pi agent：流式正文 / 工具步骤 / 思考折叠 / 完成卡（成本可能空）/ 同话题续聊（第二句带 `--session`）
+- 托管 skill 真加载；mcp 提示 unsupported
+- worktree → `origin/main` 提 PR

--- a/server/internal/capability/render/pi.go
+++ b/server/internal/capability/render/pi.go
@@ -1,0 +1,40 @@
+package render
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+)
+
+// piRenderer serializes capability specs for the pi agent runtime
+// (`pi --mode json`). pi consumes Agent Skills via the same SKILL.md
+// standard as Claude Code, so KindSkill reuses renderClaudeCodeSkill to
+// keep the descriptor byte-identical — the daemon decodes pi and
+// claudecode skills with one claudeCodeSkillDocument unmarshal. Managed
+// MCP and plugin delivery are out of scope for pi, so both return
+// ErrUnsupported, which the agentdaemon connector treats as a soft
+// degrade (skip + disabled-capability notice). This makes pi the mirror
+// of codex: codex renders MCP and rejects Skill; pi renders Skill and
+// rejects MCP.
+type piRenderer struct{}
+
+func (piRenderer) Target() Target { return TargetPi }
+
+func (piRenderer) Render(_ context.Context, spec canonical.Spec) (Output, error) {
+	if err := spec.Validate(); err != nil {
+		return Output{}, fmt.Errorf("pi render: invalid spec: %w", err)
+	}
+	switch spec.Kind {
+	case canonical.KindSkill:
+		return renderClaudeCodeSkill(spec.Skill)
+	case canonical.KindSystemPrompt:
+		return renderSystemPrompt(spec.SystemPrompt)
+	case canonical.KindMCP:
+		return Output{}, ErrUnsupported
+	case canonical.KindPlugin:
+		return Output{}, ErrUnsupported
+	default:
+		return Output{}, fmt.Errorf("pi render: unknown kind %q", spec.Kind)
+	}
+}

--- a/server/internal/capability/render/renderer.go
+++ b/server/internal/capability/render/renderer.go
@@ -28,6 +28,7 @@ const (
 	TargetOpenCode   Target = "opencode"
 	TargetClaudeCode Target = "claudecode"
 	TargetCodex      Target = "codex"
+	TargetPi         Target = "pi"
 )
 
 // Output is what a Renderer returns. Content is the scaffold-specific JSON
@@ -57,6 +58,8 @@ func For(target Target) (Renderer, error) {
 		return claudeCodeRenderer{}, nil
 	case TargetCodex:
 		return codexRenderer{}, nil
+	case TargetPi:
+		return piRenderer{}, nil
 	default:
 		return nil, fmt.Errorf("render: unknown target %q", target)
 	}

--- a/server/internal/capability/render/renderer_test.go
+++ b/server/internal/capability/render/renderer_test.go
@@ -47,7 +47,7 @@ func skillFixture() canonical.Spec {
 
 // TestFor_KnownTargets catches "added a Target without wiring For()".
 func TestFor_KnownTargets(t *testing.T) {
-	for _, target := range []Target{TargetOpenCode, TargetClaudeCode, TargetCodex} {
+	for _, target := range []Target{TargetOpenCode, TargetClaudeCode, TargetCodex, TargetPi} {
 		r, err := For(target)
 		if err != nil {
 			t.Fatalf("For(%q) error: %v", target, err)
@@ -273,6 +273,111 @@ func TestCodexRenderer_MCPByteEqualsClaudeCode(t *testing.T) {
 	if codexCanon != claudeCanon {
 		t.Fatalf("codex and claudecode MCP shapes diverged.\ncodex     = %s\nclaudecode= %s",
 			codexCanon, claudeCanon)
+	}
+}
+
+// TestPiRenderer_SkillGolden mirrors the claudecode skill golden: pi
+// reuses Claude Code's skill descriptor verbatim so the daemon's generic
+// zip installer decodes pi's --skill payload with one code path.
+func TestPiRenderer_SkillGolden(t *testing.T) {
+	out, err := piRenderer{}.Render(context.Background(), skillFixture())
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	var got claudeCodeSkillDocument
+	if err := json.Unmarshal(out.Content, &got); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, out.Content)
+	}
+	if got.Name == "" {
+		t.Fatalf("name should be populated from SkillSpec.Slug, got empty: %s", out.Content)
+	}
+	for _, key := range []string{`"name"`, `"version"`, `"oss_key"`, `"sha256"`} {
+		if !strings.Contains(string(out.Content), key) {
+			t.Fatalf("payload missing %s key: %s", key, out.Content)
+		}
+	}
+}
+
+// TestPiRenderer_SkillByteEqualsClaudeCode is the parity guard the daemon
+// relies on: pi and claudecode skill descriptors decode through the same
+// claudeCodeSkillDocument unmarshal, so any field that lands on one shape
+// and not the other silently breaks pi skill installs. Compared through
+// canonicalize() so map-key ordering jitter isn't a false positive.
+func TestPiRenderer_SkillByteEqualsClaudeCode(t *testing.T) {
+	piOut, err := piRenderer{}.Render(context.Background(), skillFixture())
+	if err != nil {
+		t.Fatalf("pi render: %v", err)
+	}
+	claudeOut, err := claudeCodeRenderer{}.Render(context.Background(), skillFixture())
+	if err != nil {
+		t.Fatalf("claudecode render: %v", err)
+	}
+	piCanon, err := canonicalizeJSON(piOut.Content)
+	if err != nil {
+		t.Fatalf("canonicalize pi: %v\nraw=%s", err, piOut.Content)
+	}
+	claudeCanon, err := canonicalizeJSON(claudeOut.Content)
+	if err != nil {
+		t.Fatalf("canonicalize claudecode: %v\nraw=%s", err, claudeOut.Content)
+	}
+	if piCanon != claudeCanon {
+		t.Fatalf("pi and claudecode skill shapes diverged.\npi        = %s\nclaudecode= %s",
+			piCanon, claudeCanon)
+	}
+}
+
+// TestPiRenderer_MCPAndPluginUnsupported pins pi's soft-degrade contract:
+// managed MCP and plugin delivery are out of scope, so both return
+// ErrUnsupported and the agentdaemon connector skips them with a Disabled
+// notice instead of hard-failing the prompt. pi is the mirror of codex —
+// it supports Skill (which codex rejects) and rejects MCP (which codex
+// renders) — so keep this distinct from the codex unsupported test.
+func TestPiRenderer_MCPAndPluginUnsupported(t *testing.T) {
+	cases := []canonical.Spec{
+		mcpFixture(),
+		{
+			SchemaVersion: canonical.SchemaVersionCurrent,
+			Kind:          canonical.KindPlugin,
+			Plugin: &canonical.PluginSpec{
+				Name:         "my-plugin",
+				Version:      "1.0.0",
+				Description:  "x",
+				OssKey:       "capabilities/plugins/u1/my-plugin.zip",
+				SHA256:       "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+				UploadSource: canonical.UploadSourceZip,
+			},
+		},
+	}
+	for _, spec := range cases {
+		_, err := piRenderer{}.Render(context.Background(), spec)
+		if !errors.Is(err, ErrUnsupported) {
+			t.Fatalf("expected ErrUnsupported for kind=%s, got %v", spec.Kind, err)
+		}
+	}
+}
+
+// TestPiRenderer_SystemPromptShared confirms pi rides the shared
+// renderSystemPrompt path (system prompt injection is in scope), emitting
+// the {prompt, mode} document every scaffold uses.
+func TestPiRenderer_SystemPromptShared(t *testing.T) {
+	spec := canonical.Spec{
+		SchemaVersion: canonical.SchemaVersionCurrent,
+		Kind:          canonical.KindSystemPrompt,
+		SystemPrompt: &canonical.SystemPromptSpec{
+			Prompt: "Stay terse.",
+			Mode:   canonical.SystemPromptModeAppend,
+		},
+	}
+	out, err := piRenderer{}.Render(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	var got systemPromptDocument
+	if err := json.Unmarshal(out.Content, &got); err != nil {
+		t.Fatalf("unmarshal: %v\nraw=%s", err, out.Content)
+	}
+	if got.Prompt != "Stay terse." {
+		t.Fatalf("prompt = %q, want 'Stay terse.'", got.Prompt)
 	}
 }
 

--- a/server/internal/connector/agentdaemon/capability_runtime.go
+++ b/server/internal/connector/agentdaemon/capability_runtime.go
@@ -186,6 +186,8 @@ func agentKindToRenderTarget(agentKind string) render.Target {
 		return render.TargetOpenCode
 	case "codex":
 		return render.TargetCodex
+	case "pi":
+		return render.TargetPi
 	default:
 		return render.TargetClaudeCode
 	}

--- a/server/internal/connector/agentdaemon/capability_runtime_dispatch_test.go
+++ b/server/internal/connector/agentdaemon/capability_runtime_dispatch_test.go
@@ -24,6 +24,7 @@ func TestAgentKindToRenderTarget(t *testing.T) {
 		{"claude_code", render.TargetClaudeCode},
 		{"opencode", render.TargetOpenCode},
 		{"codex", render.TargetCodex},
+		{"pi", render.TargetPi},
 		{"", render.TargetClaudeCode},
 		{"  claude_code  ", render.TargetClaudeCode},
 		{"unknown_engine", render.TargetClaudeCode},
@@ -119,6 +120,58 @@ func TestResolveCapabilityAdditions_OpenCodeMCPStillRenders(t *testing.T) {
 	}
 	if len(got.Disabled) != 0 {
 		t.Fatalf("opencode mcp must not be disabled, got %+v", got.Disabled)
+	}
+}
+
+// TestResolveCapabilityAdditions_PiSkillRenders is the positive half of
+// pi's scope: pi delivers managed skills (via --skill), so a skill row on
+// a pi agent must render, not degrade. pi is the inverse of codex here —
+// codex rejects skills, pi accepts them.
+func TestResolveCapabilityAdditions_PiSkillRenders(t *testing.T) {
+	presigner := &stubPluginPresigner{}
+	c := &Connector{
+		capabilities: stubCapabilityStore{rows: []store.EnabledCapabilityRead{
+			newSkillRow(t, "skill-a", "Skill A", "do a"),
+		}},
+		oss: presigner,
+		log: discardLogger(),
+	}
+	got, err := c.resolveCapabilityAdditions(context.Background(), defaultPromptInput(), "pi")
+	if err != nil {
+		t.Fatalf("pi skill must render: %v", err)
+	}
+	if len(got.Skills) != 1 {
+		t.Fatalf("pi must render skills, got %d (%+v)", len(got.Skills), got.Skills)
+	}
+	if len(got.Disabled) != 0 {
+		t.Fatalf("pi skill must not be disabled, got %+v", got.Disabled)
+	}
+}
+
+// TestResolveCapabilityAdditions_PiMCPSoftDegrades is the negative half:
+// managed MCP is out of scope for pi, so the pi renderer returns
+// ErrUnsupported and the connector must skip the row as a Disabled
+// capability rather than hard-fail. This depends on agentKindToRenderTarget
+// mapping "pi"→TargetPi; were pi to fall back to TargetClaudeCode it would
+// wrongly render the MCP server instead of degrading.
+func TestResolveCapabilityAdditions_PiMCPSoftDegrades(t *testing.T) {
+	c := &Connector{
+		capabilities: stubCapabilityStore{rows: []store.EnabledCapabilityRead{
+			newMCPRow(t, "mcp-1", "github", []canonical.MCPServer{
+				{Name: "github", Command: "npx", Args: []string{"@modelcontextprotocol/server-github"}},
+			}, nil),
+		}},
+		log: discardLogger(),
+	}
+	got, err := c.resolveCapabilityAdditions(context.Background(), defaultPromptInput(), "pi")
+	if err != nil {
+		t.Fatalf("pi mcp must soft-degrade, got hard error: %v", err)
+	}
+	if len(got.MCPServers) != 0 {
+		t.Fatalf("pi must not produce mcp servers, got %+v", got.MCPServers)
+	}
+	if len(got.Disabled) != 1 || got.Disabled[0].CapabilityID != "mcp-1" {
+		t.Fatalf("expected 1 disabled mcp capability with id=mcp-1, got %+v", got.Disabled)
 	}
 }
 

--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -276,6 +276,18 @@ func (c *Connector) injectManagedModel(ctx context.Context, in connector.PromptI
 			"provider_slug", mr.ProviderType,
 			"env_key_count", len(copyStringAnyMap(opts["env"])))
 		return nil
+	case "pi":
+		if err := injectPiManagedModel(opts, modelID, mr, apiKey); err != nil {
+			return err
+		}
+		c.log.Info("agent_daemon: injectManagedModel ok",
+			"run_id", in.RunID,
+			"agent_kind", agentKind,
+			"model_id", modelID,
+			"model_key", mr.ModelKey,
+			"provider_slug", mr.ProviderType,
+			"pi_model", stringFromMap(opts, "model"))
+		return nil
 	default:
 		return fmt.Errorf("%w: %q", ErrUnsupportedAgentKind, agentKind)
 	}
@@ -440,6 +452,45 @@ func isOpenAICompatibleRuntime(mr store.ModelRuntime) bool {
 		}
 	}
 	return false
+}
+
+// injectPiManagedModel stamps the Parsar-managed model into an
+// agent_kind="pi" prompt_request. pi requires --api-key to be paired
+// with --model and selects via the combined "<provider>/<model>" form,
+// so the secret rides opts["api_key"] (never env) and opts["model"]
+// carries the provider-qualified key. Unmapped providers reject as
+// ErrManagedModelUnsupported so the caller emits a credential-form notice.
+func injectPiManagedModel(opts map[string]any, modelID string, mr store.ModelRuntime, apiKey string) error {
+	provider := piProviderID(mr)
+	if provider == "" {
+		return fmt.Errorf("%w: model_id=%s provider_type=%q adapter=%q",
+			ErrManagedModelUnsupported, modelID, mr.ProviderType, mr.Adapter)
+	}
+	modelKey := strings.TrimSpace(mr.ModelKey)
+	if modelKey == "" {
+		return fmt.Errorf("%w: model_id=%s pi requires a model_key to pair with --api-key",
+			ErrManagedModelConfigInvalid, modelID)
+	}
+	opts["model"] = provider + "/" + modelKey
+	opts["api_key"] = apiKey
+	return nil
+}
+
+// piProviderID maps a Parsar provider_type / adapter slug onto the
+// provider id pi expects in its "<provider>/<model>" selector.
+func piProviderID(mr store.ModelRuntime) string {
+	for _, v := range []string{mr.ProviderType, mr.Adapter} {
+		switch strings.ToLower(strings.TrimSpace(v)) {
+		case "anthropic", "anthropic-compatible", "anthropic_compatible", "@ai-sdk/anthropic":
+			return "anthropic"
+		case "openai", "openai-compatible", "openai_compatible",
+			"@ai-sdk/openai", "@ai-sdk/openai-compatible":
+			return "openai"
+		case "google", "gemini", "google-generative-ai", "google_generative_ai", "@ai-sdk/google":
+			return "google"
+		}
+	}
+	return ""
 }
 
 // applySpecMemoryInjection appends the SessionStart spec/memory bundle

--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -454,40 +454,104 @@ func isOpenAICompatibleRuntime(mr store.ModelRuntime) bool {
 	return false
 }
 
+// piAPIKeyEnv is the env var the daemon sets to the decrypted secret and
+// references from the materialised models.json "parsar" provider's apiKey
+// field. Carrying the key by env-var name (never inline, never --api-key)
+// keeps it out of the pi child's argv, where `ps` would leak it.
+const piAPIKeyEnv = "PARSAR_PI_API_KEY"
+
+// piManagedProviderID is the fixed models.json provider id the daemon
+// materialises for every managed pi run, mirroring codex's "parsar" slug.
+// opts["model"] is "<piManagedProviderID>/<model_key>".
+const piManagedProviderID = "parsar"
+
 // injectPiManagedModel stamps the Parsar-managed model into an
-// agent_kind="pi" prompt_request. pi requires --api-key to be paired
-// with --model and selects via the combined "<provider>/<model>" form,
-// so the secret rides opts["api_key"] (never env) and opts["model"]
-// carries the provider-qualified key. Unmapped providers reject as
-// ErrManagedModelUnsupported so the caller emits a credential-form notice.
+// agent_kind="pi" prompt_request.
+//
+// pi's builtin providers (anthropic/openai/google) hard-code their upstream
+// endpoints, so the old "anthropic/<model>" selector dropped mr.BaseURL and
+// sent the platform proxy key to api.anthropic.com → 401 invalid x-api-key.
+// Like codex, pi therefore needs a structured provider block the daemon
+// materialises into a config file (models.json) rather than relying on
+// flags/env alone.
+//
+// What lands in agent_options:
+//
+//	model         — "parsar/<model_key>", selecting the materialised provider
+//	pi_provider:
+//	  base_url    — mr.BaseURL (required; forwarding it is the whole point)
+//	  api         — pi wire protocol (anthropic-messages / openai-completions
+//	                / google-generative-ai)
+//	  api_key_env — piAPIKeyEnv; daemon writes models.json apiKey to reference
+//	                this env var, whose value rides opts["env"]
+//	  model       — mr.ModelKey, for the provider's models:[{id}] list
+//	  name        — mr.ModelName (display, optional)
+//	  headers     — flattened mr.ProviderConfig.headers (e.g. X-Sub-Module)
+//	  auth_header — true for openai-completions (Bearer); anthropic uses
+//	                x-api-key so it is omitted
+//	env[piAPIKeyEnv] — the decrypted secret
+//
+// Provider gating: only the three custom-provider APIs pi documents are
+// supported; anything else surfaces ErrManagedModelUnsupported so the caller
+// emits a credential-form notice. A missing base_url or model_key is
+// ErrManagedModelConfigInvalid — fail loud rather than ship a half-built
+// provider the daemon can't serialise. All guards run before any opts
+// mutation so a rejection leaves opts clean.
 func injectPiManagedModel(opts map[string]any, modelID string, mr store.ModelRuntime, apiKey string) error {
-	provider := piProviderID(mr)
-	if provider == "" {
+	api := piAPIProtocol(mr)
+	if api == "" {
 		return fmt.Errorf("%w: model_id=%s provider_type=%q adapter=%q",
 			ErrManagedModelUnsupported, modelID, mr.ProviderType, mr.Adapter)
 	}
 	modelKey := strings.TrimSpace(mr.ModelKey)
 	if modelKey == "" {
-		return fmt.Errorf("%w: model_id=%s pi requires a model_key to pair with --api-key",
+		return fmt.Errorf("%w: model_id=%s pi requires a model_key",
 			ErrManagedModelConfigInvalid, modelID)
 	}
-	opts["model"] = provider + "/" + modelKey
-	opts["api_key"] = apiKey
+	baseURL := strings.TrimSpace(mr.BaseURL)
+	if baseURL == "" {
+		return fmt.Errorf("%w: model_id=%s base_url is required for pi provider injection",
+			ErrManagedModelConfigInvalid, modelID)
+	}
+
+	provider := map[string]any{
+		"base_url":    baseURL,
+		"api":         api,
+		"api_key_env": piAPIKeyEnv,
+		"model":       modelKey,
+	}
+	if name := strings.TrimSpace(mr.ModelName); name != "" {
+		provider["name"] = name
+	}
+	if headers := flattenStringMap(mr.ProviderConfig, "headers"); len(headers) > 0 {
+		provider["headers"] = headers
+	}
+	if api == "openai-completions" {
+		provider["auth_header"] = true
+	}
+
+	opts["model"] = piManagedProviderID + "/" + modelKey
+	opts["pi_provider"] = provider
+
+	env := copyStringAnyMap(opts["env"])
+	env[piAPIKeyEnv] = apiKey
+	opts["env"] = env
 	return nil
 }
 
-// piProviderID maps a Parsar provider_type / adapter slug onto the
-// provider id pi expects in its "<provider>/<model>" selector.
-func piProviderID(mr store.ModelRuntime) string {
+// piAPIProtocol maps a Parsar provider_type / adapter slug onto the pi
+// `api` wire protocol the materialised provider speaks. Empty string means
+// unsupported (rejected upstream as ErrManagedModelUnsupported).
+func piAPIProtocol(mr store.ModelRuntime) string {
 	for _, v := range []string{mr.ProviderType, mr.Adapter} {
 		switch strings.ToLower(strings.TrimSpace(v)) {
 		case "anthropic", "anthropic-compatible", "anthropic_compatible", "@ai-sdk/anthropic":
-			return "anthropic"
+			return "anthropic-messages"
 		case "openai", "openai-compatible", "openai_compatible",
 			"@ai-sdk/openai", "@ai-sdk/openai-compatible":
-			return "openai"
+			return "openai-completions"
 		case "google", "gemini", "google-generative-ai", "google_generative_ai", "@ai-sdk/google":
-			return "google"
+			return "google-generative-ai"
 		}
 	}
 	return ""

--- a/server/internal/connector/agentdaemon/model_injection_test.go
+++ b/server/internal/connector/agentdaemon/model_injection_test.go
@@ -1021,6 +1021,155 @@ func TestInjectCodexManagedModel_NoBaseURLRejected(t *testing.T) {
 }
 
 // ----------------------------------------------------------------------
+// injectPiManagedModel
+// ----------------------------------------------------------------------
+
+// TestInjectPiManagedModel_AnthropicHappyPath pins the contract pi's
+// daemon adapter relies on: opts["model"] is pi's combined
+// "<provider>/<model_key>" selector and opts["api_key"] carries the
+// decrypted secret (pi authenticates via --api-key, NOT env), so the
+// platform key must never leak into the child env.
+func TestInjectPiManagedModel_AnthropicHappyPath(t *testing.T) {
+	opts := map[string]any{
+		"env": map[string]any{"OTHER_FLAG": "kept"},
+	}
+	mr := store.ModelRuntime{
+		ModelID:      "model-anthropic",
+		ModelKey:     "claude-opus-4-7",
+		ProviderType: "anthropic-compatible",
+		Adapter:      "@ai-sdk/anthropic",
+	}
+	if err := injectPiManagedModel(opts, mr.ModelID, mr, "sk-pi"); err != nil {
+		t.Fatalf("injectPiManagedModel: %v", err)
+	}
+	if got := opts["model"]; got != "anthropic/claude-opus-4-7" {
+		t.Fatalf("opts[model] = %v, want anthropic/claude-opus-4-7", got)
+	}
+	if got := opts["api_key"]; got != "sk-pi" {
+		t.Fatalf("opts[api_key] = %v, want sk-pi", got)
+	}
+	env, _ := opts["env"].(map[string]any)
+	if _, hasKey := env["ANTHROPIC_API_KEY"]; hasKey {
+		t.Fatalf("secret must NOT be placed in env for pi — auth flows through --api-key: %+v", env)
+	}
+	if got := env["OTHER_FLAG"]; got != "kept" {
+		t.Fatalf("unrelated env key lost: %+v", env)
+	}
+}
+
+func TestInjectPiManagedModel_ProviderMapping(t *testing.T) {
+	cases := []struct {
+		name string
+		mr   store.ModelRuntime
+		want string
+	}{
+		{"openai", store.ModelRuntime{ModelKey: "gpt-4o", ProviderType: "openai"}, "openai/gpt-4o"},
+		{"openai-compatible adapter", store.ModelRuntime{ModelKey: "gpt-4o-mini", Adapter: "@ai-sdk/openai"}, "openai/gpt-4o-mini"},
+		{"anthropic", store.ModelRuntime{ModelKey: "claude-sonnet-4-5", ProviderType: "anthropic"}, "anthropic/claude-sonnet-4-5"},
+		{"google", store.ModelRuntime{ModelKey: "gemini-2.5-pro", ProviderType: "google"}, "google/gemini-2.5-pro"},
+		{"gemini alias", store.ModelRuntime{ModelKey: "gemini-2.5-flash", ProviderType: "gemini"}, "google/gemini-2.5-flash"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := map[string]any{}
+			if err := injectPiManagedModel(opts, "model-x", tc.mr, "sk-x"); err != nil {
+				t.Fatalf("inject: %v", err)
+			}
+			if got := opts["model"]; got != tc.want {
+				t.Fatalf("opts[model] = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInjectPiManagedModel_UnmappedProviderRejected confirms an
+// unrecognised provider surfaces ErrManagedModelUnsupported (so the
+// credential-form flow can steer the admin) and leaves opts untouched.
+func TestInjectPiManagedModel_UnmappedProviderRejected(t *testing.T) {
+	opts := map[string]any{}
+	mr := store.ModelRuntime{
+		ModelID:      "model-cohere",
+		ModelKey:     "command-r",
+		ProviderType: "cohere",
+	}
+	err := injectPiManagedModel(opts, mr.ModelID, mr, "sk-x")
+	if err == nil {
+		t.Fatal("expected ErrManagedModelUnsupported for unmapped provider, got nil")
+	}
+	if !errors.Is(err, ErrManagedModelUnsupported) {
+		t.Fatalf("expected ErrManagedModelUnsupported, got %v", err)
+	}
+	if _, ok := opts["model"]; ok {
+		t.Fatalf("opts[model] must not be set on rejection: %+v", opts)
+	}
+	if _, ok := opts["api_key"]; ok {
+		t.Fatalf("opts[api_key] must not be set on rejection: %+v", opts)
+	}
+}
+
+// TestInjectPiManagedModel_MissingModelKeyRejected guards the
+// half-built selector: pi requires --api-key to be paired with --model,
+// so an empty model_key must fail loud rather than emit "<provider>/".
+func TestInjectPiManagedModel_MissingModelKeyRejected(t *testing.T) {
+	opts := map[string]any{}
+	mr := store.ModelRuntime{ModelID: "model-x", ProviderType: "anthropic"}
+	err := injectPiManagedModel(opts, mr.ModelID, mr, "sk-x")
+	if err == nil {
+		t.Fatal("expected ErrManagedModelConfigInvalid for missing model_key, got nil")
+	}
+	if !errors.Is(err, ErrManagedModelConfigInvalid) {
+		t.Fatalf("expected ErrManagedModelConfigInvalid, got %v", err)
+	}
+}
+
+// TestInjectManagedModel_PiSwitchWired drives the full
+// c.injectManagedModel path with agent_kind="pi" to prove the switch
+// dispatches to injectPiManagedModel (without a case "pi" it falls
+// through to ErrUnsupportedAgentKind).
+func TestInjectManagedModel_PiSwitchWired(t *testing.T) {
+	const masterKey = "test-master-key"
+	svc, err := secrets.New(masterKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc, err := svc.Encrypt(map[string]any{"api_key": "sk-pi"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver := fakeModelResolver{
+		runtime: store.ModelRuntime{
+			ModelID:      "model-pi",
+			ModelKey:     "claude-opus-4-7",
+			ProviderType: "anthropic-compatible",
+			Adapter:      "@ai-sdk/anthropic",
+			SecretID:     "secret-pi",
+		},
+		secret: store.SecretPayload{SecretRead: store.SecretRead{Status: "active"}, EncryptedPayload: enc},
+	}
+	c := New(Config{
+		Registry:      gateway.NewRegistry(),
+		Binder:        binding.NewInMemoryBinder(),
+		ModelResolver: &resolver,
+		Secrets:       svc,
+	})
+
+	in := basicInput()
+	in.WorkspaceID = "ws-1"
+	in.ProjectAgentConfig = map[string]any{"model_id": "model-pi"}
+	opts := renderStaticAgentOptions(in)
+
+	if err := c.injectManagedModel(context.Background(), in, opts, "pi"); err != nil {
+		t.Fatalf("injectManagedModel(pi): %v", err)
+	}
+	if got := opts["model"]; got != "anthropic/claude-opus-4-7" {
+		t.Fatalf("opts[model] = %v, want anthropic/claude-opus-4-7", got)
+	}
+	if got := opts["api_key"]; got != "sk-pi" {
+		t.Fatalf("opts[api_key] = %v, want sk-pi", got)
+	}
+}
+
+// ----------------------------------------------------------------------
 // model_credential_binding (shared API key on the agent)
 // ----------------------------------------------------------------------
 

--- a/server/internal/connector/agentdaemon/model_injection_test.go
+++ b/server/internal/connector/agentdaemon/model_injection_test.go
@@ -1024,11 +1024,17 @@ func TestInjectCodexManagedModel_NoBaseURLRejected(t *testing.T) {
 // injectPiManagedModel
 // ----------------------------------------------------------------------
 
-// TestInjectPiManagedModel_AnthropicHappyPath pins the contract pi's
-// daemon adapter relies on: opts["model"] is pi's combined
-// "<provider>/<model_key>" selector and opts["api_key"] carries the
-// decrypted secret (pi authenticates via --api-key, NOT env), so the
-// platform key must never leak into the child env.
+// TestInjectPiManagedModel_AnthropicHappyPath pins the Option-B contract
+// pi's daemon adapter relies on. The previous design emitted pi's builtin
+// "<provider>/<model>" selector and dropped mr.BaseURL, so the platform
+// proxy key was sent to api.anthropic.com → 401 invalid x-api-key.
+//
+// The injector now mirrors codex: it stamps a structured opts["pi_provider"]
+// block (base_url + api protocol + headers) that the daemon materialises
+// into a models.json "parsar" provider, sets opts["model"] to the
+// provider-qualified "parsar/<model_key>" selector, and rides the secret on
+// opts["env"][PARSAR_PI_API_KEY] (referenced by api_key_env) so it never
+// leaks through --api-key argv.
 func TestInjectPiManagedModel_AnthropicHappyPath(t *testing.T) {
 	opts := map[string]any{
 		"env": map[string]any{"OTHER_FLAG": "kept"},
@@ -1036,38 +1042,74 @@ func TestInjectPiManagedModel_AnthropicHappyPath(t *testing.T) {
 	mr := store.ModelRuntime{
 		ModelID:      "model-anthropic",
 		ModelKey:     "claude-opus-4-7",
+		ModelName:    "Claude Opus 4.7",
 		ProviderType: "anthropic-compatible",
 		Adapter:      "@ai-sdk/anthropic",
+		BaseURL:      "https://platform-api.example.com",
+		ProviderConfig: map[string]any{
+			"headers": map[string]any{
+				"X-Sub-Module": "claude-code-internal",
+			},
+		},
 	}
 	if err := injectPiManagedModel(opts, mr.ModelID, mr, "sk-pi"); err != nil {
 		t.Fatalf("injectPiManagedModel: %v", err)
 	}
-	if got := opts["model"]; got != "anthropic/claude-opus-4-7" {
-		t.Fatalf("opts[model] = %v, want anthropic/claude-opus-4-7", got)
+	// model selects the materialised "parsar" provider (which carries
+	// base_url + headers), NOT pi's builtin anthropic provider.
+	if got := opts["model"]; got != "parsar/claude-opus-4-7" {
+		t.Fatalf("opts[model] = %v, want parsar/claude-opus-4-7", got)
 	}
-	if got := opts["api_key"]; got != "sk-pi" {
-		t.Fatalf("opts[api_key] = %v, want sk-pi", got)
+	provider, ok := opts["pi_provider"].(map[string]any)
+	if !ok {
+		t.Fatalf("opts[pi_provider] has type %T, want map[string]any", opts["pi_provider"])
 	}
+	if got := provider["base_url"]; got != "https://platform-api.example.com" {
+		t.Fatalf("pi_provider.base_url = %v, want the platform base_url", got)
+	}
+	if got := provider["api"]; got != "anthropic-messages" {
+		t.Fatalf("pi_provider.api = %v, want anthropic-messages", got)
+	}
+	if got := provider["api_key_env"]; got != "PARSAR_PI_API_KEY" {
+		t.Fatalf("pi_provider.api_key_env = %v, want PARSAR_PI_API_KEY", got)
+	}
+	headers, ok := provider["headers"].(map[string]string)
+	if !ok {
+		t.Fatalf("pi_provider.headers has type %T, want map[string]string", provider["headers"])
+	}
+	if got := headers["X-Sub-Module"]; got != "claude-code-internal" {
+		t.Fatalf("custom header lost: %+v", headers)
+	}
+	// secret rides env (referenced by api_key_env), never --api-key argv.
 	env, _ := opts["env"].(map[string]any)
-	if _, hasKey := env["ANTHROPIC_API_KEY"]; hasKey {
-		t.Fatalf("secret must NOT be placed in env for pi — auth flows through --api-key: %+v", env)
+	if got := env["PARSAR_PI_API_KEY"]; got != "sk-pi" {
+		t.Fatalf("env[PARSAR_PI_API_KEY] = %v, want sk-pi", got)
 	}
 	if got := env["OTHER_FLAG"]; got != "kept" {
 		t.Fatalf("unrelated env key lost: %+v", env)
 	}
+	if _, hasKey := opts["api_key"]; hasKey {
+		t.Fatalf("opts[api_key] must be absent — pi auth flows through models.json apiKey env ref, not --api-key: %+v", opts)
+	}
 }
 
+// TestInjectPiManagedModel_ProviderMapping pins the provider_type/adapter
+// → pi `api` protocol mapping. opts["model"] is ALWAYS the fixed "parsar"
+// provider — the daemon materialises one provider per run regardless of the
+// upstream family; the family only selects which wire protocol that
+// provider speaks (anthropic-messages / openai-completions /
+// google-generative-ai — the three custom-provider APIs pi documents).
 func TestInjectPiManagedModel_ProviderMapping(t *testing.T) {
 	cases := []struct {
-		name string
-		mr   store.ModelRuntime
-		want string
+		name    string
+		mr      store.ModelRuntime
+		wantAPI string
 	}{
-		{"openai", store.ModelRuntime{ModelKey: "gpt-4o", ProviderType: "openai"}, "openai/gpt-4o"},
-		{"openai-compatible adapter", store.ModelRuntime{ModelKey: "gpt-4o-mini", Adapter: "@ai-sdk/openai"}, "openai/gpt-4o-mini"},
-		{"anthropic", store.ModelRuntime{ModelKey: "claude-sonnet-4-5", ProviderType: "anthropic"}, "anthropic/claude-sonnet-4-5"},
-		{"google", store.ModelRuntime{ModelKey: "gemini-2.5-pro", ProviderType: "google"}, "google/gemini-2.5-pro"},
-		{"gemini alias", store.ModelRuntime{ModelKey: "gemini-2.5-flash", ProviderType: "gemini"}, "google/gemini-2.5-flash"},
+		{"openai", store.ModelRuntime{ModelKey: "gpt-4o", ProviderType: "openai", BaseURL: "https://x/v1"}, "openai-completions"},
+		{"openai-compatible adapter", store.ModelRuntime{ModelKey: "gpt-4o-mini", Adapter: "@ai-sdk/openai", BaseURL: "https://x/v1"}, "openai-completions"},
+		{"anthropic", store.ModelRuntime{ModelKey: "claude-sonnet-4-5", ProviderType: "anthropic", BaseURL: "https://x"}, "anthropic-messages"},
+		{"google", store.ModelRuntime{ModelKey: "gemini-2.5-pro", ProviderType: "google", BaseURL: "https://x"}, "google-generative-ai"},
+		{"gemini alias", store.ModelRuntime{ModelKey: "gemini-2.5-flash", ProviderType: "gemini", BaseURL: "https://x"}, "google-generative-ai"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1075,8 +1117,15 @@ func TestInjectPiManagedModel_ProviderMapping(t *testing.T) {
 			if err := injectPiManagedModel(opts, "model-x", tc.mr, "sk-x"); err != nil {
 				t.Fatalf("inject: %v", err)
 			}
-			if got := opts["model"]; got != tc.want {
-				t.Fatalf("opts[model] = %v, want %v", got, tc.want)
+			if got := opts["model"]; got != "parsar/"+tc.mr.ModelKey {
+				t.Fatalf("opts[model] = %v, want parsar/%s", got, tc.mr.ModelKey)
+			}
+			provider, ok := opts["pi_provider"].(map[string]any)
+			if !ok {
+				t.Fatalf("opts[pi_provider] has type %T", opts["pi_provider"])
+			}
+			if got := provider["api"]; got != tc.wantAPI {
+				t.Fatalf("pi_provider.api = %v, want %v", got, tc.wantAPI)
 			}
 		})
 	}
@@ -1122,6 +1171,35 @@ func TestInjectPiManagedModel_MissingModelKeyRejected(t *testing.T) {
 	}
 }
 
+// TestInjectPiManagedModel_NoBaseURLRejected guards the half-built
+// provider, mirroring the codex rule: without base_url the daemon can't
+// materialise a models.json "parsar" provider, and pi would silently fall
+// back to the upstream default endpoint (api.anthropic.com) with the
+// platform proxy key → 401. Fail loud at the server boundary instead.
+func TestInjectPiManagedModel_NoBaseURLRejected(t *testing.T) {
+	opts := map[string]any{}
+	mr := store.ModelRuntime{
+		ModelID:      "model-anthropic",
+		ModelKey:     "claude-opus-4-7",
+		ProviderType: "anthropic-compatible",
+		Adapter:      "@ai-sdk/anthropic",
+		// BaseURL deliberately empty
+	}
+	err := injectPiManagedModel(opts, mr.ModelID, mr, "sk-pi")
+	if err == nil {
+		t.Fatal("expected ErrManagedModelConfigInvalid for missing base_url, got nil")
+	}
+	if !errors.Is(err, ErrManagedModelConfigInvalid) {
+		t.Fatalf("expected ErrManagedModelConfigInvalid, got %v", err)
+	}
+	if _, ok := opts["model"]; ok {
+		t.Fatalf("opts[model] must not be set on rejection: %+v", opts)
+	}
+	if _, ok := opts["pi_provider"]; ok {
+		t.Fatalf("opts[pi_provider] must not be set on rejection: %+v", opts)
+	}
+}
+
 // TestInjectManagedModel_PiSwitchWired drives the full
 // c.injectManagedModel path with agent_kind="pi" to prove the switch
 // dispatches to injectPiManagedModel (without a case "pi" it falls
@@ -1142,6 +1220,7 @@ func TestInjectManagedModel_PiSwitchWired(t *testing.T) {
 			ModelKey:     "claude-opus-4-7",
 			ProviderType: "anthropic-compatible",
 			Adapter:      "@ai-sdk/anthropic",
+			BaseURL:      "https://platform-api.example.com",
 			SecretID:     "secret-pi",
 		},
 		secret: store.SecretPayload{SecretRead: store.SecretRead{Status: "active"}, EncryptedPayload: enc},
@@ -1161,11 +1240,18 @@ func TestInjectManagedModel_PiSwitchWired(t *testing.T) {
 	if err := c.injectManagedModel(context.Background(), in, opts, "pi"); err != nil {
 		t.Fatalf("injectManagedModel(pi): %v", err)
 	}
-	if got := opts["model"]; got != "anthropic/claude-opus-4-7" {
-		t.Fatalf("opts[model] = %v, want anthropic/claude-opus-4-7", got)
+	if got := opts["model"]; got != "parsar/claude-opus-4-7" {
+		t.Fatalf("opts[model] = %v, want parsar/claude-opus-4-7", got)
 	}
-	if got := opts["api_key"]; got != "sk-pi" {
-		t.Fatalf("opts[api_key] = %v, want sk-pi", got)
+	if _, ok := opts["pi_provider"].(map[string]any); !ok {
+		t.Fatalf("opts[pi_provider] must be set, got %T", opts["pi_provider"])
+	}
+	env, _ := opts["env"].(map[string]any)
+	if got := env["PARSAR_PI_API_KEY"]; got != "sk-pi" {
+		t.Fatalf("env[PARSAR_PI_API_KEY] = %v, want sk-pi (secret must ride env, not --api-key)", got)
+	}
+	if _, ok := opts["api_key"]; ok {
+		t.Fatalf("opts[api_key] must be absent for pi: %+v", opts)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds the **pi** coding agent (`@earendil-works/pi`) as a fourth `agent_kind` alongside `claude_code`, `opencode`, and `codex`.
- **Daemon:** new pi `agent.Session` adapter (`pi --mode json`) with options/parser/skills + CLI `connect` wiring.
- **Server:** capability render `TargetPi` (managed skills via the shared SKILL.md path; managed mcp/plugin return `ErrUnsupported` and soft-degrade to disabled-capability notices) + managed model injection for pi.
- **Web:** pi engine option in the create-agent dialog (managed model required, like claude_code/codex).
- **Docs:** pi integration manual under `docs/integrations/`.

## Scope notes
- Managed MCP and plugin delivery are intentionally out of scope for pi and degrade gracefully — pi is the mirror of codex (codex renders MCP + rejects Skill; pi renders Skill + rejects MCP).
- No DB migration: `agent_kind` is data-driven (JSONB), no CHECK constraint.

## Test plan
- [x] `make check` (`go test ./server/...`, sqlc no-drift, `pnpm typecheck` across 7 projects) — green
- [x] `go test ./apps/parsar-daemon/internal/agent/pi/... ./apps/parsar-daemon/internal/cli/...` — green
- [ ] e2e (manual, live Feishu): @ a pi agent → streaming / tool calls / thinking / done-card / resume
- [ ] e2e: managed skill loads on a pi agent
- [ ] e2e: enabling an MCP/plugin on a pi agent surfaces the unsupported (disabled-capability) notice