### PR TITLE
Phase 1: local one-command stack + served-daemon device pairing

### DIFF
--- a/.github/workflows/parsar-server-release.yml
+++ b/.github/workflows/parsar-server-release.yml
@@ -27,6 +27,11 @@ on:
       - "server/**"
       - "internal/**"
       - "apps/web/**"
+      # The image bakes cross-compiled parsar-daemon binaries (served at
+      # /api/v1/parsar-daemon/download), so a daemon-only change must also
+      # rebuild + republish the server image — else the served binary goes
+      # stale against source.
+      - "apps/parsar-daemon/**"
       - "packages/**"
       - "go.mod"
       - "go.sum"

--- a/.github/workflows/parsar-server-release.yml
+++ b/.github/workflows/parsar-server-release.yml
@@ -1,0 +1,86 @@
+# Build + push the parsar-server image to GitHub Container Registry.
+#
+# This is the Phase 1 deliverable's "one command" enabler: docker-compose.local.yml
+# (and the Phase 2 self-host compose) pull ghcr.io/<owner>/parsar-server by
+# default. Same image, two compose profiles — profile not fork.
+#
+# Triggers:
+#   - Push to main touching server/web/build inputs -> :latest + :<sha>
+#   - Tag push matching `parsar-server-v*`          -> :<release-tag>
+#   - Manual workflow_dispatch
+#
+# Output: ghcr.io/${{ github.repository_owner }}/parsar-server:<tag>
+#   - latest        on default-branch pushes
+#   - <short-sha>   on every build
+#   - <release-tag> on tag pushes (e.g. parsar-server-v0.1.0)
+#
+# Operators using their own registry: copy this into a fork and swap the
+# `images:` field, or just override PARSAR_SERVER_IMAGE in the compose .env
+# and never run this workflow.
+
+name: parsar-server image release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "server/**"
+      - "internal/**"
+      - "apps/web/**"
+      - "packages/**"
+      - "go.mod"
+      - "go.sum"
+      - "go.work"
+      - "pnpm-lock.yaml"
+      - "Dockerfile"
+      - ".github/workflows/parsar-server-release.yml"
+    tags:
+      - "parsar-server-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/parsar-server
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,12 @@ coverage/
 # never part of the merged history.
 deliverable.md
 
+# Superpowers brainstorming/planning scratch (design specs + implementation
+# plans). Working docs kept locally for reference — never merged into the
+# product tree. Same posture as deliverable.md above.
+docs/superpowers/plans/
+docs/superpowers/specs/
+
 # go.work.sum is regenerated on every `go run` / `go build` and
 # should not be tracked (Go convention: only go.work itself is
 # committed; the .sum gets rebuilt from go.work + module sums).

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,25 @@ RUN cd server \
  && CGO_ENABLED=0 GOFLAGS=-trimpath go build -ldflags="-s -w" \
       -o /out/parsar-bootstrap ./cmd/parsar-bootstrap
 
+# parsar-daemon source (root module, no separate go.mod). Copied after the
+# server build so editing the daemon doesn't invalidate the layer above.
+COPY apps/parsar-daemon ./apps/parsar-daemon
+
+# Cross-compile the daemon for every platform the install script serves —
+# the allowlist in server/internal/api/parsar_daemon_download.go is
+# {darwin,linux}×{amd64,arm64}. Baking all four into the image lets the
+# minting server hand the host-appropriate binary to the one-line connect
+# command with no GitHub release (PARSAR_DAEMON_CONNECT_URL path). CGO
+# stays off so each cross-target links statically.
+RUN mkdir -p /out/daemon \
+ && for target in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64; do \
+      os="${target%/*}"; arch="${target#*/}"; \
+      CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" GOFLAGS=-trimpath \
+        go build -ldflags="-s -w" \
+          -o "/out/daemon/parsar-daemon-${os}-${arch}" \
+          ./apps/parsar-daemon/cmd/parsar-daemon; \
+    done
+
 ###############################################################################
 # Stage 3: runtime — debian-slim with a non-root user.
 #
@@ -137,6 +156,14 @@ COPY --from=go-builder /out/parsar-server    /usr/local/bin/parsar-server
 COPY --from=go-builder /out/parsar-migrate   /usr/local/bin/parsar-migrate
 COPY --from=go-builder /out/parsar-bootstrap /usr/local/bin/parsar-bootstrap
 
+# Per-platform parsar-daemon binaries. RegisterParsarDaemonDownloadRoute
+# serves these (from PARSAR_DAEMON_BINARY_DIR) to the one-line connect
+# command, so a local or air-gapped self-host install needs no GitHub
+# release. World-readable on purpose: the binary is public; the pairing
+# token gates connecting. NOT on $PATH — they are other-OS/arch artefacts,
+# not meant to run in this container.
+COPY --from=go-builder /out/daemon /usr/local/share/parsar/daemon
+
 # SPA artefacts. Owner = root, perms = world-readable (handler runs
 # as the non-root parsar user and only needs read access).
 COPY --from=web-builder /src/apps/web/dist /app/web/dist
@@ -151,7 +178,8 @@ COPY server/migrations /app/migrations
 ENV PARSAR_ADDR=":8080" \
     PARSAR_DATA_DIR="/var/lib/parsar" \
     PARSAR_MIGRATIONS_DIR="/app/migrations" \
-    PARSAR_WEB_DIST="/app/web/dist"
+    PARSAR_WEB_DIST="/app/web/dist" \
+    PARSAR_DAEMON_BINARY_DIR="/usr/local/share/parsar/daemon"
 
 USER ${PARSAR_USER}
 WORKDIR /var/lib/parsar

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,403 +1,155 @@
-# INSTALL — Local Quickstart (for AI coding agents)
+# INSTALL — Parsar 本地版快速上手(Local Quickstart)
 
-> **Audience:** an AI coding agent (Claude Code, Cursor, Codex, etc.) the
-> user has just opened inside a fresh clone of this repo.
-> **Human readers:** skip to `docs/deploy/deploy-runbook.md` for the
-> manual version.
->
-> **What this gives the user:** a working parsar instance on
-> `http://localhost:8080` in roughly 5 minutes of wall-clock time
-> (mostly waiting for the first `docker build`). Mock Feishu auth is
-> on by default so the user can poke at the UI without registering a
-> real OAuth app.
+> **面向:** 想在本机自用或验收 Parsar 的开发者 / AI 编码 agent(Claude Code、Cursor、Codex 等)。
+> **给你什么:** 几分钟内拉起一个可用的 Parsar(mock 登录,无需配置飞书或任何密钥),并把你本机的 Claude Code / OpenCode / Codex 接入成一台**在线设备**——全程「浏览器复制一条命令 → 终端粘贴 → 设备在线」。
+> **不在本页:** 自部署 / 生产部署(真实飞书 OIDC、自定义端口与密钥、bootstrap token)是另一条路径,见 `deploy/compose/compose.example.yml` 与 `docs/deploy/`。
 
 ---
 
-## 本地版（Local）—— 一条命令在本机跑起来
+## 总览
 
-面向单个开发者自用，all-in-one，mock 登录开箱即用，无需配置飞书或任何密钥。
-
-### 前置
-- 已安装 Docker（含 `docker compose`）。
-- 本机至少装好一个 Agent CLI 并完成登录：Claude Code、OpenCode 或 Codex 之一。
-  daemon 会复用它的登录态与订阅，并看见你本机真实的仓库。
-
-### 启动
-```bash
-docker compose -f docker-compose.local.yml up
 ```
-首次启动会拉取 `parsar-server` 镜像、跑数据库迁移、并自动创建第一个工作区
-（owner = mock 身份 `admin@example.com`）。
+clone → (拉取/构建镜像) → docker compose up → 浏览器登录 → 接入设备 → 设备在线
+```
 
-> 镜像尚未发布、或想跑你本地改动时，先本地构建再覆盖镜像变量：
+本地栈是 all-in-one:`postgres` + 一次性 `init`(迁移 + 建首个 owner)+ `parsar-server`(mock 登录)。**profile not fork**:它与自部署版用的是**同一个镜像 / 迁移 / SPA / install.sh**,差异只在 compose 文件与环境变量。
+
+---
+
+## 0 · 前置
+
+```bash
+docker compose version                                       # 需要 v2+
+claude --version || opencode --version || codex --version    # 至少一个,且已登录
+```
+
+- **Docker** 已安装并正在运行(macOS 需先打开 Docker Desktop,`docker info` 能看到 server 段)。
+- 本机已装好并**登录**至少一个 Agent CLI(Claude Code / OpenCode / Codex)。daemon 不自带模型登录,它复用这个 CLI 的登录态与订阅,并能看见你本机真实的仓库。
+
+---
+
+## 1 · 拉代码
+
+```bash
+git clone <your-repo-url> parsar
+cd parsar
+# 本地版交付目前在 feature/deliverables-design 分支;合并主干后忽略此步,用默认分支即可
+git checkout feature/deliverables-design
+```
+
+---
+
+## 2 · 选择镜像 + 设置环境变量
+
+默认从 GHCR 拉预构建镜像(下一步 `docker compose` 会自动完成,无需手动 pull):
+
+```bash
+# 端口默认 18080 / 15432;被占用就改这两个数(例:18088 / 15488)
+export PARSAR_LOCAL_PORT=18080
+export PARSAR_PG_PORT=15432
+```
+
+> **当前状态(待镜像发布到 GHCR 后删除本提示):**
+> 让「接入设备」离线零配置的关键——**镜像内置的 4 平台 daemon 二进制**——尚未随镜像发布到 GHCR。在它发布之前,直接拉 GHCR 的镜像**不含**内置 daemon,**第 4 步接入设备会下载 daemon 失败(404)**。此期间请走本地构建作为 fallback:
 > ```bash
