### PR TITLE
fix(web): add system_prompt tab to agent wizard capability filter

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1401,7 +1401,8 @@
         "all": "All",
         "mcp": "MCP",
         "skill": "Skill",
-        "plugin": "Plugin"
+        "plugin": "Plugin",
+        "systemPrompt": "System Prompt"
       },
       "capabilitySections": {
         "workspace": "This Workspace",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1401,7 +1401,8 @@
         "all": "全部",
         "mcp": "MCP",
         "skill": "Skill",
-        "plugin": "插件"
+        "plugin": "插件",
+        "systemPrompt": "系统提示词"
       },
       "capabilitySections": {
         "workspace": "本 Workspace",

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -217,7 +217,7 @@ export function CreateAgentDialog({
   const [capabilityVersionChoices, setCapabilityVersionChoices] = useState<Record<string, { pinningMode: "latest" | "pinned"; versionID: string; pinnedVersion?: string }>>({})
   const [visibility, setVisibility] = useState<"workspace" | "tenant" | "public">("workspace")
   const [capabilitySearch, setCapabilitySearch] = useState("")
-  const [capabilityTypeFilter, setCapabilityTypeFilter] = useState<"all" | "mcp" | "skill" | "plugin">("all")
+  const [capabilityTypeFilter, setCapabilityTypeFilter] = useState<"all" | "mcp" | "skill" | "plugin" | "system_prompt">("all")
   const [deviceID, setDeviceID] = useState("")
   const [workDir, setWorkDir] = useState("")
   const [pairDialogOpen, setPairDialogOpen] = useState(false)
@@ -328,12 +328,13 @@ export function CreateAgentDialog({
   const capabilityTypeCounts = useMemo(() => {
     // Ghost rows have unknown type, so they're excluded from per-type tallies
     // (still count toward "all").
-    const counts = { all: capabilityOptions.length, mcp: 0, skill: 0, plugin: 0 }
+    const counts = { all: capabilityOptions.length, mcp: 0, skill: 0, plugin: 0, system_prompt: 0 }
     for (const cap of capabilityOptions) {
       if (cap.deprecated) continue
       if (cap.type === "mcp") counts.mcp++
       else if (cap.type === "skill") counts.skill++
       else if (cap.type === "plugin") counts.plugin++
+      else if (cap.type === "system_prompt") counts.system_prompt++
     }
     return counts
   }, [capabilityOptions])
@@ -1346,6 +1347,7 @@ export function CreateAgentDialog({
                         <TabsTrigger value="mcp">{t("agents.form.capabilityTypeTabs.mcp")} ({capabilityTypeCounts.mcp})</TabsTrigger>
                         <TabsTrigger value="skill">{t("agents.form.capabilityTypeTabs.skill")} ({capabilityTypeCounts.skill})</TabsTrigger>
                         <TabsTrigger value="plugin">{t("agents.form.capabilityTypeTabs.plugin")} ({capabilityTypeCounts.plugin})</TabsTrigger>
+                        <TabsTrigger value="system_prompt">{t("agents.form.capabilityTypeTabs.systemPrompt")} ({capabilityTypeCounts.system_prompt})</TabsTrigger>
                       </TabsList>
                     </Tabs>
                     <div className="max-h-56 overflow-y-auto rounded-md border border-slate-200 bg-white">


### PR DESCRIPTION
## Summary
- The step-3 **能力 / Capabilities** filter in the New Agent wizard (`CreateAgentDialog.tsx`) hardcoded only `all / mcp / skill / plugin` tabs. `system_prompt` capabilities had no tab, so they were silently absent from the type filter.
- Add the missing `system_prompt` tab: extend the filter state union, add a per-type count, render the new `TabsTrigger`, and add localized labels for en-US ("System Prompt") and zh-CN ("系统提示词").

This is a **frontend-only** regression. `CapabilityType`, the create-agent request payload, and the backend list/normalize paths already support `system_prompt`, so no backend or type changes are needed. The generic `visibleCapabilityOptions` filter (`cap.type === capabilityTypeFilter`) picks up the new value automatically.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm build` passes (only the pre-existing chunk-size warning)
- [x] Both locale JSONs parse with matching keys (`all, mcp, skill, plugin, systemPrompt`)
- [ ] Manual: open New Agent → step 3, confirm a **System Prompt** tab appears with the correct count and filters to system_prompt capabilities