### PR TITLE
fix: green make check — agent-run claim, queue, and run-transition store fixes

### DIFF
--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -1589,7 +1589,13 @@ picked as (
   select c.id, r.id as run_id
   from conversations c
   join agent_runs r on r.conversation_id = c.id
-  left join run_event_max rem on rem.agent_run_id = r.id
+  -- INNER (not LEFT) join: a run is only claimable once it has >=1
+  -- renderable event. Without a rem row the first-send branch below
+  -- (agent_run_id <> r.id) would otherwise claim a run carrying only
+  -- non-renderable lifecycle events (run.cancelled/requeued/superseded)
+  -- and spam an empty card. The sibling ListActive query reaches the
+  -- same exclusion via its `seq_emitted < max_seq` predicate.
+  join run_event_max rem on rem.agent_run_id = r.id
   left join messages m on m.id = r.output_message_id
   where c.platform = 'feishu'
     and c.status = 'active'
@@ -1649,6 +1655,18 @@ picked as (
   for update of c skip locked
 ),
 claimed as (
+  -- Stamp the claim once PER CONVERSATION, then fan back out to one
+  -- row per run in the final SELECT. The previous shape did
+  -- `update conversations c ... from picked ... returning picked.run_id`,
+  -- but Postgres UPDATE...FROM updates each target row once and emits a
+  -- single RETURNING row even when picked holds several runs for that
+  -- conversation — so a conv with two claimable runs (e.g. two failed
+  -- runs) returned only one. The dropped run never reached the
+  -- terminal_delivered fingerprint and got re-claimed every tick (the
+  -- other half of the prod 2026-06-22 card storm; see fingerprint note
+  -- above). Updating `where c.id in (select id from picked)` keeps the
+  -- claim stamp idempotent per conversation while the run fan-out moves
+  -- to the join below.
   update conversations c
   set metadata = jsonb_set(
         coalesce(c.metadata, '{}'::jsonb),
@@ -1660,11 +1678,9 @@ claimed as (
         true
       ),
       updated_at = @now::timestamptz
-  from picked
-  where c.id = picked.id
+  where c.id in (select id from picked)
   returning c.id, c.workspace_id, c.project_id, c.external_id,
-            c.external_thread_id, c.source_app_id, c.metadata,
-            picked.run_id
+            c.external_thread_id, c.source_app_id, c.metadata
 )
 select claimed.id::text                 as conversation_id,
        claimed.workspace_id::text       as workspace_id,
@@ -1673,7 +1689,7 @@ select claimed.id::text                 as conversation_id,
        claimed.external_thread_id       as external_thread_id,
        claimed.source_app_id            as source_app_id,
        claimed.metadata                 as conversation_metadata,
-       claimed.run_id::text             as agent_run_id,
+       picked.run_id::text              as agent_run_id,
        r.status                         as run_status,
        r.started_at                     as run_started_at,
        r.finished_at                    as run_finished_at,
@@ -1691,8 +1707,9 @@ select claimed.id::text                 as conversation_id,
        -- open_id (legacy fixtures, system-initiated runs); the ping
        -- helper degrades to a plain-text message.
        coalesce(trig.metadata->>'sender_open_id', '')::text as sender_open_id
-from claimed
-join agent_runs r on r.id = claimed.run_id
+from picked
+join claimed on claimed.id = picked.id
+join agent_runs r on r.id = picked.run_id
 left join messages trig on trig.id = r.trigger_message_id
 left join project_agents pa on pa.id = r.project_agent_id and pa.deleted_at is null
 left join agents a on a.id = pa.agent_id and a.deleted_at is null
@@ -1705,7 +1722,7 @@ left join (
   -- seq_emitted compare gets confused. See same set ~line 1705.
   where event_kind in ('tool.call', 'message.delta', 'message.thinking', 'permission.asked', 'prompt_for_user_choice.asked', 'run.started', 'run.completed', 'run.failed')
   group by agent_run_id
-) rem on rem.agent_run_id = claimed.run_id;
+) rem on rem.agent_run_id = picked.run_id;
 
 -- name: ListAgentRunEventsAfterSeq :many
 -- Pull the slice of events the driver hasn't rendered yet, in

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -414,7 +414,13 @@ picked as (
   select c.id, r.id as run_id
   from conversations c
   join agent_runs r on r.conversation_id = c.id
-  left join run_event_max rem on rem.agent_run_id = r.id
+  -- INNER (not LEFT) join: a run is only claimable once it has >=1
+  -- renderable event. Without a rem row the first-send branch below
+  -- (agent_run_id <> r.id) would otherwise claim a run carrying only
+  -- non-renderable lifecycle events (run.cancelled/requeued/superseded)
+  -- and spam an empty card. The sibling ListActive query reaches the
+  -- same exclusion via its ` + "`" + `seq_emitted < max_seq` + "`" + ` predicate.
+  join run_event_max rem on rem.agent_run_id = r.id
   left join messages m on m.id = r.output_message_id
   where c.platform = 'feishu'
     and c.status = 'active'
@@ -474,6 +480,18 @@ picked as (
   for update of c skip locked
 ),
 claimed as (
+  -- Stamp the claim once PER CONVERSATION, then fan back out to one
+  -- row per run in the final SELECT. The previous shape did
+  -- ` + "`" + `update conversations c ... from picked ... returning picked.run_id` + "`" + `,
+  -- but Postgres UPDATE...FROM updates each target row once and emits a
+  -- single RETURNING row even when picked holds several runs for that
+  -- conversation — so a conv with two claimable runs (e.g. two failed
+  -- runs) returned only one. The dropped run never reached the
+  -- terminal_delivered fingerprint and got re-claimed every tick (the
+  -- other half of the prod 2026-06-22 card storm; see fingerprint note
+  -- above). Updating ` + "`" + `where c.id in (select id from picked)` + "`" + ` keeps the
+  -- claim stamp idempotent per conversation while the run fan-out moves
+  -- to the join below.
   update conversations c
   set metadata = jsonb_set(
         coalesce(c.metadata, '{}'::jsonb),
@@ -485,11 +503,9 @@ claimed as (
         true
       ),
       updated_at = $2::timestamptz
-  from picked
-  where c.id = picked.id
+  where c.id in (select id from picked)
   returning c.id, c.workspace_id, c.project_id, c.external_id,
-            c.external_thread_id, c.source_app_id, c.metadata,
-            picked.run_id
+            c.external_thread_id, c.source_app_id, c.metadata
 )
 select claimed.id::text                 as conversation_id,
        claimed.workspace_id::text       as workspace_id,
@@ -498,7 +514,7 @@ select claimed.id::text                 as conversation_id,
        claimed.external_thread_id       as external_thread_id,
        claimed.source_app_id            as source_app_id,
        claimed.metadata                 as conversation_metadata,
-       claimed.run_id::text             as agent_run_id,
+       picked.run_id::text              as agent_run_id,
        r.status                         as run_status,
        r.started_at                     as run_started_at,
        r.finished_at                    as run_finished_at,
@@ -516,8 +532,9 @@ select claimed.id::text                 as conversation_id,
        -- open_id (legacy fixtures, system-initiated runs); the ping
        -- helper degrades to a plain-text message.
        coalesce(trig.metadata->>'sender_open_id', '')::text as sender_open_id
-from claimed
-join agent_runs r on r.id = claimed.run_id
+from picked
+join claimed on claimed.id = picked.id
+join agent_runs r on r.id = picked.run_id
 left join messages trig on trig.id = r.trigger_message_id
 left join project_agents pa on pa.id = r.project_agent_id and pa.deleted_at is null
 left join agents a on a.id = pa.agent_id and a.deleted_at is null
@@ -530,7 +547,7 @@ left join (
   -- seq_emitted compare gets confused. See same set ~line 1705.
   where event_kind in ('tool.call', 'message.delta', 'message.thinking', 'permission.asked', 'prompt_for_user_choice.asked', 'run.started', 'run.completed', 'run.failed')
   group by agent_run_id
-) rem on rem.agent_run_id = claimed.run_id
+) rem on rem.agent_run_id = picked.run_id
 `
 
 type ClaimActiveFeishuInflightConversationsParams struct {

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -6613,10 +6613,14 @@ returning id::text, workspace_id::text, project_id::text, conversation_id::text,
 			if !exists {
 				return MarkAgentRunRunningResult{}, fmt.Errorf("%w: %s", ErrUnknownAgentRun, runID)
 			}
-			// Disambiguate: still queued (blocked by sibling) vs past queued (not startable).
+			// Disambiguate: queued in THIS conversation (blocked by sibling)
+			// vs past-queued or foreign-conversation (not startable). The
+			// conversation_id predicate keeps a wrong-conversation run — queued
+			// but not ours to start — off the blocked-by-queue branch.
 			var status string
 			if err := s.db.QueryRow(ctx,
-				`select status from agent_runs where id = $1::uuid`, runUUID).Scan(&status); err == nil && status == "queued" {
+				`select status from agent_runs where id = $1::uuid and conversation_id = $2::uuid`,
+				runUUID, conversationUUID).Scan(&status); err == nil && status == "queued" {
 				return MarkAgentRunRunningResult{}, fmt.Errorf("%w: %s", ErrAgentRunBlockedByQueue, runID)
 			}
 			return MarkAgentRunRunningResult{}, fmt.Errorf("%w: %s", ErrAgentRunNotStartable, runID)

--- a/server/internal/store/store_queue_position_test.go
+++ b/server/internal/store/store_queue_position_test.go
@@ -22,11 +22,11 @@ func seedRunsForQueuePosition(t *testing.T, store *Store, conversationID string,
 		if _, err := store.db.Exec(ctx, `
 			insert into agent_runs (
 			  id, workspace_id, project_id, conversation_id, project_agent_id,
-			  status, trigger_source, trigger_channel, requested_by_type, requested_by_id,
+			  connector_type, status, trigger_source, trigger_channel, requested_by_type, requested_by_id,
 			  created_at, updated_at
 			) values (
 			  $1::uuid, $2::uuid, $3::uuid, $4::uuid, $5::uuid,
-			  $6, 'message', 'web', 'user', $7::uuid,
+			  'agent_daemon', $6, 'message', 'web', 'user', $7::uuid,
 			  $8, $8
 			)`,
 			mustUUID(id), mustUUID(ids.WorkspaceID), mustUUID(ids.ProjectID),


### PR DESCRIPTION
## Summary
Fixes the four `internal/store` test failures that were blocking `make check`, spanning the agent-run queue-position seed, the run-transition conversation guard, and the Feishu inflight claim query.

## Changes
- **connector_type seed (queue position):** the raw `seedRunsForQueuePosition` INSERT omitted the `NOT NULL` `connector_type` column (23502); add literal `'agent_daemon'` to match the dev-fixture agent.
- **MarkAgentRunRunning conversation guard:** scope the post-failure queued-status probe to the caller's `conversation_id`, so a wrong-conversation run returns `ErrAgentRunNotStartable` instead of being misreported as `ErrAgentRunBlockedByQueue`. The blocked-by-sibling path (same conversation) is unchanged.
- **Claim INNER JOIN:** `picked` CTE now joins `run_event_max` with INNER, so a run is claimable only once it has ≥1 renderable event — mirroring `ListActiveFeishuInflightConversations`. Closes the first-send hole that claimed runs carrying only `run.cancelled/requeued/superseded`.
- **Claim multi-run fan-out:** stamp the claim once per conversation (`where c.id in (select id from picked)`) and project one row per run in the final SELECT. Fixes the Postgres `UPDATE…FROM` collapse that emitted a single RETURNING row per conversation, dropping a second failed run that then never got fingerprinted and re-claimed every tick.
- Regenerated sqlc v1.31.1 (`store.sql.go`); the generated row struct is unchanged (only the embedded SQL text differs).

## Test plan
- [x] `make check` passes end-to-end: sqlc drift, `go test -p 1 ./server/...`, hermetic migrate+seed `internal/store`/`internal/seed` smoke tests, `pnpm typecheck` (7 projects), CWD-pollution guards.
- [x] The four previously-failing tests pass individually and within the full `internal/store` package.

## Note (not addressed here)
While running the full `internal/store` package against a *reused* DB, `TestGetAgentRunDetailShowsCompletedOutputMessage` hit a `connector_session_bindings` unique-key collision: that table isn't in `resetTestDB`'s truncate list and has no cascading FK, so binding rows survive resets. It doesn't affect `make check` (which provisions a fresh volume each run), so it's out of scope here — flagging in case we want to add `connector_session_bindings` to the truncate list separately.