-> make docker-build PARSAR_IMAGE=parsar PARSAR_IMAGE_TAG=local
-> PARSAR_SERVER_IMAGE=parsar:local docker compose -f docker-compose.local.yml up
+> make docker-build PARSAR_IMAGE=parsar PARSAR_IMAGE_TAG=local   # 首次约 5–10 分钟
+> export PARSAR_SERVER_IMAGE=parsar:local
 > ```
+> 构建后验证镜像确实内置了 daemon:
+> ```bash
+> docker run --rm --entrypoint ls parsar:local /usr/local/share/parsar/daemon
+> # 预期列出 4 个:parsar-daemon-{darwin,linux}-{amd64,arm64}
+> ```
+> 该镜像发布到 GHCR 后,本提示连同上面的构建步骤一并删除——届时直接进第 3 步用默认镜像即可。
 
-### 接入你的宿主机 daemon（北极星：复制一条命令）
-1. 浏览器打开 http://127.0.0.1:18080 ，点击登录（mock 登录，无需账号密码）。
-2. 进入设备/运行时管理，点「接入新设备」，填一个设备名，点「生成连接命令」。
-3. 复制弹窗里的**那一条**命令，粘贴到本机另一个终端执行。它会自动下载对应
-   平台的 daemon、就地连接，无需你 chmod、改 PATH 或手动跑 connect。
-4. 弹窗显示「设备已连接」后，即可创建 Agent、跑通一个 issue。
+---
 
-### 关停 / 清理
+## 3 · 一条命令拉起本地栈
+
 ```bash
-docker compose -f docker-compose.local.yml down          # 停止，保留数据卷
-docker compose -f docker-compose.local.yml down -v       # 连数据卷一起删除
+docker compose -f docker-compose.local.yml up -d
+```
+
+首次会拉取/使用 `parsar-server` 镜像、跑数据库迁移、并自动创建第一个工作区(owner = mock 身份 `admin@example.com`)。
+
+**预期:** 三个容器;`parsar-local-server` 与 `parsar-local-postgres` 在约 15 秒内 healthy,`parsar-local-init` 跑完后退出。
+
+**验证:**
+```bash
+docker compose -f docker-compose.local.yml ps
+docker inspect parsar-local-init --format 'init exit={{.State.ExitCode}}'
+# 0;重复 up 时为 2(已 bootstrap,幂等),也正常
+```
+
+命令行快速自检(进浏览器前 30 秒确认整栈通):
+```bash
+B="http://127.0.0.1:${PARSAR_LOCAL_PORT}"
+for p in /healthz /api/v1/health / ; do
+  printf '%-18s -> %s\n' "$p" "$(curl -fsS -o /dev/null -w '%{http_code}' "$B$p")"
+done
+curl -fsS "$B/api/v1/bootstrap/status"; echo
+```
+**预期:**
+```
+/healthz           -> 200
+/api/v1/health     -> 200
+/                  -> 200
+{"needed":false,"has_owners":true,"owner_count":1, ...}
 ```
 
 ---
 
-> 以下是面向 AI agent 的**手动 / 进阶** runbook（基于
-> `deploy/compose/compose.example.yml`，可自定义端口、密钥、bootstrap token、
-> 真实飞书）。只想本机自用，上面的「本地版」一条命令即可，无需继续往下读。
+## 4 · 浏览器 E2E 验收(北极星:接入你的设备)
 
-## Hard rules for the agent
-
-1. **Never invent values.** If something below says "ask the user", ask
-   the user — do not guess a port, a path, an email, or a workspace name.
-2. **Never commit `.env`** — it is already in `.gitignore` and contains
-   real secrets after step 2.
-3. **Never write inside the repo working tree** for runtime state. Use
-   the paths the user picks in step 1; defaults below are
-   `/tmp/parsar-data` + `/tmp/parsar-config` (no sudo, lost on
-   reboot — fine for a quickstart).
-4. **Verify each step before moving on.** Every step has an "Expected"
-   block; if reality doesn't match, run the "If it fails" block before
-   asking the user.
-5. **Print only what helps the user.** Suppress noisy command output
-   except when surfacing a real error.
+1. 浏览器打开 **http://127.0.0.1:18080**(改过端口就用你的端口)。
+2. 点**登录**(界面可能显示「飞书登录」;mock 模式下无需账号密码,直接进)——身份 `admin@example.com`,落在 `Local Workspace`。
+3. 进**设备 / 运行时管理** → 点**「接入新设备」** → 填一个设备名 → 点**「生成连接命令」**。
+4. 复制弹窗里**那一条**命令 → 粘到**本机另一个终端**执行。命令形如:
+   ```bash
+   curl -fsSL http://127.0.0.1:18080/api/v1/parsar-daemon/install.sh \
+     | PARSAR_DAEMON_CONNECT_URL=http://127.0.0.1:18080 \
+       PARSAR_DAEMON_CONNECT_TOKEN=<一次性 token> \
+       PARSAR_DAEMON_CONNECT_DEVICE_NAME=<设备名> bash
+   ```
+   - server 地址由网页按 `PARSAR_PUBLIC_URL` 自动填好,**不用手改**。
+   - 脚本会:从本机 server 下载对应平台 daemon → `chmod` → 后台 `connect`;token 走环境变量,不进命令行 argv,因此不落到 `ps` 输出或访问日志。你**全程不碰二进制、路径、token**。
+5. 几秒后该设备从 `pending_pairing` → **「在线 / online」**。**E2E 通过。**
+   想再确认能干活:建一个 Agent、跑通一个 issue。
 
 ---
 
-## Platform notes — read once, then act
-
-This runbook is tested on **macOS (Docker Desktop)** and **Linux**
-(Ubuntu / Debian / Amazon Linux with `docker-ce`). Windows / WSL2 is
-not tested — assume rough edges.
-
-### macOS
-
-- Docker Desktop must be **running** before step 3 (build) — the daemon
-  is not auto-started on first install. Verify with `docker info` →
-  should print a server section, not just a client section.
-- Default Docker Desktop resource limits (2 CPU / 2 GB RAM) are enough
-  for runtime but may stretch the first build to 8-10 min. If the user
-  later complains about slowness, suggest raising to 4 CPU / 4 GB in
-  Docker Desktop → Settings → Resources.
-- Apple Silicon: the Dockerfile builds `linux/arm64` natively, no
-  emulation needed. If the agent ever sees an `exec format error` at
-  runtime, the image was built on x86 CI and pulled on M-series —
-  rebuild locally with `make docker-build`.
-
-### Linux
-
-- The current shell user **must be in the `docker` group**, otherwise
-  step 3 fails with `permission denied while trying to connect to the
-  Docker daemon socket`. Check with `id -nG | tr ' ' '\n' | grep -x
-  docker`. If missing, instruct the user to run `sudo usermod -aG docker
-  $USER` and **log out and back in** (group membership is per-session).
-- Use `docker compose` (v2 plugin), NOT the standalone `docker-compose`
-  binary. If `docker compose version` errors with `is not a docker
-  command`, install the v2 plugin: `sudo apt-get install
-  docker-compose-plugin` on Debian-family, or follow Docker's official
-  install guide for the distro.
-- SELinux-enabled hosts (RHEL / Rocky / Amazon Linux 2023) may block
-  bind-mounts. If step 4 logs show `Permission denied` reading
-  `init.sql`, append `:Z` to the mount line in the compose file or
-  temporarily `sudo setenforce 0` (re-enable after verifying it was the
-  cause).
-
-### Both
-
-- `lsof` behaves the same on macOS and Linux for the port-check lines
-  below. `sed -i.bak` in step 8 is portable across both (the `.bak`
-  argument is required for BSD sed on macOS, harmless on GNU sed).
-
----
-
-## Prerequisites — check first, before step 1
-
-Run these and report any miss to the user before doing anything else:
+## 5 · 关停 / 清理
 
 ```bash
-docker compose version       # need v2+
-make --version               # any GNU make
-openssl version              # any modern openssl
-command -v curl
-command -v python3           # used by smoke.sh
+docker compose -f docker-compose.local.yml down       # 停,保留数据卷
+docker compose -f docker-compose.local.yml down -v    # 连 Postgres 数据一起删
 ```
-
-Also check ports:
-
-```bash
-lsof -iTCP:8080 -sTCP:LISTEN   # should print nothing
-lsof -iTCP:5432 -sTCP:LISTEN   # should print nothing
-```
-
-If a port is busy, ask the user for an alternative in step 1.
-
-Free disk: image build needs ~3 GB. `df -h .` and warn if free space < 5 GB.
 
 ---
 
-## Step 1 — Ask the user three things
+## 排错
 
-Use your AskUserQuestion (or equivalent) tool. The first two are
-optional; use defaults unless `lsof` above already showed the default
-port is busy.
-
-| Question | Default | When to ask |
+| 现象 | 原因 | 处理 |
 |---|---|---|
-| Host port for parsar web/api? | `8080` | If port 8080 is busy |
-| Host port for postgres? | `5432` | If port 5432 is busy |
-| Where to put runtime data + config? | `/tmp/parsar-data` + `/tmp/parsar-config` (no sudo) | Always — also offer `/var/lib/parsar` + `/etc/parsar` if user wants the install to survive reboot |
+| 接入设备时下载 daemon 报 **404** | 用的 GHCR 镜像不含内置 daemon(尚未发布) | 走第 2 步的本地构建,`export PARSAR_SERVER_IMAGE=parsar:local` 后 `up -d --force-recreate` |
+| 端口报 `address already in use` | 18080 / 15432 被占 | 改 `PARSAR_LOCAL_PORT` / `PARSAR_PG_PORT` 后重新 `up -d` |
+| `server` 崩溃循环 `agent_daemon owner URL not resolvable` | 缺 `PARSAR_AGENT_DAEMON_OWNER_URL`(本地 compose 已设默认 `http://parsar-server:8080`) | 若你改/删过该 env,补回即可 |
+| `server` 一直 unhealthy 但其实能访问 | 镜像内置 HEALTHCHECK 用 HEAD,`/healthz` 仅接受 GET(本地 compose 已覆盖为 GET 探针) | 若你改过 compose,确认 healthcheck 用 GET |
+| 设备在线但创建 Agent 时无可用 kind | 本机 Agent CLI 没装 / 没登录 | 在本机 `claude` / `opencode` / `codex` 登录后,daemon 会自动识别 |
+| macOS `exec format error` | 在 x86 上构建、Apple Silicon 上运行 | 本机 `make docker-build` 重新构建为原生架构 |
 
-Remember the answers; you'll need them in step 2.
-
----
-
-## Step 2 — Prepare directories + `.env`
-
-Substitute the four shell variables at the top with what the user picked
-in step 1.
-
-```bash
-HOST_PORT=8080                            # from step 1, question 1
-PG_HOST_PORT=5432                         # from step 1, question 2
-DATA_DIR=/tmp/parsar-data               # from step 1, question 3
-CONFIG_DIR=/tmp/parsar-config           # from step 1, question 3
-
-mkdir -p "$DATA_DIR" "$CONFIG_DIR"
-cp docs/deploy/config.example.yaml "$CONFIG_DIR/config.yaml"
-cp deploy/compose/.env.example deploy/compose/.env
-
-# Generate secrets fresh — never reuse across machines.
-PG_PASSWORD="$(openssl rand -hex 24)"
-MASTER_KEY="$(openssl rand -hex 32)"
-BOOTSTRAP_TOKEN="$(openssl rand -hex 32)"
-
-python3 - <<PY
-import re
-path = "deploy/compose/.env"
-with open(path) as f: s = f.read()
-subs = {
-    "PARSAR_SERVER_IMAGE":      "parsar:dev",
-    "PARSAR_PUBLIC_URL":        "http://localhost:${HOST_PORT}",
-    "PARSAR_PG_PASSWORD":       "${PG_PASSWORD}",
-    "PARSAR_MASTER_KEY":        "${MASTER_KEY}",
-    "PARSAR_BOOTSTRAP_TOKEN":   "${BOOTSTRAP_TOKEN}",
-    "PARSAR_CONFIG_HOST_PATH":  "${CONFIG_DIR}/config.yaml",
-    "PARSAR_DATA_HOST_PATH":    "${DATA_DIR}",
-    "PARSAR_HOST_PORT":         "${HOST_PORT}",
-    "PARSAR_PG_HOST_PORT":      "${PG_HOST_PORT}",
-}
-for k, v in subs.items():
-    s = re.sub(rf"^{re.escape(k)}=.*", f"{k}={v}", s, flags=re.M)
-with open(path, "w") as f: f.write(s)
-print("OK")
-PY
-```
-
-**Verify:**
-
-```bash
-grep -E "PARSAR_SERVER_IMAGE|PARSAR_PUBLIC_URL|PARSAR_PG_PASSWORD|PARSAR_MASTER_KEY|PARSAR_BOOTSTRAP_TOKEN|PARSAR_CONFIG_HOST_PATH|PARSAR_DATA_HOST_PATH|PARSAR_HOST_PORT|PARSAR_PG_HOST_PORT" deploy/compose/.env
-```
-
-**Expected:** every variable shows a real value (not `<placeholder>`).
-`PARSAR_FEISHU_MOCK=true` should also be present — it's the default in
-the example file. **If it isn't**, add the line manually:
-
-```bash
-echo "PARSAR_FEISHU_MOCK=true" >> deploy/compose/.env
-```
+查看日志:`docker logs -f parsar-local-server`
 
 ---
 
-## Step 3 — Build the server image
+## TL;DR
 
 ```bash
-make docker-build PARSAR_IMAGE=parsar PARSAR_IMAGE_TAG=dev
+git clone <repo> parsar && cd parsar && git checkout feature/deliverables-design
+export PARSAR_LOCAL_PORT=18080 PARSAR_PG_PORT=15432
+# 当前阶段(GHCR 尚无内置 daemon 镜像)→ 本地构建;发布后这两行可删,直接用默认镜像
+make docker-build PARSAR_IMAGE=parsar PARSAR_IMAGE_TAG=local
+export PARSAR_SERVER_IMAGE=parsar:local
+docker compose -f docker-compose.local.yml up -d
+# 浏览器 http://127.0.0.1:18080 → 登录 → 接入新设备 → 复制命令 → 另一个终端跑 → 设备在线
 ```
-
-**Expected:** 5-10 min on first build. Ends with a line like
-`naming to docker.io/library/parsar:dev`.
-
-**If it fails:**
-
-| Symptom | Cause | Fix |
-|---|---|---|
-| `Cannot connect to the Docker daemon` | docker engine not running | Start Docker Desktop / `systemctl start docker`; retry |
-| `no space left on device` | docker disk full | `docker system prune -af`; retry |
-| `pnpm install` or `apt-get` network timeout | DNS / VPN issue | Wait, retry; layer cache means it picks up where it stopped |
-| `ERROR: failed to solve: ... port is already allocated` | unrelated build artifact | `docker ps -a | grep parsar` then `docker rm -f` any leftovers; retry |
-| `denied: requested access to the resource is denied` | trying to pull from a private registry | This shouldn't happen on a clean clone; check if user fiddled with `Dockerfile` or `compose.example.yml` |
-
-After the build, verify the image exists:
-
-```bash
-docker image inspect parsar:dev --format '{{.Id}}'    # any sha256: line is fine
-```
-
----
-
-## Step 4 — Postgres up + healthy
-
-```bash
-docker compose -f deploy/compose/compose.example.yml --env-file deploy/compose/.env up -d postgres
-sleep 6
-docker compose -f deploy/compose/compose.example.yml --env-file deploy/compose/.env ps postgres
-```
-
-**Expected:** the `STATUS` column shows `Up X seconds (healthy)`.
-
-**If unhealthy:**
-
-```bash
-docker compose -f deploy/compose/compose.example.yml --env-file deploy/compose/.env logs postgres | tail -30
-```
-
-| Log says | Fix |
-|---|---|
-| `FATAL: password authentication failed` | leftover volume from a previous run with a different password. `docker compose ... down -v` then re-run step 4. **This deletes any old data — confirm with user first.** |
-| `could not bind IPv4 address` | the host port from step 1 is busy. Pick a different `PARSAR_PG_HOST_PORT`, re-run step 2 substitution, re-run step 4. |
-| keeps restarting with no obvious error | give it 30 more seconds; alpine postgres init can be slow on first run. |
-
----
-
-## Step 5 — Run the schema migration
-
-```bash
-docker compose -f deploy/compose/compose.example.yml --env-file deploy/compose/.env run --rm parsar-server parsar-migrate
-```
-
-**Expected:** exit code 0. May print nothing (idempotent — if schema is
-already there, no output).
-
-**Verify:**
-
-```bash
-docker exec parsar-postgres psql -U parsar -d parsar -c '\dt' | grep -c "^ public"
-```
-
-**Expected:** `30` (thirty tables created).
-
-**If 0 tables:** migration silently failed.
-
-```bash
-docker compose -f deploy/compose/compose.example.yml --env-file deploy/compose/.env run --rm parsar-server parsar-migrate 2>&1
-```
-
-Read the output. If it mentions `dial tcp ... connect: connection
-refused`, postgres isn't reachable from the run container — re-check
-step 4 status, then retry step 5.
-
----
-
-## Step 6 — Server up + healthy
-
-```bash
-docker compose -f deploy/compose/compose.example.yml --env-file deploy/compose/.env up -d parsar-server
-sleep 8
-docker compose -f deploy/compose/compose.example.yml --env-file deploy/compose/.env ps parsar-server
-```
-
-**Expected:** `STATUS` shows `Up X seconds (healthy)`.
-
-**If `Restarting (1) X seconds ago`:**
-
-```bash
-docker logs parsar-server 2>&1 | tail -30
-```
-
-| Log says | Fix |
-|---|---|
-| `PARSAR_FEISHU_APP_ID/APP_SECRET/REDIRECT_URI ... required when not in mock mode` | `PARSAR_FEISHU_MOCK=true` is missing or set to false. Edit `deploy/compose/.env`, re-run step 6 with `--force-recreate`. |
-| `agent_daemon owner URL not resolvable` | `PARSAR_AGENT_DAEMON_OWNER_URL` not transparent to the container. `grep PARSAR_AGENT_DAEMON_OWNER_URL deploy/compose/.env` — if empty, leave empty (compose has a `:-http://parsar-server:8080` default that should engage). If still failing, set explicitly: `echo "PARSAR_AGENT_DAEMON_OWNER_URL=http://parsar-server:8080" >> deploy/compose/.env`, then re-run step 6 with `--force-recreate`. |
-| `create workspace: ERROR: ... visibility_check` | You're on an outdated branch missing stage 2 fixup #2. `git pull origin main` then redo step 3+ from scratch. |
-| `PARSAR_MASTER_KEY is required for secrets` | step 2's substitution didn't land. Re-run step 2's python block. |
-| anything else | give the user the last 30 log lines verbatim and stop. |
-
-After fixing, re-run step 6 with `--force-recreate parsar-server`.
-
----
-
-## Step 7 — Smoke test (proves the whole chain works)
-
-```bash
-BOOT_TOKEN="$(grep '^PARSAR_BOOTSTRAP_TOKEN=' deploy/compose/.env | cut -d= -f2)"
-HOST_PORT="$(grep '^PARSAR_HOST_PORT=' deploy/compose/.env | cut -d= -f2)"
-bash scripts/smoke.sh --core \
-  --api-url "http://localhost:${HOST_PORT}" \
-  --bootstrap-token "$BOOT_TOKEN"
-```
-
-**Expected:** last line `[smoke] all required probes passed`, summary
-`pass=8 fail=0 skip=1`. The 1 SKIP is `runtime_chain` — a known limit
-of the unauthenticated smoke surface, not a deployment failure.
-
-**If any `FAIL`:** the smoke script prints the exact endpoint, HTTP
-status, and response body. Fix the root cause it points to, then re-run.
-
----
-
-## Step 8 — Close the bootstrap door
-
-The bootstrap token is a one-shot owner-provision credential. Once
-step 7 proved the chain works (and provisioned the first owner),
-remove it from `.env` and restart the server so the door latches shut.
-
-```bash
-sed -i.bak 's/^PARSAR_BOOTSTRAP_TOKEN=.*/PARSAR_BOOTSTRAP_TOKEN=/' deploy/compose/.env
-rm -f deploy/compose/.env.bak
-docker compose -f deploy/compose/compose.example.yml --env-file deploy/compose/.env up -d --force-recreate parsar-server
-sleep 6
-```
-
-**Verify:**
-
-```bash
-curl -s http://localhost:"$HOST_PORT"/api/v1/bootstrap/status
-```
-
-**Expected:** JSON with `"http_enabled":false`.
-
----
-
-## Step 9 — Report success to the user
-
-Tell the user (use these exact words; substitute `$HOST_PORT`):
-
-> Done. Open http://localhost:$HOST_PORT in your browser, click 「飞书登录」,
-> and you'll be logged in as `admin@example.com` (mock auth — anyone hitting
-> this endpoint becomes the same user, fine for local poking).
->
-> Useful follow-up commands:
->
-> - View logs:   `docker logs -f parsar-server`
-> - Stop:        `docker compose -f deploy/compose/compose.example.yml --env-file deploy/compose/.env down`
-> - Wipe data:   add `-v` to the down command above (deletes the postgres volume)
-> - Rebuild + redeploy after code change:
->     `make docker-build && docker compose -f deploy/compose/compose.example.yml --env-file deploy/compose/.env up -d --force-recreate`
->
-> To go to production: see `docs/deploy/feishu-prod.md` for registering a
-> real Feishu OAuth app, then set `PARSAR_FEISHU_MOCK=false` and fill the
-> four `PARSAR_FEISHU_*` variables.
-
----
-
-## Self-check for the agent
-
-Before declaring "done", confirm all of these:
-
-- [ ] `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:$HOST_PORT/healthz` → `200`
-- [ ] `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:$HOST_PORT/api/v1/health` → `200`
-- [ ] `curl -s -o /dev/null -w "%{http_code}\n" http://localhost:$HOST_PORT/` → `200` (SPA)
-- [ ] `curl -s http://localhost:$HOST_PORT/api/v1/bootstrap/status` returns JSON with `"has_owners":true`
-- [ ] `deploy/compose/.env` exists, is `git status`-clean (covered by `.gitignore`), and `PARSAR_BOOTSTRAP_TOKEN=` is empty
-
-If any check fails, do not tell the user "done" — diagnose and fix
-first, or hand the user a verbatim error.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,6 +13,47 @@
 
 ---
 
+## 本地版（Local）—— 一条命令在本机跑起来
+
+面向单个开发者自用，all-in-one，mock 登录开箱即用，无需配置飞书或任何密钥。
+
+### 前置
+- 已安装 Docker（含 `docker compose`）。
+- 本机至少装好一个 Agent CLI 并完成登录：Claude Code、OpenCode 或 Codex 之一。
+  daemon 会复用它的登录态与订阅，并看见你本机真实的仓库。
+
+### 启动
+```bash
+docker compose -f docker-compose.local.yml up
+```
+首次启动会拉取 `parsar-server` 镜像、跑数据库迁移、并自动创建第一个工作区
+（owner = mock 身份 `admin@example.com`）。
+
+> 镜像尚未发布、或想跑你本地改动时，先本地构建再覆盖镜像变量：
+> ```bash
+> make docker-build PARSAR_IMAGE=parsar PARSAR_IMAGE_TAG=local
+> PARSAR_SERVER_IMAGE=parsar:local docker compose -f docker-compose.local.yml up
+> ```
+
+### 接入你的宿主机 daemon（北极星：复制一条命令）
+1. 浏览器打开 http://127.0.0.1:18080 ，点击登录（mock 登录，无需账号密码）。
+2. 进入设备/运行时管理，点「接入新设备」，填一个设备名，点「生成连接命令」。
+3. 复制弹窗里的**那一条**命令，粘贴到本机另一个终端执行。它会自动下载对应
+   平台的 daemon、就地连接，无需你 chmod、改 PATH 或手动跑 connect。
+4. 弹窗显示「设备已连接」后，即可创建 Agent、跑通一个 issue。
+
+### 关停 / 清理
+```bash
+docker compose -f docker-compose.local.yml down          # 停止，保留数据卷
+docker compose -f docker-compose.local.yml down -v       # 连数据卷一起删除
+```
+
+---
+
+> 以下是面向 AI agent 的**手动 / 进阶** runbook（基于
+> `deploy/compose/compose.example.yml`，可自定义端口、密钥、bootstrap token、
+> 真实飞书）。只想本机自用，上面的「本地版」一条命令即可，无需继续往下读。
+
 ## Hard rules for the agent
 
 1. **Never invent values.** If something below says "ask the user", ask

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,7 +78,7 @@ docker compose -f docker-compose.local.yml up -d
 ```bash
 docker compose -f docker-compose.local.yml ps
 docker inspect parsar-local-init --format 'init exit={{.State.ExitCode}}'
-# 0;重复 up 时为 2(已 bootstrap,幂等),也正常
+# 预期 0;重复 up 仍是 0(已 bootstrap 时 parsar-bootstrap 退 2,compose 用 `|| [ $? -eq 2 ]` 收敛为 0)
 ```
 
 命令行快速自检(进浏览器前 30 秒确认整栈通):

--- a/apps/web/src/components/admin/PairDaemonDialog.tsx
+++ b/apps/web/src/components/admin/PairDaemonDialog.tsx
@@ -160,35 +160,24 @@ export function PairDaemonDialog({
         ) : (
           <div className="space-y-3">
             <p className="text-[12px] text-emerald-700">
-              {t("runtime.agentDaemon.pair.success", {
-                defaultValue: "请在 {{name}} 上依次执行下列两条命令:",
+              {t("runtime.agentDaemon.pair.successOneLine", {
+                defaultValue:
+                  "在 {{name}} 上执行这一条命令即可连接（自动下载并连接,无需手动安装二进制):",
                 name: result.runtimeName,
               })}
             </p>
-            <div className="space-y-2">
-              <DaemonCommandBlock
-                command={buildInstallCommand()}
-                label={t("runtime.agentDaemon.pair.installLabel", {
-                  defaultValue: "1. 安装 parsar-daemon",
-                })}
-                description={t("runtime.agentDaemon.pair.installHint", {
-                  defaultValue: "安装到 ~/.local/bin；不写系统目录、不需要 sudo",
-                })}
-                onCopy={copyToClipboard}
-                testId="agent-daemon-pair-copy-install"
-              />
-              <DaemonCommandBlock
-                command={buildConnectCommand(result.token, result.runtimeName)}
-                label={t("runtime.agentDaemon.pair.connectLabel", {
-                  defaultValue: "2. 连接 Parsar",
-                })}
-                description={t("runtime.agentDaemon.pair.connectHint", {
-                  defaultValue: "成功后这台设备会变为「在线」,可在创建 Agent 时被选中",
-                })}
-                onCopy={copyToClipboard}
-                testId="agent-daemon-pair-copy-connect"
-              />
-            </div>
+            <DaemonCommandBlock
+              command={buildOneLineCommand(result.token, result.runtimeName)}
+              label={t("runtime.agentDaemon.pair.oneLineLabel", {
+                defaultValue: "复制并在目标机器上运行",
+              })}
+              description={t("runtime.agentDaemon.pair.oneLineHint", {
+                defaultValue:
+                  "目标机器需已安装 Claude Code / OpenCode / Codex 之一;成功后这台设备会变为「在线」",
+              })}
+              onCopy={copyToClipboard}
+              testId="agent-daemon-pair-copy-oneline"
+            />
             <div className="flex items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[12px]">
               {connected ? (
                 <>
@@ -257,16 +246,23 @@ function DaemonCommandBlock({
   )
 }
 
-// Download only. Chmod / install path is left to the user — managed
-// laptops often forbid writes to /usr/local/bin.
-function buildInstallCommand(): string {
+// Single command the operator pastes on the target machine: download via
+// the server's install endpoint, then connect — all in one pipe. Pairing
+// inputs ride as env vars (NOT a URL query string and NOT connect flags)
+// so the one-shot token never lands in server/proxy access logs or `ps`
+// output: `connect` hydrates these same vars and scrubs them from child
+// argv (see apps/parsar-daemon/internal/cli/connect.go). The piped
+// install script chmods the binary and execs `connect -b`, so the
+// operator never sees the binary, its path, or the token.
+function buildOneLineCommand(token: string, deviceName: string): string {
   const origin = serverOrigin()
-  return `curl -fsSL ${origin}/api/v1/parsar-daemon/install.sh | bash`
-}
-
-function buildConnectCommand(token: string, deviceName: string): string {
-  const origin = serverOrigin()
-  return `parsar-daemon connect --url ${origin} --token ${token} --device-name ${shellEscape(deviceName)} -b`
+  return [
+    `curl -fsSL ${origin}/api/v1/parsar-daemon/install.sh |`,
+    `PARSAR_DAEMON_CONNECT_URL=${origin}`,
+    `PARSAR_DAEMON_CONNECT_TOKEN=${token}`,
+    `PARSAR_DAEMON_CONNECT_DEVICE_NAME=${shellEscape(deviceName)}`,
+    `bash`,
+  ].join(" ")
 }
 
 function serverOrigin(): string {

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -92,14 +92,34 @@ services:
       # callbacks AND the minted one-line connect command line up. Kept in
       # sync with the published port via the same variable.
       PARSAR_PUBLIC_URL: "http://127.0.0.1:${PARSAR_LOCAL_PORT:-18080}"
+      # Inter-pod owner-routing URL. The server refuses to boot until this
+      # resolves (no fallback to PublicURL/127.0.0.1, which are unsafe under
+      # multi-replica load balancing — see resolveAgentDaemonOwnerURL in
+      # server/cmd/server/main.go). On this single-node stack the owner is
+      # always THIS server, so the URL is stamped but never dialed for
+      # forwarding; it just has to point back here on the compose network.
+      # Same service-name default the self-host compose uses (profile not
+      # fork) — `parsar-server` is this service's network alias.
+      PARSAR_AGENT_DAEMON_OWNER_URL: "http://parsar-server:8080"
       # NOTE: deliberately NOT setting PARSAR_MASTER_KEY. In ProfileDev the
       # server auto-seeds the dev master key (parsar-dev-master-key-2026),
       # which the web admin UI hardcodes (apps/web/src/lib/api-models.ts
       # DEV_MASTER_KEY). Overriding it here would desync the two.
     volumes:
       - parsar-local-data:/var/lib/parsar
-    # parsar-server image ships its own HEALTHCHECK (wget /healthz); no
-    # service depends on its health so no compose-level probe is needed.
+    # The image's baked-in HEALTHCHECK probes /healthz with `wget --spider`
+    # (an HTTP HEAD), but /healthz is GET-only and answers HEAD with 405 —
+    # so the default probe reports the container "unhealthy" even though it
+    # serves fine. Override with the same GET probe the self-host compose
+    # uses (deploy/compose/compose.example.yml) — profile not fork.
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - wget -qO- --tries=1 --timeout=3 http://127.0.0.1:8080/healthz >/dev/null
+      interval: 10s
+      timeout: 3s
+      start_period: 15s
+      retries: 3
 
 volumes:
   parsar-local-pg:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,106 @@
+# Parsar 本地版 (local all-in-one) — Phase 1 deliverable.
+#
+# One command, single machine, zero secrets to generate:
+#
+#   docker compose -f docker-compose.local.yml up
+#
+# Brings up Postgres + a one-shot init (migrate + first-owner bootstrap) +
+# parsar-server with mock auth. Open http://127.0.0.1:18080, click
+# 「接入新设备」, copy the single command, run it on THIS host, and your
+# local Claude Code / OpenCode / Codex login is paired in.
+#
+# Profile not fork: this is the SAME image as the self-host deployment
+# (deploy/compose/compose.example.yml). Differences live only in this file
+# + the env values below. No separate "local" binary or image.
+#
+# Image source:
+#   - Default: GHCR prebuilt image (PARSAR_SERVER_IMAGE below).
+#   - Local build fallback (before the tag is published, or to test your
+#     own changes):
+#       make docker-build PARSAR_IMAGE=parsar PARSAR_IMAGE_TAG=local
+#       PARSAR_SERVER_IMAGE=parsar:local docker compose -f docker-compose.local.yml up
+#
+# Override knobs (all optional — defaults make `up` work with no .env):
+#   PARSAR_SERVER_IMAGE   server image ref (default: GHCR latest)
+#   PARSAR_LOCAL_PORT     host port for the web UI (default: 18080)
+#   PARSAR_PG_PORT        host port for Postgres (default: 15432)
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: parsar-local-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: parsar
+      POSTGRES_PASSWORD: parsar
+      POSTGRES_DB: parsar
+    ports:
+      - "127.0.0.1:${PARSAR_PG_PORT:-15432}:5432"
+    volumes:
+      - parsar-local-pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U parsar -d parsar"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+
+  # One-shot: run migrations, then provision the first owner as the mock
+  # identity (admin@example.com — see server/internal/auth/feishu/mock.go)
+  # so the very first mock login lands in a ready workspace. Tolerates
+  # exit code 2 (store.ErrBootstrapClosed) so re-running `up` is idempotent.
+  # Binaries live on $PATH at /usr/local/bin (WORKDIR is /var/lib/parsar),
+  # so they are invoked by bare name, NOT ./parsar-migrate.
+  parsar-init:
+    image: ${PARSAR_SERVER_IMAGE:-ghcr.io/MiniMax-ai-dev/parsar-server:latest}
+    container_name: parsar-local-init
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://parsar:parsar@postgres:5432/parsar?sslmode=disable
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        set -e
+        parsar-migrate
+        parsar-bootstrap \
+          --email=admin@example.com \
+          --workspace="Local Workspace" \
+          --name="Local Admin" \
+        || [ "$$?" -eq 2 ]
+    restart: "no"
+
+  parsar-server:
+    image: ${PARSAR_SERVER_IMAGE:-ghcr.io/MiniMax-ai-dev/parsar-server:latest}
+    container_name: parsar-local-server
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      parsar-init:
+        condition: service_completed_successfully
+    ports:
+      - "127.0.0.1:${PARSAR_LOCAL_PORT:-18080}:8080"
+    environment:
+      DATABASE_URL: postgres://parsar:parsar@postgres:5432/parsar?sslmode=disable
+      # Mock auth -> ProfileDev: full cookie login as admin@example.com with
+      # no IdP. (PARSAR_DEV_AUTH stays unset: we want real cookie login, not
+      # the header bypass.)
+      PARSAR_FEISHU_MOCK: "true"
+      # Public URL must match the host port the browser hits so OAuth
+      # callbacks AND the minted one-line connect command line up. Kept in
+      # sync with the published port via the same variable.
+      PARSAR_PUBLIC_URL: "http://127.0.0.1:${PARSAR_LOCAL_PORT:-18080}"
+      # NOTE: deliberately NOT setting PARSAR_MASTER_KEY. In ProfileDev the
+      # server auto-seeds the dev master key (parsar-dev-master-key-2026),
+      # which the web admin UI hardcodes (apps/web/src/lib/api-models.ts
+      # DEV_MASTER_KEY). Overriding it here would desync the two.
+    volumes:
+      - parsar-local-data:/var/lib/parsar
+    # parsar-server image ships its own HEALTHCHECK (wget /healthz); no
+    # service depends on its health so no compose-level probe is needed.
+
+volumes:
+  parsar-local-pg:
+  parsar-local-data:

--- a/scripts/install-parsar-daemon.sh
+++ b/scripts/install-parsar-daemon.sh
@@ -20,6 +20,12 @@
 #   curl -fsSL .../install.sh | PARSAR_DAEMON_VERSION=v0.1.0 bash
 #   curl -fsSL .../install.sh | PARSAR_DAEMON_REPO=your-org/your-fork bash
 #
+#   # One-line connect (what the Parsar web UI mints — never run by hand):
+#   curl -fsSL .../install.sh \
+#     | PARSAR_DAEMON_CONNECT_URL=https://<server> \
+#       PARSAR_DAEMON_CONNECT_TOKEN=<one-shot> \
+#       PARSAR_DAEMON_CONNECT_DEVICE_NAME=<name> bash
+#
 # Exit codes: 0 on success, non-zero on any error (set -e).
 
 set -euo pipefail
@@ -84,6 +90,36 @@ ERR
 fi
 
 printf 'Downloaded to %s\n' "$OUT_FILE"
+
+# --- One-line connect mode (north star) -------------------------------
+# When the Parsar web "接入新设备 / copy one command" button mints a
+# command, it pipes this script with the pairing env vars set:
+#
+#   curl -fsSL .../install.sh \
+#     | PARSAR_DAEMON_CONNECT_URL=<server> \
+#       PARSAR_DAEMON_CONNECT_TOKEN=<one-shot-token> \
+#       PARSAR_DAEMON_CONNECT_DEVICE_NAME=<name> bash
+#
+# In that mode we finish the job: chmod the freshly-downloaded binary and
+# hand off to `connect`, so the operator never touches the binary, its
+# path, or the token. `connect` hydrates URL/token/device-name from these
+# same env vars and scrubs them from child argv, so the one-shot token
+# never appears in any process listing. `exec` replaces this shell; the
+# `-b` flag then re-spawns the daemon detached and returns.
+#
+# Without PARSAR_DAEMON_CONNECT_TOKEN we fall through to the download-only
+# enterprise posture below (no chmod, no $PATH changes) — same script,
+# behaviour gated purely on env. Profile-not-fork applied to the installer.
+if [ -n "${PARSAR_DAEMON_CONNECT_TOKEN:-}" ]; then
+  if [ -z "${PARSAR_DAEMON_CONNECT_URL:-}" ]; then
+    echo "parsar-daemon: PARSAR_DAEMON_CONNECT_TOKEN is set but PARSAR_DAEMON_CONNECT_URL is empty" >&2
+    exit 1
+  fi
+  printf 'Pairing this device with %s ...\n' "$PARSAR_DAEMON_CONNECT_URL"
+  chmod +x "$OUT_FILE"
+  exec "$OUT_FILE" connect -b
+fi
+
 printf 'Parsar does not install or chmod this file. Review it, then move/install it according to your machine policy:\n'
 printf '  chmod +x %s\n' "$OUT_FILE"
 printf '  mv %s /usr/local/bin/parsar-daemon   # or any directory on your $PATH\n' "$OUT_FILE"

--- a/scripts/install-parsar-daemon.sh
+++ b/scripts/install-parsar-daemon.sh
@@ -54,31 +54,59 @@ case "$ARCH" in
   *) echo "parsar-daemon: unsupported architecture '${ARCH}'" >&2; exit 1 ;;
 esac
 
-if [ -z "$VERSION" ]; then
-  echo "Resolving latest parsar-daemon release from github.com/${REPO}..."
-  # GitHub redirects /releases/latest to /releases/tag/<tag>; capture
-  # the final URL and strip the tag suffix. -sIL follows redirects with
-  # HEAD requests so we don't pull the whole release page.
-  LATEST_URL="$(curl -fsILo /dev/null -w '%{url_effective}' \
-    "https://github.com/${REPO}/releases/latest")"
-  VERSION="${LATEST_URL##*/tag/}"
-  if [ -z "$VERSION" ] || [ "$VERSION" = "$LATEST_URL" ]; then
-    echo "parsar-daemon: could not resolve latest release tag from ${LATEST_URL}" >&2
-    exit 1
+# --- Prefer the minting server's own binary (local / self-host) -------
+# The one-line connect command the web UI mints always exports
+# PARSAR_DAEMON_CONNECT_URL=<this server's origin>, and that same server
+# bakes the cross-compiled daemons into its image and serves them at
+# /api/v1/parsar-daemon/download. Trying there first lets a pure-local or
+# air-gapped self-host install succeed with no published GitHub Release.
+# If the server has no binary for this platform (404) we fall through to
+# the GitHub Releases path below — same script, source chosen purely on
+# what is reachable.
+SERVED_LOCALLY=""
+SERVER_ORIGIN="${PARSAR_DAEMON_CONNECT_URL:-}"
+if [ -n "$SERVER_ORIGIN" ]; then
+  SERVER_ORIGIN="${SERVER_ORIGIN%/}"
+  OUT_FILE="${OUT_DIR}/parsar-daemon-${OS}-${ARCH}"
+  echo "Fetching parsar-daemon for ${OS}/${ARCH} from ${SERVER_ORIGIN}..."
+  mkdir -p "$OUT_DIR"
+  if curl -fL "${SERVER_ORIGIN}/api/v1/parsar-daemon/download?os=${OS}&arch=${ARCH}" -o "$OUT_FILE"; then
+    printf 'Downloaded to %s\n' "$OUT_FILE"
+    SERVED_LOCALLY=1
+  else
+    echo "Parsar server has no prebuilt binary for ${OS}/${ARCH}; falling back to GitHub Releases." >&2
+    rm -f "$OUT_FILE"
   fi
 fi
 
-# Strip the `parsar-daemon-` prefix the release workflow stamps onto the
-# binary filename (parsar-daemon-release.yml `OUTPUT=parsar-daemon-${VERSION}-${GOOS}-${GOARCH}`).
-BARE_VERSION="${VERSION#parsar-daemon-}"
-BINARY="parsar-daemon-${BARE_VERSION}-${OS}-${ARCH}"
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}"
-OUT_FILE="${OUT_DIR}/${BINARY}"
+# GitHub Releases path — used for managed-laptop installs (no connect URL)
+# and whenever the minting server did not serve a binary above.
+if [ -z "$SERVED_LOCALLY" ]; then
+  if [ -z "$VERSION" ]; then
+    echo "Resolving latest parsar-daemon release from github.com/${REPO}..."
+    # GitHub redirects /releases/latest to /releases/tag/<tag>; capture
+    # the final URL and strip the tag suffix. -sIL follows redirects with
+    # HEAD requests so we don't pull the whole release page.
+    LATEST_URL="$(curl -fsILo /dev/null -w '%{url_effective}' \
+      "https://github.com/${REPO}/releases/latest")"
+    VERSION="${LATEST_URL##*/tag/}"
+    if [ -z "$VERSION" ] || [ "$VERSION" = "$LATEST_URL" ]; then
+      echo "parsar-daemon: could not resolve latest release tag from ${LATEST_URL}" >&2
+      exit 1
+    fi
+  fi
 
-echo "Downloading ${BINARY} from ${DOWNLOAD_URL}..."
-mkdir -p "$OUT_DIR"
-if ! curl -fL "$DOWNLOAD_URL" -o "$OUT_FILE"; then
-  cat >&2 <<ERR
+  # Strip the `parsar-daemon-` prefix the release workflow stamps onto the
+  # binary filename (parsar-daemon-release.yml `OUTPUT=parsar-daemon-${VERSION}-${GOOS}-${GOARCH}`).
+  BARE_VERSION="${VERSION#parsar-daemon-}"
+  BINARY="parsar-daemon-${BARE_VERSION}-${OS}-${ARCH}"
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}"
+  OUT_FILE="${OUT_DIR}/${BINARY}"
+
+  echo "Downloading ${BINARY} from ${DOWNLOAD_URL}..."
+  mkdir -p "$OUT_DIR"
+  if ! curl -fL "$DOWNLOAD_URL" -o "$OUT_FILE"; then
+    cat >&2 <<ERR
 
 parsar-daemon: download failed.
 URL: ${DOWNLOAD_URL}
@@ -86,10 +114,11 @@ URL: ${DOWNLOAD_URL}
 If the release tag does not exist, override with PARSAR_DAEMON_VERSION.
 If you forked the repo, override with PARSAR_DAEMON_REPO=<owner>/<name>.
 ERR
-  exit 1
-fi
+    exit 1
+  fi
 
-printf 'Downloaded to %s\n' "$OUT_FILE"
+  printf 'Downloaded to %s\n' "$OUT_FILE"
+fi
 
 # --- One-line connect mode (north star) -------------------------------
 # When the Parsar web "接入新设备 / copy one command" button mints a

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -217,6 +217,9 @@ func main() {
 	api.RegisterParsarDaemonInstallRoute(r, api.ParsarDaemonInstallConfig{
 		Repo: strings.TrimSpace(os.Getenv("PARSAR_DAEMON_REPO")),
 	})
+	api.RegisterParsarDaemonDownloadRoute(r, api.ParsarDaemonDownloadConfig{
+		BinaryDir: strings.TrimSpace(os.Getenv("PARSAR_DAEMON_BINARY_DIR")),
+	})
 
 	// Bootstrap (first-owner provisioning) mounts OUTSIDE the auth
 	// middleware because no user exists yet to log in. Token-gated

--- a/server/internal/api/install_parsar_daemon.sh
+++ b/server/internal/api/install_parsar_daemon.sh
@@ -20,6 +20,12 @@
 #   curl -fsSL .../install.sh | PARSAR_DAEMON_VERSION=v0.1.0 bash
 #   curl -fsSL .../install.sh | PARSAR_DAEMON_REPO=your-org/your-fork bash
 #
+#   # One-line connect (what the Parsar web UI mints — never run by hand):
+#   curl -fsSL .../install.sh \
+#     | PARSAR_DAEMON_CONNECT_URL=https://<server> \
+#       PARSAR_DAEMON_CONNECT_TOKEN=<one-shot> \
+#       PARSAR_DAEMON_CONNECT_DEVICE_NAME=<name> bash
+#
 # Exit codes: 0 on success, non-zero on any error (set -e).
 
 set -euo pipefail
@@ -84,6 +90,36 @@ ERR
 fi
 
 printf 'Downloaded to %s\n' "$OUT_FILE"
+
+# --- One-line connect mode (north star) -------------------------------
+# When the Parsar web "接入新设备 / copy one command" button mints a
+# command, it pipes this script with the pairing env vars set:
+#
+#   curl -fsSL .../install.sh \
+#     | PARSAR_DAEMON_CONNECT_URL=<server> \
+#       PARSAR_DAEMON_CONNECT_TOKEN=<one-shot-token> \
+#       PARSAR_DAEMON_CONNECT_DEVICE_NAME=<name> bash
+#
+# In that mode we finish the job: chmod the freshly-downloaded binary and
+# hand off to `connect`, so the operator never touches the binary, its
+# path, or the token. `connect` hydrates URL/token/device-name from these
+# same env vars and scrubs them from child argv, so the one-shot token
+# never appears in any process listing. `exec` replaces this shell; the
+# `-b` flag then re-spawns the daemon detached and returns.
+#
+# Without PARSAR_DAEMON_CONNECT_TOKEN we fall through to the download-only
+# enterprise posture below (no chmod, no $PATH changes) — same script,
+# behaviour gated purely on env. Profile-not-fork applied to the installer.
+if [ -n "${PARSAR_DAEMON_CONNECT_TOKEN:-}" ]; then
+  if [ -z "${PARSAR_DAEMON_CONNECT_URL:-}" ]; then
+    echo "parsar-daemon: PARSAR_DAEMON_CONNECT_TOKEN is set but PARSAR_DAEMON_CONNECT_URL is empty" >&2
+    exit 1
+  fi
+  printf 'Pairing this device with %s ...\n' "$PARSAR_DAEMON_CONNECT_URL"
+  chmod +x "$OUT_FILE"
+  exec "$OUT_FILE" connect -b
+fi
+
 printf 'Parsar does not install or chmod this file. Review it, then move/install it according to your machine policy:\n'
 printf '  chmod +x %s\n' "$OUT_FILE"
 printf '  mv %s /usr/local/bin/parsar-daemon   # or any directory on your $PATH\n' "$OUT_FILE"

--- a/server/internal/api/install_parsar_daemon.sh
+++ b/server/internal/api/install_parsar_daemon.sh
@@ -54,31 +54,59 @@ case "$ARCH" in
   *) echo "parsar-daemon: unsupported architecture '${ARCH}'" >&2; exit 1 ;;
 esac
 
-if [ -z "$VERSION" ]; then
-  echo "Resolving latest parsar-daemon release from github.com/${REPO}..."
-  # GitHub redirects /releases/latest to /releases/tag/<tag>; capture
-  # the final URL and strip the tag suffix. -sIL follows redirects with
-  # HEAD requests so we don't pull the whole release page.
-  LATEST_URL="$(curl -fsILo /dev/null -w '%{url_effective}' \
-    "https://github.com/${REPO}/releases/latest")"
-  VERSION="${LATEST_URL##*/tag/}"
-  if [ -z "$VERSION" ] || [ "$VERSION" = "$LATEST_URL" ]; then
-    echo "parsar-daemon: could not resolve latest release tag from ${LATEST_URL}" >&2
-    exit 1
+# --- Prefer the minting server's own binary (local / self-host) -------
+# The one-line connect command the web UI mints always exports
+# PARSAR_DAEMON_CONNECT_URL=<this server's origin>, and that same server
+# bakes the cross-compiled daemons into its image and serves them at
+# /api/v1/parsar-daemon/download. Trying there first lets a pure-local or
+# air-gapped self-host install succeed with no published GitHub Release.
+# If the server has no binary for this platform (404) we fall through to
+# the GitHub Releases path below — same script, source chosen purely on
+# what is reachable.
+SERVED_LOCALLY=""
+SERVER_ORIGIN="${PARSAR_DAEMON_CONNECT_URL:-}"
+if [ -n "$SERVER_ORIGIN" ]; then
+  SERVER_ORIGIN="${SERVER_ORIGIN%/}"
+  OUT_FILE="${OUT_DIR}/parsar-daemon-${OS}-${ARCH}"
+  echo "Fetching parsar-daemon for ${OS}/${ARCH} from ${SERVER_ORIGIN}..."
+  mkdir -p "$OUT_DIR"
+  if curl -fL "${SERVER_ORIGIN}/api/v1/parsar-daemon/download?os=${OS}&arch=${ARCH}" -o "$OUT_FILE"; then
+    printf 'Downloaded to %s\n' "$OUT_FILE"
+    SERVED_LOCALLY=1
+  else
+    echo "Parsar server has no prebuilt binary for ${OS}/${ARCH}; falling back to GitHub Releases." >&2
+    rm -f "$OUT_FILE"
   fi
 fi
 
-# Strip the `parsar-daemon-` prefix the release workflow stamps onto the
-# binary filename (parsar-daemon-release.yml `OUTPUT=parsar-daemon-${VERSION}-${GOOS}-${GOARCH}`).
-BARE_VERSION="${VERSION#parsar-daemon-}"
-BINARY="parsar-daemon-${BARE_VERSION}-${OS}-${ARCH}"
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}"
-OUT_FILE="${OUT_DIR}/${BINARY}"
+# GitHub Releases path — used for managed-laptop installs (no connect URL)
+# and whenever the minting server did not serve a binary above.
+if [ -z "$SERVED_LOCALLY" ]; then
+  if [ -z "$VERSION" ]; then
+    echo "Resolving latest parsar-daemon release from github.com/${REPO}..."
+    # GitHub redirects /releases/latest to /releases/tag/<tag>; capture
+    # the final URL and strip the tag suffix. -sIL follows redirects with
+    # HEAD requests so we don't pull the whole release page.
+    LATEST_URL="$(curl -fsILo /dev/null -w '%{url_effective}' \
+      "https://github.com/${REPO}/releases/latest")"
+    VERSION="${LATEST_URL##*/tag/}"
+    if [ -z "$VERSION" ] || [ "$VERSION" = "$LATEST_URL" ]; then
+      echo "parsar-daemon: could not resolve latest release tag from ${LATEST_URL}" >&2
+      exit 1
+    fi
+  fi
 
-echo "Downloading ${BINARY} from ${DOWNLOAD_URL}..."
-mkdir -p "$OUT_DIR"
-if ! curl -fL "$DOWNLOAD_URL" -o "$OUT_FILE"; then
-  cat >&2 <<ERR
+  # Strip the `parsar-daemon-` prefix the release workflow stamps onto the
+  # binary filename (parsar-daemon-release.yml `OUTPUT=parsar-daemon-${VERSION}-${GOOS}-${GOARCH}`).
+  BARE_VERSION="${VERSION#parsar-daemon-}"
+  BINARY="parsar-daemon-${BARE_VERSION}-${OS}-${ARCH}"
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}"
+  OUT_FILE="${OUT_DIR}/${BINARY}"
+
+  echo "Downloading ${BINARY} from ${DOWNLOAD_URL}..."
+  mkdir -p "$OUT_DIR"
+  if ! curl -fL "$DOWNLOAD_URL" -o "$OUT_FILE"; then
+    cat >&2 <<ERR
 
 parsar-daemon: download failed.
 URL: ${DOWNLOAD_URL}
@@ -86,10 +114,11 @@ URL: ${DOWNLOAD_URL}
 If the release tag does not exist, override with PARSAR_DAEMON_VERSION.
 If you forked the repo, override with PARSAR_DAEMON_REPO=<owner>/<name>.
 ERR
-  exit 1
-fi
+    exit 1
+  fi
 
-printf 'Downloaded to %s\n' "$OUT_FILE"
+  printf 'Downloaded to %s\n' "$OUT_FILE"
+fi
 
 # --- One-line connect mode (north star) -------------------------------
 # When the Parsar web "接入新设备 / copy one command" button mints a

--- a/server/internal/api/parsar_daemon_download.go
+++ b/server/internal/api/parsar_daemon_download.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// defaultDaemonBinaryDir is where the image bakes the cross-compiled daemon
+// binaries (see Dockerfile runtime stage). Overridable so self-host images
+// or tests can point elsewhere.
+const defaultDaemonBinaryDir = "/usr/local/share/parsar/daemon"
+
+// daemonBinaryOS / daemonBinaryArch are the only values the install script
+// ever sends (it normalizes uname output to these). Treating them as a fixed
+// allowlist is what keeps a crafted os/arch from escaping BinaryDir.
+var (
+	daemonBinaryOS   = map[string]bool{"darwin": true, "linux": true}
+	daemonBinaryArch = map[string]bool{"amd64": true, "arm64": true}
+)
+
+type ParsarDaemonDownloadConfig struct {
+	// BinaryDir holds the per-platform parsar-daemon binaries named
+	// parsar-daemon-<os>-<arch>. Empty falls back to defaultDaemonBinaryDir.
+	BinaryDir string
+}
+
+// RegisterParsarDaemonDownloadRoute serves the host-appropriate parsar-daemon
+// binary baked into the image, so the one-line connect command can fetch it
+// from the minting server (PARSAR_DAEMON_CONNECT_URL) instead of a GitHub
+// release. Unauthenticated: the binary is public; the pairing token is what
+// gates connecting.
+func RegisterParsarDaemonDownloadRoute(r chi.Router, cfg ParsarDaemonDownloadConfig) {
+	dir := cfg.BinaryDir
+	if dir == "" {
+		dir = defaultDaemonBinaryDir
+	}
+	r.Get("/api/v1/parsar-daemon/download", func(w http.ResponseWriter, req *http.Request) {
+		goos := req.URL.Query().Get("os")
+		goarch := req.URL.Query().Get("arch")
+		if !daemonBinaryOS[goos] || !daemonBinaryArch[goarch] {
+			http.Error(w, "os must be one of [darwin linux] and arch one of [amd64 arm64]", http.StatusBadRequest)
+			return
+		}
+
+		name := "parsar-daemon-" + goos + "-" + goarch
+		f, err := os.Open(filepath.Join(dir, name))
+		if err != nil {
+			http.Error(w, "no parsar-daemon binary for "+goos+"/"+goarch+" in this image", http.StatusNotFound)
+			return
+		}
+		defer func() { _ = f.Close() }()
+
+		stat, err := f.Stat()
+		if err != nil || stat.IsDir() {
+			http.Error(w, "no parsar-daemon binary for "+goos+"/"+goarch+" in this image", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Disposition", `attachment; filename="`+name+`"`)
+		w.Header().Set("Cache-Control", "no-store")
+		http.ServeContent(w, req, name, stat.ModTime(), f)
+	})
+}

--- a/server/internal/api/parsar_daemon_download_test.go
+++ b/server/internal/api/parsar_daemon_download_test.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// TestParsarDaemonDownloadRoute pins the local binary-serve endpoint so the
+// one-line connect command can fetch the daemon from the minting server
+// instead of a GitHub release. The os/arch allowlist is load-bearing: it
+// stops a crafted `os=../../etc` from escaping BinaryDir.
+func TestParsarDaemonDownloadRoute(t *testing.T) {
+	t.Parallel()
+
+	// Stage a binary dir with two of the four platform binaries present,
+	// leaving linux/arm64 absent so the 404 path is exercised too.
+	dir := t.TempDir()
+	darwinArm64 := []byte("fake-darwin-arm64-binary\x00\x01\x02")
+	linuxAmd64 := []byte("fake-linux-amd64-binary")
+	if err := os.WriteFile(filepath.Join(dir, "parsar-daemon-darwin-arm64"), darwinArm64, 0o755); err != nil {
+		t.Fatalf("write darwin binary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "parsar-daemon-linux-amd64"), linuxAmd64, 0o755); err != nil {
+		t.Fatalf("write linux binary: %v", err)
+	}
+
+	r := chi.NewRouter()
+	RegisterParsarDaemonDownloadRoute(r, ParsarDaemonDownloadConfig{BinaryDir: dir})
+
+	t.Run("serves darwin/arm64 bytes with attachment headers", func(t *testing.T) {
+		t.Parallel()
+		rec := daemonDownloadGet(r, "/api/v1/parsar-daemon/download?os=darwin&arch=arm64")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		body, _ := io.ReadAll(rec.Body)
+		if !bytes.Equal(body, darwinArm64) {
+			t.Fatalf("body = %d bytes, want %d", len(body), len(darwinArm64))
+		}
+		if ct := rec.Header().Get("Content-Type"); ct != "application/octet-stream" {
+			t.Fatalf("Content-Type = %q, want application/octet-stream", ct)
+		}
+		if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, "parsar-daemon-darwin-arm64") {
+			t.Fatalf("Content-Disposition = %q, want it to name the binary", cd)
+		}
+	})
+
+	t.Run("serves linux/amd64 bytes", func(t *testing.T) {
+		t.Parallel()
+		rec := daemonDownloadGet(r, "/api/v1/parsar-daemon/download?os=linux&arch=amd64")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200", rec.Code)
+		}
+		body, _ := io.ReadAll(rec.Body)
+		if !bytes.Equal(body, linuxAmd64) {
+			t.Fatalf("linux/amd64 body mismatch")
+		}
+	})
+
+	t.Run("404 when that platform binary is not baked in", func(t *testing.T) {
+		t.Parallel()
+		rec := daemonDownloadGet(r, "/api/v1/parsar-daemon/download?os=linux&arch=arm64")
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("status = %d, want 404", rec.Code)
+		}
+	})
+
+	badCases := []struct {
+		name string
+		path string
+	}{
+		{"missing os", "/api/v1/parsar-daemon/download?arch=arm64"},
+		{"missing arch", "/api/v1/parsar-daemon/download?os=darwin"},
+		{"unknown os", "/api/v1/parsar-daemon/download?os=windows&arch=amd64"},
+		{"unknown arch", "/api/v1/parsar-daemon/download?os=linux&arch=riscv64"},
+		{"path traversal via os", "/api/v1/parsar-daemon/download?os=..%2F..%2Fetc&arch=amd64"},
+		{"path traversal via arch", "/api/v1/parsar-daemon/download?os=linux&arch=..%2F..%2Fpasswd"},
+	}
+	for _, tc := range badCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rec := daemonDownloadGet(r, tc.path)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+		})
+	}
+}
+
+func daemonDownloadGet(r http.Handler, target string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	return rec
+}

--- a/server/internal/api/parsar_daemon_install_test.go
+++ b/server/internal/api/parsar_daemon_install_test.go
@@ -95,3 +95,20 @@ func TestInstallScriptSupportsOneLineConnect(t *testing.T) {
 		}
 	}
 }
+
+// TestInstallScriptPrefersLocalServerBinary pins the local binary-serve leg:
+// in connect mode the script must try the minting server's
+// /api/v1/parsar-daemon/download before the GitHub release path, so a
+// pure-local install needs no published release. Drop either marker and that
+// offline path silently regresses to GitHub.
+func TestInstallScriptPrefersLocalServerBinary(t *testing.T) {
+	t.Parallel()
+	for _, want := range []string{
+		`/api/v1/parsar-daemon/download`,
+		`SERVED_LOCALLY`,
+	} {
+		if !strings.Contains(installParsarDaemonScript, want) {
+			t.Fatalf("install script missing local-serve marker %q", want)
+		}
+	}
+}

--- a/server/internal/api/parsar_daemon_install_test.go
+++ b/server/internal/api/parsar_daemon_install_test.go
@@ -78,3 +78,20 @@ func TestParsarDaemonInstallRoute(t *testing.T) {
 		})
 	}
 }
+
+// TestInstallScriptSupportsOneLineConnect pins the north-star one-liner:
+// the web "copy one command" button pipes this script with the pairing
+// env vars set, and the script must finish the job (chmod + hand off to
+// `connect`). If a future edit drops either marker the one-liner silently
+// regresses to the old two-step flow, so fail loudly here.
+func TestInstallScriptSupportsOneLineConnect(t *testing.T) {
+	t.Parallel()
+	for _, want := range []string{
+		`PARSAR_DAEMON_CONNECT_TOKEN`,
+		`exec "$OUT_FILE" connect -b`,
+	} {
+		if !strings.Contains(installParsarDaemonScript, want) {
+			t.Fatalf("install script missing one-line connect marker %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## 这个 PR 是什么
Phase 1「本地版」交付:一条命令在本机拉起 all-in-one 栈(postgres + 一次性 init + parsar-server,mock 登录)。北极星 UX:网页复制**一条**命令 → 终端粘贴 → 设备在线,二进制 / arch / token / $PATH 全程不可见。

## 主要内容
- `docker-compose.local.yml` — 本地一体化栈(pg + init 迁移/建首 owner + mock-auth server,零密钥)
- `PairDaemonDialog.tsx` — 网页「接入新设备」折叠成一条 copy-paste 命令
- install.sh — 带 token 时 chmod + `exec connect -b`;token 走 env,不进 argv/日志
- **Option A(离线零配置)**:镜像内置 4 平台 daemon → server `/api/v1/parsar-daemon/download` 代发(os/arch allowlist 防穿越,公开免鉴权)→ install.sh 本地优先,404 才回退 GitHub。一条命令不再依赖 GitHub Release。
- `parsar-server-release.yml` — 发布 server 镜像到 GHCR
- INSTALL.md 重写为本地版 quickstart(自部署后续单独出流程)
- **profile-not-fork**:本地与自部署同一个 image / 迁移 / SPA / install.sh,差异只在 compose + env

## Reviewer / 合并后须知
- **合并到 main 会自动触发 `parsar-server-release.yml`**,构建并推 `ghcr.io/MiniMax-ai-dev/parsar-server:latest`(linux/amd64+arm64,已内置 daemon)。**首次 push 后需把该 GHCR package 设为 public**,否则新人匿名 `docker compose pull` 报 401/403。
- 目前 GHCR 上还没有这个镜像(package 404)。发布前本地走 `make docker-build` fallback —— INSTALL.md §2「当前状态」块已写明;镜像上 GHCR 并设 public 后,该块连同本地构建步骤整段删除,新人即回到纯 `docker compose up`。
- **pre-existing 失败**:`server/internal/store` 4 个集成测试在 base `4b0f145` 即失败;本分支对 store 包改动 = 0,非本 PR 引入。
- 本分支落后 main 5 个 commit,合并可能需 rebase / 解冲突。

## 验证(已在本地实测)
- 本地栈 `docker compose -f docker-compose.local.yml up -d` → 浏览器接入设备 `pending_pairing → online → offline` 全程通过,用的是 **server 代发的二进制**(非源码构建、非 GitHub)。
- `/api/v1/parsar-daemon/download` 代发字节与镜像内 baked **逐字节一致**(sha256 `d8b55358…`);路径穿越 `os=../../etc` → 400。
- `go test ./server/...`(api 包通过,含新增 `parsar_daemon_install_test.go` + `parsar_daemon_download_test.go`)。

## Reviewer 测试计划
- [ ] `docker compose -f docker-compose.local.yml up -d` → 浏览器登录 → 接入新设备 → 设备在线
- [ ] 合并后确认 GHCR 镜像产出,并把 package 设为 public
- [ ] daemon download 端点字节一致性 / allowlist 400