### PR TITLE
web: 统一字体与字号系统,修复中文与 Inter 字体加载

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,6 +4,17 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/favicon.png" />
+    <!-- Kimi-style: clean sans. Inter for Latin, Noto Sans SC for Chinese
+         (Inter has NO CJK glyphs, so Chinese must have its own webfont or it
+         silently falls back to the OS font). Geist Mono for ids. Loaded via
+         <link> not CSS @import: Tailwind v4 inlines its own @import above,
+         which would make a CSS @import spec-invalid (silently dropped). -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300..700&family=Noto+Sans+SC:wght@400;500;700&family=Geist+Mono:wght@400..600&display=swap"
+    />
     <title>Parsar</title>
   </head>
   <body>

--- a/apps/web/src/components/UserSearchCombobox.tsx
+++ b/apps/web/src/components/UserSearchCombobox.tsx
@@ -102,7 +102,7 @@ export function UserSearchCombobox({
           >
             <span className="flex min-w-0 items-center gap-2">
               <Search className="h-3.5 w-3.5 shrink-0 text-slate-400" />
-              <span className="truncate text-[12px]">{triggerLabel}</span>
+              <span className="truncate text-[13px]">{triggerLabel}</span>
             </span>
             <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-slate-400" />
           </Button>
@@ -126,25 +126,25 @@ export function UserSearchCombobox({
                 // Content level; without stopPropagation those steal
                 // the input's cursor movement.
                 onKeyDown={(e) => e.stopPropagation()}
-                className="h-8 text-[12px]"
+                className="h-8 text-[13px]"
                 autoFocus
               />
             </div>
 
             <div className="max-h-[280px] overflow-auto py-1">
               {trimmed.length === 0 ? (
-                <p className="px-3 py-2 text-[12px] text-slate-500">
+                <p className="px-3 py-2 text-[13px] text-slate-500">
                   {t("members.add.search.typeToSearch")}
                 </p>
               ) : isLoading ? (
-                <div className="flex items-center gap-2 px-3 py-2 text-[12px] text-slate-500">
+                <div className="flex items-center gap-2 px-3 py-2 text-[13px] text-slate-500">
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
                   {t("members.add.search.loading")}
                 </div>
               ) : errMsg ? (
-                <p className="px-3 py-2 text-[12px] text-red-700">{errMsg}</p>
+                <p className="px-3 py-2 text-[13px] text-red-700">{errMsg}</p>
               ) : showEmpty ? (
-                <p className="px-3 py-2 text-[12px] text-slate-500">
+                <p className="px-3 py-2 text-[13px] text-slate-500">
                   {t("members.add.search.empty")}
                 </p>
               ) : (
@@ -170,7 +170,7 @@ export function UserSearchCombobox({
               type="button"
               onClick={() => remove(u.id)}
               disabled={disabled}
-              className="group inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11.5px] text-slate-700 hover:border-slate-300 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
+              className="group inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[12px] text-slate-700 hover:border-slate-300 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <UserAvatar user={u} size="xs" />
               <span className="max-w-[140px] truncate">
@@ -208,11 +208,11 @@ function UserRow({
     >
       <UserAvatar user={user} size="sm" />
       <div className="min-w-0 flex-1">
-        <div className="truncate text-[12.5px] font-medium text-slate-900">
+        <div className="truncate text-[13px] font-medium text-slate-900">
           {user.name || user.email.split("@")[0]}
         </div>
         {user.name && (
-          <div className="truncate text-[11px] text-slate-500">
+          <div className="truncate text-[12px] text-slate-500">
             {user.email}
           </div>
         )}
@@ -229,7 +229,7 @@ function UserAvatar({
   user: PlatformUser
   size: "xs" | "sm"
 }) {
-  const dims = size === "xs" ? "h-4 w-4 text-[8px]" : "h-6 w-6 text-[10px]"
+  const dims = size === "xs" ? "h-4 w-4 text-[11px]" : "h-6 w-6 text-[11px]"
   if (user.avatar_url) {
     return (
       <img

--- a/apps/web/src/components/admin/CredentialCheckPanel.tsx
+++ b/apps/web/src/components/admin/CredentialCheckPanel.tsx
@@ -236,8 +236,8 @@ export function CredentialCheckPanel({
           <div key={rc.kind} className="rounded-md border border-slate-200 bg-white">
             <div className="flex items-center gap-2 border-b border-slate-100 px-3 py-2">
               <span className="text-[13px] font-medium text-slate-900">{displayName}</span>
-              <span className="text-[11px] text-slate-500">({rc.kind})</span>
-              {rc.required && <span className="ml-auto rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-700">{t("credentialCheck.requiredBadge")}</span>}
+              <span className="text-[12px] text-slate-500">({rc.kind})</span>
+              {rc.required && <span className="ml-auto rounded bg-amber-50 px-1.5 py-0.5 text-[11px] font-medium text-amber-700">{t("credentialCheck.requiredBadge")}</span>}
             </div>
             <div className="space-y-1.5 px-3 py-2">
               {/* Option 1: personal */}
@@ -250,9 +250,9 @@ export function CredentialCheckPanel({
                   disabled={personalDisabled}
                   onChange={() => setKindChoice(rc.kind, { source: "personal" })}
                 />
-                <span className="text-[12px]">
+                <span className="text-[13px]">
                   <span className="block text-slate-800">{t("credentialCheck.sourcePersonal")}</span>
-                  <span className="block text-[11px] text-slate-500">
+                  <span className="block text-[12px] text-slate-500">
                     {personalDisabled
                       ? t("credentialCheck.personalDisabledHint")
                       : hasPersonalCredential
@@ -260,7 +260,7 @@ export function CredentialCheckPanel({
                         : t("credentialCheck.personalYouMissing")}
                   </span>
                   {!personalDisabled && !hasPersonalCredential && getUrl && (
-                    <a href={getUrl} target="_blank" rel="noopener noreferrer" className="mt-0.5 inline-flex items-center gap-1 text-[11px] text-amber-700 underline underline-offset-2">
+                    <a href={getUrl} target="_blank" rel="noopener noreferrer" className="mt-0.5 inline-flex items-center gap-1 text-[12px] text-amber-700 underline underline-offset-2">
                       {t("credentialCheck.form.getToken")}
                       <ExternalLink className="h-3 w-3" />
                     </a>
@@ -296,7 +296,7 @@ export function CredentialCheckPanel({
                     }
                   }}
                 />
-                <span className="flex-1 text-[12px]">
+                <span className="flex-1 text-[13px]">
                   <span className="flex items-center gap-1 text-slate-800">
                     <Users className="h-3 w-3" />
                     {t("credentialCheck.sourceShared")}
@@ -320,7 +320,7 @@ export function CredentialCheckPanel({
                             }
                           }}
                           onClick={(e) => e.stopPropagation()}
-                          className="h-7 w-full rounded border border-slate-200 bg-white px-2 text-[12px]"
+                          className="h-7 w-full rounded border border-slate-200 bg-white px-2 text-[13px]"
                         >
                           {kindSecrets.map((s) => (
                             <option key={s.id} value={s.id}>{s.name}</option>
@@ -331,7 +331,7 @@ export function CredentialCheckPanel({
                       {kindSecrets.length === 0 && expandedNewSecretFor !== rc.kind && !("new_secret" in choice) && (
                         <button
                           type="button"
-                          className="inline-flex h-7 items-center gap-1 rounded border border-dashed border-slate-300 px-2 text-[12px] text-slate-700 hover:bg-slate-50"
+                          className="inline-flex h-7 items-center gap-1 rounded border border-dashed border-slate-300 px-2 text-[13px] text-slate-700 hover:bg-slate-50"
                           onClick={(e) => {
                             e.preventDefault()
                             e.stopPropagation()
@@ -345,7 +345,7 @@ export function CredentialCheckPanel({
                         </button>
                       )}
                       {"new_secret" in choice && expandedNewSecretFor !== rc.kind && (
-                        <div className="flex items-center gap-2 rounded border border-emerald-200 bg-emerald-50 px-2 py-1 text-[11px] text-emerald-800">
+                        <div className="flex items-center gap-2 rounded border border-emerald-200 bg-emerald-50 px-2 py-1 text-[12px] text-emerald-800">
                           <Check className="h-3 w-3 shrink-0" />
                           <span className="flex-1 truncate">
                             {t("credentialCheck.sharedNewQueued", { name: choice.new_secret.display_name || rc.kind })}
@@ -373,16 +373,16 @@ export function CredentialCheckPanel({
               {expandedNewSecretFor === rc.kind && (
                 <div className="ml-6 mt-1 space-y-2 rounded border border-slate-200 bg-slate-50 p-2" onClick={(e) => e.stopPropagation()}>
                   <div className="grid gap-1">
-                    <label className="text-[11px] font-medium text-slate-600">{t("credentialCheck.form.displayName")}</label>
+                    <label className="text-[12px] font-medium text-slate-600">{t("credentialCheck.form.displayName")}</label>
                     <Input
                       value={newSecretDisplayName}
                       onChange={(e) => setNewSecretDisplayName(e.target.value)}
                       placeholder={displayName}
-                      className="h-7 text-[12px]"
+                      className="h-7 text-[13px]"
                     />
                   </div>
                   <div className="grid gap-1">
-                    <label className="text-[11px] font-medium text-slate-600">
+                    <label className="text-[12px] font-medium text-slate-600">
                       {t("credentialCheck.form.value")}
                       <span className="ml-0.5 text-red-500">*</span>
                     </label>
@@ -392,7 +392,7 @@ export function CredentialCheckPanel({
                         value={newSecretPlaintext}
                         onChange={(e) => setNewSecretPlaintext(e.target.value)}
                         placeholder={placeholder}
-                        className="h-7 pr-8 text-[12px]"
+                        className="h-7 pr-8 text-[13px]"
                       />
                       <button
                         type="button"
@@ -408,7 +408,7 @@ export function CredentialCheckPanel({
                       type="button"
                       variant="ghost"
                       size="sm"
-                      className="h-6 text-[11px]"
+                      className="h-6 text-[12px]"
                       onClick={() => {
                         setExpandedNewSecretFor(null)
                         // Same fallback as the model binding cancel: if the user cancels and no
@@ -437,7 +437,7 @@ export function CredentialCheckPanel({
                     <Button
                       type="button"
                       size="sm"
-                      className="h-6 text-[11px]"
+                      className="h-6 text-[12px]"
                       disabled={!newSecretPlaintext.trim()}
                       onClick={() => commitNewSecret(rc.kind)}
                     >

--- a/apps/web/src/components/admin/DevicePicker.tsx
+++ b/apps/web/src/components/admin/DevicePicker.tsx
@@ -73,7 +73,7 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
   }
   if (q.error) {
     return (
-      <p className="text-[12px] text-red-600">
+      <p className="text-[13px] text-red-600">
         {(q.error as Error).message}
       </p>
     )
@@ -101,7 +101,7 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
             onClick={onAddDevice}
             disabled={disabled}
             data-testid="device-picker-add-empty"
-            className="mt-2 inline-flex items-center gap-1 rounded-md border border-slate-900 bg-slate-900 px-3 py-1.5 text-[12px] font-medium text-white hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
+            className="mt-2 inline-flex items-center gap-1 rounded-md border border-slate-900 bg-slate-900 px-3 py-1.5 text-[13px] font-medium text-white hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-50"
           >
             <Plus className="h-3 w-3" />
             {t("agents.form.devicePicker.addDevice", {
@@ -109,7 +109,7 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
             })}
           </button>
         ) : (
-          <p className="mt-1 text-[12px] text-slate-500">
+          <p className="mt-1 text-[13px] text-slate-500">
             {t(
               hasOnlineDevices
                 ? "agents.form.devicePicker.noCompatibleDescription"
@@ -153,7 +153,7 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
           disabled={disabled}
           data-testid="device-picker-add"
           title={t("agents.form.devicePicker.addDevice", { defaultValue: "接入新设备" })}
-          className="inline-flex h-9 shrink-0 items-center gap-1 rounded-md border border-slate-200 bg-white px-3 text-[12px] text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+          className="inline-flex h-9 shrink-0 items-center gap-1 rounded-md border border-slate-200 bg-white px-3 text-[13px] text-slate-700 shadow-sm hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Plus className="h-3 w-3" />
           {t("agents.form.devicePicker.addDevice", { defaultValue: "接入新设备" })}

--- a/apps/web/src/components/admin/FeishuConnectorPanel.tsx
+++ b/apps/web/src/components/admin/FeishuConnectorPanel.tsx
@@ -28,8 +28,8 @@ function Card({
   return (
     <section className={`rounded-lg border border-slate-200 bg-white p-4 ${className ?? ""}`}>
       <header className="mb-3">
-        <h3 className="text-[12px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>
-        {description && <p className="mt-1 text-[12px] text-slate-500">{description}</p>}
+        <h3 className="text-[13px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>
+        {description && <p className="mt-1 text-[13px] text-slate-500">{description}</p>}
       </header>
       {children}
     </section>
@@ -49,12 +49,12 @@ function Field({
 }) {
   return (
     <div className="mb-3 last:mb-0">
-      <label className="mb-1 block text-[11px] uppercase tracking-wider text-slate-400">
+      <label className="mb-1 block text-[12px] uppercase tracking-wider text-slate-400">
         {label}
         {required && <span className="ml-1 text-rose-500">*</span>}
       </label>
       {children}
-      {hint && <p className="mt-1 text-[11px] text-slate-500">{hint}</p>}
+      {hint && <p className="mt-1 text-[12px] text-slate-500">{hint}</p>}
     </div>
   )
 }
@@ -344,7 +344,7 @@ export function FeishuConnectorPanel({
                 <p className="text-[13px] font-medium text-slate-900">
                   {t("agents.feishuConnector.provision.title")}
                 </p>
-                <p className="text-[12px] text-slate-500">
+                <p className="text-[13px] text-slate-500">
                   {t("agents.feishuConnector.provision.subtitle")}
                 </p>
               </div>
@@ -371,14 +371,14 @@ export function FeishuConnectorPanel({
                   data-testid="feishu-provision-qr"
                 />
               )}
-              <div className="min-w-0 space-y-2 text-[12px] text-slate-600">
+              <div className="min-w-0 space-y-2 text-[13px] text-slate-600">
                 <ProvisionStatusIcon status={provision.status} loading={pollProvisionPending} />
-                <p className="font-mono text-[12px] text-slate-800">{provision.userCode}</p>
+                <p className="font-mono text-[13px] text-slate-800">{provision.userCode}</p>
                 <a
                   href={provision.verificationUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="inline-flex max-w-full items-center gap-1 text-[12px] text-slate-700 underline underline-offset-2"
+                  className="inline-flex max-w-full items-center gap-1 text-[13px] text-slate-700 underline underline-offset-2"
                 >
                   <span className="truncate">{t("agents.feishuConnector.provision.openLink")}</span>
                   <ExternalLink className="h-3.5 w-3.5 shrink-0" />
@@ -508,11 +508,11 @@ export function FeishuConnectorPanel({
       )}
 
       {!canEdit && (
-        <p className="mt-3 text-[12px] text-slate-400">{t("agents.feishuConnector.ownerOnly")}</p>
+        <p className="mt-3 text-[13px] text-slate-400">{t("agents.feishuConnector.ownerOnly")}</p>
       )}
 
       {errorMsg && (
-        <p className="mt-3 text-[12px] text-rose-600" role="alert" data-testid="feishu-error">
+        <p className="mt-3 text-[13px] text-rose-600" role="alert" data-testid="feishu-error">
           {errorMsg}
         </p>
       )}
@@ -593,7 +593,7 @@ function FeishuDiagnosticsStrip({
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <FeishuDiagnosticsBadge status={status} />
-        <span className="rounded-md bg-white px-2 py-1 font-mono text-[11px] text-slate-500 ring-1 ring-slate-200">
+        <span className="rounded-md bg-white px-2 py-1 font-mono text-[12px] text-slate-500 ring-1 ring-slate-200">
           {mode}
         </span>
       </div>
@@ -601,7 +601,7 @@ function FeishuDiagnosticsStrip({
       <div className="mt-3 grid grid-cols-1 gap-2 min-[520px]:grid-cols-3 sm:grid-cols-6">
         {counts.map(([key, value]) => (
           <div key={key} className="min-w-0 rounded-md bg-white px-2 py-2 ring-1 ring-slate-200">
-            <p className="truncate text-[10.5px] uppercase tracking-wider text-slate-400">
+            <p className="truncate text-[11px] uppercase tracking-wider text-slate-400">
               {t(`agents.feishuConnector.diagnostics.stats.${key}`)}
             </p>
             <p className="mt-0.5 truncate font-mono text-[13px] font-semibold tabular-nums text-slate-800">
@@ -622,7 +622,7 @@ function FeishuDiagnosticsStrip({
       </div>
 
       {diagnostics?.last_error && (
-        <p className="mt-2 flex items-start gap-1.5 break-words text-[12px] text-rose-700">
+        <p className="mt-2 flex items-start gap-1.5 break-words text-[13px] text-rose-700">
           <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
           <span>
             {t("agents.feishuConnector.diagnostics.lastError")}: {diagnostics.last_error}
@@ -657,7 +657,7 @@ function FeishuDiagnosticsBadge({ status }: { status: FeishuDiagnosticsStatus })
             : MessageCircle
 
   return (
-    <span className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[12px] font-medium ring-1 ${tone}`}>
+    <span className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[13px] font-medium ring-1 ${tone}`}>
       <Icon className={`h-3.5 w-3.5 ${status === "loading" ? "animate-spin" : ""}`} />
       {label}
     </span>
@@ -667,8 +667,8 @@ function FeishuDiagnosticsBadge({ status }: { status: FeishuDiagnosticsStatus })
 function FeishuDiagnosticTime({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0">
-      <p className="text-[10.5px] uppercase tracking-wider text-slate-400">{label}</p>
-      <p className="mt-0.5 truncate text-[12px] text-slate-700" title={value}>
+      <p className="text-[11px] uppercase tracking-wider text-slate-400">{label}</p>
+      <p className="mt-0.5 truncate text-[13px] text-slate-700" title={value}>
         {value}
       </p>
     </div>

--- a/apps/web/src/components/admin/PairDaemonDialog.tsx
+++ b/apps/web/src/components/admin/PairDaemonDialog.tsx
@@ -98,19 +98,19 @@ export function PairDaemonDialog({
 
         {!result ? (
           <div className="space-y-3">
-            <label className="block text-[12px]">
+            <label className="block text-[13px]">
               <span className="mb-1 block text-slate-700">
                 {t("runtime.agentDaemon.pair.nameLabel", { defaultValue: "设备名称" })}
               </span>
               <input
-                className="w-full rounded border border-slate-300 px-2 py-1 font-mono text-[12px]"
+                className="w-full rounded border border-slate-300 px-2 py-1 font-mono text-[13px]"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="my-laptop"
                 data-testid="agent-daemon-pair-name"
               />
             </label>
-            <div className="rounded-md border border-emerald-100 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-900">
+            <div className="rounded-md border border-emerald-100 bg-emerald-50 px-3 py-2 text-[13px] text-emerald-900">
               <p className="mb-1 font-medium">
                 {t("runtime.agentDaemon.pair.safetyTitle", { defaultValue: "连接说明" })}
               </p>
@@ -133,7 +133,7 @@ export function PairDaemonDialog({
               </ul>
             </div>
             {create.error && (
-              <p className="text-[12px] text-red-600">
+              <p className="text-[13px] text-red-600">
                 {(create.error as Error).message}
               </p>
             )}
@@ -159,7 +159,7 @@ export function PairDaemonDialog({
           </div>
         ) : (
           <div className="space-y-3">
-            <p className="text-[12px] text-emerald-700">
+            <p className="text-[13px] text-emerald-700">
               {t("runtime.agentDaemon.pair.successOneLine", {
                 defaultValue:
                   "在 {{name}} 上执行这一条命令即可连接（自动下载并连接,无需手动安装二进制):",
@@ -178,7 +178,7 @@ export function PairDaemonDialog({
               onCopy={copyToClipboard}
               testId="agent-daemon-pair-copy-oneline"
             />
-            <div className="flex items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[12px]">
+            <div className="flex items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[13px]">
               {connected ? (
                 <>
                   <span className="h-2 w-2 shrink-0 rounded-full bg-emerald-500" />
@@ -222,16 +222,16 @@ function DaemonCommandBlock({
 }) {
   const { t } = useTranslation("admin")
   return (
-    <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-[11px] text-slate-700">
+    <div className="rounded-md border border-slate-200 bg-slate-50 p-3 text-[12px] text-slate-700">
       <div className="mb-2 flex items-start justify-between gap-3">
         <div className="min-w-0">
           <p className="font-medium text-slate-800">{label}</p>
-          <p className="mt-0.5 text-[11px] text-slate-500">{description}</p>
+          <p className="mt-0.5 text-[12px] text-slate-500">{description}</p>
         </div>
         <button
           type="button"
           onClick={() => onCopy(command)}
-          className="inline-flex shrink-0 items-center gap-1 rounded border border-slate-200 bg-white px-2 py-1 text-[11px] text-slate-600 hover:bg-slate-100"
+          className="inline-flex shrink-0 items-center gap-1 rounded border border-slate-200 bg-white px-2 py-1 text-[12px] text-slate-600 hover:bg-slate-100"
           data-testid={testId}
           title={t("runtime.agentDaemon.pair.copyCommand", { defaultValue: "复制命令" })}
         >
@@ -239,7 +239,7 @@ function DaemonCommandBlock({
           {t("runtime.agentDaemon.pair.copy", { defaultValue: "复制" })}
         </button>
       </div>
-      <code className="block break-all rounded bg-white p-2 font-mono text-[11px] leading-relaxed text-slate-800">
+      <code className="block break-all rounded bg-white p-2 font-mono text-[12px] leading-relaxed text-slate-800">
         {command}
       </code>
     </div>

--- a/apps/web/src/components/admin/ResourceAuditTimeline.tsx
+++ b/apps/web/src/components/admin/ResourceAuditTimeline.tsx
@@ -37,7 +37,7 @@ function PayloadPreview({ payload }: { payload?: Record<string, unknown> }) {
   if (entries.length === 0) return null
   const preview = entries.slice(0, 3).map(([k, v]) => `${k}=${typeof v === "string" ? v : JSON.stringify(v)}`).join(" · ")
   return (
-    <p className="mt-1 truncate font-mono text-[11px] text-slate-500" title={preview}>
+    <p className="mt-1 truncate font-mono text-[12px] text-slate-500" title={preview}>
       {preview}
     </p>
   )
@@ -47,7 +47,7 @@ function TimelineRow({ record, fmtAgo }: { record: AuditRecord; fmtAgo: (iso: st
   return (
     <li className="flex gap-3 border-b border-slate-100 px-1 py-2.5 last:border-b-0">
       <div className="flex w-32 shrink-0 flex-col gap-0.5 pt-0.5">
-        <span className="text-[12px] text-slate-700" title={record.occurred_at}>
+        <span className="text-[13px] text-slate-700" title={record.occurred_at}>
           {fmtAgo(record.occurred_at)}
         </span>
         <Badge variant={SOURCE_BADGE[record.source]} className="w-fit">
@@ -58,7 +58,7 @@ function TimelineRow({ record, fmtAgo }: { record: AuditRecord; fmtAgo: (iso: st
         <p className="truncate text-[13px] font-medium text-slate-800" title={record.event_type}>
           {record.event_type}
         </p>
-        <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
+        <div className="mt-0.5 flex items-center gap-1.5 text-[12px] text-slate-500">
           <ActorIcon type={record.actor_type} />
           <span className="font-mono">
             {record.actor_type}

--- a/apps/web/src/components/admin/SandboxPanel.tsx
+++ b/apps/web/src/components/admin/SandboxPanel.tsx
@@ -21,7 +21,7 @@ import { useNow } from "../../lib/use-now"
 function Card({ title, className, children }: { title: string; className?: string; children: React.ReactNode }) {
   return (
     <section className={`rounded-lg border border-slate-200 bg-white p-4 ${className ?? ""}`}>
-      <h3 className="mb-3 text-[12px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>
+      <h3 className="mb-3 text-[13px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>
       {children}
     </section>
   )
@@ -30,7 +30,7 @@ function Card({ title, className, children }: { title: string; className?: strin
 function Field({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
   return (
     <div className="mb-2 last:mb-0">
-      <dt className="mb-0.5 text-[11px] uppercase tracking-wider text-slate-400">{label}</dt>
+      <dt className="mb-0.5 text-[12px] uppercase tracking-wider text-slate-400">{label}</dt>
       <dd className={`text-[13px] text-slate-800 ${mono ? "font-mono break-all" : ""}`}>{value}</dd>
     </div>
   )
@@ -111,7 +111,7 @@ function ExpiresValue({ iso }: { iso?: string }) {
   return (
     <span title={iso} className="text-[13px] text-slate-800">
       {absolute}
-      {label && <span className={`ml-2 text-[12px] ${toneClass}`}>({label})</span>}
+      {label && <span className={`ml-2 text-[13px] ${toneClass}`}>({label})</span>}
     </span>
   )
 }
@@ -237,7 +237,7 @@ export function SandboxPanel({
           </Button>
         </div>
         {acquireMut.isSuccess && (
-          <p className="mt-2 text-center text-[12px] text-slate-500">
+          <p className="mt-2 text-center text-[13px] text-slate-500">
             {t("agents.detail.sandbox.provisioningHint")}
           </p>
         )}
@@ -290,7 +290,7 @@ export function SandboxPanel({
           <Field label={t("agents.detail.sandbox.fields.cacheKey")} value={binding.cache_key} mono />
         </dl>
         {binding.status_kind !== "live" && (
-          <p className="mt-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[12px] text-slate-600">
+          <p className="mt-3 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[13px] text-slate-600">
             {t("agents.detail.sandbox.notLiveHint")}
           </p>
         )}
@@ -309,7 +309,7 @@ export function SandboxPanel({
         />
       )}
       {renewMut.isSuccess && renewMut.data?.expires_at && (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-800">
+        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[13px] text-emerald-800">
           {t("agents.detail.sandbox.renewedToast", { expiresAt: new Date(renewMut.data.expires_at).toLocaleString() })}
         </div>
       )}

--- a/apps/web/src/components/conversation/StepDisplay.tsx
+++ b/apps/web/src/components/conversation/StepDisplay.tsx
@@ -103,7 +103,7 @@ export function StepItem({
   const upper = (name || "tool").toUpperCase()
   const summary = detail ? ellipsizeMiddle(detail) : ""
   return (
-    <div className="flex items-center gap-1.5 py-0.5 text-[12px]">
+    <div className="flex items-center gap-1.5 py-0.5 text-[13px]">
       {status === "running" ? (
         <Loader2 className="h-3 w-3 shrink-0 animate-spin text-blue-500" strokeWidth={2.5} />
       ) : status === "failed" ? (
@@ -126,7 +126,7 @@ export function StepItem({
       </span>
       {summary && (
         <span
-          className="min-w-0 flex-1 truncate font-mono text-[11.5px] text-slate-500"
+          className="min-w-0 flex-1 truncate font-mono text-[12px] text-slate-500"
           title={detail}
         >
           {summary}
@@ -134,7 +134,7 @@ export function StepItem({
       )}
       {!summary && <span className="min-w-0 flex-1" aria-hidden="true" />}
       {durationMs !== undefined && (
-        <span className="shrink-0 tabular-nums text-[11px] text-slate-400">
+        <span className="shrink-0 tabular-nums text-[12px] text-slate-400">
           {formatElapsed(durationMs)}
         </span>
       )}
@@ -173,7 +173,7 @@ export function WorkingSteps({
     firstStart === null ? 0 : (lastEnded ?? now) - firstStart
 
   return (
-    <div className="flex w-fit min-w-[240px] flex-col gap-1 rounded-md bg-white px-3 py-2 text-[12px] shadow-sm ring-1 ring-slate-200/70">
+    <div className="flex w-fit min-w-[240px] flex-col gap-1 rounded-md bg-white px-3 py-2 text-[13px] shadow-sm ring-1 ring-slate-200/70">
       <div className="flex items-center gap-2">
         <button
           type="button"
@@ -194,7 +194,7 @@ export function WorkingSteps({
         </button>
         <div className="min-w-0 flex-1">
           {total > 0 ? (
-            <div className="flex items-center gap-2 text-[12px]">
+            <div className="flex items-center gap-2 text-[13px]">
               <span className="font-medium text-slate-700">
                 {t("conversations.steps.totalLabel", {
                   count: total,
@@ -226,7 +226,7 @@ export function WorkingSteps({
           )}
         </div>
         {overallMs > 0 && (
-          <span className="shrink-0 tabular-nums text-[11px] text-slate-400">
+          <span className="shrink-0 tabular-nums text-[12px] text-slate-400">
             {formatElapsed(overallMs)}
           </span>
         )}
@@ -294,7 +294,7 @@ export function StepTrace({ steps }: { steps: ToolStep[] }) {
         aria-expanded={expanded}
         aria-label={expanded ? t("conversations.steps.collapseAria") : t("conversations.steps.expandAria")}
         onClick={() => setExpanded((v) => !v)}
-        className="flex items-center gap-1 rounded-md px-1.5 py-1 text-[11.5px] font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700"
+        className="flex items-center gap-1 rounded-md px-1.5 py-1 text-[12px] font-medium text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-700"
       >
         {expanded ? (
           <ChevronDown className="h-3 w-3" strokeWidth={2.2} />

--- a/apps/web/src/components/layout/AdminLayout.tsx
+++ b/apps/web/src/components/layout/AdminLayout.tsx
@@ -160,7 +160,7 @@ export function AdminLayout({
                 <button
                   type="button"
                   onClick={() => toggle(group.groupKey)}
-                  className="group/header mb-0.5 flex h-5 w-full items-center gap-1 rounded px-2 text-[12px] font-normal text-slate-500 transition-colors hover:text-slate-700"
+                  className="group/header mb-0.5 flex h-5 w-full items-center gap-1 rounded px-2 text-[13px] font-normal text-slate-500 transition-colors hover:text-slate-700"
                 >
                   <span>
                     {t(`nav.${group.groupKey}` as never)}
@@ -202,12 +202,12 @@ export function AdminLayout({
                           {t(`nav.items.${item.itemKey}` as never)}
                         </span>
                         {item.badge !== undefined && (
-                          <span className="ml-auto inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-amber-100 px-1.5 text-[10.5px] font-medium text-amber-700">
+                          <span className="ml-auto inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-amber-100 px-1.5 text-[11px] font-medium text-amber-700">
                             {item.badge}
                           </span>
                         )}
                         {item.hint && (
-                          <span className="ml-auto text-[10px] uppercase tracking-wider text-slate-400">
+                          <span className="ml-auto text-[11px] uppercase tracking-wider text-slate-400">
                             {t(`nav.${item.hint}` as never)}
                           </span>
                         )}

--- a/apps/web/src/components/layout/DiscoverWorkspacesDialog.tsx
+++ b/apps/web/src/components/layout/DiscoverWorkspacesDialog.tsx
@@ -84,7 +84,7 @@ export function DiscoverWorkspacesDialog({
               <Dialog.Title className="text-[15px] font-semibold text-slate-900">
                 {t("workspaceSwitcher.discoverDialogTitle")}
               </Dialog.Title>
-              <Dialog.Description className="text-[12px] text-slate-500">
+              <Dialog.Description className="text-[13px] text-slate-500">
                 {t("workspaceSwitcher.discoverDialogDescription")}
               </Dialog.Description>
             </div>
@@ -144,11 +144,11 @@ export function DiscoverWorkspacesDialog({
                       <span className="truncate text-[13px] text-slate-900">
                         {ws.name}
                       </span>
-                      <span className="truncate font-mono text-[10.5px] text-slate-400">
+                      <span className="truncate font-mono text-[11px] text-slate-400">
                         {ws.slug}
                       </span>
                     </div>
-                    <span className="text-[11px] text-slate-500">
+                    <span className="text-[12px] text-slate-500">
                       {t("workspaceSwitcher.memberCount", {
                         count: ws.member_count,
                       })}
@@ -156,7 +156,7 @@ export function DiscoverWorkspacesDialog({
                     {ws.has_pending_request ? (
                       <div className="flex items-center gap-1.5">
                         <span
-                          className="inline-flex items-center gap-1 rounded px-2 py-1 text-[11px] text-amber-700"
+                          className="inline-flex items-center gap-1 rounded px-2 py-1 text-[12px] text-amber-700"
                           title={t("workspaceSwitcher.pendingRequestTitle")}
                         >
                           <Clock className="h-3 w-3" strokeWidth={1.75} />
@@ -191,7 +191,7 @@ export function DiscoverWorkspacesDialog({
             )}
           </div>
 
-          <div className="flex items-center justify-between text-[12px] text-slate-500">
+          <div className="flex items-center justify-between text-[13px] text-slate-500">
             <span>{rangeLabel}</span>
             <div className="flex items-center gap-2">
               <Button

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -13,7 +13,7 @@ export function PageHeader({ title, description, action, backLink }: PageHeaderP
       {backLink && <div className="text-xs text-slate-500">{backLink}</div>}
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-1">
-          <h1 className="text-[22px] font-semibold leading-tight tracking-display text-slate-900">{title}</h1>
+          <h1 className="font-display text-[22px] leading-tight text-slate-900">{title}</h1>
           {description && (
             <div className="max-w-2xl text-[13px] leading-relaxed text-slate-500">{description}</div>
           )}

--- a/apps/web/src/components/layout/UserMenu.tsx
+++ b/apps/web/src/components/layout/UserMenu.tsx
@@ -26,7 +26,7 @@ export function UserMenu() {
           type="button"
           className="inline-flex items-center gap-1.5 rounded-full px-1 py-0.5 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200 data-[state=open]:bg-slate-100"
         >
-          <span className="grid h-8 w-8 place-items-center overflow-hidden rounded-full bg-slate-200 text-[12px] font-semibold text-slate-700">
+          <span className="grid h-8 w-8 place-items-center overflow-hidden rounded-full bg-slate-200 text-[13px] font-semibold text-slate-700">
             {user.avatar_url ? (
               <img src={user.avatar_url} alt="" className="h-full w-full object-cover" />
             ) : (
@@ -40,11 +40,11 @@ export function UserMenu() {
         <DropdownMenu.Content
           align="end"
           sideOffset={6}
-          className="z-50 min-w-[220px] overflow-hidden rounded-md border border-slate-200 bg-white p-1 text-[12.5px] text-slate-700 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+          className="z-50 min-w-[220px] overflow-hidden rounded-md border border-slate-200 bg-white p-1 text-[13px] text-slate-700 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
         >
           <DropdownMenu.Label className="px-2 py-1.5">
             <div className="truncate text-[13px] font-medium text-slate-900">{user.name || user.email}</div>
-            <div className="truncate text-[12px] text-slate-400">{user.email}</div>
+            <div className="truncate text-[13px] text-slate-400">{user.email}</div>
           </DropdownMenu.Label>
           <DropdownMenu.Separator className="my-1 h-px bg-slate-100" />
           <DropdownMenu.Item

--- a/apps/web/src/components/layout/WorkspaceCrudDialogs.tsx
+++ b/apps/web/src/components/layout/WorkspaceCrudDialogs.tsx
@@ -92,7 +92,7 @@ export function WorkspaceFormDialog({
           }}
         >
           <div className="grid gap-1.5">
-            <label className="text-[12px] font-medium text-slate-700" htmlFor="ws-name">
+            <label className="text-[13px] font-medium text-slate-700" htmlFor="ws-name">
               {t("workspaceCrud.fields.name")}
             </label>
             <Input
@@ -106,7 +106,7 @@ export function WorkspaceFormDialog({
           </div>
 
           <fieldset className="grid gap-1.5">
-            <legend className="text-[12px] font-medium text-slate-700">
+            <legend className="text-[13px] font-medium text-slate-700">
               {t("workspaceCrud.fields.visibility")}
             </legend>
             <div className="grid grid-cols-2 gap-2">
@@ -114,7 +114,7 @@ export function WorkspaceFormDialog({
                 <label
                   key={v}
                   className={
-                    "flex cursor-pointer items-center gap-2 rounded-md border px-2.5 py-1.5 text-[12px] " +
+                    "flex cursor-pointer items-center gap-2 rounded-md border px-2.5 py-1.5 text-[13px] " +
                     (visibility === v
                       ? "border-slate-700 bg-slate-50 text-slate-900"
                       : "border-slate-200 text-slate-700 hover:bg-slate-50")
@@ -135,7 +135,7 @@ export function WorkspaceFormDialog({
           </fieldset>
 
           {errMsg && (
-            <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">
+            <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">
               {errMsg}
             </p>
           )}
@@ -225,7 +225,7 @@ export function ProjectFormDialog({
         >
           <div className="grid gap-1.5">
             <label
-              className="text-[12px] font-medium text-slate-700"
+              className="text-[13px] font-medium text-slate-700"
               htmlFor="proj-name"
             >
               {t("workspaceCrud.fields.name")}
@@ -242,11 +242,11 @@ export function ProjectFormDialog({
 
           <div className="grid gap-1.5">
             <label
-              className="text-[12px] font-medium text-slate-700"
+              className="text-[13px] font-medium text-slate-700"
               htmlFor="proj-desc"
             >
               {t("workspaceCrud.fields.description")}
-              <span className="ml-1 text-[11px] font-normal text-slate-400">
+              <span className="ml-1 text-[12px] font-normal text-slate-400">
                 {t("workspaceCrud.fields.optional")}
               </span>
             </label>
@@ -259,7 +259,7 @@ export function ProjectFormDialog({
           </div>
 
           {errMsg && (
-            <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">
+            <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">
               {errMsg}
             </p>
           )}
@@ -313,7 +313,7 @@ export function ConfirmArchiveDialog({
         </DialogHeader>
 
         {errMsg && (
-          <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">
+          <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">
             {errMsg}
           </p>
         )}
@@ -391,11 +391,11 @@ export function JoinRequestDialog({
         >
           <div className="grid gap-1.5">
             <label
-              className="text-[12px] font-medium text-slate-700"
+              className="text-[13px] font-medium text-slate-700"
               htmlFor="join-reason"
             >
               {t("workspaceCrud.fields.reason")}
-              <span className="ml-1 text-[11px] font-normal text-slate-400">
+              <span className="ml-1 text-[12px] font-normal text-slate-400">
                 {t("workspaceCrud.fields.optional")}
               </span>
             </label>
@@ -406,17 +406,17 @@ export function JoinRequestDialog({
               rows={3}
               onChange={(e) => setReason(e.target.value)}
               placeholder={t("workspaceCrud.join.reasonPlaceholder")}
-              className="rounded-md border border-slate-200 px-3 py-2 text-[12px] outline-none focus:border-slate-400"
+              className="rounded-md border border-slate-200 px-3 py-2 text-[13px] outline-none focus:border-slate-400"
             />
             {tooLong && (
-              <p className="text-[11px] text-red-600">
+              <p className="text-[12px] text-red-600">
                 {t("workspaceCrud.join.reasonTooLong")}
               </p>
             )}
           </div>
 
           {errMsg && (
-            <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">
+            <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">
               {errMsg}
             </p>
           )}

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -127,18 +127,18 @@ export function WorkspaceSwitcher() {
           <button
             type="button"
             aria-label={t("workspaceSwitcher.triggerAriaLabel")}
-            className="ml-2 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[12.5px] text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200 data-[state=open]:bg-slate-100"
+            className="ml-2 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-[13px] text-slate-700 hover:bg-slate-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200 data-[state=open]:bg-slate-100"
           >
             <span className="font-medium">{triggerLabel}</span>
             {triggerProjectLabel && (
-              <span className="rounded bg-slate-100 px-1 py-0 text-[10px] font-mono text-slate-600">
+              <span className="rounded bg-slate-100 px-1 py-0 text-[11px] font-mono text-slate-600">
                 {triggerProjectLabel}
               </span>
             )}
             {!wsId && (
               <span
                 title={t("workspace.mockTooltip")}
-                className="rounded bg-amber-100 px-1 py-0 text-[10px] font-medium text-amber-700"
+                className="rounded bg-amber-100 px-1 py-0 text-[11px] font-medium text-amber-700"
               >
                 {t("workspace.mockBadge")}
               </span>
@@ -151,15 +151,15 @@ export function WorkspaceSwitcher() {
           <DropdownMenu.Content
             align="start"
             sideOffset={6}
-            className="z-50 min-w-[300px] overflow-hidden rounded-md border border-slate-200 bg-white p-1 text-[12.5px] text-slate-700 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+            className="z-50 min-w-[300px] overflow-hidden rounded-md border border-slate-200 bg-white p-1 text-[13px] text-slate-700 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
           >
-            <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-[10.5px] font-medium uppercase tracking-wider text-slate-500">
+            <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-[11px] font-medium uppercase tracking-wider text-slate-500">
               <Layers className="h-3 w-3" strokeWidth={1.75} />
               {t("workspaceSwitcher.workspaceLabel")}
             </DropdownMenu.Label>
 
             {workspaces.length === 0 && (
-              <div className="px-2 py-2 text-[12px] text-slate-400">
+              <div className="px-2 py-2 text-[13px] text-slate-400">
                 {workspacesQuery.isLoading
                   ? t("states.loading")
                   : t("workspaceSwitcher.noWorkspaces")}
@@ -187,11 +187,11 @@ export function WorkspaceSwitcher() {
                   >
                     <div className="flex flex-1 flex-col min-w-0">
                       <span className="truncate">{ws.name}</span>
-                      <span className="truncate font-mono text-[10px] text-slate-400">
+                      <span className="truncate font-mono text-[11px] text-slate-400">
                         {ws.slug}
                       </span>
                     </div>
-                    <span className="text-[10px] uppercase tracking-wider text-slate-400">
+                    <span className="text-[11px] uppercase tracking-wider text-slate-400">
                       {ws.role}
                     </span>
                     {isActive && (
@@ -227,7 +227,7 @@ export function WorkspaceSwitcher() {
             {discoverable.length > 0 && (
               <>
                 <DropdownMenu.Separator className="my-1 h-px bg-slate-100" />
-                <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-[10.5px] font-medium uppercase tracking-wider text-slate-500">
+                <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-[11px] font-medium uppercase tracking-wider text-slate-500">
                   <Globe className="h-3 w-3" strokeWidth={1.75} />
                   {t("workspaceSwitcher.discoverLabel")}
                 </DropdownMenu.Label>
@@ -239,11 +239,11 @@ export function WorkspaceSwitcher() {
                     <div className="flex flex-1 items-center gap-2 rounded-sm px-2 py-1.5">
                       <div className="flex flex-1 flex-col min-w-0">
                         <span className="truncate">{ws.name}</span>
-                        <span className="truncate font-mono text-[10px] text-slate-400">
+                        <span className="truncate font-mono text-[11px] text-slate-400">
                           {ws.slug}
                         </span>
                       </div>
-                      <span className="text-[10px] text-slate-400">
+                      <span className="text-[11px] text-slate-400">
                         {t("workspaceSwitcher.memberCount", {
                           count: ws.member_count,
                         })}
@@ -252,7 +252,7 @@ export function WorkspaceSwitcher() {
                     {ws.has_pending_request ? (
                       <div className="flex items-center gap-1">
                         <span
-                          className="inline-flex items-center gap-1 rounded px-2 py-1 text-[11px] text-amber-700"
+                          className="inline-flex items-center gap-1 rounded px-2 py-1 text-[12px] text-amber-700"
                           title={t("workspaceSwitcher.pendingRequestTitle")}
                         >
                           <Clock className="h-3 w-3" strokeWidth={1.75} />
@@ -264,7 +264,7 @@ export function WorkspaceSwitcher() {
                             withdrawJoinMut.mutate({ wsId: ws.id })
                           }}
                           disabled={withdrawJoinMut.isPending}
-                          className="flex cursor-pointer items-center gap-1 rounded-sm px-2 py-1 text-[11px] text-slate-500 outline-none data-[highlighted]:bg-slate-100 data-[disabled]:opacity-50"
+                          className="flex cursor-pointer items-center gap-1 rounded-sm px-2 py-1 text-[12px] text-slate-500 outline-none data-[highlighted]:bg-slate-100 data-[disabled]:opacity-50"
                           title={t("workspaceSwitcher.withdrawRequestTitle")}
                         >
                           <X className="h-3 w-3" strokeWidth={1.75} />
@@ -279,7 +279,7 @@ export function WorkspaceSwitcher() {
                           e.preventDefault()
                           setJoinTarget(ws)
                         }}
-                        className="flex cursor-pointer items-center gap-1 rounded-sm px-2 py-1 text-[11px] text-slate-700 outline-none data-[highlighted]:bg-slate-100"
+                        className="flex cursor-pointer items-center gap-1 rounded-sm px-2 py-1 text-[12px] text-slate-700 outline-none data-[highlighted]:bg-slate-100"
                         title={t("workspaceSwitcher.requestJoinTitle")}
                       >
                         <Send className="h-3 w-3" strokeWidth={1.75} />
@@ -308,14 +308,14 @@ export function WorkspaceSwitcher() {
             )}
 
             {joinToast && (
-              <div className="mx-1 my-1 rounded-md border border-emerald-200 bg-emerald-50 px-2 py-1.5 text-[11px] text-emerald-800">
+              <div className="mx-1 my-1 rounded-md border border-emerald-200 bg-emerald-50 px-2 py-1.5 text-[12px] text-emerald-800">
                 {joinToast}
               </div>
             )}
 
             <DropdownMenu.Separator className="my-1 h-px bg-slate-100" />
 
-            <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-[10.5px] font-medium uppercase tracking-wider text-slate-500">
+            <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-[11px] font-medium uppercase tracking-wider text-slate-500">
               <FolderKanban className="h-3 w-3" strokeWidth={1.75} />
               {currentWorkspace?.name
                 ? t("workspaceSwitcher.projectsInLabel", {
@@ -325,13 +325,13 @@ export function WorkspaceSwitcher() {
             </DropdownMenu.Label>
 
             {!wsId && (
-              <div className="px-2 py-2 text-[12px] text-slate-400">
+              <div className="px-2 py-2 text-[13px] text-slate-400">
                 {t("workspaceSwitcher.pickWorkspaceFirst")}
               </div>
             )}
 
             {wsId && projects.length === 0 && (
-              <div className="px-2 py-2 text-[12px] text-slate-400">
+              <div className="px-2 py-2 text-[13px] text-slate-400">
                 {projectsQuery.isLoading
                   ? t("states.loading")
                   : t("workspaceSwitcher.noProjects")}
@@ -355,7 +355,7 @@ export function WorkspaceSwitcher() {
                     >
                       <div className="flex flex-1 flex-col min-w-0">
                         <span className="truncate">{p.name}</span>
-                        <span className="truncate font-mono text-[10px] text-slate-400">
+                        <span className="truncate font-mono text-[11px] text-slate-400">
                           {p.slug}
                         </span>
                       </div>

--- a/apps/web/src/components/runtime/ConnectivityResultPanel.tsx
+++ b/apps/web/src/components/runtime/ConnectivityResultPanel.tsx
@@ -75,7 +75,7 @@ export function ConnectivityResultPanel({
         <button
           type="button"
           onClick={onDismiss}
-          className={`flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[12px] font-normal ${styles.dismiss} focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300`}
+          className={`flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[13px] font-normal ${styles.dismiss} focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300`}
           data-testid="connectivity-result-dismiss"
         >
           <X className="h-3 w-3" />
@@ -111,7 +111,7 @@ function CheckRow({
   const iconClr = check.pass ? "text-emerald-600" : "text-red-600"
   const isSkipped = !check.pass && !check.error
   return (
-    <li className="flex items-start gap-2 text-[12px]">
+    <li className="flex items-start gap-2 text-[13px]">
       {isSkipped ? (
         <span className="mt-0.5 h-3.5 w-3.5 shrink-0 rounded-full bg-slate-200" aria-hidden />
       ) : (
@@ -147,7 +147,7 @@ function FailureSuggestion({ checks }: { checks: ConnectivityCheck[] }): ReactNo
   const failIdx = checks.findIndex((c) => c === firstFail)
   const hasSkipped = checks.slice(failIdx + 1).some((c) => !c.pass && !c.error)
   return (
-    <div className="mt-2 rounded-md bg-slate-50/70 px-2.5 py-2 text-[12px] text-slate-700">
+    <div className="mt-2 rounded-md bg-slate-50/70 px-2.5 py-2 text-[13px] text-slate-700">
       <span className="font-medium text-slate-800">
         {t("runtime.connectivity.suggestionLabel")}：
       </span>

--- a/apps/web/src/components/runtime/RuntimeCapabilityHeader.tsx
+++ b/apps/web/src/components/runtime/RuntimeCapabilityHeader.tsx
@@ -122,8 +122,8 @@ function Chip({
     >
       <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${styles.icon}`} strokeWidth={1.75} />
       <div className="min-w-0">
-        <p className={`text-[12px] font-medium leading-tight ${styles.title}`}>{title}</p>
-        <p className={`mt-0.5 text-[11.5px] leading-snug ${styles.body}`}>{body}</p>
+        <p className={`text-[13px] font-medium leading-tight ${styles.title}`}>{title}</p>
+        <p className={`mt-0.5 text-[12px] leading-snug ${styles.body}`}>{body}</p>
       </div>
     </div>
   )

--- a/apps/web/src/components/runtime/RuntimeCredentialCard.tsx
+++ b/apps/web/src/components/runtime/RuntimeCredentialCard.tsx
@@ -129,7 +129,7 @@ export function RuntimeCredentialCard({ workspaceID, isAdmin, variant = "card" }
               {t("runtime.credential.title")}
             </h3>
           </div>
-          <p className="mt-1 text-[12px] leading-relaxed text-slate-500 max-w-xl">
+          <p className="mt-1 text-[13px] leading-relaxed text-slate-500 max-w-xl">
             {t("runtime.credential.description")}
           </p>
         </div>
@@ -152,7 +152,7 @@ export function RuntimeCredentialCard({ workspaceID, isAdmin, variant = "card" }
           </div>
         )}
       </div>
-      <div className="mt-3 rounded-md border border-slate-200 bg-slate-50/60 px-3 py-2 text-[12px]">
+      <div className="mt-3 rounded-md border border-slate-200 bg-slate-50/60 px-3 py-2 text-[13px]">
         {hasCredential ? (
           <div className="flex items-center gap-2 text-slate-700">
             <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" strokeWidth={2} />
@@ -218,7 +218,7 @@ function CredentialManageDialog({
           <DialogTitle>{t("runtime.credential.title")}</DialogTitle>
           <DialogDescription>{t("runtime.credential.description")}</DialogDescription>
         </DialogHeader>
-        <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[12px]">
+        <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[13px]">
           {hasCredential ? (
             <div className="flex items-center gap-2 text-slate-700">
               <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" strokeWidth={2} />
@@ -270,7 +270,7 @@ function ClearCredentialDialog({
           <AlertDialogDescription>{t("runtime.credential.delete.description")}</AlertDialogDescription>
         </AlertDialogHeader>
         {clearMut.error && (
-          <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">
+          <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">
             {clearMut.error instanceof ApiError ? clearMut.error.envelope.message : t("runtime.credential.error.generic")}
           </p>
         )}
@@ -338,7 +338,7 @@ function SaveDialog({ open, pending, error, existing, onOpenChange, onSubmit }: 
             />
           </FieldLabel>
           {errMsg && (
-            <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">{errMsg}</p>
+            <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">{errMsg}</p>
           )}
         </div>
         <DialogFooter>
@@ -363,8 +363,8 @@ function SaveDialog({ open, pending, error, existing, onOpenChange, onSubmit }: 
 function FieldLabel({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
   return (
     <label className="block">
-      <span className="text-[12px] font-medium text-slate-700">{label}</span>
-      {hint && <span className="ml-1 text-[11px] text-slate-500">{hint}</span>}
+      <span className="text-[13px] font-medium text-slate-700">{label}</span>
+      {hint && <span className="ml-1 text-[12px] text-slate-500">{hint}</span>}
       <div className="mt-1.5">{children}</div>
     </label>
   )

--- a/apps/web/src/components/runtime/RuntimeEmptyState.tsx
+++ b/apps/web/src/components/runtime/RuntimeEmptyState.tsx
@@ -83,7 +83,7 @@ function EmptyShell({
         </div>
         <p className={`text-[14px] font-medium ${styles.title}`}>{title}</p>
       </div>
-      <div className="max-w-xl space-y-2 text-[12.5px] leading-relaxed text-slate-600">
+      <div className="max-w-xl space-y-2 text-[13px] leading-relaxed text-slate-600">
         {children}
       </div>
     </div>

--- a/apps/web/src/components/runtime/RuntimeStatusBanner.tsx
+++ b/apps/web/src/components/runtime/RuntimeStatusBanner.tsx
@@ -148,7 +148,7 @@ function BannerView({
       <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${styles.icon}`} strokeWidth={1.75} />
       <div className="min-w-0 flex-1">
         <p className={`text-[13px] font-medium ${styles.title}`}>{title}</p>
-        {hint && <p className={`mt-0.5 text-[12px] leading-relaxed ${styles.hint}`}>{hint}</p>}
+        {hint && <p className={`mt-0.5 text-[13px] leading-relaxed ${styles.hint}`}>{hint}</p>}
       </div>
       {action}
     </div>

--- a/apps/web/src/components/ui/action-button.tsx
+++ b/apps/web/src/components/ui/action-button.tsx
@@ -60,7 +60,7 @@ export function ActionIconButton({
         </span>
       </Tooltip.Trigger>
       <Tooltip.Portal>
-        <Tooltip.Content className="z-50 rounded-md border border-slate-200 bg-white px-2 py-1 text-[12px] text-slate-600 shadow-md">
+        <Tooltip.Content className="z-50 rounded-md border border-slate-200 bg-white px-2 py-1 text-[13px] text-slate-600 shadow-md">
           {label}
           <Tooltip.Arrow className="fill-white" />
         </Tooltip.Content>

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -64,7 +64,7 @@ export const AlertDialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
     ref={ref}
-    className={cn("text-[12.5px] leading-relaxed text-slate-500", className)}
+    className={cn("text-[13px] leading-relaxed text-slate-500", className)}
     {...props}
   />
 ))

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -24,9 +24,11 @@ interface BadgeProps
   extends React.HTMLAttributes<HTMLSpanElement>,
     VariantProps<typeof badgeVariants> {
   dot?: boolean
+  /** Animate the dot (use for live/in-progress states like "running"). */
+  pulse?: boolean
 }
 
-export function Badge({ className, variant, dot, children, ...props }: BadgeProps) {
+export function Badge({ className, variant, dot, pulse, children, ...props }: BadgeProps) {
   const dotColor = {
     success: "bg-emerald-500",
     warning: "bg-amber-500",
@@ -37,7 +39,19 @@ export function Badge({ className, variant, dot, children, ...props }: BadgeProp
 
   return (
     <span className={cn(badgeVariants({ variant }), className)} {...props}>
-      {dot && <span className={cn("h-1.5 w-1.5 rounded-full", dotColor)} />}
+      {dot && (
+        <span className="relative flex h-1.5 w-1.5">
+          {pulse && (
+            <span
+              className={cn(
+                "absolute inline-flex h-full w-full animate-ping rounded-full opacity-75",
+                dotColor
+              )}
+            />
+          )}
+          <span className={cn("relative inline-flex h-1.5 w-1.5 rounded-full", dotColor)} />
+        </span>
+      )}
       {children}
     </span>
   )

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -107,7 +107,7 @@ export const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-[12.5px] leading-relaxed text-slate-500", className)}
+    className={cn("text-[13px] leading-relaxed text-slate-500", className)}
     {...props}
   />
 ))

--- a/apps/web/src/components/ui/managed-badge.tsx
+++ b/apps/web/src/components/ui/managed-badge.tsx
@@ -39,7 +39,7 @@ export function ManagedBadge({ unmanaged, className }: ManagedBadgeProps) {
         <Tooltip.Portal>
           <Tooltip.Content
             side="top"
-            className="z-50 max-w-xs rounded-md border border-slate-200 bg-white px-3 py-2 text-[12px] leading-relaxed text-slate-700 shadow-lg"
+            className="z-50 max-w-xs rounded-md border border-slate-200 bg-white px-3 py-2 text-[13px] leading-relaxed text-slate-700 shadow-lg"
           >
             {tooltip}
             <Tooltip.Arrow className="fill-white" />

--- a/apps/web/src/pages/JoinWorkspaceLanding.tsx
+++ b/apps/web/src/pages/JoinWorkspaceLanding.tsx
@@ -163,11 +163,11 @@ function RequestForm({ workspace }: { workspace: DiscoverableWorkspace }) {
         <p className="mt-2 text-[13px] text-slate-500">
           {t("workspaceCrud.join.landing.successDescription")}
         </p>
-        <div className="mt-2 rounded-md bg-amber-50 px-3 py-2 text-[12px] text-amber-800">
+        <div className="mt-2 rounded-md bg-amber-50 px-3 py-2 text-[13px] text-amber-800">
           {t("workspaceCrud.join.landing.pendingTitle")}
         </div>
         {errMsg && (
-          <p className="mt-2 rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">
+          <p className="mt-2 rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">
             {errMsg}
           </p>
         )}
@@ -212,11 +212,11 @@ function RequestForm({ workspace }: { workspace: DiscoverableWorkspace }) {
       >
         <div className="grid gap-1.5">
           <label
-            className="text-[12px] font-medium text-slate-700"
+            className="text-[13px] font-medium text-slate-700"
             htmlFor="join-reason"
           >
             {t("workspaceCrud.fields.reason")}
-            <span className="ml-1 text-[11px] font-normal text-slate-400">
+            <span className="ml-1 text-[12px] font-normal text-slate-400">
               {t("workspaceCrud.fields.optional")}
             </span>
           </label>
@@ -230,14 +230,14 @@ function RequestForm({ workspace }: { workspace: DiscoverableWorkspace }) {
             className="rounded-md border border-slate-200 px-3 py-2 text-[13px] outline-none focus:border-slate-400"
           />
           {tooLong && (
-            <p className="text-[11px] text-red-600">
+            <p className="text-[12px] text-red-600">
               {t("workspaceCrud.join.reasonTooLong")}
             </p>
           )}
         </div>
 
         {errMsg && (
-          <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">
+          <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">
             {errMsg}
           </p>
         )}

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -5,13 +5,13 @@ export function LoginPage() {
   const { t } = useTranslation("common")
   return (
     <main className="grid min-h-screen place-items-center bg-white px-6 text-slate-900">
-      <section className="w-full max-w-[380px] rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
+      <section className="w-full max-w-[380px] rounded-2xl border border-slate-200/80 bg-white p-8 shadow-[0_1px_2px_rgb(15_23_42/0.04),0_12px_32px_-12px_rgb(15_23_42/0.12)]">
         <div className="mb-8 flex flex-col items-center text-center">
-          <div className="mb-3 grid h-11 w-11 place-items-center rounded-xl bg-slate-900 text-[18px] font-bold text-white">
-            T
+          <div className="mb-4 grid h-12 w-12 place-items-center rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <img src="/favicon.png" alt="" className="h-7 w-7" />
           </div>
-          <h1 className="text-2xl font-semibold tracking-display">{t("login.title")}</h1>
-          <p className="mt-2 text-[14px] text-slate-500">{t("login.subtitle")}</p>
+          <h1 className="font-display text-[26px] leading-none">{t("login.title")}</h1>
+          <p className="mt-2 text-[14px] leading-relaxed text-slate-500">{t("login.subtitle")}</p>
         </div>
 
         <a
@@ -21,7 +21,7 @@ export function LoginPage() {
           {t("login.feishuButton")}
         </a>
 
-        <div className="mt-5 space-y-1 text-center text-[12px] leading-5 text-slate-400">
+        <div className="mt-5 space-y-1 text-center text-[13px] leading-5 text-slate-400">
           <p>{t("login.firstLoginNote")}</p>
           <p>
             <a href="#" className="hover:text-slate-600">

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -76,7 +76,7 @@ export function OnboardingPage() {
           </div>
 
           {errMsg && (
-            <p className="mt-3 rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">
+            <p className="mt-3 rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">
               {errMsg}
             </p>
           )}

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -227,7 +227,7 @@ function TruncatedName({
         <Tooltip.Portal>
           <Tooltip.Content
             side="top"
-            className="z-50 max-w-sm break-all rounded-md border border-slate-200 bg-white px-3 py-2 text-[12px] leading-relaxed text-slate-700 shadow-lg"
+            className="z-50 max-w-sm break-all rounded-md border border-slate-200 bg-white px-3 py-2 text-[13px] leading-relaxed text-slate-700 shadow-lg"
           >
             {tip}
             <Tooltip.Arrow className="fill-white" />
@@ -260,7 +260,7 @@ function RuntimeCell({ agent }: { agent: ProjectAgent }) {
             ? "pending"
             : "offline"
       return (
-        <span className="inline-flex items-center gap-1.5 text-[12px] text-slate-700">
+        <span className="inline-flex items-center gap-1.5 text-[13px] text-slate-700">
           <span className="font-medium text-slate-500">Sandbox</span>
           <span className="text-slate-400">·</span>
           <TruncatedName
@@ -275,7 +275,7 @@ function RuntimeCell({ agent }: { agent: ProjectAgent }) {
     // Sandbox placement, no live binding (not yet dispatched, or reaped).
     // Neutral placeholder so users don't mistake it for misconfiguration.
     return (
-      <span className="inline-flex items-center gap-1.5 text-[12px] text-slate-500">
+      <span className="inline-flex items-center gap-1.5 text-[13px] text-slate-500">
         <span className="font-medium">Sandbox</span>
         <span className="text-slate-400">·</span>
         <span>{t("agents.runtimeCell.pending")}</span>
@@ -290,7 +290,7 @@ function RuntimeCell({ agent }: { agent: ProjectAgent }) {
   if (placement === "local" && runtimeID && name) {
     const tone = runtimeLivenessTone(agent) ?? "offline"
     return (
-      <span className="inline-flex items-center gap-1.5 text-[12px] text-slate-700">
+      <span className="inline-flex items-center gap-1.5 text-[13px] text-slate-700">
         <span className="font-medium text-slate-500">Local</span>
         <span className="text-slate-400">·</span>
         <TruncatedName display={name} />
@@ -382,12 +382,12 @@ export function AgentsPage() {
         }
       />
       {toast && (
-        <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-800">
+        <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[13px] text-emerald-800">
           {toast}
         </div>
       )}
       {pendingCapabilityID && (
-        <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-[12px] text-blue-800">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-[13px] text-blue-800">
           <span>{pendingCapability ? t("agents.pendingCapability.banner", { name: pendingCapability.name, source: pendingCapability.source_workspace_name ?? "—" }) : t("agents.pendingCapability.loading")}</span>
           <Button variant="outline" size="sm" onClick={() => navigate("agents", { pendingCapability: null })}>{t("agents.pendingCapability.cancel")}</Button>
         </div>
@@ -475,11 +475,11 @@ export function AgentsPage() {
                         </div>
                       </TableCell>
                       <TableCell><RuntimeCell agent={a} /></TableCell>
-                      <TableCell className="font-mono text-[12px] text-slate-600">{defaultModelOf(a, modelsQ.data?.models ?? [])}</TableCell>
-                      <TableCell className="text-[12px] text-slate-500">
+                      <TableCell className="font-mono text-[13px] text-slate-600">{defaultModelOf(a, modelsQ.data?.models ?? [])}</TableCell>
+                      <TableCell className="text-[13px] text-slate-500">
                         {t(`agents.visibility.${a.visibility ?? "workspace"}`)}
                       </TableCell>
-                      <TableCell className="text-[12px] text-slate-600">{a.created_by_name || "—"}</TableCell>
+                      <TableCell className="text-[13px] text-slate-600">{a.created_by_name || "—"}</TableCell>
                       <TableCell className="pr-4">
                         <RowActions>
                           <ActionIconButton
@@ -747,12 +747,12 @@ export function AgentDetailPage({ id }: { id: string }) {
       />
 
       {toast && (
-        <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-800">
+        <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[13px] text-emerald-800">
           {toast}
         </div>
       )}
       {pendingCapabilityID && (
-        <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-[12px] text-blue-800">
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-[13px] text-blue-800">
           <span>{t("agents.pendingCapability.detailBanner", { name: (marketplaceQ.data ?? []).find((capability) => capability.id === pendingCapabilityID)?.name ?? pendingCapabilityID, source: (marketplaceQ.data ?? []).find((capability) => capability.id === pendingCapabilityID)?.source_workspace_name ?? "—" })}</span>
           <Button variant="outline" size="sm" onClick={() => navigate("agents", { id: agent.project_agent_id, tab: "config", pendingCapability: null })}>{t("agents.pendingCapability.cancel")}</Button>
         </div>
@@ -802,7 +802,7 @@ export function AgentDetailPage({ id }: { id: string }) {
 function Field({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
   return (
     <div className="mb-2 last:mb-0">
-      <dt className="mb-0.5 text-[11px] uppercase tracking-wider text-slate-400">{label}</dt>
+      <dt className="mb-0.5 text-[12px] uppercase tracking-wider text-slate-400">{label}</dt>
       <dd className={`text-[13px] text-slate-800 ${mono ? "font-mono" : ""}`}>{value}</dd>
     </div>
   )
@@ -811,7 +811,7 @@ function Field({ label, value, mono }: { label: string; value: React.ReactNode; 
 function TagsField({ label, tags }: { label: string; tags: string[] }) {
   return (
     <div className="mb-2 last:mb-0">
-      <dt className="mb-1 text-[11px] uppercase tracking-wider text-slate-400">{label}</dt>
+      <dt className="mb-1 text-[12px] uppercase tracking-wider text-slate-400">{label}</dt>
       <dd className="flex flex-wrap gap-1.5">
         {tags.length === 0 ? (
           <span className="text-[13px] text-slate-400">—</span>
@@ -893,7 +893,7 @@ function CapabilityCard({
     return (
       <div className="rounded-md border border-amber-200 bg-amber-50/60 p-3">
         <p className="text-[13px] font-medium text-amber-900">{t("agents.detail.capabilities.deletedCapability.title")}</p>
-        <p className="mt-1 text-[12px] text-amber-800">{t("agents.detail.capabilities.deletedCapability.description")}</p>
+        <p className="mt-1 text-[13px] text-amber-800">{t("agents.detail.capabilities.deletedCapability.description")}</p>
         <RemoveCapabilityDialog
           agent={agent}
           binding={binding}
@@ -929,13 +929,13 @@ function CapabilityCard({
               />
             )}
           </div>
-          {capability.description && <p className="mt-1 text-[12px] text-slate-500">{capability.description}</p>}
-          {fromMarketplace && <p className="mt-1 text-[12px] text-slate-500">{t("agents.detail.capabilities.marketplace.source", { source: capability.source_workspace_name ?? "—", version: boundVersion?.version ?? capability.pinned_version ?? latest?.version ?? "—" })}</p>}
+          {capability.description && <p className="mt-1 text-[13px] text-slate-500">{capability.description}</p>}
+          {fromMarketplace && <p className="mt-1 text-[13px] text-slate-500">{t("agents.detail.capabilities.marketplace.source", { source: capability.source_workspace_name ?? "—", version: boundVersion?.version ?? capability.pinned_version ?? latest?.version ?? "—" })}</p>}
         </div>
       </div>
 
       {mode === "enabled" && deprecated && (
-        <div className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-800">
+        <div className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] leading-5 text-red-800">
           {t("agents.detail.capabilities.marketplace.deprecatedBanner", { version: boundVersion?.version ?? capability.pinned_version ?? "—" })}
         </div>
       )}
@@ -1004,7 +1004,7 @@ function CredentialStatus({ capability, credentials, language }: { capability: C
   const { t } = useTranslation("admin")
   const requiredCreds = capability.required_credentials ?? []
   if (requiredCreds.length === 0) {
-    return <p className="mt-3 text-[12px] text-slate-500">{t("agents.detail.capabilities.credential.none")}</p>
+    return <p className="mt-3 text-[13px] text-slate-500">{t("agents.detail.capabilities.credential.none")}</p>
   }
   return (
     <div className="mt-3 space-y-1.5">
@@ -1012,7 +1012,7 @@ function CredentialStatus({ capability, credentials, language }: { capability: C
         const credential = credentials.find((cred) => cred.kind === rc.kind)
         const label = credentialKindLabel(rc.kind, language, rc.kind)
         return (
-          <div key={rc.kind} className={`rounded-md border px-3 py-2 text-[12px] ${credential ? "border-emerald-200 bg-emerald-50 text-emerald-800" : "border-red-200 bg-red-50 text-red-800"}`}>
+          <div key={rc.kind} className={`rounded-md border px-3 py-2 text-[13px] ${credential ? "border-emerald-200 bg-emerald-50 text-emerald-800" : "border-red-200 bg-red-50 text-red-800"}`}>
             {credential ? (
               <span>{t("agents.detail.capabilities.credential.present", { kind: label, name: credential.display_name || t("agents.detail.capabilities.credential.defaultName") })}</span>
             ) : (
@@ -1030,7 +1030,7 @@ function CredentialLink({ kind, className, children }: { kind?: string; classNam
   const { t } = useTranslation("admin")
   if (!kind) return null
   return (
-    <a className={className ?? "text-[12px] font-medium text-slate-900 underline underline-offset-2"} href={credentialURL(kind)}>
+    <a className={className ?? "text-[13px] font-medium text-slate-900 underline underline-offset-2"} href={credentialURL(kind)}>
       {children ?? t("agents.detail.capabilities.credential.addCta")}
     </a>
   )
@@ -1096,13 +1096,13 @@ function EnableCredentialStatusList({
             key={rc.kind}
             className={
               has
-                ? "flex items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-[12px] text-emerald-800"
-                : "flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-1.5 text-[12px] text-amber-900"
+                ? "flex items-center gap-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-[13px] text-emerald-800"
+                : "flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-1.5 text-[13px] text-amber-900"
             }
           >
             <span>{has ? "✓" : "⚠"}</span>
             <span>{rc.kind}</span>
-            {!has && <span className="ml-auto text-[11px]">{t("credentialCheck.personalYouMissing")}</span>}
+            {!has && <span className="ml-auto text-[12px]">{t("credentialCheck.personalYouMissing")}</span>}
           </div>
         )
       })}
@@ -1173,7 +1173,7 @@ function EnableCapabilityDialog({
         </DialogHeader>
         <div className="space-y-4">
           <div className="grid gap-1.5">
-            <label className="text-[12px] font-medium text-slate-700">{t("agents.detail.capabilities.enableDialog.version")}</label>
+            <label className="text-[13px] font-medium text-slate-700">{t("agents.detail.capabilities.enableDialog.version")}</label>
             {versionsQ.isLoading ? <Skeleton className="h-8 w-full" /> : <VersionSelect versions={versions} value={selectedVersion?.id ?? ""} onChange={setSelected} />}
           </div>
           {requiredKinds.length > 0 ? (
@@ -1182,11 +1182,11 @@ function EnableCapabilityDialog({
               onAllReady={setAllCredentialsSatisfied}
             />
           ) : (
-            <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-800">
+            <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[13px] text-emerald-800">
               {t("agents.detail.capabilities.enableDialog.noCredential")}
             </div>
           )}
-          {mutationError(mut.error) && <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">{mutationError(mut.error)}</p>}
+          {mutationError(mut.error) && <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">{mutationError(mut.error)}</p>}
         </div>
         <DialogFooter>
           <Button variant="outline" size="sm" onClick={() => setOpen(false)} disabled={mut.isPending}>{t("agents.detail.capabilities.actions.cancel")}</Button>
@@ -1242,7 +1242,7 @@ function SwitchVersionDialog({
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <Button variant={triggerVariant} size="sm" className={triggerVariant === "link" ? "h-auto px-1 py-0 text-[12px] text-red-700" : undefined} onClick={() => setOpen(true)}>{triggerLabel ?? t("agents.detail.capabilities.actions.switchVersion")}</Button>
+      <Button variant={triggerVariant} size="sm" className={triggerVariant === "link" ? "h-auto px-1 py-0 text-[13px] text-red-700" : undefined} onClick={() => setOpen(true)}>{triggerLabel ?? t("agents.detail.capabilities.actions.switchVersion")}</Button>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{t("agents.detail.capabilities.switchDialog.title", { cap: capability.name })}</DialogTitle>
@@ -1255,8 +1255,8 @@ function SwitchVersionDialog({
               <span className="flex-1 text-[13px] text-slate-800">v{version.version}{index === 0 ? ` · ${t("agents.detail.capabilities.switchDialog.latest")}` : ""}{version.id === binding.capability_version_id ? ` · ${t("agents.detail.capabilities.switchDialog.current")}` : ""}</span>
             </label>
           ))}
-          <p className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-[12px] text-blue-800">{t("agents.detail.capabilities.switchDialog.notice", { agent: agent.name })}</p>
-          {mutationError(mut.error) && <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">{mutationError(mut.error)}</p>}
+          <p className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-[13px] text-blue-800">{t("agents.detail.capabilities.switchDialog.notice", { agent: agent.name })}</p>
+          {mutationError(mut.error) && <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">{mutationError(mut.error)}</p>}
         </div>
         <DialogFooter>
           <Button variant="outline" size="sm" onClick={() => setOpen(false)} disabled={mut.isPending}>{t("agents.detail.capabilities.actions.cancel")}</Button>
@@ -1300,12 +1300,12 @@ function RemoveCapabilityDialog({
           <AlertDialogTitle>{t("agents.detail.capabilities.removeDialog.title", { agent: agent.name, cap: capabilityName })}</AlertDialogTitle>
           <AlertDialogDescription>{t("agents.detail.capabilities.removeDialog.description")}</AlertDialogDescription>
         </AlertDialogHeader>
-        <ul className="space-y-1 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[12px] text-slate-600">
+        <ul className="space-y-1 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[13px] text-slate-600">
           <li>{t("agents.detail.capabilities.removeDialog.impactRun")}</li>
           <li>{t("agents.detail.capabilities.removeDialog.impactCapability")}</li>
           <li>{t("agents.detail.capabilities.removeDialog.impactCredential")}</li>
         </ul>
-        {mutationError(mut.error) && <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">{mutationError(mut.error)}</p>}
+        {mutationError(mut.error) && <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">{mutationError(mut.error)}</p>}
         <AlertDialogFooter>
           <AlertDialogCancel asChild><Button variant="outline" size="sm" disabled={mut.isPending}>{t("agents.detail.capabilities.actions.cancel")}</Button></AlertDialogCancel>
           <Button variant="destructive" size="sm" disabled={mut.isPending} onClick={submit}>{mut.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}{t("agents.detail.capabilities.actions.removeConfirm")}</Button>
@@ -1318,7 +1318,7 @@ function RemoveCapabilityDialog({
 function Card({ title, className, children }: { title: string; className?: string; children: React.ReactNode }) {
   return (
     <section className={`rounded-lg border border-slate-200 bg-white p-4 ${className ?? ""}`}>
-      <h3 className="mb-3 text-[12px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>
+      <h3 className="mb-3 text-[13px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>
       {children}
     </section>
   )
@@ -1327,7 +1327,7 @@ function Card({ title, className, children }: { title: string; className?: strin
 function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-lg border border-slate-200 bg-white p-4">
-      <div className="text-[11px] uppercase tracking-wider text-slate-400">{label}</div>
+      <div className="text-[12px] uppercase tracking-wider text-slate-400">{label}</div>
       <div className="mt-1 text-[22px] font-semibold tabular-nums text-slate-900">{value}</div>
     </div>
   )
@@ -1412,18 +1412,18 @@ function VisibilityCard({
               <div className="text-[13px] font-medium text-slate-900">
                 {t(`agents.visibility.${tier.value}`)}
               </div>
-              <div className="mt-0.5 text-[12px] text-slate-500">{tier.hint}</div>
+              <div className="mt-0.5 text-[13px] text-slate-500">{tier.hint}</div>
             </div>
           </label>
         ))}
       </div>
       {!canEdit && (
-        <p className="mt-2 text-[12px] text-slate-400">
+        <p className="mt-2 text-[13px] text-slate-400">
           {t("agents.visibility.ownerOnly")}
         </p>
       )}
       {errorMsg && (
-        <p className="mt-2 text-[12px] text-rose-600" role="alert">
+        <p className="mt-2 text-[13px] text-rose-600" role="alert">
           {errorMsg}
         </p>
       )}
@@ -1525,11 +1525,11 @@ function CurrentWorkCard({ runs, loading }: { runs: AgentRunSummary[]; loading: 
             <li key={run.id} className="flex items-center justify-between rounded-md border border-slate-200 px-3 py-2">
               <div className="flex items-center gap-2 text-[13px]">
                 <RunStatusDot status={run.status} />
-                <code className="font-mono text-[12px] text-slate-700">{shortRunId(run.id)}</code>
+                <code className="font-mono text-[13px] text-slate-700">{shortRunId(run.id)}</code>
                 <span className="text-slate-500">·</span>
                 <span className="text-slate-700">{run.agent_name ?? "—"}</span>
               </div>
-              <span className="text-[12px] text-slate-500">{run.status}</span>
+              <span className="text-[13px] text-slate-500">{run.status}</span>
             </li>
           ))}
         </ul>
@@ -1574,7 +1574,7 @@ function MetricsCard({ metrics, loading }: { metrics?: AgentMetrics; loading: bo
 function MetricStat({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md border border-slate-200 bg-slate-50/40 px-3 py-2">
-      <div className="text-[11px] uppercase tracking-wider text-slate-400">{label}</div>
+      <div className="text-[12px] uppercase tracking-wider text-slate-400">{label}</div>
       <div className="mt-0.5 text-[20px] font-semibold tabular-nums text-slate-900">{value}</div>
     </div>
   )
@@ -1615,10 +1615,10 @@ function RecentRunsCard({
                 <RunStatusDot status={run.status} />
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2 text-[13px]">
-                    <code className="font-mono text-[12px] text-slate-700">{shortRunId(run.id)}</code>
+                    <code className="font-mono text-[13px] text-slate-700">{shortRunId(run.id)}</code>
                     <span className="truncate text-slate-700">{run.agent_name ?? t("agents.detail.dynamics.recent.untitled")}</span>
                   </div>
-                  <div className="mt-0.5 text-[11px] text-slate-500">
+                  <div className="mt-0.5 text-[12px] text-slate-500">
                     {fmtAgo(run.created_at)}
                     {run.started_at && run.finished_at && (
                       <> · {formatDurationMs(durationMs(run.started_at, run.finished_at))}</>
@@ -1648,7 +1648,7 @@ function DynamicsCard({
     <section className="rounded-lg border border-slate-200 bg-white p-4">
       <div className="mb-3 flex items-baseline gap-2">
         <h3 className="text-[14px] font-semibold text-slate-900">{title}</h3>
-        {subtitle && <span className="text-[12px] text-slate-500">{subtitle}</span>}
+        {subtitle && <span className="text-[13px] text-slate-500">{subtitle}</span>}
       </div>
       {children}
     </section>
@@ -1750,7 +1750,7 @@ function AgentConfigTab({
           value={
             <span>
               {connectorLabel}
-              <span className="ml-1 text-[12px] text-slate-500">· {agent.connector_type}</span>
+              <span className="ml-1 text-[13px] text-slate-500">· {agent.connector_type}</span>
             </span>
           }
         />
@@ -1829,7 +1829,7 @@ function ConfigCapabilitiesSection({
   return (
     <section className="rounded-lg border border-slate-200 bg-white p-4">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-[12px] font-semibold uppercase tracking-wider text-slate-500">
+        <h3 className="text-[13px] font-semibold uppercase tracking-wider text-slate-500">
           {t("agents.detail.config.capabilities.title")}
         </h3>
         {isAdmin && installable.length > 0 && (
@@ -1937,7 +1937,7 @@ function AddCapabilityDialog({
           </div>
           <div className="max-h-80 space-y-2 overflow-y-auto">
             {filtered.length === 0 ? (
-              <p className="rounded-md border border-dashed border-slate-200 px-3 py-6 text-center text-[12px] text-slate-500">
+              <p className="rounded-md border border-dashed border-slate-200 px-3 py-6 text-center text-[13px] text-slate-500">
                 {t("agents.detail.capabilities.emptyAvailable")}
               </p>
             ) : (
@@ -1953,7 +1953,7 @@ function AddCapabilityDialog({
                         <CapabilityTypeBadge type={capability.type} />
                       </div>
                       {capability.description && (
-                        <p className="mt-1 text-[12px] text-slate-500">{capability.description}</p>
+                        <p className="mt-1 text-[13px] text-slate-500">{capability.description}</p>
                       )}
                     </div>
                     <EnableCapabilityDialog

--- a/apps/web/src/pages/admin/AuditPage.tsx
+++ b/apps/web/src/pages/admin/AuditPage.tsx
@@ -108,9 +108,9 @@ function shortId(s: string | undefined | null, n = 10): string {
 function ActorCell({ row }: { row: AuditRecord }) {
   if (row.actor_type === "agent") {
     return (
-      <span className="inline-flex items-center gap-1.5 text-[12px] text-slate-700">
+      <span className="inline-flex items-center gap-1.5 text-[13px] text-slate-700">
         <Bot className="h-3 w-3 text-slate-400" strokeWidth={1.75} />
-        <span className="font-mono text-[11px] text-slate-500">
+        <span className="font-mono text-[12px] text-slate-500">
           {shortId(row.actor_id, 10)}
         </span>
       </span>
@@ -118,9 +118,9 @@ function ActorCell({ row }: { row: AuditRecord }) {
   }
   if (row.actor_type === "user") {
     return (
-      <span className="inline-flex items-center gap-1.5 text-[12px] text-slate-700">
+      <span className="inline-flex items-center gap-1.5 text-[13px] text-slate-700">
         <UserIcon className="h-3 w-3 text-slate-400" strokeWidth={1.75} />
-        <span className="font-mono text-[11px] text-slate-500">
+        <span className="font-mono text-[12px] text-slate-500">
           {shortId(row.actor_id, 10)}
         </span>
       </span>
@@ -128,14 +128,14 @@ function ActorCell({ row }: { row: AuditRecord }) {
   }
   if (row.actor_type === "external") {
     return (
-      <span className="inline-flex items-center gap-1.5 text-[12px] text-slate-600">
+      <span className="inline-flex items-center gap-1.5 text-[13px] text-slate-600">
         <Globe className="h-3 w-3 text-slate-400" strokeWidth={1.75} />
         external
       </span>
     )
   }
   return (
-    <span className="inline-flex items-center gap-1.5 text-[12px] text-slate-600">
+    <span className="inline-flex items-center gap-1.5 text-[13px] text-slate-600">
       <Cog className="h-3 w-3 text-slate-400" strokeWidth={1.75} />
       system
     </span>
@@ -253,7 +253,7 @@ export function AuditPage() {
                   <TabsTrigger key={s} value={s}>
                     {t(`audit.tabs.${s}`)}
                     {counts && counts[s] > 0 && (
-                      <span className="ml-1.5 text-[11px] text-slate-400 tabular-nums">
+                      <span className="ml-1.5 text-[12px] text-slate-400 tabular-nums">
                         {counts[s]}
                       </span>
                     )}
@@ -268,7 +268,7 @@ export function AuditPage() {
                 onChange={(e) => setTargetType(e.target.value)}
                 aria-label={t("audit.filters.targetType")}
                 disabled={targetTypeOptions.length === 0}
-                className="rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-[12px] text-slate-700 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-200 disabled:opacity-50"
+                className="rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-[13px] text-slate-700 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-200 disabled:opacity-50"
               >
                 <option value="">
                   {targetTypeOptions.length === 0
@@ -341,10 +341,10 @@ export function AuditPage() {
                         >
                           <TableCell>
                             <div className="flex flex-col">
-                              <span className="text-[12px] text-slate-700">
+                              <span className="text-[13px] text-slate-700">
                                 {fmtAgo(r.occurred_at)}
                               </span>
-                              <span className="font-mono text-[10px] text-slate-400 tabular-nums">
+                              <span className="font-mono text-[11px] text-slate-400 tabular-nums">
                                 {fmtAbsTime(r.occurred_at)}
                               </span>
                             </div>
@@ -352,12 +352,12 @@ export function AuditPage() {
                           <TableCell><SourceBadge source={r.source} /></TableCell>
                           <TableCell><ActorCell row={r} /></TableCell>
                           <TableCell>
-                            <code className="text-[12px] text-slate-800">{r.event_type}</code>
+                            <code className="text-[13px] text-slate-800">{r.event_type}</code>
                           </TableCell>
                           <TableCell>
                             {targetClickable ? (
                               <button
-                                className="font-mono text-[11px] text-slate-700 hover:underline"
+                                className="font-mono text-[12px] text-slate-700 hover:underline"
                                 onClick={(e) => {
                                   e.stopPropagation()
                                   navigate("runs", { id: r.target_id! })
@@ -366,11 +366,11 @@ export function AuditPage() {
                                 {r.target_type} · {shortId(r.target_id, 10)}
                               </button>
                             ) : r.target_type ? (
-                              <span className="font-mono text-[11px] text-slate-600">
+                              <span className="font-mono text-[12px] text-slate-600">
                                 {r.target_type} · {shortId(r.target_id, 10)}
                               </span>
                             ) : (
-                              <span className="text-[11px] text-slate-400">—</span>
+                              <span className="text-[12px] text-slate-400">—</span>
                             )}
                           </TableCell>
                           <TableCell className="text-right pr-4">
@@ -379,7 +379,7 @@ export function AuditPage() {
                                 {t("audit.table.payloadFields", { count: payloadEntries })}
                               </Badge>
                             ) : (
-                              <span className="text-[11px] text-slate-400">—</span>
+                              <span className="text-[12px] text-slate-400">—</span>
                             )}
                           </TableCell>
                         </TableRow>
@@ -399,7 +399,7 @@ export function AuditPage() {
           )}
 
           {rows.length > 0 && (
-            <p className="text-[11px] text-slate-400">
+            <p className="text-[12px] text-slate-400">
               {t("audit.footer.shownCount", {
                 shown: filtered.length,
                 total: rows.length,
@@ -436,16 +436,16 @@ function PayloadView({ record }: { record: AuditRecord }) {
       <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
         <Field
           label={t("audit.detail.recordId")}
-          value={<span className="font-mono text-[11px]">{record.id}</span>}
+          value={<span className="font-mono text-[12px]">{record.id}</span>}
         />
         <Field
           label={t("audit.detail.actorType")}
-          value={<span className="font-mono text-[11px]">{record.actor_type}</span>}
+          value={<span className="font-mono text-[12px]">{record.actor_type}</span>}
         />
         <Field
           label={t("audit.detail.target")}
           value={
-            <span className="font-mono text-[11px] break-all">
+            <span className="font-mono text-[12px] break-all">
               {record.target_type ?? "—"} · {record.target_id ?? "—"}
             </span>
           }
@@ -468,10 +468,10 @@ function PayloadView({ record }: { record: AuditRecord }) {
       )}
 
       <div>
-        <p className="mb-1 text-[11px] uppercase tracking-wider text-slate-400">
+        <p className="mb-1 text-[12px] uppercase tracking-wider text-slate-400">
           {t("audit.detail.payload")}
         </p>
-        <pre className="whitespace-pre-wrap rounded-md bg-white p-3 font-mono text-[11px] text-slate-700 ring-1 ring-slate-200">
+        <pre className="whitespace-pre-wrap rounded-md bg-white p-3 font-mono text-[12px] text-slate-700 ring-1 ring-slate-200">
 {JSON.stringify(record.payload ?? {}, null, 2)}
         </pre>
       </div>
@@ -482,7 +482,7 @@ function PayloadView({ record }: { record: AuditRecord }) {
 function Field({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div>
-      <dt className="mb-0.5 text-[11px] uppercase tracking-wider text-slate-400">{label}</dt>
+      <dt className="mb-0.5 text-[12px] uppercase tracking-wider text-slate-400">{label}</dt>
       <dd className="text-[13px] text-slate-800">{value}</dd>
     </div>
   )

--- a/apps/web/src/pages/admin/ConnectionsPage.tsx
+++ b/apps/web/src/pages/admin/ConnectionsPage.tsx
@@ -67,7 +67,7 @@ export function ConnectionsPage() {
           <section>
             <h2 className="mb-3 text-[14px] font-semibold text-slate-900">{t("connections.oauth.title")}</h2>
             {oauthKinds.length === 0 ? (
-              <p className="text-[12.5px] text-slate-500">{t("connections.oauth.empty")}</p>
+              <p className="text-[13px] text-slate-500">{t("connections.oauth.empty")}</p>
             ) : (
               <div className="grid gap-3 lg:grid-cols-3">
                 {oauthKinds.map((kind) => {
@@ -98,7 +98,7 @@ export function ConnectionsPage() {
               )}
             </div>
             {modelKinds.length === 0 ? (
-              <p className="text-[12.5px] text-slate-500">{t("connections.model.empty")}</p>
+              <p className="text-[13px] text-slate-500">{t("connections.model.empty")}</p>
             ) : (
               <div className="grid gap-3 lg:grid-cols-3">
                 {modelKinds.map((kind) => {
@@ -257,7 +257,7 @@ function OAuthConnectionCard({
           </div>
           <div>
             <h3 className="text-[14px] font-semibold text-slate-900">{title}</h3>
-            <p className="mt-0.5 min-h-10 text-[12px] leading-5 text-slate-500">{description}</p>
+            <p className="mt-0.5 min-h-10 text-[13px] leading-5 text-slate-500">{description}</p>
           </div>
         </div>
         {loading ? (
@@ -313,7 +313,7 @@ function ModelKeyCard({
           <div>
             <h3 className="text-[14px] font-semibold text-slate-900">{title}</h3>
             {description && (
-              <p className="mt-0.5 min-h-10 text-[12px] leading-5 text-slate-500">{description}</p>
+              <p className="mt-0.5 min-h-10 text-[13px] leading-5 text-slate-500">{description}</p>
             )}
           </div>
         </div>
@@ -385,7 +385,7 @@ function CreateModelKindDialog({
           }}
         >
           <div className="space-y-1.5">
-            <label htmlFor="create-kind-code" className="text-[12px] font-medium text-slate-700">
+            <label htmlFor="create-kind-code" className="text-[13px] font-medium text-slate-700">
               {t("connections.createKind.code")}
             </label>
             <Input
@@ -397,11 +397,11 @@ function CreateModelKindDialog({
               autoComplete="off"
               spellCheck={false}
             />
-            <p className="text-[11px] text-slate-500">{t("connections.createKind.codeHint")}</p>
+            <p className="text-[12px] text-slate-500">{t("connections.createKind.codeHint")}</p>
           </div>
 
           <div className="space-y-1.5">
-            <label htmlFor="create-kind-name" className="text-[12px] font-medium text-slate-700">
+            <label htmlFor="create-kind-name" className="text-[13px] font-medium text-slate-700">
               {t("connections.createKind.displayName")}
             </label>
             <Input
@@ -413,7 +413,7 @@ function CreateModelKindDialog({
           </div>
 
           <div className="space-y-1.5">
-            <label htmlFor="create-kind-desc" className="text-[12px] font-medium text-slate-700">
+            <label htmlFor="create-kind-desc" className="text-[13px] font-medium text-slate-700">
               {t("connections.createKind.descriptionField")}
             </label>
             <Input
@@ -425,7 +425,7 @@ function CreateModelKindDialog({
           </div>
 
           {error && (
-            <p className="text-[12px] text-red-600">
+            <p className="text-[13px] text-red-600">
               {error.envelope.message || t("connections.createKind.errorGeneric")}
             </p>
           )}

--- a/apps/web/src/pages/admin/ConnectorsPage.tsx
+++ b/apps/web/src/pages/admin/ConnectorsPage.tsx
@@ -76,7 +76,7 @@ export function ConnectorsPage() {
         description={t("connectors.page.description")}
       />
 
-      <p className="mb-4 rounded-lg border border-dashed border-slate-200 bg-slate-50/60 p-3 text-[12px] leading-relaxed text-slate-600">
+      <p className="mb-4 rounded-lg border border-dashed border-slate-200 bg-slate-50/60 p-3 text-[13px] leading-relaxed text-slate-600">
         {t("connectors.aggregateHint")}
       </p>
       {!pid ? (
@@ -101,7 +101,7 @@ export function ConnectorsPage() {
       ) : (
         <div className="space-y-4">
           <div className="flex items-center justify-between gap-3">
-            <span className="text-[12px] text-slate-500">
+            <span className="text-[13px] text-slate-500">
               {t("connectors.summary", { count: connectors.length })}
             </span>
             <div className="relative w-72">
@@ -143,13 +143,13 @@ export function ConnectorsPage() {
                         <div className="flex items-center gap-2">
                           <Cable className="h-3.5 w-3.5 shrink-0 text-slate-400" strokeWidth={1.75} />
                           <span className="text-[14px] font-medium text-slate-900">{c.label}</span>
-                          <code className="text-[11px] text-slate-400">{c.connector_type}</code>
+                          <code className="text-[12px] text-slate-400">{c.connector_type}</code>
                         </div>
                       </TableCell>
                       <TableCell><ConnectorStatusBadge status={c.status} /></TableCell>
-                      <TableCell className="text-right text-[12px] tabular-nums text-slate-700">{c.agent_count}</TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums text-slate-700">{c.agent_count}</TableCell>
                       <TableCell className="text-right pr-4">
-                        <span className="text-[11px] text-slate-500">
+                        <span className="text-[12px] text-slate-500">
                           {c.agent_count === 0 ? "—" : t("connectors.table.agentSummary", { count: c.agent_count })}
                         </span>
                       </TableCell>
@@ -214,7 +214,7 @@ export function ConnectorDetailPage({ id }: { id: string }) {
           </button>
         }
         title={connector.label}
-        description={<code className="font-mono text-[12px]">{connector.connector_type}</code>}
+        description={<code className="font-mono text-[13px]">{connector.connector_type}</code>}
         action={<ConnectorStatusBadge status={connector.status} />}
       />
 
@@ -225,11 +225,11 @@ export function ConnectorDetailPage({ id }: { id: string }) {
       </div>
 
       <section className="mt-6 rounded-lg border border-slate-200 bg-white p-4">
-        <h3 className="mb-3 text-[12px] font-semibold uppercase tracking-wider text-slate-500">
+        <h3 className="mb-3 text-[13px] font-semibold uppercase tracking-wider text-slate-500">
           {t("connectors.detail.agents")}
         </h3>
         {connector.agent_count === 0 ? (
-          <p className="text-[12px] text-slate-500">{t("connectors.detail.noAgents")}</p>
+          <p className="text-[13px] text-slate-500">{t("connectors.detail.noAgents")}</p>
         ) : (
           <Button
             variant="ghost"
@@ -250,7 +250,7 @@ export function ConnectorDetailPage({ id }: { id: string }) {
 function Stat({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
   return (
     <div className="rounded-lg border border-slate-200 bg-white p-4">
-      <div className="text-[11px] uppercase tracking-wider text-slate-400">{label}</div>
+      <div className="text-[12px] uppercase tracking-wider text-slate-400">{label}</div>
       <div className={`mt-1 text-[20px] font-semibold tabular-nums text-slate-900 ${mono ? "font-mono" : ""}`}>{value}</div>
     </div>
   )

--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -305,13 +305,13 @@ function ConversationSidebar(p: SidebarProps) {
       >
         <div className="flex min-w-0 flex-1 flex-col">
           <div className="flex items-center gap-1">
-            <span className="truncate text-[13.5px] font-semibold text-slate-900">
+            <span className="truncate text-[14px] font-semibold text-slate-900">
               {selectedAgent?.name || t("conversations.sidebar.allAgentsHint")}
             </span>
             <ChevronDown className="h-3 w-3 shrink-0 text-slate-400" strokeWidth={2} />
           </div>
           {selectedAgent && (
-            <span className="mt-0.5 truncate text-[11.5px] text-slate-500">
+            <span className="mt-0.5 truncate text-[12px] text-slate-500">
               {selectedAgent.description || t("conversations.sidebar.currentAgentDesc")}
             </span>
           )}
@@ -326,7 +326,7 @@ function ConversationSidebar(p: SidebarProps) {
           {p.agentsLoading ? (
             <div className="p-3"><Skeleton className="h-8 w-full" /></div>
           ) : p.agents.length === 0 ? (
-            <p className="p-3 text-[12px] text-slate-500">{t("conversations.sidebar.allAgentsHint")}</p>
+            <p className="p-3 text-[13px] text-slate-500">{t("conversations.sidebar.allAgentsHint")}</p>
           ) : (
             p.agents.map((a) => (
               <button
@@ -345,7 +345,7 @@ function ConversationSidebar(p: SidebarProps) {
               >
                 <div className="font-medium">{a.name}</div>
                 {a.description && (
-                  <div className="mt-0.5 truncate text-[11.5px] text-slate-500">{a.description}</div>
+                  <div className="mt-0.5 truncate text-[12px] text-slate-500">{a.description}</div>
                 )}
               </button>
             ))
@@ -359,7 +359,7 @@ function ConversationSidebar(p: SidebarProps) {
         onClick={p.onNewConversation}
         disabled={!p.selectedAgentId}
         className={cn(
-          "mt-2 flex h-9 w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-slate-900 px-2.5 text-[13.5px] font-medium text-white shadow-sm transition-colors",
+          "mt-2 flex h-9 w-full cursor-pointer items-center justify-center gap-2 rounded-lg bg-slate-900 px-2.5 text-[14px] font-medium text-white shadow-sm transition-colors",
           "hover:bg-slate-800",
           "disabled:cursor-not-allowed disabled:opacity-50",
         )}
@@ -377,7 +377,7 @@ function ConversationSidebar(p: SidebarProps) {
             ))}
           </div>
         ) : p.conversations.length === 0 ? (
-          <p className="px-3 pt-4 text-[12px] leading-relaxed text-slate-400">
+          <p className="px-3 pt-4 text-[13px] leading-relaxed text-slate-400">
             {t("conversations.sidebar.emptyForAgent")}
           </p>
         ) : (
@@ -431,7 +431,7 @@ function ConversationSidebar(p: SidebarProps) {
                     />
                     <div className="flex items-center justify-end gap-1">
                       {renameError && (
-                        <span className="mr-auto text-[11px] text-red-500">
+                        <span className="mr-auto text-[12px] text-red-500">
                           {renameError}
                         </span>
                       )}
@@ -478,7 +478,7 @@ function ConversationSidebar(p: SidebarProps) {
                         {truncate(c.title || "", 18)}
                       </div>
                     </div>
-                    <div className="mt-1 flex items-center gap-1.5 text-[11px] text-slate-400">
+                    <div className="mt-1 flex items-center gap-1.5 text-[12px] text-slate-400">
                       <span className="min-w-0 flex-1 truncate">
                         {c.last_message_preview || (c.last_message_at ? fmtAgo(c.last_message_at) : fmtAgo(c.created_at))}
                       </span>
@@ -542,7 +542,7 @@ function ConversationSidebar(p: SidebarProps) {
           </DialogHeader>
           <DialogFooter className="flex flex-row items-center justify-end gap-2 border-t border-slate-100 bg-slate-50/60 px-4 py-3">
             {deleteError && (
-              <span className="mr-auto text-[12px] text-red-600">{deleteError}</span>
+              <span className="mr-auto text-[13px] text-red-600">{deleteError}</span>
             )}
             <Button
               variant="outline"
@@ -689,7 +689,7 @@ function EmptyChat({
   return (
     <div className="flex flex-1 flex-col bg-[radial-gradient(circle_at_58%_28%,rgba(226,232,240,0.72),transparent_34%),linear-gradient(180deg,#fbfcfd_0%,#ffffff_72%)] px-5 py-6 sm:px-8">
       <div className="mx-auto flex min-h-0 w-full max-w-4xl flex-1 flex-col">
-        <div className="flex items-center justify-between gap-3 text-[11px] text-slate-500">
+        <div className="flex items-center justify-between gap-3 text-[12px] text-slate-500">
           <span className="inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white/80 px-2 py-1 font-medium shadow-sm">
             <Bot className="h-3.5 w-3.5 text-slate-500" strokeWidth={2} />
             {agent?.name || t("conversations.sidebar.allAgentsHint")}
@@ -803,12 +803,12 @@ function ChatStream({ conversationId, agent, sidebarFolded }: { conversationId: 
       <div className={cn("border-b border-slate-200/70 bg-white/80 px-5 py-3 sm:px-6 lg:px-10", sidebarFolded && "pl-14 sm:pl-16 lg:pl-[72px]")}>
         <div className="mx-auto flex max-w-4xl items-center justify-between gap-4">
           <div className="min-w-0">
-            <p className="text-[11px] font-medium uppercase text-slate-400">{t("conversations.detail.kind")}</p>
+            <p className="text-[12px] font-medium uppercase text-slate-400">{t("conversations.detail.kind")}</p>
             <h2 className="truncate text-[15px] font-semibold text-slate-950">
               {agent?.name || t("conversations.sidebar.allAgentsHint")}
             </h2>
           </div>
-          <div className="flex shrink-0 items-center gap-2 text-[11px] text-slate-500">
+          <div className="flex shrink-0 items-center gap-2 text-[12px] text-slate-500">
             <span className={cn(
               "rounded-md border px-2 py-1 font-medium",
               someRunActive ? "border-emerald-200 bg-emerald-50 text-emerald-700" : "border-slate-200 bg-white text-slate-500",
@@ -835,7 +835,7 @@ function ChatStream({ conversationId, agent, sidebarFolded }: { conversationId: 
                   setActiveRunId(null)
                   cancelConvMut.mutate({ conversationID: conversationId, reason: "user_clicked_cancel_all" })
                 }}
-                className="h-7 gap-1 px-2 text-[11px] text-red-600 hover:text-red-700"
+                className="h-7 gap-1 px-2 text-[12px] text-red-600 hover:text-red-700"
                 title={t("conversations.detail.cancelAllAria", { defaultValue: "取消该会话所有进行中的任务" })}
               >
                 {cancelConvMut.isPending ? (
@@ -884,7 +884,7 @@ function ChatStream({ conversationId, agent, sidebarFolded }: { conversationId: 
             />
           )}
           {stream.status === "error" && (
-            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700">
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-700">
               {t("conversations.stream.error", { error: stream.error ?? "" })}
             </div>
           )}
@@ -902,7 +902,7 @@ function ChatStream({ conversationId, agent, sidebarFolded }: { conversationId: 
                 }
               />
             ) : (
-              <div className="flex w-fit items-center gap-2 rounded-md bg-white px-3 py-2 text-[12px] text-slate-500 shadow-sm ring-1 ring-slate-200/70">
+              <div className="flex w-fit items-center gap-2 rounded-md bg-white px-3 py-2 text-[13px] text-slate-500 shadow-sm ring-1 ring-slate-200/70">
                 <span className="flex items-center gap-1" aria-hidden="true">
                   <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-emerald-400 [animation-delay:-300ms]" />
                   <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-emerald-400 [animation-delay:-150ms]" />
@@ -927,7 +927,7 @@ function ChatStream({ conversationId, agent, sidebarFolded }: { conversationId: 
             .map((r) => (
               <div
                 key={r.id}
-                className="flex w-fit items-center gap-2 rounded-md border border-slate-200/70 bg-slate-50 px-3 py-2 text-[12px] text-slate-500 shadow-sm"
+                className="flex w-fit items-center gap-2 rounded-md border border-slate-200/70 bg-slate-50 px-3 py-2 text-[13px] text-slate-500 shadow-sm"
               >
                 <Clock className="h-3.5 w-3.5" strokeWidth={2.25} aria-hidden="true" />
                 {r.queue_position && r.queue_position > 1
@@ -982,12 +982,12 @@ function ChatStream({ conversationId, agent, sidebarFolded }: { conversationId: 
  */
 function ChatErrorToast({ message, onDismiss }: { message: string; onDismiss: () => void }) {
   return (
-    <div className="mb-2 flex items-start justify-between gap-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700">
+    <div className="mb-2 flex items-start justify-between gap-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-700">
       <span className="break-words">{message}</span>
       <button
         type="button"
         onClick={onDismiss}
-        className="shrink-0 rounded px-1.5 py-0.5 text-[11px] font-medium text-red-700 hover:bg-red-100"
+        className="shrink-0 rounded px-1.5 py-0.5 text-[12px] font-medium text-red-700 hover:bg-red-100"
       >
         ×
       </button>
@@ -1022,10 +1022,10 @@ function MessageRow({
     return (
       <div className="flex justify-end">
         <div className="flex max-w-[88%] flex-col items-end sm:max-w-[78%]">
-          <div className="rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-2.5 text-[14.5px] leading-relaxed text-emerald-950 shadow-sm">
+          <div className="rounded-lg border border-emerald-100 bg-emerald-50 px-4 py-2.5 text-[14px] leading-relaxed text-emerald-950 shadow-sm">
             <p className="whitespace-pre-wrap">{content}</p>
           </div>
-          <div className="mt-1.5 text-right text-[11px] text-slate-400">{stamp}</div>
+          <div className="mt-1.5 text-right text-[12px] text-slate-400">{stamp}</div>
         </div>
       </div>
     )
@@ -1035,23 +1035,23 @@ function MessageRow({
     return (
       <div className="flex">
         <div className="max-w-[78%]">
-          <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium text-red-700">
+          <div className="mb-1.5 flex items-center gap-1.5 text-[12px] font-medium text-red-700">
             <AlertTriangle className="h-3.5 w-3.5" strokeWidth={2.25} />
             <span>{t("conversations.runtime_error.badge")}</span>
           </div>
-          <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-2.5 text-[13.5px] leading-relaxed text-red-950 shadow-sm">
+          <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-2.5 text-[14px] leading-relaxed text-red-950 shadow-sm">
             <p className="font-medium">{runtimeError.message}</p>
             {runtimeError.href && runtimeError.action && (
               <a
                 href={runtimeError.href}
-                className="mt-2 inline-flex items-center rounded-md border border-red-200 bg-white px-2.5 py-1 text-[12px] font-medium text-red-700 transition-colors hover:bg-red-100"
+                className="mt-2 inline-flex items-center rounded-md border border-red-200 bg-white px-2.5 py-1 text-[13px] font-medium text-red-700 transition-colors hover:bg-red-100"
               >
                 {runtimeError.action}
               </a>
             )}
-            <p className="mt-2 text-[12px] text-red-700/80">{t("conversations.runtime_error.retryHint")}</p>
+            <p className="mt-2 text-[13px] text-red-700/80">{t("conversations.runtime_error.retryHint")}</p>
           </div>
-          <div className="mt-1.5 text-[11px] text-slate-400">
+          <div className="mt-1.5 text-[12px] text-slate-400">
             {agentName ? `${stamp} · ${agentName}` : stamp}
           </div>
         </div>
@@ -1071,10 +1071,10 @@ function MessageRow({
   return (
     <div className="flex">
       <div className="max-w-[82%] border-l border-slate-200 pl-4">
-        <div className="mb-1.5 text-[11px] font-medium text-slate-400">
+        <div className="mb-1.5 text-[12px] font-medium text-slate-400">
           {agentName || "Agent"}
         </div>
-        <div className="text-[14.5px] leading-[1.7] text-slate-900">
+        <div className="text-[14px] leading-[1.7] text-slate-900">
           <p className="whitespace-pre-wrap">{content}</p>
         </div>
         {allSteps.length > 0 && <StepTrace steps={allSteps} />}
@@ -1082,12 +1082,12 @@ function MessageRow({
           <button
             type="button"
             onClick={() => onOpenRun(failedRun.id)}
-            className="mt-1.5 text-[12px] text-slate-500 hover:text-slate-700 hover:underline"
+            className="mt-1.5 text-[13px] text-slate-500 hover:text-slate-700 hover:underline"
           >
             {t("conversations.detail.viewRunLink")} →
           </button>
         )}
-        <div className="mt-1.5 text-[11px] text-slate-400">{stamp}</div>
+        <div className="mt-1.5 text-[12px] text-slate-400">{stamp}</div>
       </div>
     </div>
   )
@@ -1279,7 +1279,7 @@ function ComposerForm({
           onChange={(e) => setContent(e.target.value)}
           placeholder={placeholder}
           disabled={disabled || (!conversationId && !onSendDirect)}
-          className="flex-1 border-0 bg-transparent px-2 text-[14.5px] shadow-none focus-visible:ring-0"
+          className="flex-1 border-0 bg-transparent px-2 text-[14px] shadow-none focus-visible:ring-0"
         />
         {showStop ? (
           <button

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -898,7 +898,7 @@ export function CreateAgentDialog({
           }}
         >
           {mode === "edit" && attachedCount > 1 && (
-            <div className="rounded-lg border border-amber-200 bg-amber-50/50 p-3 text-[12px] text-amber-900">
+            <div className="rounded-lg border border-amber-200 bg-amber-50/50 p-3 text-[13px] text-amber-900">
               <div className="flex items-start gap-2">
                 <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
                 <div>
@@ -928,7 +928,7 @@ export function CreateAgentDialog({
                 <Field label={t("agents.table.visibility")} required>
                   <div className="grid gap-2 sm:grid-cols-3">
                     {(["workspace", "tenant", "public"] as const).map((tier) => (
-                      <label key={tier} className={"flex cursor-pointer flex-col gap-1 rounded-md border px-3 py-2 text-[12.5px] " + (visibility === tier ? "border-slate-900 bg-slate-50 text-slate-900" : "border-slate-200 bg-white text-slate-700")}>
+                      <label key={tier} className={"flex cursor-pointer flex-col gap-1 rounded-md border px-3 py-2 text-[13px] " + (visibility === tier ? "border-slate-900 bg-slate-50 text-slate-900" : "border-slate-200 bg-white text-slate-700")}>
                         <span className="flex items-center gap-2 font-medium">
                           <input
                             type="radio"
@@ -939,18 +939,18 @@ export function CreateAgentDialog({
                           />
                           {t(`agents.visibility.${tier}` as never)}
                         </span>
-                        <span className="pl-5 text-[11px] leading-4 text-slate-500">{t(`agents.visibility.${tier}Hint` as never)}</span>
+                        <span className="pl-5 text-[12px] leading-4 text-slate-500">{t(`agents.visibility.${tier}Hint` as never)}</span>
                       </label>
                     ))}
                   </div>
                   {visibility === "public" && (
-                    <div className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[11.5px] leading-5 text-red-800">
+                    <div className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-800">
                       <AlertTriangle className="mr-1 inline h-3.5 w-3.5" />
                       {t("credentialCheck.publicWarning")}
                     </div>
                   )}
                   {visibility === "tenant" && (
-                    <div className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[11.5px] leading-5 text-amber-800">
+                    <div className="mt-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] leading-5 text-amber-800">
                       <AlertTriangle className="mr-1 inline h-3.5 w-3.5" />
                       {t("credentialCheck.tenantHint")}
                     </div>
@@ -1114,7 +1114,7 @@ export function CreateAgentDialog({
                         className="absolute z-50 mt-1 max-h-52 w-full overflow-y-auto rounded-md border border-slate-200 bg-white py-1 text-[13px] shadow-lg"
                       >
                         {filteredModels.length === 0 ? (
-                          <div className="px-3 py-2 text-[12px] text-slate-500">{t("agents.form.emptyModelSearch")}</div>
+                          <div className="px-3 py-2 text-[13px] text-slate-500">{t("agents.form.emptyModelSearch")}</div>
                         ) : filteredModels.map((m) => {
                           const selected = modelID === m.id
                           const highlighted = highlightedModelID === m.id
@@ -1131,7 +1131,7 @@ export function CreateAgentDialog({
                             >
                               <span className="min-w-0 truncate">{modelLabel(m)}</span>
                               {selected && (
-                                <span className="inline-flex shrink-0 items-center gap-1 text-[11px] text-slate-500">
+                                <span className="inline-flex shrink-0 items-center gap-1 text-[12px] text-slate-500">
                                   <Check className="h-3.5 w-3.5" />
                                   {t("agents.form.selected")}
                                 </span>
@@ -1159,10 +1159,10 @@ export function CreateAgentDialog({
                         disabled={visibility === "public"}
                         onChange={() => setModelBindingChoice({ source: "personal" })}
                       />
-                      <span className="text-[12px]">
+                      <span className="text-[13px]">
                         <span className="block text-slate-800">{t("credentialCheck.modelBindingPersonal")}</span>
                         {visibility === "public" && (
-                          <span className="block text-[11px] text-slate-500">{t("credentialCheck.personalDisabledHint")}</span>
+                          <span className="block text-[12px] text-slate-500">{t("credentialCheck.personalDisabledHint")}</span>
                         )}
                       </span>
                     </label>
@@ -1183,7 +1183,7 @@ export function CreateAgentDialog({
                           }
                         }}
                       />
-                      <span className="flex-1 text-[12px]">
+                      <span className="flex-1 text-[13px]">
                         <span className="block text-slate-800">{t("credentialCheck.modelBindingShared")}</span>
                         {modelBindingChoice.source === "shared" && (
                           <div className="mt-1 space-y-1.5">
@@ -1204,7 +1204,7 @@ export function CreateAgentDialog({
                                   }
                                 }}
                                 onClick={(e) => e.stopPropagation()}
-                                className="h-7 w-full rounded border border-slate-200 bg-white px-2 text-[12px]"
+                                className="h-7 w-full rounded border border-slate-200 bg-white px-2 text-[13px]"
                               >
                                 {sharedSecrets.map((s) => (
                                   <option key={s.id} value={s.id}>{s.name}</option>
@@ -1215,7 +1215,7 @@ export function CreateAgentDialog({
                             {sharedSecrets.length === 0 && !modelNewSecretExpanded && !("new_secret" in modelBindingChoice) && (
                               <button
                                 type="button"
-                                className="inline-flex h-7 items-center gap-1 rounded border border-dashed border-slate-300 px-2 text-[12px] text-slate-700 hover:bg-slate-50"
+                                className="inline-flex h-7 items-center gap-1 rounded border border-dashed border-slate-300 px-2 text-[13px] text-slate-700 hover:bg-slate-50"
                                 onClick={(e) => {
                                   e.preventDefault()
                                   e.stopPropagation()
@@ -1229,7 +1229,7 @@ export function CreateAgentDialog({
                               </button>
                             )}
                             {"new_secret" in modelBindingChoice && !modelNewSecretExpanded && (
-                              <div className="flex items-center gap-2 rounded border border-emerald-200 bg-emerald-50 px-2 py-1 text-[11px] text-emerald-800">
+                              <div className="flex items-center gap-2 rounded border border-emerald-200 bg-emerald-50 px-2 py-1 text-[12px] text-emerald-800">
                                 <Check className="h-3 w-3 shrink-0" />
                                 <span className="flex-1 truncate">
                                   {t("credentialCheck.sharedNewQueued", { name: modelBindingChoice.new_secret.display_name || t("credentialCheck.modelBindingTitle") })}
@@ -1254,16 +1254,16 @@ export function CreateAgentDialog({
                             {modelNewSecretExpanded && (
                               <div className="space-y-2 rounded border border-slate-200 bg-slate-50 p-2" onClick={(e) => e.stopPropagation()}>
                                 <div className="grid gap-1">
-                                  <label className="text-[11px] font-medium text-slate-600">{t("credentialCheck.form.displayName")}</label>
+                                  <label className="text-[12px] font-medium text-slate-600">{t("credentialCheck.form.displayName")}</label>
                                   <Input
                                     value={modelNewSecretDisplayName}
                                     onChange={(e) => setModelNewSecretDisplayName(e.target.value)}
                                     placeholder={selectedModel?.name ?? t("credentialCheck.modelBindingTitle")}
-                                    className="h-7 text-[12px]"
+                                    className="h-7 text-[13px]"
                                   />
                                 </div>
                                 <div className="grid gap-1">
-                                  <label className="text-[11px] font-medium text-slate-600">
+                                  <label className="text-[12px] font-medium text-slate-600">
                                     {t("credentialCheck.form.value")}
                                     <span className="ml-0.5 text-red-500">*</span>
                                   </label>
@@ -1273,7 +1273,7 @@ export function CreateAgentDialog({
                                       value={modelNewSecretPlaintext}
                                       onChange={(e) => setModelNewSecretPlaintext(e.target.value)}
                                       placeholder="sk-..."
-                                      className="h-7 pr-8 text-[12px]"
+                                      className="h-7 pr-8 text-[13px]"
                                     />
                                     <button
                                       type="button"
@@ -1289,7 +1289,7 @@ export function CreateAgentDialog({
                                     type="button"
                                     variant="ghost"
                                     size="sm"
-                                    className="h-6 text-[11px]"
+                                    className="h-6 text-[12px]"
                                     onClick={() => {
                                       setModelNewSecretExpanded(false)
                                       // If the user cancels and no existing secret has been chosen yet,
@@ -1309,7 +1309,7 @@ export function CreateAgentDialog({
                                   <Button
                                     type="button"
                                     size="sm"
-                                    className="h-6 text-[11px]"
+                                    className="h-6 text-[12px]"
                                     disabled={!modelNewSecretPlaintext.trim()}
                                     onClick={() => {
                                       if (!modelNewSecretPlaintext.trim()) return
@@ -1343,7 +1343,7 @@ export function CreateAgentDialog({
               <section className="space-y-3">
                 <Input value={capabilitySearch} onChange={(e) => setCapabilitySearch(e.target.value)} placeholder={t("agents.form.placeholders.capabilitySearch")} />
                 {capabilityOptions.length === 0 ? (
-                  <p className="rounded-md bg-slate-50 px-3 py-2 text-[12px] text-slate-500">
+                  <p className="rounded-md bg-slate-50 px-3 py-2 text-[13px] text-slate-500">
                     {admin ? t("agents.form.noTagsAdmin") : t("agents.form.noTagsMember")}
                   </p>
                 ) : (
@@ -1359,7 +1359,7 @@ export function CreateAgentDialog({
                     </Tabs>
                     <div className="max-h-56 overflow-y-auto rounded-md border border-slate-200 bg-white">
                       {visibleCapabilityOptions.length === 0 ? (
-                        <p className="px-3 py-2 text-[12px] text-slate-500">{tc("states.noResults")}</p>
+                        <p className="px-3 py-2 text-[13px] text-slate-500">{tc("states.noResults")}</p>
                       ) : (() => {
                         const sections = (["workspace", "marketplace"] as const)
                           .map((sec) => ({ sec, rows: visibleCapabilityOptions.filter((o) => o.section === sec) }))
@@ -1367,7 +1367,7 @@ export function CreateAgentDialog({
                         let rowCounter = 0
                         return sections.map(({ sec, rows }, sectionIdx) => (
                           <Fragment key={sec}>
-                            <div className={"px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-slate-500 bg-slate-50" + (sectionIdx > 0 ? " border-t border-slate-200" : "")}>
+                            <div className={"px-3 py-1.5 text-[12px] font-semibold uppercase tracking-wider text-slate-500 bg-slate-50" + (sectionIdx > 0 ? " border-t border-slate-200" : "")}>
                               {t(`agents.form.capabilitySections.${sec}`)}
                             </div>
                             {rows.map((cap) => {
@@ -1406,7 +1406,7 @@ export function CreateAgentDialog({
                                         />
                                       )}
                                     </span>
-                                    {cap.description && !cap.deprecated && <span className="mt-0.5 block truncate text-[12px] leading-4 text-slate-500">{cap.description}</span>}
+                                    {cap.description && !cap.deprecated && <span className="mt-0.5 block truncate text-[13px] leading-4 text-slate-500">{cap.description}</span>}
                                   </span>
                                 </label>
                               )
@@ -1421,7 +1421,7 @@ export function CreateAgentDialog({
 
               {aggregatedRequiredKinds.length > 0 && (
                 <section className="space-y-3">
-                  <h3 className="text-[12px] font-semibold uppercase tracking-wider text-slate-500">{t("agents.form.sections.credentials")}</h3>
+                  <h3 className="text-[13px] font-semibold uppercase tracking-wider text-slate-500">{t("agents.form.sections.credentials")}</h3>
                   <CredentialCheckPanel
                     requiredKinds={aggregatedRequiredKinds}
                     workspaceID={workspaceID}
@@ -1439,7 +1439,7 @@ export function CreateAgentDialog({
             </>
           )}
 
-          {errMsg && <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">{errMsg}</p>}
+          {errMsg && <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">{errMsg}</p>}
         </form>
 
         <DialogFooter className="shrink-0 border-t border-slate-100 pt-4">
@@ -1514,12 +1514,12 @@ function WizardProgress({
   return (
     <div className="shrink-0 space-y-1.5">
       <div className="flex items-baseline justify-between gap-2">
-        <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">{stepOfLabel}</p>
-        <p className="text-[11px] text-slate-400">{completeLabel}</p>
+        <p className="text-[12px] font-semibold uppercase tracking-wider text-slate-500">{stepOfLabel}</p>
+        <p className="text-[12px] text-slate-400">{completeLabel}</p>
       </div>
       <div className="flex items-baseline justify-between gap-2">
         <h2 className="shrink-0 text-[16px] font-semibold leading-none text-slate-900">{title}</h2>
-        <p className="min-w-0 truncate text-[12px] text-slate-500">{summary}</p>
+        <p className="min-w-0 truncate text-[13px] text-slate-500">{summary}</p>
       </div>
       <div className="relative h-1 w-full overflow-hidden rounded-full bg-slate-100">
         <div
@@ -1546,12 +1546,12 @@ const Field = forwardRef<HTMLDivElement, FieldProps>(function Field(
 ) {
   return (
     <div ref={ref} className="grid gap-1.5">
-      <label className="text-[12px] font-medium text-slate-700">
+      <label className="text-[13px] font-medium text-slate-700">
         {label}{required && <span className="ml-0.5 text-red-500">*</span>}
       </label>
       {children}
-      {hint && <span className="text-[11px] text-slate-400">{hint}</span>}
-      {error && <span className="text-[11px] text-red-600">{error}</span>}
+      {hint && <span className="text-[12px] text-slate-400">{hint}</span>}
+      {error && <span className="text-[12px] text-red-600">{error}</span>}
     </div>
   )
 })
@@ -1560,8 +1560,8 @@ function ChoiceCard({ icon, title, description, selected, onSelect, disabled = f
   // cards without one collapse to natural height to avoid an empty body block.
   const heightClass = description ? "min-h-[92px] items-start" : "items-center"
   const className = disabled
-    ? `flex w-full ${heightClass} gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-left text-[12.5px] text-slate-400`
-    : `flex w-full ${heightClass} gap-2 rounded-md border px-3 py-2 text-left text-[12.5px] transition ` + (selected ? "border-slate-900 bg-slate-50 text-slate-900" : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50")
+    ? `flex w-full ${heightClass} gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-left text-[13px] text-slate-400`
+    : `flex w-full ${heightClass} gap-2 rounded-md border px-3 py-2 text-left text-[13px] transition ` + (selected ? "border-slate-900 bg-slate-50 text-slate-900" : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50")
   return (
     <button
       type="button"
@@ -1573,7 +1573,7 @@ function ChoiceCard({ icon, title, description, selected, onSelect, disabled = f
       <span className="min-w-0">
         <span className="block font-medium">{title}</span>
         {description && (
-          <span className="mt-0.5 block text-[11px] leading-4 text-slate-500">{description}</span>
+          <span className="mt-0.5 block text-[12px] leading-4 text-slate-500">{description}</span>
         )}
       </span>
     </button>
@@ -1584,8 +1584,8 @@ function DependencyCard({ title, description, href, cta }: { title: string; desc
   return (
     <div className="rounded-lg border border-dashed border-slate-300 bg-slate-50 p-3">
       <p className="text-[13px] font-medium text-slate-900">{title}</p>
-      <p className="mt-1 text-[12px] text-slate-500">{description}</p>
-      <a href={href} className="mt-2 inline-flex items-center gap-1 text-[12px] font-medium text-slate-900 underline">
+      <p className="mt-1 text-[13px] text-slate-500">{description}</p>
+      <a href={href} className="mt-2 inline-flex items-center gap-1 text-[13px] font-medium text-slate-900 underline">
         {cta} <ArrowUpRight className="h-3 w-3" />
       </a>
     </div>
@@ -1662,7 +1662,7 @@ function CapabilityVersionPicker({
       // suffix) reminds the user that breaking changes can land
       // without warning. We don't disable "latest" outright — opting
       // into it is a deliberate user choice we surface explicitly.
-      className="ml-1 h-7 shrink-0 rounded-md border border-slate-200 bg-white px-2 text-[12px] text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-300"
+      className="ml-1 h-7 shrink-0 rounded-md border border-slate-200 bg-white px-2 text-[13px] text-slate-900 focus:outline-none focus:ring-2 focus:ring-slate-300"
       title={fromMarketplace ? t("agents.form.versionPicker.marketplaceHint") : t("agents.form.versionPicker.localHint")}
     >
       <option value="__latest__">

--- a/apps/web/src/pages/admin/MembersPage.tsx
+++ b/apps/web/src/pages/admin/MembersPage.tsx
@@ -109,7 +109,7 @@ function UserCell({ name, email }: { name: string; email: string }) {
         <div className="truncate text-[13px] font-medium text-slate-900">
           {name || "—"}
         </div>
-        <div className="truncate text-[11.5px] text-slate-500">{email}</div>
+        <div className="truncate text-[12px] text-slate-500">{email}</div>
       </div>
     </div>
   )
@@ -167,7 +167,7 @@ export function MembersPage() {
             <Users className="h-3.5 w-3.5" />
             {t("members.tabs.workspace")}
             {wsQ.data && (
-              <span className="ml-1 text-[11px] text-slate-500">
+              <span className="ml-1 text-[12px] text-slate-500">
                 ({wsQ.data.members.length})
               </span>
             )}
@@ -356,7 +356,7 @@ function MembersTable({
                     onChange={(e) =>
                       onChangeRole(m, e.target.value as MemberRole)
                     }
-                    className="rounded-md border border-slate-200 bg-white px-2 py-1 text-[12px] text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-200 disabled:opacity-50"
+                    className="rounded-md border border-slate-200 bg-white px-2 py-1 text-[13px] text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-200 disabled:opacity-50"
                   >
                     {ROLES.map((r) => (
                       <option key={r} value={r}>
@@ -372,7 +372,7 @@ function MembersTable({
                 <UserStatusBadge status={m.user_status} />
               </TableCell>
               <TableCell>
-                <span className="text-[12px] text-slate-500">
+                <span className="text-[13px] text-slate-500">
                   {fmtAgo(m.created_at)}
                 </span>
               </TableCell>
@@ -512,7 +512,7 @@ function AddMemberDialog({
 
             {failures.length > 0 && (
               <div className="space-y-1 rounded-md border border-red-200 bg-red-50 px-3 py-2">
-                <p className="text-[12px] font-medium text-red-900">
+                <p className="text-[13px] font-medium text-red-900">
                   {t("members.add.partialError.title", {
                     success: successCount,
                     failed: failures.length,
@@ -524,7 +524,7 @@ function AddMemberDialog({
                   {failures.map((f) => (
                     <li
                       key={f.user.id}
-                      className="text-[11.5px] text-red-700"
+                      className="text-[12px] text-red-700"
                     >
                       {f.user.email}: {f.message}
                     </li>
@@ -577,7 +577,7 @@ function DialogField({
 }) {
   return (
     <label className="block space-y-1">
-      <span className="text-[12px] font-medium text-slate-700">
+      <span className="text-[13px] font-medium text-slate-700">
         {label}
         {required && <span className="ml-0.5 text-red-500">*</span>}
       </span>
@@ -623,7 +623,7 @@ function ConfirmRemoveDialog({
               {description}
             </DialogDescription>
             {error && (
-              <p className="text-[12px] text-red-700">{error.message}</p>
+              <p className="text-[13px] text-red-700">{error.message}</p>
             )}
           </div>
         </DialogHeader>
@@ -659,10 +659,10 @@ function ErrorBanner({ message }: { message: string }) {
   const { t } = useTranslation("admin")
   return (
     <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2">
-      <p className="text-[12px] font-medium text-red-900">
+      <p className="text-[13px] font-medium text-red-900">
         {t("members.mutation.errorTitle")}
       </p>
-      <p className="text-[11.5px] text-red-700">{message}</p>
+      <p className="text-[12px] text-red-700">{message}</p>
     </div>
   )
 }
@@ -689,7 +689,7 @@ function MockBanner({
             scope: t("members.tabs.workspace"),
           })}
         </p>
-        <p className="text-[12px] leading-relaxed text-amber-800">{hint}</p>
+        <p className="text-[13px] leading-relaxed text-amber-800">{hint}</p>
       </div>
     </div>
   )
@@ -711,7 +711,7 @@ function PendingBadge({ wsId }: { wsId: string | null }) {
   const count = q.data?.requests.length ?? 0
   if (count === 0) return null
   return (
-    <span className="ml-1 rounded-full bg-amber-100 px-1.5 py-0 text-[10px] font-medium text-amber-700">
+    <span className="ml-1 rounded-full bg-amber-100 px-1.5 py-0 text-[11px] font-medium text-amber-700">
       {count}
     </span>
   )
@@ -862,17 +862,17 @@ function PendingRequestRow({
           <span className="text-[13px] font-medium text-slate-900">
             {req.user_name || req.user_email}
           </span>
-          <span className="text-[11px] text-slate-500">{req.user_email}</span>
+          <span className="text-[12px] text-slate-500">{req.user_email}</span>
         </div>
       </TableCell>
-      <TableCell className="text-[12px] text-slate-700">
+      <TableCell className="text-[13px] text-slate-700">
         {req.request_reason || (
           <span className="text-slate-400">
             {t("members.pendingRequests.noReason")}
           </span>
         )}
       </TableCell>
-      <TableCell className="text-[12px] text-slate-500">
+      <TableCell className="text-[13px] text-slate-500">
         {fmtAgo(req.requested_at)}
       </TableCell>
       <TableCell className="text-right">

--- a/apps/web/src/pages/admin/MemoryPage.tsx
+++ b/apps/web/src/pages/admin/MemoryPage.tsx
@@ -360,20 +360,20 @@ function MemoryRow({ memory, fmtAgo, onEdit, onDelete, onAudit }: MemoryRowProps
           )}
           <MemorySourceBadge source={memory.source} />
           {memory.tags.map((tag) => (
-            <Badge key={tag} variant="neutral" className="font-mono text-[10.5px]">
+            <Badge key={tag} variant="neutral" className="font-mono text-[11px]">
               {tag}
             </Badge>
           ))}
         </div>
         {preview && (
-          <p className="line-clamp-2 text-[12.5px] text-slate-600">{preview}</p>
+          <p className="line-clamp-2 text-[13px] text-slate-600">{preview}</p>
         )}
         {memory.why && (
-          <p className="line-clamp-2 text-[11.5px] italic text-slate-500">
+          <p className="line-clamp-2 text-[12px] italic text-slate-500">
             Why: {memory.why}
           </p>
         )}
-        <p className="text-[11px] text-slate-400">
+        <p className="text-[12px] text-slate-400">
           {t("memory.row.updatedAt", { time: fmtAgo(memory.updated_at) })}
           {memory.agent_actor && (
             <>
@@ -452,8 +452,8 @@ function TypeFilterChip({
       onClick={onClick}
       className={
         active
-          ? "rounded-full bg-slate-900 px-3 py-1 text-[11.5px] font-medium text-white"
-          : "rounded-full bg-slate-100 px-3 py-1 text-[11.5px] font-medium text-slate-600 transition-colors hover:bg-slate-200 hover:text-slate-900"
+          ? "rounded-full bg-slate-900 px-3 py-1 text-[12px] font-medium text-white"
+          : "rounded-full bg-slate-100 px-3 py-1 text-[12px] font-medium text-slate-600 transition-colors hover:bg-slate-200 hover:text-slate-900"
       }
     >
       {label}
@@ -529,7 +529,7 @@ function MemoryEditorDialog({
           </DialogHeader>
           <div className="space-y-3 px-5 py-4">
             <label className="block space-y-1">
-              <span className="text-[12px] font-medium text-slate-700">
+              <span className="text-[13px] font-medium text-slate-700">
                 {t("memory.editor.field.type")}
                 <span className="ml-0.5 text-red-500">*</span>
               </span>
@@ -549,7 +549,7 @@ function MemoryEditorDialog({
               </select>
             </label>
             <label className="block space-y-1">
-              <span className="text-[12px] font-medium text-slate-700">
+              <span className="text-[13px] font-medium text-slate-700">
                 {t("memory.editor.field.title")}
               </span>
               <Input
@@ -560,7 +560,7 @@ function MemoryEditorDialog({
               />
             </label>
             <label className="block space-y-1">
-              <span className="text-[12px] font-medium text-slate-700">
+              <span className="text-[13px] font-medium text-slate-700">
                 {t("memory.editor.field.body")}
                 <span className="ml-0.5 text-red-500">*</span>
               </span>
@@ -570,11 +570,11 @@ function MemoryEditorDialog({
                 placeholder={t("memory.editor.placeholder.body")}
                 required
                 rows={8}
-                className="block w-full rounded-md border border-slate-200 px-3 py-2 font-mono text-[12.5px] leading-relaxed text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
+                className="block w-full rounded-md border border-slate-200 px-3 py-2 font-mono text-[13px] leading-relaxed text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
               />
             </label>
             <label className="block space-y-1">
-              <span className="text-[12px] font-medium text-slate-700">
+              <span className="text-[13px] font-medium text-slate-700">
                 {t("memory.editor.field.why")}
               </span>
               <textarea
@@ -582,11 +582,11 @@ function MemoryEditorDialog({
                 onChange={(event) => setWhy(event.target.value)}
                 placeholder={t("memory.editor.placeholder.why")}
                 rows={3}
-                className="block w-full rounded-md border border-slate-200 px-3 py-2 text-[12.5px] leading-relaxed text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
+                className="block w-full rounded-md border border-slate-200 px-3 py-2 text-[13px] leading-relaxed text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
               />
             </label>
             <label className="block space-y-1">
-              <span className="text-[12px] font-medium text-slate-700">
+              <span className="text-[13px] font-medium text-slate-700">
                 {t("memory.editor.field.tags")}
               </span>
               <Input
@@ -597,10 +597,10 @@ function MemoryEditorDialog({
             </label>
             {error && (
               <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2">
-                <p className="text-[12px] font-medium text-red-900">
+                <p className="text-[13px] font-medium text-red-900">
                   {t("memory.editor.error.title")}
                 </p>
-                <p className="text-[11.5px] text-red-700">{error.message}</p>
+                <p className="text-[12px] text-red-700">{error.message}</p>
               </div>
             )}
           </div>
@@ -648,7 +648,7 @@ function MemoryDeleteDialog({
             <div className="space-y-1.5">
               <AlertDialogTitle>{t("memory.delete.title")}</AlertDialogTitle>
               <AlertDialogDescription>{t("memory.delete.description")}</AlertDialogDescription>
-              {error && <p className="text-[12px] text-red-700">{error.message}</p>}
+              {error && <p className="text-[13px] text-red-700">{error.message}</p>}
             </div>
           </div>
         </AlertDialogHeader>

--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -164,20 +164,20 @@ function HeadersEditor({
 
   return (
     <div className="grid gap-1.5">
-      <label className="text-[12px] font-medium text-slate-700">{label}</label>
+      <label className="text-[13px] font-medium text-slate-700">{label}</label>
       {rows.map((row) => (
         <div key={row.id} className="flex gap-2">
           <Input
             value={row.key}
             onChange={(e) => updateRow(row.id, "key", e.target.value)}
             placeholder="Header"
-            className="flex-1 font-mono text-[12.5px]"
+            className="flex-1 font-mono text-[13px]"
           />
           <Input
             value={row.value}
             onChange={(e) => updateRow(row.id, "value", e.target.value)}
             placeholder="value"
-            className="flex-1 font-mono text-[12.5px]"
+            className="flex-1 font-mono text-[13px]"
           />
           <Button
             type="button"
@@ -225,7 +225,7 @@ function Field({
 }: FieldProps) {
   return (
     <div className="grid gap-1.5">
-      <label className="text-[12px] font-medium text-slate-700" htmlFor={id}>
+      <label className="text-[13px] font-medium text-slate-700" htmlFor={id}>
         {label}
         {required && <span className="ml-0.5 text-red-500">*</span>}
       </label>
@@ -237,9 +237,9 @@ function Field({
         required={required}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className={mono ? "font-mono text-[12.5px]" : undefined}
+        className={mono ? "font-mono text-[13px]" : undefined}
       />
-      {hint && <span className="text-[11px] text-slate-400">{hint}</span>}
+      {hint && <span className="text-[12px] text-slate-400">{hint}</span>}
     </div>
   )
 }
@@ -466,7 +466,7 @@ export function CreateModelDialog({
 
           {/* --- Provider type + endpoint --- */}
           <div className="grid gap-1.5">
-            <label className="text-[12px] font-medium text-slate-700" htmlFor="model-provider-type">
+            <label className="text-[13px] font-medium text-slate-700" htmlFor="model-provider-type">
               {t("models.createProvider.fields.providerType")}
               <span className="ml-0.5 text-red-500">*</span>
             </label>
@@ -482,7 +482,7 @@ export function CreateModelDialog({
                 </option>
               ))}
             </select>
-            <span className="text-[11px] text-slate-400">
+            <span className="text-[12px] text-slate-400">
               {t("models.createProvider.fields.adapterHint", { adapter })}
             </span>
           </div>
@@ -522,7 +522,7 @@ export function CreateModelDialog({
           {/* --- Auth scheme (only for anthropic-compatible) --- */}
           {showAuthSchemeSelector && (
             <div className="grid gap-1.5">
-              <label className="text-[12px] font-medium text-slate-700" htmlFor="model-auth-scheme">
+              <label className="text-[13px] font-medium text-slate-700" htmlFor="model-auth-scheme">
                 {t("models.createProvider.fields.authScheme")}
               </label>
               <select
@@ -539,7 +539,7 @@ export function CreateModelDialog({
 
           {/* --- Credential mode --- */}
           <fieldset className="rounded-md border border-slate-200 p-3">
-            <legend className="px-1 text-[12px] font-medium text-slate-700">
+            <legend className="px-1 text-[13px] font-medium text-slate-700">
               {t("models.createModel.fields.credentialMode")}
               <span className="ml-0.5 text-red-500">*</span>
             </legend>
@@ -588,7 +588,7 @@ export function CreateModelDialog({
               />
               {(activeSecrets.length > 0 || sourceSecretMissing) && (
                 <div className="grid gap-1.5">
-                  <label className="text-[12px] font-medium text-slate-700" htmlFor="model-existing-secret">
+                  <label className="text-[13px] font-medium text-slate-700" htmlFor="model-existing-secret">
                     {t("models.createModel.credentialMode.inlineSecret.reuseSecret")}
                   </label>
                   <select
@@ -620,7 +620,7 @@ export function CreateModelDialog({
                     ))}
                   </select>
                   {sourceSecretMissing && (
-                    <span className="text-[11px] text-red-600">
+                    <span className="text-[12px] text-red-600">
                       {t("models.copy.secretInaccessible")}
                     </span>
                   )}
@@ -633,7 +633,7 @@ export function CreateModelDialog({
           {credentialMode === "credential_ref" && (
             <div className="grid gap-3 rounded-md bg-slate-50/60 p-3">
               <div className="grid gap-1.5">
-                <label className="text-[12px] font-medium text-slate-700" htmlFor="model-credential-kind">
+                <label className="text-[13px] font-medium text-slate-700" htmlFor="model-credential-kind">
                   {t("models.createModel.credentialMode.credentialRef.kindLabel")}
                   <span className="ml-0.5 text-red-500">*</span>
                 </label>
@@ -643,7 +643,7 @@ export function CreateModelDialog({
                   onChange={setCredentialKindCode}
                   className="w-full"
                 />
-                <span className="text-[11px] text-slate-400">
+                <span className="text-[12px] text-slate-400">
                   {t("models.createModel.credentialMode.credentialRef.kindHint")}
                 </span>
               </div>
@@ -651,7 +651,7 @@ export function CreateModelDialog({
           )}
 
           {errMsg && (
-            <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">
+            <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">
               {errMsg}
             </p>
           )}
@@ -801,7 +801,7 @@ export function EditModelDialog({
         </DialogHeader>
         <form className="grid gap-4" onSubmit={handleSubmit}>
           {/* --- Locked identity --- */}
-          <div className="grid grid-cols-2 gap-3 rounded-md bg-slate-50/60 p-3 text-[12px]">
+          <div className="grid grid-cols-2 gap-3 rounded-md bg-slate-50/60 p-3 text-[13px]">
             <div>
               <div className="text-slate-500">{t("models.editModel.locked.providerType")}</div>
               <div className="mt-0.5 font-medium text-slate-700">{model.provider_type}</div>
@@ -865,7 +865,7 @@ export function EditModelDialog({
           {isInline && (
             <div className="grid gap-3 rounded-md bg-slate-50/60 p-3">
               <div className="grid gap-1.5">
-                <label className="text-[12px] font-medium text-slate-700" htmlFor="edit-model-secret">
+                <label className="text-[13px] font-medium text-slate-700" htmlFor="edit-model-secret">
                   {t("models.editModel.credentialBinding.boundSecret")}
                 </label>
                 <select
@@ -900,7 +900,7 @@ export function EditModelDialog({
           {isCredentialRef && (
             <div className="grid gap-3 rounded-md bg-slate-50/60 p-3">
               <div className="grid gap-1.5">
-                <label className="text-[12px] font-medium text-slate-700" htmlFor="edit-model-credential-kind">
+                <label className="text-[13px] font-medium text-slate-700" htmlFor="edit-model-credential-kind">
                   {t("models.editModel.credentialBinding.kindCode")}
                   <span className="ml-0.5 text-red-500">*</span>
                 </label>
@@ -910,7 +910,7 @@ export function EditModelDialog({
                   onChange={setCredentialKindCode}
                   className="w-full"
                 />
-                <span className="text-[11px] text-slate-400">
+                <span className="text-[12px] text-slate-400">
                   {t("models.editModel.credentialBinding.kindCodeHint")}
                 </span>
               </div>
@@ -918,7 +918,7 @@ export function EditModelDialog({
           )}
 
           {errMsg && (
-            <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">
+            <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">
               {errMsg}
             </p>
           )}

--- a/apps/web/src/pages/admin/ModelsPage.tsx
+++ b/apps/web/src/pages/admin/ModelsPage.tsx
@@ -94,14 +94,14 @@ function CredentialModeBadge({ mode }: { mode: Model["credential_mode"] }) {
   const { t } = useTranslation("admin")
   if (mode === "inline_secret") {
     return (
-      <span className="inline-flex items-center gap-1 rounded-md bg-slate-100 px-1.5 py-0.5 text-[11px] font-medium text-slate-700">
+      <span className="inline-flex items-center gap-1 rounded-md bg-slate-100 px-1.5 py-0.5 text-[12px] font-medium text-slate-700">
         <KeyRound className="h-3 w-3" />
         {t("models.credentialMode.shared")}
       </span>
     )
   }
   return (
-    <span className="inline-flex items-center gap-1 rounded-md bg-indigo-50 px-1.5 py-0.5 text-[11px] font-medium text-indigo-700">
+    <span className="inline-flex items-center gap-1 rounded-md bg-indigo-50 px-1.5 py-0.5 text-[12px] font-medium text-indigo-700">
       <UserCircle className="h-3 w-3" />
       {t("models.credentialMode.personal")}
     </span>
@@ -144,7 +144,7 @@ function ProviderCompatibilityCell({ type }: { type: string }) {
 
   return (
     <span
-      className="inline-flex max-w-full items-center gap-1.5 text-[12.5px] text-slate-700"
+      className="inline-flex max-w-full items-center gap-1.5 text-[13px] text-slate-700"
       title={label}
     >
       <Icon className="h-3.5 w-3.5 shrink-0 text-slate-400" />
@@ -237,14 +237,14 @@ function TestResultBanner({
         ) : (
           <AlertCircle className="mt-0.5 h-4 w-4 text-red-700" />
         )}
-        <div className="flex-1 text-[12.5px]">
+        <div className="flex-1 text-[13px]">
           {ok ? (
             <>
               <div className="font-medium text-emerald-900">
                 {t("models.test.success", { ms: data.latency_ms })}
               </div>
               {data.sample && (
-                <div className="mt-1 text-[11.5px] text-emerald-800/80 line-clamp-2">
+                <div className="mt-1 text-[12px] text-emerald-800/80 line-clamp-2">
                   {data.sample}
                 </div>
               )}
@@ -255,7 +255,7 @@ function TestResultBanner({
                 {data.supported ? t("models.test.failure") : t("models.test.unsupported")}
               </div>
               {data.error && (
-                <div className="mt-1 text-[11.5px] text-red-800/80 line-clamp-3">
+                <div className="mt-1 text-[12px] text-red-800/80 line-clamp-3">
                   {data.error}
                 </div>
               )}
@@ -265,7 +265,7 @@ function TestResultBanner({
         <button
           type="button"
           onClick={onClose}
-          className="text-[11px] text-slate-500 hover:text-slate-700"
+          className="text-[12px] text-slate-500 hover:text-slate-700"
         >
           ×
         </button>
@@ -349,7 +349,7 @@ function ModelsTable({
                 </TableCell>
                 <TableCell className="overflow-hidden">
                   <span
-                    className="block truncate font-mono text-[12px] text-slate-600"
+                    className="block truncate font-mono text-[13px] text-slate-600"
                     title={m.model_key}
                   >
                     {m.model_key}

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -349,7 +349,7 @@ function RunStatusBadge({ status }: { status: AgentRunStatus }) {
             : "interrupted"
   switch (status) {
     case "queued": return <Badge variant="neutral">{t(`runStatus.${labelKey}`)}</Badge>
-    case "running": return <Badge variant="primary" dot>{t(`runStatus.${labelKey}`)}</Badge>
+    case "running": return <Badge variant="primary" dot pulse>{t(`runStatus.${labelKey}`)}</Badge>
     case "completed": return <Badge variant="success" dot>{t(`runStatus.${labelKey}`)}</Badge>
     case "failed": return <Badge variant="destructive" dot>{t(`runStatus.${labelKey}`)}</Badge>
     case "cancelled": return <Badge variant="neutral">{t(`runStatus.${labelKey}`)}</Badge>
@@ -533,7 +533,7 @@ function RunsPager({
   const onFirstPage = offset === 0
   const onLastPage = offset + limit >= total
   return (
-    <div className="flex items-center justify-between gap-3 px-1 text-[12px] text-slate-600">
+    <div className="flex items-center justify-between gap-3 px-1 text-[13px] text-slate-600">
       <span className="tabular-nums">
         {t("runs.table.pagination.range", { from, to, total })}
       </span>
@@ -562,22 +562,22 @@ function RunRow({ run, onClick }: { run: AgentRunSummary; onClick: () => void })
             <Bot className="h-3.5 w-3.5 shrink-0 text-slate-400" strokeWidth={1.75} />
             <span className="text-[14px] font-medium text-slate-900">{run.agent_name ?? run.agent_slug ?? "(unknown)"}</span>
           </div>
-          <span className="font-mono text-[11px] text-slate-500">
+          <span className="font-mono text-[12px] text-slate-500">
             {shortId(run.id)} · {fmtAgo(run.created_at)}
           </span>
           {errorSummary && (
-            <span className="mt-0.5 line-clamp-1 text-[11px] text-red-600">{errorSummary}</span>
+            <span className="mt-0.5 line-clamp-1 text-[12px] text-red-600">{errorSummary}</span>
           )}
         </div>
       </TableCell>
       <TableCell><RunStatusBadge status={run.status} /></TableCell>
       <TableCell>
-        <span className="font-mono text-[11px] text-slate-500">{shortId(run.conversation_id)}</span>
+        <span className="font-mono text-[12px] text-slate-500">{shortId(run.conversation_id)}</span>
       </TableCell>
-      <TableCell className="text-right text-[12px] tabular-nums text-slate-600">
+      <TableCell className="text-right text-[13px] tabular-nums text-slate-600">
         {fmtDuration(run.started_at, run.finished_at)}
       </TableCell>
-      <TableCell className="text-right pr-4 text-[12px] tabular-nums text-slate-400">—</TableCell>
+      <TableCell className="text-right pr-4 text-[13px] tabular-nums text-slate-400">—</TableCell>
     </TableRow>
   )
 }
@@ -678,7 +678,7 @@ export function RunDetailPage({ id }: { id: string }) {
         }
         title={run.agent_name ?? run.agent_slug ?? "(unknown agent)"}
         description={
-          <span className="font-mono text-[12px]">
+          <span className="font-mono text-[13px]">
             {shortId(run.id, 12)} · {connectorLabel(run.connector_type)}
           </span>
         }
@@ -709,7 +709,7 @@ export function RunDetailPage({ id }: { id: string }) {
                 className="inline-flex items-center gap-1 hover:underline"
                 onClick={() => navigate("conversations", { id: run.conversation_id! })}
               >
-                <span className="font-mono text-[12px]">{shortId(run.conversation_id, 10)}</span>
+                <span className="font-mono text-[13px]">{shortId(run.conversation_id, 10)}</span>
                 <ArrowUpRight className="h-3 w-3 text-slate-400" />
               </button>
             ) : (
@@ -723,7 +723,7 @@ export function RunDetailPage({ id }: { id: string }) {
       {cancelError && (
         <div className="mb-4 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50/40 p-3">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-600" strokeWidth={2} />
-          <p className="font-mono text-[12px] text-red-700">{cancelError}</p>
+          <p className="font-mono text-[13px] text-red-700">{cancelError}</p>
         </div>
       )}
 
@@ -732,7 +732,7 @@ export function RunDetailPage({ id }: { id: string }) {
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red-600" strokeWidth={2} />
           <div className="space-y-1">
             <p className="text-[13px] font-medium text-red-900">{t("runs.detail.errorTitle")}</p>
-            <p className="text-[12px] text-red-700/85">{t("runs.detail.errorHint")}</p>
+            <p className="text-[13px] text-red-700/85">{t("runs.detail.errorHint")}</p>
           </div>
         </div>
       )}
@@ -788,7 +788,7 @@ export function RunDetailPage({ id }: { id: string }) {
                       <div>
                         <span>{run.runtime.name || shortId(run.runtime.id, 12)}</span>
                         {run.runtime.id && run.runtime.name ? (
-                          <div className="font-mono text-[11px] text-slate-500">{shortId(run.runtime.id, 12)}</div>
+                          <div className="font-mono text-[12px] text-slate-500">{shortId(run.runtime.id, 12)}</div>
                         ) : null}
                       </div>
                     }
@@ -851,7 +851,7 @@ export function RunDetailPage({ id }: { id: string }) {
                     value={<ToneBadge tone={runtimeDiagnosis.tone} label={runtimeDiagnosis.health} />}
                   />
                   <Field label={t("runs.detail.runtime.action")} value={runtimeDiagnosis.action} />
-                  <p className="text-[12px] text-slate-500">{t("runs.detail.runtime.empty")}</p>
+                  <p className="text-[13px] text-slate-500">{t("runs.detail.runtime.empty")}</p>
                 </>
               )}
             </Card>
@@ -869,7 +869,7 @@ export function RunDetailPage({ id }: { id: string }) {
                 <ArtifactRow key={a.id} medium={a.medium} kind={a.kind} name={a.name} meta={a.uri || undefined} />
               ))
             ) : (
-              <div className="p-6 text-center text-[12px] text-slate-500">No artifacts.</div>
+              <div className="p-6 text-center text-[13px] text-slate-500">No artifacts.</div>
             )}
           </div>
         </TabsContent>
@@ -941,7 +941,7 @@ function RuntimeCapabilities({ capabilities }: { capabilities?: Record<string, b
 function Field({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
   return (
     <div className="mb-2 last:mb-0">
-      <dt className="mb-0.5 text-[11px] uppercase tracking-wider text-slate-400">{label}</dt>
+      <dt className="mb-0.5 text-[12px] uppercase tracking-wider text-slate-400">{label}</dt>
       <dd className={["min-w-0 text-[13px] text-slate-800 [overflow-wrap:anywhere]", mono ? "font-mono" : ""].filter(Boolean).join(" ")}>{value}</dd>
     </div>
   )
@@ -951,7 +951,7 @@ function Card({ title, actions, className, children }: { title: string; actions?
   return (
     <section className={`rounded-lg border border-slate-200 bg-white p-4 ${className ?? ""}`}>
       <div className="mb-3 flex items-center justify-between gap-3">
-        <h3 className="text-[12px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>
+        <h3 className="text-[13px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>
         {actions}
       </div>
       {children}
@@ -985,7 +985,7 @@ function RunSteps({ events, loading }: { events: AgentRunEvent[]; loading: boole
           <button
             type="button"
             onClick={toggleAll}
-            className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-[11.5px] font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
+            className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-[12px] font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
           >
             <Code className="h-3.5 w-3.5" strokeWidth={1.9} />
             {allOpen ? t("runs.detail.steps.hideAllRaw") : t("runs.detail.steps.viewAllRaw")}
@@ -999,7 +999,7 @@ function RunSteps({ events, loading }: { events: AgentRunEvent[]; loading: boole
           <Skeleton className="h-10 w-3/4" />
         </div>
       ) : steps.length === 0 ? (
-        <p className="text-[12px] text-slate-500">{t("runs.detail.steps.empty")}</p>
+        <p className="text-[13px] text-slate-500">{t("runs.detail.steps.empty")}</p>
       ) : (
         <ol className="space-y-3">
           {steps.map((step) => {
@@ -1012,7 +1012,7 @@ function RunSteps({ events, loading }: { events: AgentRunEvent[]; loading: boole
                     <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
                       <p className="text-[13px] font-medium text-slate-900">{step.title}</p>
                       <div className="flex shrink-0 items-center gap-2">
-                        <span className="whitespace-nowrap font-mono text-[11px] text-slate-400">
+                        <span className="whitespace-nowrap font-mono text-[12px] text-slate-400">
                           {"#" + step.sequence + (step.occurredAt ? " · " + fmtDateTime(step.occurredAt) : "")}
                         </span>
                         {step.rawEvents.length > 0 && (
@@ -1033,13 +1033,13 @@ function RunSteps({ events, loading }: { events: AgentRunEvent[]; loading: boole
                         )}
                       </div>
                     </div>
-                    {step.detail && <p className="mt-1 break-words text-[12px] text-slate-500">{step.detail}</p>}
+                    {step.detail && <p className="mt-1 break-words text-[13px] text-slate-500">{step.detail}</p>}
                   </div>
                 </div>
                 {open && step.rawEvents.length > 0 && (
                   <div className="mt-2 space-y-2">
                     {step.rawEvents.map((ev) => (
-                      <pre key={ev.id} className="whitespace-pre-wrap break-all rounded-md bg-slate-950 p-3 text-[11px] leading-relaxed text-slate-100">
+                      <pre key={ev.id} className="whitespace-pre-wrap break-all rounded-md bg-slate-950 p-3 text-[12px] leading-relaxed text-slate-100">
                         {`#${ev.sequence} ${ev.event_kind}\n${JSON.stringify(ev.payload ?? {}, null, 2)}`}
                       </pre>
                     ))}
@@ -1150,7 +1150,7 @@ function ArtifactRow({ medium, kind, name, meta }: { medium: string; kind: strin
       )}
       <div className="flex-1">
         <code className="text-[13px] font-medium text-slate-900">{name}</code>
-        {meta && <p className="text-[11px] text-slate-500">{kind} · {medium} · {meta}</p>}
+        {meta && <p className="text-[12px] text-slate-500">{kind} · {medium} · {meta}</p>}
       </div>
       <ArrowUpRight className="h-3 w-3 text-slate-400" strokeWidth={1.75} />
     </button>

--- a/apps/web/src/pages/admin/RuntimeDetailPage.tsx
+++ b/apps/web/src/pages/admin/RuntimeDetailPage.tsx
@@ -41,7 +41,7 @@ function ManagedBoundaryCard() {
           <h2 className="text-[13px] font-semibold text-slate-900">
             {t("runtime.managedBoundary.title")}
           </h2>
-          <p className="mt-1 text-[12px] leading-relaxed text-slate-500">
+          <p className="mt-1 text-[13px] leading-relaxed text-slate-500">
             {t("runtime.managedBoundary.description")}
           </p>
         </div>
@@ -85,12 +85,12 @@ function BoundaryColumn({
 }) {
   return (
     <div className="rounded-md border border-slate-200 bg-slate-50/40 p-3">
-      <div className="mb-2 flex items-center gap-2 text-[12px] font-semibold text-slate-800">
+      <div className="mb-2 flex items-center gap-2 text-[13px] font-semibold text-slate-800">
         {icon}
         <span>{title}</span>
         <ManagedBadge unmanaged={unmanaged} className="ml-auto" />
       </div>
-      <ul className="space-y-1.5 text-[12px] text-slate-600">
+      <ul className="space-y-1.5 text-[13px] text-slate-600">
         {items.map((item) => (
           <li key={item}>• {item}</li>
         ))}

--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -442,15 +442,15 @@ function CloudInstancesPanel({
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-4 py-3">
         <div>
           <h3 className="text-[14px] font-medium text-slate-900">{t("runtime.cloud.instances.title")}</h3>
-          <p className="mt-0.5 text-[12px] text-slate-500">
+          <p className="mt-0.5 text-[13px] text-slate-500">
             {t("runtime.list.summary", { count: bindings.length })}
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <label className="flex items-center gap-2 text-[12px] text-slate-500">
+          <label className="flex items-center gap-2 text-[13px] text-slate-500">
             {t("runtime.list.sort.label")}
             <select
-              className="rounded border border-slate-200 bg-white px-2 py-1 text-[12px]"
+              className="rounded border border-slate-200 bg-white px-2 py-1 text-[13px]"
               value={sortKey}
               onChange={(e) => onSortChange(e.target.value as SortKey)}
               data-testid="runtime-sort"
@@ -478,22 +478,22 @@ function CloudInstancesPanel({
       {bulkErrors.length > 0 && (
         <div className="mx-4 mt-3 rounded-md border border-red-200 bg-red-50/70 p-3">
           <div className="mb-2 flex items-center justify-between gap-2">
-            <span className="text-[12px] font-medium text-red-900">
+            <span className="text-[13px] font-medium text-red-900">
               {t("runtime.list.errors.bulkKillPartial")} ({bulkErrors.length})
             </span>
             <button
               type="button"
               onClick={onClearBulkErrors}
-              className="text-[11px] text-red-700 hover:underline"
+              className="text-[12px] text-red-700 hover:underline"
               data-testid="runtime-bulk-error-dismiss"
             >
               {t("runtime.list.errors.bulkKillDismiss")}
             </button>
           </div>
-          <ul className="max-h-40 space-y-1 overflow-y-auto text-[11px] text-red-800">
+          <ul className="max-h-40 space-y-1 overflow-y-auto text-[12px] text-red-800">
             {bulkErrors.map((e) => (
               <li key={e.sandboxID} className="flex items-start gap-2 font-mono">
-                <span className="shrink-0 rounded bg-red-200/70 px-1.5 py-0.5 text-[10px] text-red-900">{e.status}</span>
+                <span className="shrink-0 rounded bg-red-200/70 px-1.5 py-0.5 text-[11px] text-red-900">{e.status}</span>
                 <span className="shrink-0 text-red-900">{e.sandboxID}</span>
                 <span className="text-red-700">{e.message}</span>
               </li>
@@ -565,19 +565,19 @@ function CloudInstancesPanel({
                         data-testid={`runtime-select-${b.binding_id}`}
                       />
                     </TableCell>
-                    <TableCell className="max-w-[180px] truncate font-mono text-[12px] text-slate-800" title={b.sandbox_id}>
+                    <TableCell className="max-w-[180px] truncate font-mono text-[13px] text-slate-800" title={b.sandbox_id}>
                       {b.sandbox_id}
                     </TableCell>
-                    <TableCell className="font-mono text-[11px] text-slate-500">{b.project_agent_id ?? "—"}</TableCell>
-                    <TableCell className="text-[12px] text-slate-600">{b.template_id}</TableCell>
+                    <TableCell className="font-mono text-[12px] text-slate-500">{b.project_agent_id ?? "—"}</TableCell>
+                    <TableCell className="text-[13px] text-slate-600">{b.template_id}</TableCell>
                     <TableCell><SandboxStatusBadge kind={b.status_kind} status={b.status} /></TableCell>
                     <TableCell>
-                      <span title={b.last_active_at} className="text-[12px] text-slate-600">
+                      <span title={b.last_active_at} className="text-[13px] text-slate-600">
                         {relativeAgo(b.last_active_at)}
                       </span>
                     </TableCell>
                     <TableCell>
-                      <span title={b.created_at} className="text-[12px] text-slate-600">
+                      <span title={b.created_at} className="text-[13px] text-slate-600">
                         {relativeAgo(b.created_at)}
                       </span>
                     </TableCell>
@@ -585,7 +585,7 @@ function CloudInstancesPanel({
                       <Button
                         variant="ghost"
                         size="sm"
-                        className="h-7 gap-1 px-2 text-[12px]"
+                        className="h-7 gap-1 px-2 text-[13px]"
                         disabled={!canTest || isTesting || (testingId !== null && testingId !== b.binding_id)}
                         onClick={() => handleTestConnection(b)}
                         data-testid={`runtime-test-conn-${b.binding_id}`}
@@ -661,7 +661,7 @@ function CloudDaemonRuntimesPanel({
           <h3 className="text-[14px] font-medium text-slate-900">
             {t("runtime.cloud.daemonRuntimes.title", { defaultValue: "沙盒内 Daemon" })}
           </h3>
-          <p className="mt-0.5 max-w-3xl text-[12px] leading-relaxed text-slate-500">
+          <p className="mt-0.5 max-w-3xl text-[13px] leading-relaxed text-slate-500">
             {t("runtime.cloud.daemonRuntimes.description", {
               count: runtimes.length,
               defaultValue: "运行在云端沙盒里的 parsar-daemon 进程。它们属于云端沙盒，不是本地设备。",
@@ -686,25 +686,25 @@ function CloudDaemonRuntimesPanel({
         <TableBody>
           {runtimes.map((runtime) => (
             <TableRow key={runtime.id} data-testid={`sandbox-daemon-runtime-row-${runtime.id}`}>
-              <TableCell className="font-mono text-[12px] text-slate-800">
+              <TableCell className="font-mono text-[13px] text-slate-800">
                 <div className="space-y-1">
                   <div>{runtime.name || shortID(runtime.id)}</div>
-                  <div className="text-[11px] text-slate-500">{shortID(runtime.id)}</div>
+                  <div className="text-[12px] text-slate-500">{shortID(runtime.id)}</div>
                 </div>
               </TableCell>
-              <TableCell className="font-mono text-[11px] text-slate-500">
+              <TableCell className="font-mono text-[12px] text-slate-500">
                 {runtimeConfigText(runtime, "project_agent_id") || "—"}
               </TableCell>
-              <TableCell className="text-[12px] text-slate-600">
+              <TableCell className="text-[13px] text-slate-600">
                 {runtimeConfigText(runtime, "sandbox_kind") || runtime.provider}
               </TableCell>
-              <TableCell className="text-[12px] text-slate-600">
+              <TableCell className="text-[13px] text-slate-600">
                 {formatRuntimeAgentKinds(runtime)}
               </TableCell>
               <TableCell>
                 <RuntimeLivenessBadge runtime={runtime} />
               </TableCell>
-              <TableCell className="text-[12px] text-slate-600" title={runtime.last_heartbeat_at ?? undefined}>
+              <TableCell className="text-[13px] text-slate-600" title={runtime.last_heartbeat_at ?? undefined}>
                 {runtime.last_heartbeat_at ? relativeAgo(runtime.last_heartbeat_at) : "—"}
               </TableCell>
             </TableRow>
@@ -891,7 +891,7 @@ function ConfirmBulkKillDialog({
               {t("runtime.list.confirmBulkKill.description")}
             </DialogDescription>
             {preview.length > 0 && (
-              <ul className="mt-2 list-disc space-y-0.5 pl-5 text-[12px] text-slate-600">
+              <ul className="mt-2 list-disc space-y-0.5 pl-5 text-[13px] text-slate-600">
                 {preview.map((id) => <li key={id} className="font-mono">{id}</li>)}
                 {count > preview.length && (
                   <li className="list-none text-slate-400">

--- a/apps/web/src/pages/admin/SettingsPage.tsx
+++ b/apps/web/src/pages/admin/SettingsPage.tsx
@@ -101,7 +101,7 @@ function Section({
       <header className="mb-4">
         <h2 className="text-[14px] font-semibold text-slate-900">{title}</h2>
         {description && (
-          <p className="mt-0.5 text-[12px] text-slate-500">{description}</p>
+          <p className="mt-0.5 text-[13px] text-slate-500">{description}</p>
         )}
       </header>
       <div className="space-y-4">{children}</div>
@@ -122,7 +122,7 @@ function FormRow({
     <div className="grid grid-cols-1 gap-2 md:grid-cols-[200px_1fr] md:gap-6">
       <div>
         <label className="text-[13px] font-medium text-slate-800">{label}</label>
-        {hint && <p className="mt-0.5 text-[11px] text-slate-500">{hint}</p>}
+        {hint && <p className="mt-0.5 text-[12px] text-slate-500">{hint}</p>}
       </div>
       <div>{children}</div>
     </div>
@@ -141,8 +141,8 @@ function PolicyCard({
   return (
     <article className="rounded-md border border-slate-200 bg-slate-50/70 p-4">
       <div className="text-[13px] font-semibold text-slate-900">{title}</div>
-      <p className="mt-1 min-h-10 text-[12px] leading-5 text-slate-500">{body}</p>
-      <div className="mt-3 rounded-md border border-slate-200 bg-white px-3 py-2 font-mono text-[12px] text-slate-700">
+      <p className="mt-1 min-h-10 text-[13px] leading-5 text-slate-500">{body}</p>
+      <div className="mt-3 rounded-md border border-slate-200 bg-white px-3 py-2 font-mono text-[13px] text-slate-700">
         {value}
       </div>
     </article>

--- a/apps/web/src/pages/admin/SpecImportDialog.tsx
+++ b/apps/web/src/pages/admin/SpecImportDialog.tsx
@@ -79,7 +79,7 @@ export function SpecImportDialog({ workspaceID, onClose }: SpecImportDialogProps
         {stage.kind === "edit" ? (
           <div className="space-y-3 px-5 py-4">
             <label className="block space-y-1">
-              <span className="text-[12px] font-medium text-slate-700">
+              <span className="text-[13px] font-medium text-slate-700">
                 {t("specs.import.field.text")}
               </span>
               <textarea
@@ -87,25 +87,25 @@ export function SpecImportDialog({ workspaceID, onClose }: SpecImportDialogProps
                 onChange={(event) => setText(event.target.value)}
                 placeholder={t("specs.import.placeholder.text")}
                 rows={18}
-                className="block w-full rounded-md border border-slate-200 px-3 py-2 font-mono text-[12.5px] leading-relaxed text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
+                className="block w-full rounded-md border border-slate-200 px-3 py-2 font-mono text-[13px] leading-relaxed text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
               />
             </label>
             {previewErr && (
               <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2">
-                <p className="text-[12px] font-medium text-red-900">
+                <p className="text-[13px] font-medium text-red-900">
                   {t("specs.import.error.previewTitle")}
                 </p>
-                <p className="text-[11.5px] text-red-700">{previewErr.message}</p>
+                <p className="text-[12px] text-red-700">{previewErr.message}</p>
               </div>
             )}
           </div>
         ) : (
           <div className="space-y-3 px-5 py-4">
-            <p className="text-[12.5px] font-medium text-slate-700">
+            <p className="text-[13px] font-medium text-slate-700">
               {t("specs.import.preview.title", { count: stage.pieces.length })}
             </p>
             {stage.pieces.length === 0 ? (
-              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-800">
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[13px] text-amber-800">
                 {t("specs.import.preview.empty")}
               </div>
             ) : (
@@ -116,7 +116,7 @@ export function SpecImportDialog({ workspaceID, onClose }: SpecImportDialogProps
                     className="rounded-md border border-slate-200 bg-white px-3 py-2"
                   >
                     <p className="text-[13px] font-semibold text-slate-900">{piece.title}</p>
-                    <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-[11.5px] leading-relaxed text-slate-600">
+                    <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-[12px] leading-relaxed text-slate-600">
                       {piece.body}
                     </pre>
                   </li>
@@ -125,10 +125,10 @@ export function SpecImportDialog({ workspaceID, onClose }: SpecImportDialogProps
             )}
             {confirmErr && (
               <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2">
-                <p className="text-[12px] font-medium text-red-900">
+                <p className="text-[13px] font-medium text-red-900">
                   {t("specs.import.error.confirmTitle")}
                 </p>
-                <p className="text-[11.5px] text-red-700">{confirmErr.message}</p>
+                <p className="text-[12px] text-red-700">{confirmErr.message}</p>
               </div>
             )}
           </div>

--- a/apps/web/src/pages/admin/SpecsPage.tsx
+++ b/apps/web/src/pages/admin/SpecsPage.tsx
@@ -229,15 +229,15 @@ function FragmentRow({ fragment, fmtAgo, onEdit, onDelete }: FragmentRowProps) {
           <span className="text-[14px] font-semibold text-slate-900">{fragment.title}</span>
           <SourceBadge source={fragment.source} />
           {fragment.tags.map((tag) => (
-            <Badge key={tag} variant="neutral" className="font-mono text-[10.5px]">
+            <Badge key={tag} variant="neutral" className="font-mono text-[11px]">
               {tag}
             </Badge>
           ))}
         </div>
         {preview && (
-          <p className="line-clamp-2 text-[12.5px] text-slate-600">{preview}</p>
+          <p className="line-clamp-2 text-[13px] text-slate-600">{preview}</p>
         )}
-        <p className="text-[11px] text-slate-400">
+        <p className="text-[12px] text-slate-400">
           {t("specs.row.updatedAt", { time: fmtAgo(fragment.updated_at) })}
         </p>
       </button>
@@ -314,7 +314,7 @@ function EditorDialog({ mode, fragment, pending, error, onSubmit, onClose }: Edi
           </DialogHeader>
           <div className="space-y-3 px-5 py-4">
             <label className="block space-y-1">
-              <span className="text-[12px] font-medium text-slate-700">
+              <span className="text-[13px] font-medium text-slate-700">
                 {t("specs.editor.field.title")}
                 <span className="ml-0.5 text-red-500">*</span>
               </span>
@@ -327,7 +327,7 @@ function EditorDialog({ mode, fragment, pending, error, onSubmit, onClose }: Edi
               />
             </label>
             <label className="block space-y-1">
-              <span className="text-[12px] font-medium text-slate-700">
+              <span className="text-[13px] font-medium text-slate-700">
                 {t("specs.editor.field.body")}
                 <span className="ml-0.5 text-red-500">*</span>
               </span>
@@ -337,11 +337,11 @@ function EditorDialog({ mode, fragment, pending, error, onSubmit, onClose }: Edi
                 placeholder={t("specs.editor.placeholder.body")}
                 required
                 rows={12}
-                className="block w-full rounded-md border border-slate-200 px-3 py-2 font-mono text-[12.5px] leading-relaxed text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
+                className="block w-full rounded-md border border-slate-200 px-3 py-2 font-mono text-[13px] leading-relaxed text-slate-800 placeholder:text-slate-400 focus:border-slate-400 focus:outline-none focus:ring-1 focus:ring-slate-300"
               />
             </label>
             <label className="block space-y-1">
-              <span className="text-[12px] font-medium text-slate-700">
+              <span className="text-[13px] font-medium text-slate-700">
                 {t("specs.editor.field.tags")}
               </span>
               <Input
@@ -352,10 +352,10 @@ function EditorDialog({ mode, fragment, pending, error, onSubmit, onClose }: Edi
             </label>
             {error && (
               <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2">
-                <p className="text-[12px] font-medium text-red-900">
+                <p className="text-[13px] font-medium text-red-900">
                   {t("specs.editor.error.title")}
                 </p>
-                <p className="text-[11.5px] text-red-700">{error.message}</p>
+                <p className="text-[12px] text-red-700">{error.message}</p>
               </div>
             )}
           </div>
@@ -405,7 +405,7 @@ function DeleteConfirmDialog({
                 {t("specs.delete.title", { title: fragment.title })}
               </AlertDialogTitle>
               <AlertDialogDescription>{t("specs.delete.description")}</AlertDialogDescription>
-              {error && <p className="text-[12px] text-red-700">{error.message}</p>}
+              {error && <p className="text-[13px] text-red-700">{error.message}</p>}
             </div>
           </div>
         </AlertDialogHeader>

--- a/apps/web/src/pages/admin/UsagePage.tsx
+++ b/apps/web/src/pages/admin/UsagePage.tsx
@@ -179,12 +179,12 @@ export function UsagePage() {
                 <TableBody>
                   {byModel.map((m) => (
                     <TableRow key={m.key}>
-                      <TableCell className="text-[12px] text-slate-600">{m.provider}</TableCell>
-                      <TableCell><code className="text-[12px] text-slate-800">{m.model}</code></TableCell>
-                      <TableCell className="text-right text-[12px] tabular-nums text-slate-600">{m.callCount}</TableCell>
-                      <TableCell className="text-right text-[12px] tabular-nums text-slate-600">{fmtInt(m.inputTokens)}</TableCell>
-                      <TableCell className="text-right text-[12px] tabular-nums text-slate-600">{fmtInt(m.outputTokens)}</TableCell>
-                      <TableCell className="text-right pr-4 font-mono text-[12px] tabular-nums text-slate-700">{fmtUsd(m.costUsd)}</TableCell>
+                      <TableCell className="text-[13px] text-slate-600">{m.provider}</TableCell>
+                      <TableCell><code className="text-[13px] text-slate-800">{m.model}</code></TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums text-slate-600">{m.callCount}</TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums text-slate-600">{fmtInt(m.inputTokens)}</TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums text-slate-600">{fmtInt(m.outputTokens)}</TableCell>
+                      <TableCell className="text-right pr-4 font-mono text-[13px] tabular-nums text-slate-700">{fmtUsd(m.costUsd)}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
@@ -211,11 +211,11 @@ export function UsagePage() {
                 <TableBody>
                   {logs.map((u) => (
                     <TableRow key={u.id}>
-                      <TableCell className="font-mono text-[11px] text-slate-500 tabular-nums">{fmtTime(u.created_at)}</TableCell>
+                      <TableCell className="font-mono text-[12px] text-slate-500 tabular-nums">{fmtTime(u.created_at)}</TableCell>
                       <TableCell>
                         {u.agent_run_id ? (
                           <button
-                            className="font-mono text-[11px] text-slate-700 hover:underline"
+                            className="font-mono text-[12px] text-slate-700 hover:underline"
                             onClick={() => navigate("runs", { id: u.agent_run_id! })}
                           >
                             {shortId(u.agent_run_id)}
@@ -224,11 +224,11 @@ export function UsagePage() {
                           <Badge variant="neutral">{t("usage.recent.noRun")}</Badge>
                         )}
                       </TableCell>
-                      <TableCell className="text-[12px] text-slate-600">{u.provider}</TableCell>
-                      <TableCell><code className="text-[12px] text-slate-800">{u.model}</code></TableCell>
-                      <TableCell className="text-right text-[12px] tabular-nums text-slate-600">{fmtInt(u.input_tokens)}</TableCell>
-                      <TableCell className="text-right text-[12px] tabular-nums text-slate-600">{fmtInt(u.output_tokens)}</TableCell>
-                      <TableCell className="text-right pr-4 font-mono text-[12px] tabular-nums text-slate-700">{fmtUsd(u.cost_usd)}</TableCell>
+                      <TableCell className="text-[13px] text-slate-600">{u.provider}</TableCell>
+                      <TableCell><code className="text-[13px] text-slate-800">{u.model}</code></TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums text-slate-600">{fmtInt(u.input_tokens)}</TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums text-slate-600">{fmtInt(u.output_tokens)}</TableCell>
+                      <TableCell className="text-right pr-4 font-mono text-[13px] tabular-nums text-slate-700">{fmtUsd(u.cost_usd)}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
@@ -244,7 +244,7 @@ export function UsagePage() {
 function Stat({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
   return (
     <div className="rounded-lg border border-slate-200 bg-white p-4">
-      <div className="text-[11px] uppercase tracking-wider text-slate-400">{label}</div>
+      <div className="text-[12px] uppercase tracking-wider text-slate-400">{label}</div>
       <div className={`mt-1 text-[22px] font-semibold tabular-nums text-slate-900 ${mono ? "font-mono" : ""}`}>{value}</div>
     </div>
   )

--- a/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
@@ -327,7 +327,7 @@ export function AddCapabilityVersionDialog({
         {(nameError || versionError) && (
           <div
             role="alert"
-            className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800"
+            className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800"
           >
             {nameError ?? versionError}
           </div>
@@ -381,7 +381,7 @@ export function AddCapabilityVersionDialog({
         {errMsg && (
           <div
             role="alert"
-            className="break-all rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800"
+            className="break-all rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800"
           >
             {errMsg}
           </div>
@@ -470,7 +470,7 @@ function Field({
 }) {
   return (
     <label className="grid gap-1.5">
-      <span className="text-[12px] font-medium text-slate-700">
+      <span className="text-[13px] font-medium text-slate-700">
         {label}
         {required && <span className="text-red-500"> *</span>}
       </span>
@@ -481,7 +481,7 @@ function Field({
 
 function InfoBanner({ children }: { children: React.ReactNode }) {
   return (
-    <div className="mt-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[12px] text-slate-700">
+    <div className="mt-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[13px] text-slate-700">
       {children}
     </div>
   )
@@ -491,7 +491,7 @@ function WarningBanner({ children }: { children: React.ReactNode }) {
   return (
     <div
       role="alert"
-      className="mt-2 break-all rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-900"
+      className="mt-2 break-all rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[13px] text-amber-900"
     >
       {children}
     </div>

--- a/apps/web/src/pages/admin/capabilities/CredentialKindCombobox.tsx
+++ b/apps/web/src/pages/admin/capabilities/CredentialKindCombobox.tsx
@@ -74,14 +74,14 @@ export function CredentialKindCombobox({
               className,
             )}
           >
-            <span className="truncate text-[12px]">
+            <span className="truncate text-[13px]">
               {selected
                 ? selected.display_name
                 : value
                   ? value
                   : t("capabilities.import.kindPicker.placeholder", "选择凭据类型")}
               {selected && (
-                <code className="ml-2 rounded bg-slate-100 px-1.5 py-0.5 font-mono text-[10px] text-slate-500">
+                <code className="ml-2 rounded bg-slate-100 px-1.5 py-0.5 font-mono text-[11px] text-slate-500">
                   {selected.code}
                 </code>
               )}
@@ -102,21 +102,21 @@ export function CredentialKindCombobox({
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder={t("capabilities.import.kindPicker.search", "搜索…")}
                 onKeyDown={(e) => e.stopPropagation() /* keep arrow keys in input */}
-                className="h-8 text-[12px]"
+                className="h-8 text-[13px]"
                 autoFocus
               />
             </div>
 
             <div className="max-h-[200px] overflow-auto py-1">
               {kindsQ.isLoading ? (
-                <div className="flex items-center gap-2 px-3 py-2 text-[12px] text-slate-500">
+                <div className="flex items-center gap-2 px-3 py-2 text-[13px] text-slate-500">
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
                   {t("capabilities.import.kindPicker.loading", "加载中…")}
                 </div>
               ) : errMsg ? (
-                <p className="px-3 py-2 text-[12px] text-red-700">{errMsg}</p>
+                <p className="px-3 py-2 text-[13px] text-red-700">{errMsg}</p>
               ) : filtered.length === 0 ? (
-                <p className="px-3 py-2 text-[12px] text-slate-500">
+                <p className="px-3 py-2 text-[13px] text-slate-500">
                   {t("capabilities.import.kindPicker.empty", "没有匹配的凭据类型")}
                 </p>
               ) : (
@@ -138,7 +138,7 @@ export function CredentialKindCombobox({
                 e.preventDefault()
                 setCreateOpen(true)
               }}
-              className="flex cursor-pointer items-center gap-2 rounded px-3 py-2 text-[12px] font-medium text-slate-900 outline-none hover:bg-slate-50 focus:bg-slate-50"
+              className="flex cursor-pointer items-center gap-2 rounded px-3 py-2 text-[13px] font-medium text-slate-900 outline-none hover:bg-slate-50 focus:bg-slate-50"
             >
               <Plus className="h-3.5 w-3.5" />
               {t("capabilities.import.kindPicker.createNew", "新建凭据类型…")}
@@ -183,22 +183,22 @@ function KindRow({
     >
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="truncate text-[12px] font-medium text-slate-900">
+          <span className="truncate text-[13px] font-medium text-slate-900">
             {kind.display_name || kind.code}
           </span>
           {kind.built_in && (
-            <span className="rounded bg-slate-200 px-1.5 py-0.5 text-[10px] text-slate-700">
+            <span className="rounded bg-slate-200 px-1.5 py-0.5 text-[11px] text-slate-700">
               built-in
             </span>
           )}
         </div>
         <div className="mt-0.5 flex items-center gap-2">
-          <code className="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-[10px] text-slate-500">
+          <code className="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-[11px] text-slate-500">
             {kind.code}
           </code>
         </div>
         {kind.description && (
-          <p className="mt-1 line-clamp-2 text-[11px] text-slate-500">{kind.description}</p>
+          <p className="mt-1 line-clamp-2 text-[12px] text-slate-500">{kind.description}</p>
         )}
       </div>
       {selected && <Check className="h-3.5 w-3.5 shrink-0 text-slate-700" />}

--- a/apps/web/src/pages/admin/capabilities/DeleteCapabilityDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/DeleteCapabilityDialog.tsx
@@ -37,7 +37,7 @@ export function DeleteCapabilityDialog({ capability, pending, error, onOpenChang
           <AlertDialogTitle>{t("capabilities.delete.dialog.title", { name: capability.name })}</AlertDialogTitle>
           <AlertDialogDescription>{t("capabilities.delete.dialog.description")}</AlertDialogDescription>
         </AlertDialogHeader>
-        {errMsg && <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">{errMsg}</p>}
+        {errMsg && <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">{errMsg}</p>}
         <AlertDialogFooter>
           <Button variant="outline" size="sm" disabled={pending} onClick={() => onOpenChange(false)}>{t("capabilities.actions.cancel")}</Button>
           <Button variant="destructive" size="sm" disabled={pending} onClick={onConfirm}>{pending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}{t("capabilities.delete.dialog.confirm")}</Button>

--- a/apps/web/src/pages/admin/capabilities/DeprecateCapabilityDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/DeprecateCapabilityDialog.tsx
@@ -35,7 +35,7 @@ export function DeprecateCapabilityDialog({ action, capability, installCount, pe
           <AlertDialogTitle>{t(`capabilities.marketStatus.dialog.${action}.title`, { name: capability.name })}</AlertDialogTitle>
           <AlertDialogDescription>{t(`capabilities.marketStatus.dialog.${action}.description`, { count: installCount })}</AlertDialogDescription>
         </AlertDialogHeader>
-        {errMsg && <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">{errMsg}</p>}
+        {errMsg && <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">{errMsg}</p>}
         <AlertDialogFooter>
           <Button variant="outline" size="sm" disabled={pending} onClick={() => onOpenChange(false)}>{t("capabilities.actions.cancel")}</Button>
           <Button variant={destructive ? "destructive" : "default"} size="sm" disabled={pending} onClick={onConfirm}>{pending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}{t(`capabilities.marketStatus.dialog.${action}.confirm`)}</Button>

--- a/apps/web/src/pages/admin/capabilities/EnvCredentialPicker.tsx
+++ b/apps/web/src/pages/admin/capabilities/EnvCredentialPicker.tsx
@@ -80,17 +80,17 @@ export function EnvCredentialPicker({
         <div className="flex min-w-0 items-center gap-2">
           <code
             title={envKey}
-            className="block max-w-full flex-1 break-all rounded bg-slate-50 px-1.5 py-1 font-mono text-[12px] font-medium text-slate-900"
+            className="block max-w-full flex-1 break-all rounded bg-slate-50 px-1.5 py-1 font-mono text-[13px] font-medium text-slate-900"
           >
             {envKey}
           </code>
-          <span className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[10.5px] font-medium text-amber-700">
+          <span className="shrink-0 rounded bg-amber-50 px-1.5 py-0.5 text-[11px] font-medium text-amber-700">
             {t("capabilities.import.envBadge.credential", "凭据")}
           </span>
         </div>
 
         <div className="space-y-1.5">
-          <div className="text-[11px] font-medium text-slate-500">
+          <div className="text-[12px] font-medium text-slate-500">
             {t("capabilities.import.envMode.label", "凭据来源")}
           </div>
           <ModeToggle value={activeMode} onChange={setMode} />
@@ -104,13 +104,13 @@ export function EnvCredentialPicker({
               type="password"
               value={inlineSecretPlaintext ?? ""}
               onChange={(e) => onInlineSecretPlaintextChange(e.target.value)}
-              className="font-mono text-[12px]"
+              className="font-mono text-[13px]"
               placeholder={t(
                 "capabilities.import.envValue.inlineSecretPlaceholder",
                 "粘贴团队共用 token，导入时加密保存",
               )}
             />
-            <p className="flex items-center gap-1.5 text-[11px] text-emerald-700">
+            <p className="flex items-center gap-1.5 text-[12px] text-emerald-700">
               <Lock className="h-3 w-3" />
               {t(
                 "capabilities.import.envValue.inlineSecretNote",
@@ -128,7 +128,7 @@ export function EnvCredentialPicker({
               onChange={(code) => onChange({ mode: "credential_ref", credential_kind_code: code })}
               className="w-full"
             />
-            <p className="flex items-center gap-1.5 text-[11px] text-slate-500">
+            <p className="flex items-center gap-1.5 text-[12px] text-slate-500">
               <KeyRound className="h-3 w-3" />
               {t(
                 "capabilities.import.envValue.credentialRefNote",
@@ -162,7 +162,7 @@ function ModeToggle({
             size="sm"
             onClick={() => onChange(opt.value)}
             className={cn(
-              "h-7 flex-1 rounded px-2 text-[11px] sm:flex-none",
+              "h-7 flex-1 rounded px-2 text-[12px] sm:flex-none",
               active
                 ? "bg-white text-slate-900 shadow-inner"
                 : "text-slate-500 hover:bg-slate-100 hover:text-slate-700",

--- a/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
@@ -375,7 +375,7 @@ export function ImportCapabilityDialog({
         {errMsg && (
           <div
             role="alert"
-            className="break-all rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800"
+            className="break-all rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800"
           >
             {errMsg}
           </div>
@@ -413,7 +413,7 @@ function Field({
 }) {
   return (
     <label className="grid gap-1.5">
-      <span className="text-[12px] font-medium text-slate-700">
+      <span className="text-[13px] font-medium text-slate-700">
         {label}
         {required && <span className="text-red-500"> *</span>}
       </span>

--- a/apps/web/src/pages/admin/capabilities/ImportMCPForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportMCPForm.tsx
@@ -156,12 +156,12 @@ export function ImportMCPForm({
                   `{\n  "mcpServers": {\n    "github": {\n      "command": "docker",\n      "args": ["run", "-i", "ghcr.io/github/github-mcp-server"],\n      "env": {\n        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_xxx"\n      }\n    }\n  }\n}`,
                 )
           }
-          className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 font-mono text-[11px] leading-relaxed shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
+          className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 font-mono text-[12px] leading-relaxed shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
           spellCheck={false}
           autoCorrect="off"
           autoCapitalize="off"
         />
-        <p className="text-[11px] text-slate-500">
+        <p className="text-[12px] text-slate-500">
           {t(
             "capabilities.import.mcp.pasteHelp",
             "支持 Claude Code (env) / OpenCode (environment) JSON 与 Codex TOML。也可以只粘贴 mcpServers 内层对象。",
@@ -240,7 +240,7 @@ function FormatPicker({
     { value: "toml", label: "TOML" },
   ]
   return (
-    <div className="flex items-center gap-2 text-[12px]">
+    <div className="flex items-center gap-2 text-[13px]">
       <span className="font-medium text-slate-700">
         {t("capabilities.import.mcp.format", "格式")}
       </span>
@@ -252,7 +252,7 @@ function FormatPicker({
               key={opt.value}
               type="button"
               onClick={() => onChange(opt.value)}
-              className={`h-7 px-2.5 text-[11px] transition-colors ${
+              className={`h-7 px-2.5 text-[12px] transition-colors ${
                 active
                   ? "bg-white text-slate-900 shadow-inner"
                   : "text-slate-500 hover:bg-slate-100 hover:text-slate-700"
@@ -330,14 +330,14 @@ function ServerCard({
     <section className="min-w-0 overflow-hidden rounded-lg border border-slate-200 bg-white p-3">
       <header className="flex min-w-0 flex-col gap-1 border-b border-slate-100 pb-2">
         <h4 className="text-[13px] font-semibold text-slate-900">{server.name}</h4>
-        <code className="block max-w-full whitespace-pre-wrap break-all font-mono text-[11px] text-slate-500">
+        <code className="block max-w-full whitespace-pre-wrap break-all font-mono text-[12px] text-slate-500">
           {server.command}
           {server.args && server.args.length > 0 ? ` ${server.args.join(" ")}` : ""}
         </code>
       </header>
 
       {credentialEnvEntries.length === 0 ? (
-        <p className="mt-2 text-[12px] text-slate-500">
+        <p className="mt-2 text-[13px] text-slate-500">
           {t("capabilities.import.envEmpty.noCredentialPlaceholders", "无需要处理的凭据")}
         </p>
       ) : (

--- a/apps/web/src/pages/admin/capabilities/ImportPluginForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportPluginForm.tsx
@@ -167,7 +167,7 @@ export function ImportPluginForm({
   return (
     <div className="grid gap-4 md:grid-cols-2">
       <div className="grid gap-3">
-        <span className="text-[12px] font-medium text-slate-700">
+        <span className="text-[13px] font-medium text-slate-700">
           {t("capabilities.import.plugin.uploadLabel", "上传 Plugin zip")}
         </span>
         {!file ? (
@@ -181,7 +181,7 @@ export function ImportPluginForm({
             <span className="text-[13px] text-slate-700">
               {t("capabilities.import.plugin.dropHint", "拖拽或点击上传 .zip 文件")}
             </span>
-            <span className="text-[11px] text-slate-500">
+            <span className="text-[12px] text-slate-500">
               {t("capabilities.import.plugin.sizeHint", "最大 32 MiB")}
             </span>
             <input
@@ -202,7 +202,7 @@ export function ImportPluginForm({
               <FileArchive className="h-4 w-4 shrink-0 text-slate-500" />
               <div className="min-w-0">
                 <p className="truncate text-[13px] text-slate-900">{file.name}</p>
-                <p className="text-[11px] text-slate-500">
+                <p className="text-[12px] text-slate-500">
                   {formatBytes(file.size)}
                   {busy && (
                     <>
@@ -233,7 +233,7 @@ export function ImportPluginForm({
         {errMsg && (
           <div
             role="alert"
-            className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800"
+            className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800"
           >
             {errMsg}
           </div>
@@ -242,11 +242,11 @@ export function ImportPluginForm({
 
       {/* ---- validation preview pane ----------------------------------- */}
       <div className="grid gap-3">
-        <span className="text-[12px] font-medium text-slate-700">
+        <span className="text-[13px] font-medium text-slate-700">
           {t("capabilities.import.plugin.previewLabel", "校验结果")}
         </span>
         {!validation && !busy && (
-          <div className="rounded-md border border-dashed border-slate-300 bg-slate-50 px-3 py-6 text-center text-[12px] text-slate-500">
+          <div className="rounded-md border border-dashed border-slate-300 bg-slate-50 px-3 py-6 text-center text-[13px] text-slate-500">
             {t("capabilities.import.plugin.previewEmpty", "上传一个 zip 文件后在这里看到校验结果")}
           </div>
         )}
@@ -289,17 +289,17 @@ function ValidationPanel({
   return (
     <div className="grid gap-3 rounded-md border border-slate-200 bg-white p-3">
       {validation.valid ? (
-        <div className="rounded-md border border-green-200 bg-green-50 px-3 py-1.5 text-[12px] text-green-800">
+        <div className="rounded-md border border-green-200 bg-green-50 px-3 py-1.5 text-[13px] text-green-800">
           {t("capabilities.import.plugin.passed", "校验通过")}
         </div>
       ) : (
-        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-[12px] text-red-800">
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-1.5 text-[13px] text-red-800">
           {t("capabilities.import.plugin.failed", "校验失败,请修复后重新上传")}
         </div>
       )}
 
       {m && (
-        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[12px]">
+        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[13px]">
           <dt className="text-slate-500">name</dt>
           <dd className="font-mono text-slate-900">{m.name}</dd>
           <dt className="text-slate-500">version</dt>
@@ -321,10 +321,10 @@ function ValidationPanel({
 
       {errors.length > 0 && (
         <div>
-          <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-red-700">
+          <p className="mb-1 text-[12px] font-medium uppercase tracking-wide text-red-700">
             {t("capabilities.import.plugin.errorsHeader", "错误")}
           </p>
-          <ul className="ml-4 list-disc space-y-0.5 text-[12px] text-red-800">
+          <ul className="ml-4 list-disc space-y-0.5 text-[13px] text-red-800">
             {errors.map((e, i) => (
               <li key={i}>{e}</li>
             ))}
@@ -334,10 +334,10 @@ function ValidationPanel({
 
       {warnings.length > 0 && (
         <div>
-          <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-amber-700">
+          <p className="mb-1 text-[12px] font-medium uppercase tracking-wide text-amber-700">
             {t("capabilities.import.plugin.warningsHeader", "警告")}
           </p>
-          <ul className="ml-4 list-disc space-y-0.5 text-[12px] text-amber-800">
+          <ul className="ml-4 list-disc space-y-0.5 text-[13px] text-amber-800">
             {warnings.map((wn, i) => (
               <li key={i}>{wn}</li>
             ))}

--- a/apps/web/src/pages/admin/capabilities/ImportPreview.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportPreview.tsx
@@ -39,13 +39,13 @@ export function ImportPreview({
   return (
     <div className="space-y-2">
       {status === "idle" && (
-        <p className="rounded-md border border-dashed border-slate-200 bg-slate-50 px-3 py-2 text-[12px] text-slate-500">
+        <p className="rounded-md border border-dashed border-slate-200 bg-slate-50 px-3 py-2 text-[13px] text-slate-500">
           {t("capabilities.import.preview.idle", "在左侧粘贴内容后,这里会显示解析结果")}
         </p>
       )}
 
       {status === "loading" && (
-        <p className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[12px] text-slate-600">
+        <p className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[13px] text-slate-600">
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
           {t("capabilities.import.preview.loading", "正在解析…")}
         </p>
@@ -54,7 +54,7 @@ export function ImportPreview({
       {status === "error" && errorMessage && (
         <div
           role="alert"
-          className="break-all rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800"
+          className="break-all rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800"
         >
           {errorMessage}
         </div>
@@ -69,7 +69,7 @@ export function ImportPreview({
             {kind && <KindBadge kind={kind} />}
           </div>
           {description && (
-            <p className="mt-1 break-words text-[12px] leading-relaxed text-slate-600">
+            <p className="mt-1 break-words text-[13px] leading-relaxed text-slate-600">
               {description}
             </p>
           )}
@@ -77,7 +77,7 @@ export function ImportPreview({
       )}
 
       {warnings.length > 0 && (
-        <div className="space-y-1 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-800">
+        <div className="space-y-1 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[13px] text-amber-800">
           <div className="flex items-center gap-1.5 font-medium">
             <AlertTriangle className="h-3.5 w-3.5" />
             {t("capabilities.import.preview.warnings", "解析提示")}
@@ -96,7 +96,7 @@ export function ImportPreview({
 function KindBadge({ kind }: { kind: CanonicalKind }) {
   const label = kind.toUpperCase()
   return (
-    <span className="rounded-full bg-slate-900 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-white">
+    <span className="rounded-full bg-slate-900 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-white">
       {label}
     </span>
   )

--- a/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
@@ -265,7 +265,7 @@ export function ImportSkillForm({
         <div className={`min-w-0 space-y-2 ${source === "paste" ? "max-w-3xl" : ""}`}>
           {source === "paste" ? (
             <>
-              <p className="text-[12px] font-medium text-slate-700">
+              <p className="text-[13px] font-medium text-slate-700">
                 {t("capabilities.import.skill.markdown", "Markdown 内容")}
               </p>
               <textarea
@@ -276,12 +276,12 @@ export function ImportSkillForm({
                   "capabilities.import.skill.placeholder",
                   `---\nname: code-reviewer\ndescription: Review a diff and call out risky changes\n---\n\nYou are a careful code reviewer. When the user pastes a diff, walk through:\n\n1. Correctness — does the change do what it claims?\n2. Risk — what could break in production?\n3. Style — does it match the surrounding conventions?\n\nKeep responses concise.`,
                 )}
-                className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 font-mono text-[11px] leading-relaxed shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
+                className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 font-mono text-[12px] leading-relaxed shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
                 spellCheck={false}
                 autoCorrect="off"
                 autoCapitalize="off"
               />
-              <p className="text-[11px] text-slate-500">
+              <p className="text-[12px] text-slate-500">
                 {t(
                   "capabilities.import.skill.pasteHelp",
                   "支持带 YAML frontmatter 的 Markdown。name + description 来自 frontmatter,正文作为 instruction 注入到模型。",
@@ -290,7 +290,7 @@ export function ImportSkillForm({
             </>
           ) : (
             <>
-              <p className="text-[12px] font-medium text-slate-700">
+              <p className="text-[13px] font-medium text-slate-700">
                 {t("capabilities.import.skill.zipLabel", "上传 Skill zip")}
               </p>
               <SkillZipDropzone
@@ -307,7 +307,7 @@ export function ImportSkillForm({
                 onClear={clearZip}
                 localError={zipError}
               />
-              <p className="text-[11px] text-slate-500">
+              <p className="text-[12px] text-slate-500">
                 {t(
                   "capabilities.import.skill.zipHelp",
                   "zip 内需包含 SKILL.md(可在根目录或一层子目录)。references/、scripts/ 等子目录会一并导入。",
@@ -399,7 +399,7 @@ function ModeButton({
       role="tab"
       aria-selected={active}
       onClick={onClick}
-      className={`inline-flex items-center gap-1.5 rounded px-2.5 py-1 text-[12px] transition-colors ${
+      className={`inline-flex items-center gap-1.5 rounded px-2.5 py-1 text-[13px] transition-colors ${
         active
           ? "bg-white text-slate-900 shadow-sm"
           : "text-slate-500 hover:bg-slate-100 hover:text-slate-700"
@@ -423,7 +423,7 @@ function SinglePreviewCard({
         <h4 className="text-[13px] font-semibold text-slate-900">
           {skill.title || skill.slug}
         </h4>
-        <code className="font-mono text-[11px] text-slate-500">{skill.slug}</code>
+        <code className="font-mono text-[12px] text-slate-500">{skill.slug}</code>
       </header>
 
       {/* description intentionally omitted — ImportPreview above already
@@ -431,7 +431,7 @@ function SinglePreviewCard({
 
       {skill.trigger && (
         <Field label={t("capabilities.import.skill.trigger", "触发条件")}>
-          <code className="block whitespace-pre-wrap rounded bg-slate-50 px-2 py-1.5 font-mono text-[11px] text-slate-700">
+          <code className="block whitespace-pre-wrap rounded bg-slate-50 px-2 py-1.5 font-mono text-[12px] text-slate-700">
             {skill.trigger}
           </code>
         </Field>
@@ -440,7 +440,7 @@ function SinglePreviewCard({
       <Field
         label={t("capabilities.import.skill.instruction", "Instruction(注入到模型)")}
       >
-        <pre className="max-h-[280px] overflow-auto whitespace-pre-wrap rounded bg-slate-50 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-slate-700">
+        <pre className="max-h-[280px] overflow-auto whitespace-pre-wrap rounded bg-slate-50 px-2 py-1.5 font-mono text-[12px] leading-relaxed text-slate-700">
           {skill.instruction}
         </pre>
       </Field>
@@ -457,7 +457,7 @@ function Field({
 }) {
   return (
     <div className="space-y-1">
-      <span className="text-[11px] font-medium uppercase tracking-wide text-slate-500">
+      <span className="text-[12px] font-medium uppercase tracking-wide text-slate-500">
         {label}
       </span>
       {children}

--- a/apps/web/src/pages/admin/capabilities/ImportSystemPromptForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportSystemPromptForm.tsx
@@ -67,7 +67,7 @@ export function ImportSystemPromptForm({ value, onChange }: Props) {
 
       <Field label={t("capabilities.import.systemPrompt.promptLabel", "Prompt 内容")} required>
         <textarea
-          className="min-h-[260px] w-full rounded-md border border-slate-200 bg-white p-3 font-mono text-[12.5px] leading-relaxed text-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-300"
+          className="min-h-[260px] w-full rounded-md border border-slate-200 bg-white p-3 font-mono text-[13px] leading-relaxed text-slate-800 focus:outline-none focus:ring-2 focus:ring-slate-300"
           value={value.prompt}
           onChange={(e) => set({ prompt: e.target.value })}
           placeholder={t(
@@ -91,7 +91,7 @@ function Field({
 }) {
   return (
     <label className="grid gap-1.5">
-      <span className="text-[12px] font-medium text-slate-700">
+      <span className="text-[13px] font-medium text-slate-700">
         {label}
         {required && <span className="text-red-500"> *</span>}
       </span>

--- a/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityDetail.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityDetail.tsx
@@ -41,7 +41,7 @@ export function MarketplaceCapabilityDetail({ id }: { id: string }) {
     <div className="space-y-4">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <button onClick={() => navigateAdmin("capabilities")} className="inline-flex items-center gap-1 text-[12px] text-slate-500 hover:text-slate-900 hover:underline"><ArrowLeft className="h-3 w-3" />{t("capabilities.detail.backToList")}</button>
+          <button onClick={() => navigateAdmin("capabilities")} className="inline-flex items-center gap-1 text-[13px] text-slate-500 hover:text-slate-900 hover:underline"><ArrowLeft className="h-3 w-3" />{t("capabilities.detail.backToList")}</button>
           <div className="mt-2 flex flex-wrap items-center gap-2">
             <h2 className="text-[22px] font-semibold tracking-display text-slate-900">{capability.name}</h2>
             <CapabilityTypeBadge type={capability.type} />
@@ -53,7 +53,7 @@ export function MarketplaceCapabilityDetail({ id }: { id: string }) {
       </div>
 
       {deprecated && (
-        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-800">
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] leading-5 text-red-800">
           <AlertTriangle className="mr-1 inline h-3.5 w-3.5" />{t("capabilities.deprecated.bannerTarget")}
         </div>
       )}
@@ -69,7 +69,7 @@ export function MarketplaceCapabilityDetail({ id }: { id: string }) {
 
       <Card title={t("capabilities.marketplaceDetail.enabledAgents.title", { count: agents.length || capability.enabled_agent_count })}>
         {agentsQ.isLoading ? <Skeleton className="h-12 w-full" /> : agents.length === 0 ? (
-          <p className="text-[12px] text-slate-500">{t("capabilities.marketplaceDetail.enabledAgents.empty")}</p>
+          <p className="text-[13px] text-slate-500">{t("capabilities.marketplaceDetail.enabledAgents.empty")}</p>
         ) : (
           <div className="space-y-2">
             {agents.map((agent) => {
@@ -77,7 +77,7 @@ export function MarketplaceCapabilityDetail({ id }: { id: string }) {
               return (
                 <button key={id ?? agent.name} type="button" onClick={() => id && navigateAdmin("agents", { id, tab: "capabilities" })} className="flex w-full items-center justify-between rounded-md border border-slate-200 p-3 text-left hover:bg-slate-50">
                   <span className="text-[13px] font-medium text-slate-900">{agent.name ?? agent.agent_name ?? "—"}</span>
-                  <span className="flex items-center gap-2 text-[12px] text-slate-500"><span className="font-mono">v{agent.version ?? capability.pinned_version ?? "—"}</span><ArrowUpRight className="h-3.5 w-3.5" /></span>
+                  <span className="flex items-center gap-2 text-[13px] text-slate-500"><span className="font-mono">v{agent.version ?? capability.pinned_version ?? "—"}</span><ArrowUpRight className="h-3.5 w-3.5" /></span>
                 </button>
               )
             })}
@@ -89,7 +89,7 @@ export function MarketplaceCapabilityDetail({ id }: { id: string }) {
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
             <h3 className="text-[13px] font-semibold text-red-900">{t("capabilities.uninstall.sectionTitle")}</h3>
-            <p className="mt-1 text-[12px] text-red-700">{t("capabilities.uninstall.sectionDescription")}</p>
+            <p className="mt-1 text-[13px] text-red-700">{t("capabilities.uninstall.sectionDescription")}</p>
           </div>
           <Button variant="destructive" size="sm" onClick={() => setUninstallOpen(true)}>{t("capabilities.uninstall.action")}</Button>
         </div>
@@ -112,11 +112,11 @@ export function MarketplaceCapabilityDetail({ id }: { id: string }) {
 }
 
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
-  return <section className="rounded-lg border border-slate-200 bg-white p-4"><h3 className="mb-3 text-[12px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>{children}</section>
+  return <section className="rounded-lg border border-slate-200 bg-white p-4"><h3 className="mb-3 text-[13px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>{children}</section>
 }
 
 function Detail({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
-  return <div className="rounded-md border border-slate-200 bg-white p-3"><p className="text-[11px] text-slate-500">{label}</p><div className={`mt-1 text-[13px] text-slate-900 ${mono ? "font-mono" : ""}`}>{value}</div></div>
+  return <div className="rounded-md border border-slate-200 bg-white p-3"><p className="text-[12px] text-slate-500">{label}</p><div className={`mt-1 text-[13px] text-slate-900 ${mono ? "font-mono" : ""}`}>{value}</div></div>
 }
 
 function CapabilityTypeBadge({ type }: { type: Capability["type"] }) {

--- a/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
@@ -67,7 +67,7 @@ export function MarketplaceTab({ itemID, onSelectItem, onInstall }: MarketplaceT
             <TabsTrigger value="system_prompt">System Prompt</TabsTrigger>
           </TabsList>
         </Tabs>
-        <label className="inline-flex select-none items-center gap-1.5 text-[12px] text-slate-600">
+        <label className="inline-flex select-none items-center gap-1.5 text-[13px] text-slate-600">
           <input
             type="checkbox"
             className="h-3.5 w-3.5 rounded border-slate-300 text-slate-900 focus:ring-slate-400"
@@ -140,12 +140,12 @@ function MarketplaceCard({ capability, language, onOpen, onInstall }: {
               {capability.self_published && <Badge variant="neutral">{t("capabilities.marketplace.card.selfPublished")}</Badge>}
               {!capability.self_published && capability.installed && <Badge variant="success">{t("capabilities.marketplace.card.installedBadge")}</Badge>}
             </div>
-            {source && <p className="mt-1 text-[12px] text-slate-500">{t("capabilities.marketplace.card.source", { source })}</p>}
+            {source && <p className="mt-1 text-[13px] text-slate-500">{t("capabilities.marketplace.card.source", { source })}</p>}
           </div>
           <ArrowRight className="mt-1 h-3.5 w-3.5 text-slate-400" />
         </div>
         {capability.description && <p className="mt-3 line-clamp-2 text-[13px] leading-5 text-slate-600">{capability.description}</p>}
-        <div className="mt-3 flex flex-wrap items-center gap-2 text-[12px] text-slate-500">
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-[13px] text-slate-500">
           <span>{t("capabilities.marketplace.card.latest", { version: capability.latest_version ?? "—" })}</span>
           <span>·</span>
           <span>{t("capabilities.marketplace.card.added", { count })}</span>
@@ -185,7 +185,7 @@ function MarketplaceItemDetail({ capability, language, onBack, onInstall }: {
           <h3 className="text-[18px] font-semibold text-slate-900">{capability.name}</h3>
           <CapabilityTypeBadge type={capability.type} />
         </div>
-        {source && <p className="mt-2 text-[12px] text-slate-500">{t("capabilities.marketplace.card.source", { source })}</p>}
+        {source && <p className="mt-2 text-[13px] text-slate-500">{t("capabilities.marketplace.card.source", { source })}</p>}
         {capability.description && <p className="mt-4 text-[13px] leading-5 text-slate-600">{capability.description}</p>}
         <div className="mt-4 grid gap-3 md:grid-cols-3">
           <Detail label={t("capabilities.table.latestVersion")} value={capability.latest_version ? `v${capability.latest_version}` : t("capabilities.none")} mono />
@@ -205,7 +205,7 @@ function MarketplaceItemDetail({ capability, language, onBack, onInstall }: {
 function Detail({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
   return (
     <div className="rounded-md border border-slate-200 p-3">
-      <p className="text-[11px] text-slate-500">{label}</p>
+      <p className="text-[12px] text-slate-500">{label}</p>
       <p className={`mt-1 text-[13px] text-slate-900 ${mono ? "font-mono" : ""}`}>{value}</p>
     </div>
   )

--- a/apps/web/src/pages/admin/capabilities/NewCredentialKindInlineDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/NewCredentialKindInlineDialog.tsx
@@ -107,7 +107,7 @@ export function NewCredentialKindInlineDialog({
               autoFocus
             />
             {code.trim().length > 0 && !isValidCode && (
-              <p className="text-[11px] text-red-600">
+              <p className="text-[12px] text-red-600">
                 {t(
                   "capabilities.import.newKind.code.invalid",
                   "code 必须以小写字母开头,只能包含小写字母、数字、下划线",
@@ -141,7 +141,7 @@ export function NewCredentialKindInlineDialog({
           {errMsg && (
             <div
               role="alert"
-              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800"
+              className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800"
             >
               {errMsg}
             </div>
@@ -180,12 +180,12 @@ function Field({
 }) {
   return (
     <label className="grid gap-1.5">
-      <span className="text-[12px] font-medium text-slate-700">
+      <span className="text-[13px] font-medium text-slate-700">
         {label}
         {required && <span className="text-red-500"> *</span>}
       </span>
       {children}
-      {help && <span className="text-[11px] leading-relaxed text-slate-500">{help}</span>}
+      {help && <span className="text-[12px] leading-relaxed text-slate-500">{help}</span>}
     </label>
   )
 }

--- a/apps/web/src/pages/admin/capabilities/SkillFileTree.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillFileTree.tsx
@@ -76,8 +76,8 @@ function SkillMdCard({ skill }: { skill: CanonicalSkillSpec }) {
             className={`h-4 w-4 shrink-0 text-slate-500 transition-transform ${open ? "rotate-90" : ""}`}
           />
           <FileText className="h-4 w-4 shrink-0 text-emerald-600" />
-          <code className="font-mono text-[12px] text-slate-900">SKILL.md</code>
-          <span className="ml-auto rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-emerald-800">
+          <code className="font-mono text-[13px] text-slate-900">SKILL.md</code>
+          <span className="ml-auto rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide text-emerald-800">
             {t("capabilities.import.skill.fileTree.entry", "入口")}
           </span>
         </CollapsibleTrigger>
@@ -133,8 +133,8 @@ function GroupCard({
             className={`h-4 w-4 shrink-0 text-slate-500 transition-transform ${open ? "rotate-90" : ""}`}
           />
           {icon}
-          <span className="font-mono text-[12px] text-slate-700">{title}</span>
-          <span className="ml-auto text-[11px] text-slate-500">
+          <span className="font-mono text-[13px] text-slate-700">{title}</span>
+          <span className="ml-auto text-[12px] text-slate-500">
             {files.length}
           </span>
         </CollapsibleTrigger>
@@ -160,8 +160,8 @@ function FileRow({ file }: { file: SkillFile }) {
             className={`h-3.5 w-3.5 shrink-0 text-slate-400 transition-transform ${open ? "rotate-90" : ""}`}
           />
           <FileText className="h-3.5 w-3.5 shrink-0 text-slate-500" />
-          <code className="truncate font-mono text-[11.5px] text-slate-800">{file.path}</code>
-          <span className="ml-auto text-[10px] uppercase tracking-wide text-slate-400">
+          <code className="truncate font-mono text-[12px] text-slate-800">{file.path}</code>
+          <span className="ml-auto text-[11px] uppercase tracking-wide text-slate-400">
             {file.kind}
           </span>
         </CollapsibleTrigger>
@@ -204,7 +204,7 @@ function ShikiCode({ content, lang }: { content: string; lang: string }) {
 
   if (err || html === null) {
     return (
-      <pre className="max-h-[420px] overflow-y-auto whitespace-pre-wrap break-all bg-slate-50 px-3 py-2 font-mono text-[11.5px] leading-relaxed text-slate-700">
+      <pre className="max-h-[420px] overflow-y-auto whitespace-pre-wrap break-all bg-slate-50 px-3 py-2 font-mono text-[12px] leading-relaxed text-slate-700">
         {content}
       </pre>
     )
@@ -213,7 +213,7 @@ function ShikiCode({ content, lang }: { content: string; lang: string }) {
     <div
       // Force shiki's <pre> to wrap — default overflow-x: auto pushes
       // long URLs / minified JSON into horizontal dialog scroll.
-      className="max-h-[420px] overflow-y-auto text-[11.5px] leading-relaxed [&_pre]:!m-0 [&_pre]:!whitespace-pre-wrap [&_pre]:!break-all [&_pre]:!bg-slate-50 [&_pre]:!px-3 [&_pre]:!py-2"
+      className="max-h-[420px] overflow-y-auto text-[12px] leading-relaxed [&_pre]:!m-0 [&_pre]:!whitespace-pre-wrap [&_pre]:!break-all [&_pre]:!bg-slate-50 [&_pre]:!px-3 [&_pre]:!py-2"
       // shiki output is sanitized server-controlled markup.
       dangerouslySetInnerHTML={{ __html: html }}
     />

--- a/apps/web/src/pages/admin/capabilities/SkillZipDropzone.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillZipDropzone.tsx
@@ -75,14 +75,14 @@ export function SkillZipDropzone({
               ? t("capabilities.import.skill.dropActive", "松开导入 .zip")
               : t("capabilities.import.skill.dropHint", "拖拽或点击上传 .zip(SKILL.md + references / scripts)")}
           </span>
-          <span className="text-[11px] text-slate-500">
+          <span className="text-[12px] text-slate-500">
             {t("capabilities.import.skill.sizeHint", "最大 8 MiB")}
           </span>
         </div>
         {localError && (
           <div
             role="alert"
-            className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800"
+            className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800"
           >
             {localError}
           </div>
@@ -98,7 +98,7 @@ export function SkillZipDropzone({
           <FileArchive className="h-4 w-4 shrink-0 text-slate-500" />
           <div className="min-w-0">
             <p className="truncate text-[13px] text-slate-900">{file.name}</p>
-            <p className="text-[11px] text-slate-500">
+            <p className="text-[12px] text-slate-500">
               {formatBytes(file.size)}
               {busy && (
                 <>
@@ -125,7 +125,7 @@ export function SkillZipDropzone({
       {localError && (
         <div
           role="alert"
-          className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800"
+          className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800"
         >
           {localError}
         </div>

--- a/apps/web/src/pages/admin/capabilities/UninstallMarketplaceDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/UninstallMarketplaceDialog.tsx
@@ -35,15 +35,15 @@ export function UninstallMarketplaceDialog({ capability, agents, open, pending, 
           <AlertDialogDescription>{t("capabilities.uninstall.description", { count })}</AlertDialogDescription>
         </AlertDialogHeader>
         <div className="space-y-3">
-          <ul className="max-h-44 space-y-1 overflow-auto rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[12px] text-slate-700">
+          <ul className="max-h-44 space-y-1 overflow-auto rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[13px] text-slate-700">
             {(agents.length > 0 ? agents : [{ name: t("capabilities.uninstall.unknownAgent") }]).map((agent, index) => (
               <li key={agent.project_agent_id ?? agent.agent_id ?? agent.id ?? index}>· {agent.name ?? agent.agent_name ?? t("capabilities.uninstall.unknownAgent")}</li>
             ))}
           </ul>
-          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-800">
+          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[13px] text-amber-800">
             {t("capabilities.uninstall.credentialNote")}
           </div>
-          {errMsg && <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700">{errMsg}</p>}
+          {errMsg && <p className="rounded-md bg-red-50 px-3 py-2 text-[13px] text-red-700">{errMsg}</p>}
         </div>
         <AlertDialogFooter>
           <Button variant="outline" size="sm" disabled={pending} onClick={() => onOpenChange(false)}>{t("capabilities.actions.cancel")}</Button>

--- a/apps/web/src/pages/admin/capabilities/UpgradeCapabilityDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/UpgradeCapabilityDialog.tsx
@@ -22,7 +22,7 @@ export function UpgradeCapabilityDialog({ agent, capability, binding, latestVers
   const errMsg = upgradeMut.error instanceof ApiError ? upgradeMut.error.envelope.message : upgradeMut.error instanceof Error ? upgradeMut.error.message : null
   const canUpgrade = !!latestVersion && latestVersion.id !== binding.capability_version_id && !disabled && !upgradeMut.isPending
   return (
-    <div className="mt-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-[12px] text-blue-800">
+    <div className="mt-3 rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-[13px] text-blue-800">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span>{disabled ? t("agents.detail.capabilities.marketplace.upgradeBlocked") : t("agents.detail.capabilities.marketplace.upgradeAvailable", { version: latestVersion?.version ?? "—" })}</span>
         <Button size="sm" variant="outline" disabled={!canUpgrade} onClick={() => {

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -242,7 +242,7 @@ export function CapabilitiesPage() {
                   </span>
                 </Tooltip.Trigger>
                 <Tooltip.Portal>
-                  <Tooltip.Content className="z-50 rounded-md border border-slate-200 bg-white px-2 py-1 text-[12px] text-slate-600 shadow-md">
+                  <Tooltip.Content className="z-50 rounded-md border border-slate-200 bg-white px-2 py-1 text-[13px] text-slate-600 shadow-md">
                     {t("capabilities.permission.adminOnly")}
                     <Tooltip.Arrow className="fill-white" />
                   </Tooltip.Content>
@@ -353,16 +353,16 @@ export function CapabilitiesPage() {
                                   {cap.deprecated_at && <Badge variant="destructive">{fromMarketplace ? t("capabilities.deprecated.badgeTarget") : t("capabilities.deprecated.badgeSource")}</Badge>}
                                 </span>
                                 {fromMarketplace && (
-                                  <span className="truncate text-[11px] text-slate-400">{sourceLine}</span>
+                                  <span className="truncate text-[12px] text-slate-400">{sourceLine}</span>
                                 )}
                                 {cap.description && (
                                   <Tooltip.Root>
                                     <Tooltip.Trigger asChild>
-                                      <span className="block w-full truncate text-[12px] text-slate-500">{cap.description}</span>
+                                      <span className="block w-full truncate text-[13px] text-slate-500">{cap.description}</span>
                                     </Tooltip.Trigger>
                                     <Tooltip.Portal>
                                       <Tooltip.Content
-                                        className="z-50 max-w-[420px] rounded-md border border-slate-200 bg-white px-2 py-1 text-[12px] leading-snug text-slate-700 shadow-md"
+                                        className="z-50 max-w-[420px] rounded-md border border-slate-200 bg-white px-2 py-1 text-[13px] leading-snug text-slate-700 shadow-md"
                                         sideOffset={4}
                                       >
                                         {cap.description}
@@ -374,9 +374,9 @@ export function CapabilitiesPage() {
                               </button>
                             </TableCell>
                             <TableCell><CapabilityTypeBadge type={cap.type} /></TableCell>
-                            <TableCell className="font-mono text-[12px] text-slate-600">{fromMarketplace ? marketCap.pinned_version ?? marketCap.latest_version ?? marketCap.latest_published_version ?? t("capabilities.none") : latestVersions.get(cap.id)?.version ?? t("capabilities.none")}</TableCell>
-                            <TableCell className="text-[12px] text-slate-600">{enabledCount}</TableCell>
-                            <TableCell className="text-[12px] text-slate-600">
+                            <TableCell className="font-mono text-[13px] text-slate-600">{fromMarketplace ? marketCap.pinned_version ?? marketCap.latest_version ?? marketCap.latest_published_version ?? t("capabilities.none") : latestVersions.get(cap.id)?.version ?? t("capabilities.none")}</TableCell>
+                            <TableCell className="text-[13px] text-slate-600">{enabledCount}</TableCell>
+                            <TableCell className="text-[13px] text-slate-600">
                               {requiredCredentialsLabel(cap.required_credentials, i18n.language, t("capabilities.credentials.none"))}
                             </TableCell>
                             <TableCell className="pr-4">
@@ -595,13 +595,13 @@ function CapabilitiesPagination({
   const startIdx = total === 0 ? 0 : (safePage - 1) * pageSize + 1
   const endIdx = Math.min(safePage * pageSize, total)
   return (
-    <div className="flex flex-wrap items-center justify-between gap-3 px-1 text-[12px] text-slate-600">
+    <div className="flex flex-wrap items-center justify-between gap-3 px-1 text-[13px] text-slate-600">
       <div>{t("capabilities.pagination.range", { start: startIdx, end: endIdx, total })}</div>
       <div className="flex items-center gap-2">
         <label className="flex items-center gap-1">
           <span>{t("capabilities.pagination.perPage")}</span>
           <select
-            className="rounded border border-slate-200 bg-white px-1.5 py-1 text-[12px]"
+            className="rounded border border-slate-200 bg-white px-1.5 py-1 text-[13px]"
             value={pageSize}
             onChange={(e) => onPageSizeChange(Number(e.target.value))}
           >
@@ -730,7 +730,7 @@ function CapabilityRowMoreMenu({
         <DropdownMenu.Content
           align="end"
           sideOffset={6}
-          className="z-50 min-w-[180px] overflow-hidden rounded-md border border-slate-200 bg-white p-1 text-[12.5px] text-slate-700 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+          className="z-50 min-w-[180px] overflow-hidden rounded-md border border-slate-200 bg-white p-1 text-[13px] text-slate-700 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
         >
           <CapabilityMenuItem icon={Eye} label={t("capabilities.rowActions.view")} onSelect={onView} />
 
@@ -928,11 +928,11 @@ export function CapabilityDetailPage({ id }: { id: string }) {
                   const count = installationSummary.versionCounts.get(version.id) ?? 0
                   return (
                     <TableRow key={version.id}>
-                      <TableCell className="font-mono text-[12px] text-slate-700">
+                      <TableCell className="font-mono text-[13px] text-slate-700">
                         {version.version} {index === 0 && <Badge className="ml-2" variant="neutral">{t("capabilities.versions.latest")}</Badge>}
                       </TableCell>
-                      <TableCell className="text-[12px] text-slate-600">{formatDate(version.created_at)}</TableCell>
-                      <TableCell className="text-[12px] text-slate-600">{count}</TableCell>
+                      <TableCell className="text-[13px] text-slate-600">{formatDate(version.created_at)}</TableCell>
+                      <TableCell className="text-[13px] text-slate-600">{count}</TableCell>
                       <TableCell>
                         <div className="flex items-center gap-2">
                           <Button size="sm" variant="ghost" onClick={() => setViewVersion(version)}>
@@ -952,13 +952,13 @@ export function CapabilityDetailPage({ id }: { id: string }) {
           {installationSummary.isLoading ? (
             <Skeleton className="h-12 w-full" />
           ) : enabledCount === 0 ? (
-            <p className="text-[12px] text-slate-500">{t("capabilities.detail.enabledAgents.empty")}</p>
+            <p className="text-[13px] text-slate-500">{t("capabilities.detail.enabledAgents.empty")}</p>
           ) : (
             <div className="space-y-2">
               {installationSummary.installations.map((item) => (
                 <button key={item.agentID} type="button" onClick={() => navigateAdmin("agents", { id: item.agentID, tab: "capabilities" })} className="flex w-full items-center justify-between rounded-md border border-slate-200 p-3 text-left hover:bg-slate-50">
                   <span className="text-[13px] font-medium text-slate-900">{item.agentName}</span>
-                  <span className="flex items-center gap-2 text-[12px] text-slate-500">
+                  <span className="flex items-center gap-2 text-[13px] text-slate-500">
                     <span className="font-mono">{item.version}</span>
                     {!item.latest && <Badge variant="neutral">{t("capabilities.detail.enabledAgents.old")}</Badge>}
                     <ArrowUpRight className="h-3.5 w-3.5" />
@@ -979,7 +979,7 @@ export function CapabilityDetailPage({ id }: { id: string }) {
                   </Badge>
                   {capability.deprecated_at && <Badge variant="destructive">{t("capabilities.deprecated.badgeSource")}</Badge>}
                 </div>
-                <p className="text-[12px] text-slate-500">{t("capabilities.marketStatus.installCount", { count: installCountQ.data ?? 0 })}</p>
+                <p className="text-[13px] text-slate-500">{t("capabilities.marketStatus.installCount", { count: installCountQ.data ?? 0 })}</p>
               </div>
               <div className="flex flex-wrap gap-2">
                 {/*
@@ -1003,7 +1003,7 @@ export function CapabilityDetailPage({ id }: { id: string }) {
                       </span>
                     </Tooltip.Trigger>
                     <Tooltip.Portal>
-                      <Tooltip.Content className="z-50 max-w-xs rounded-md border border-slate-200 bg-white px-2 py-1 text-[12px] text-slate-600 shadow-md">
+                      <Tooltip.Content className="z-50 max-w-xs rounded-md border border-slate-200 bg-white px-2 py-1 text-[13px] text-slate-600 shadow-md">
                         {capability.deprecated_at ? t("capabilities.marketStatus.undeprecateTooltip") : t("capabilities.marketStatus.deprecateTooltip")}
                         <Tooltip.Arrow className="fill-white" />
                       </Tooltip.Content>
@@ -1186,7 +1186,7 @@ function renderViewVersionBody(version: CapabilityVersion, capability: Capabilit
         <DetailField
           label="prompt"
           value={
-            <pre className="whitespace-pre-wrap font-mono text-[12px] leading-relaxed text-slate-700">
+            <pre className="whitespace-pre-wrap font-mono text-[13px] leading-relaxed text-slate-700">
               {sp?.prompt ?? t("capabilities.none")}
             </pre>
           }
@@ -1198,13 +1198,13 @@ function renderViewVersionBody(version: CapabilityVersion, capability: Capabilit
   if (capability.type === "mcp") {
     if (canonicalSpec?.mcp) {
       return (
-        <pre className="max-h-[420px] overflow-y-auto whitespace-pre-wrap break-all rounded-md border border-slate-200 bg-slate-50 p-3 font-mono text-[12px] leading-relaxed text-slate-700">
+        <pre className="max-h-[420px] overflow-y-auto whitespace-pre-wrap break-all rounded-md border border-slate-200 bg-slate-50 p-3 font-mono text-[13px] leading-relaxed text-slate-700">
           {JSON.stringify(canonicalSpec.mcp, null, 2)}
         </pre>
       )
     }
     return (
-      <pre className="max-h-[420px] overflow-y-auto whitespace-pre-wrap break-all rounded-md border border-slate-200 bg-slate-50 p-3 font-mono text-[12px] leading-relaxed text-slate-700">
+      <pre className="max-h-[420px] overflow-y-auto whitespace-pre-wrap break-all rounded-md border border-slate-200 bg-slate-50 p-3 font-mono text-[13px] leading-relaxed text-slate-700">
         {JSON.stringify(version.content ?? {}, null, 2)}
       </pre>
     )
@@ -1223,7 +1223,7 @@ function renderViewVersionBody(version: CapabilityVersion, capability: Capabilit
         {plugin?.sha256 && <DetailField label="sha256" value={plugin.sha256} mono />}
         {plugin?.github_repo && <DetailField label="github_repo" value={plugin.github_repo} mono />}
         {!plugin && (
-          <p className="text-[12px] text-slate-500">{t("capabilities.none")}</p>
+          <p className="text-[13px] text-slate-500">{t("capabilities.none")}</p>
         )}
       </div>
     )
@@ -1241,7 +1241,7 @@ function renderViewVersionBody(version: CapabilityVersion, capability: Capabilit
         {skill.instruction && (
           <DetailField
             label="instruction"
-            value={<pre className="whitespace-pre-wrap font-mono text-[12px] leading-relaxed text-slate-700">{skill.instruction}</pre>}
+            value={<pre className="whitespace-pre-wrap font-mono text-[13px] leading-relaxed text-slate-700">{skill.instruction}</pre>}
           />
         )}
       </div>
@@ -1354,23 +1354,23 @@ function containsPlaintextSecretPattern(value: string) {
 }
 
 function FormField({ label, help, required, children }: { label: string; help?: string; required?: boolean; children: React.ReactNode }) {
-  return <label className="grid gap-1.5"><span className="text-[12px] font-medium text-slate-700">{label}{required && <span className="text-red-500"> *</span>}</span>{children}{help && <span className="text-[11px] leading-relaxed text-slate-500">{help}</span>}</label>
+  return <label className="grid gap-1.5"><span className="text-[13px] font-medium text-slate-700">{label}{required && <span className="text-red-500"> *</span>}</span>{children}{help && <span className="text-[12px] leading-relaxed text-slate-500">{help}</span>}</label>
 }
 
 function DetailField({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
-  return <div className="rounded-md border border-slate-200 bg-white p-3"><p className="text-[11px] text-slate-500">{label}</p><div className={`mt-1 text-[13px] text-slate-900 ${mono ? "font-mono" : ""}`}>{value}</div></div>
+  return <div className="rounded-md border border-slate-200 bg-white p-3"><p className="text-[12px] text-slate-500">{label}</p><div className={`mt-1 text-[13px] text-slate-900 ${mono ? "font-mono" : ""}`}>{value}</div></div>
 }
 
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
-  return <section className="rounded-lg border border-slate-200 bg-white p-4"><h3 className="mb-3 text-[12px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>{children}</section>
+  return <section className="rounded-lg border border-slate-200 bg-white p-4"><h3 className="mb-3 text-[13px] font-semibold uppercase tracking-wider text-slate-500">{title}</h3>{children}</section>
 }
 
 function ErrorBanner({ message }: { message: string }) {
-  return <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800" role="alert">{message}</div>
+  return <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-800" role="alert">{message}</div>
 }
 
 function ToastBanner({ message }: { message: string }) {
-  return <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-800">{message}</div>
+  return <div className="mb-4 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[13px] text-emerald-800">{message}</div>
 }
 
 function CapabilitiesLoading() {

--- a/apps/web/src/pages/admin/credentials/CredentialDialogs.tsx
+++ b/apps/web/src/pages/admin/credentials/CredentialDialogs.tsx
@@ -136,7 +136,7 @@ export function CredentialDialog({
             </Field>
 
             {seedMeta?.getUrl && (
-              <a className="inline-flex text-[12px] text-slate-600 underline-offset-4 hover:underline" href={seedMeta.getUrl} target="_blank" rel="noopener noreferrer">
+              <a className="inline-flex text-[13px] text-slate-600 underline-offset-4 hover:underline" href={seedMeta.getUrl} target="_blank" rel="noopener noreferrer">
                 {t("myCredentials.dialog.openProvider")}
               </a>
             )}
@@ -144,7 +144,7 @@ export function CredentialDialog({
             {mode === "edit" && !replaceToken ? (
               <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
                 <div className="flex items-center justify-between gap-3">
-                  <span className="text-[12.5px] text-slate-600">{t("myCredentials.dialog.tokenSet")}</span>
+                  <span className="text-[13px] text-slate-600">{t("myCredentials.dialog.tokenSet")}</span>
                   <Button type="button" variant="link" size="sm" className="h-auto p-0" onClick={() => setReplaceToken(true)}>
                     {t("myCredentials.dialog.replaceToken")}
                   </Button>
@@ -171,8 +171,8 @@ export function CredentialDialog({
 
             {error && (
               <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2">
-                <p className="text-[12px] font-medium text-red-900">{t("myCredentials.dialog.errorTitle")}</p>
-                <p className="text-[11.5px] text-red-700">{error.message}</p>
+                <p className="text-[13px] font-medium text-red-900">{t("myCredentials.dialog.errorTitle")}</p>
+                <p className="text-[12px] text-red-700">{error.message}</p>
               </div>
             )}
           </div>
@@ -246,21 +246,21 @@ export function DeleteCredentialDialog({ target, pending, error, onCancel, onCon
               {t("myCredentials.delete.description", { kind: kindLabel })}
             </AlertDialogDescription>
             <div className="rounded-md border border-slate-200 bg-slate-50 p-3">
-              <p className="text-[12px] font-medium text-slate-800">{t("myCredentials.delete.impactTitle")}</p>
+              <p className="text-[13px] font-medium text-slate-800">{t("myCredentials.delete.impactTitle")}</p>
               {loadingImpact ? (
                 <div className="mt-2 space-y-2">
                   <Skeleton className="h-4 w-44" />
-                  <p className="text-[11.5px] text-slate-500">{t("myCredentials.delete.loadingImpact")}</p>
+                  <p className="text-[12px] text-slate-500">{t("myCredentials.delete.loadingImpact")}</p>
                 </div>
               ) : impact.length === 0 ? (
-                <p className="mt-2 text-[12px] text-slate-600">{t("myCredentials.delete.noImpact")}</p>
+                <p className="mt-2 text-[13px] text-slate-600">{t("myCredentials.delete.noImpact")}</p>
               ) : (
-                <p className="mt-2 text-[12px] text-red-700">
+                <p className="mt-2 text-[13px] text-red-700">
                   {t("myCredentials.delete.hasImpact", { count: impact.length, workspaceCount })}
                 </p>
               )}
             </div>
-            {error && <p className="text-[12px] text-red-700">{error.message}</p>}
+            {error && <p className="text-[13px] text-red-700">{error.message}</p>}
           </div>
         </AlertDialogHeader>
         <AlertDialogFooter className="flex flex-row items-center justify-end gap-2 border-t border-slate-100 bg-slate-50/60 px-4 py-3">
@@ -294,12 +294,12 @@ function Field({
 }) {
   return (
     <label className="block space-y-1">
-      <span className="text-[12px] font-medium text-slate-700">
+      <span className="text-[13px] font-medium text-slate-700">
         {label}
         {required && <span className="ml-0.5 text-red-500">*</span>}
       </span>
       {children}
-      {hint && <span className="block text-[11px] text-slate-500">{hint}</span>}
+      {hint && <span className="block text-[12px] text-slate-500">{hint}</span>}
     </label>
   )
 }

--- a/apps/web/src/pages/admin/credentials/OrgSecretsTab.tsx
+++ b/apps/web/src/pages/admin/credentials/OrgSecretsTab.tsx
@@ -99,7 +99,7 @@ export function OrgSecretsTab({ workspaceID }: OrgSecretsTabProps) {
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between gap-3">
-        <p className="text-[12.5px] leading-relaxed text-slate-500">
+        <p className="text-[13px] leading-relaxed text-slate-500">
           {t("credentialsPage.org.scopeNote")}
         </p>
         <Button size="sm" onClick={() => setCreateOpen(true)}>
@@ -221,11 +221,11 @@ function CredentialSection({
           <Icon className="mt-0.5 h-4 w-4 text-slate-400" />
           <div>
             <h3 className="text-[14px] font-semibold text-slate-900">{title}</h3>
-            <p className="mt-0.5 text-[12px] text-slate-500">{description}</p>
+            <p className="mt-0.5 text-[13px] text-slate-500">{description}</p>
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-3">
-          <span className="text-[12px] text-slate-400">{items.length}</span>
+          <span className="text-[13px] text-slate-400">{items.length}</span>
           {readOnly && readOnlyAction}
         </div>
       </div>
@@ -240,7 +240,7 @@ function CredentialSection({
                   <span className="truncate text-[13px] font-medium text-slate-900">{secret.name}</span>
                   <StatusBadge status={secret.status} />
                 </div>
-                <div className="mt-1 flex flex-wrap items-center gap-2 text-[12px] text-slate-500">
+                <div className="mt-1 flex flex-wrap items-center gap-2 text-[13px] text-slate-500">
                   <span>{kindLabel(secret.kind)}</span>
                   <span>·</span>
                   <span>{secret.provider || t("secrets.none")}</span>
@@ -249,19 +249,19 @@ function CredentialSection({
                   {secret.slug && (
                     <>
                       <span>·</span>
-                      <code className="text-[11px] text-slate-400">{secret.slug}</code>
+                      <code className="text-[12px] text-slate-400">{secret.slug}</code>
                     </>
                   )}
                 </div>
-                <p className="mt-1 text-[12px] text-slate-500">{usageText(secret, t)}</p>
+                <p className="mt-1 text-[13px] text-slate-500">{usageText(secret, t)}</p>
               </div>
               <div className="flex shrink-0 items-center gap-2">
-                <span className="text-[12px] text-slate-400">{fmtAgo(secret.updated_at)}</span>
+                <span className="text-[13px] text-slate-400">{fmtAgo(secret.updated_at)}</span>
                 {!readOnly && (
                   secret.status === "active" ? (
                     <Button variant="outline" size="sm" onClick={() => onDisable(secret)}>{t("secrets.actions.disable")}</Button>
                   ) : (
-                    <span className="text-[11px] text-slate-400">{t("secrets.actions.alreadyDisabled")}</span>
+                    <span className="text-[12px] text-slate-400">{t("secrets.actions.alreadyDisabled")}</span>
                   )
                 )}
               </div>
@@ -338,8 +338,8 @@ function CreateDialog({ onClose, onSubmit, pending, error }: CreateDialogProps) 
             </Field>
             {error && (
               <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2">
-                <p className="text-[12px] font-medium text-red-900">{t("secrets.create.error.title")}</p>
-                <p className="text-[11.5px] text-red-700">{error.message}</p>
+                <p className="text-[13px] font-medium text-red-900">{t("secrets.create.error.title")}</p>
+                <p className="text-[12px] text-red-700">{error.message}</p>
               </div>
             )}
           </div>
@@ -356,9 +356,9 @@ function CreateDialog({ onClose, onSubmit, pending, error }: CreateDialogProps) 
 function Field({ label, hint, required, children }: { label: string; hint?: string; required?: boolean; children: React.ReactNode }) {
   return (
     <label className="block space-y-1">
-      <span className="text-[12px] font-medium text-slate-700">{label}{required && <span className="ml-0.5 text-red-500">*</span>}</span>
+      <span className="text-[13px] font-medium text-slate-700">{label}{required && <span className="ml-0.5 text-red-500">*</span>}</span>
       {children}
-      {hint && <span className="block text-[11px] text-slate-500">{hint}</span>}
+      {hint && <span className="block text-[12px] text-slate-500">{hint}</span>}
     </label>
   )
 }
@@ -373,7 +373,7 @@ function ConfirmDialog({ target, loading, error, onCancel, onConfirm }: { target
           <div className="space-y-1.5">
             <DialogTitle className="text-sm">{t("secrets.disable.title", { name: target.name })}</DialogTitle>
             <DialogDescription className="text-sm leading-relaxed">{t("secrets.disable.description")}</DialogDescription>
-            {error && <p className="text-[12px] text-red-700">{error.message}</p>}
+            {error && <p className="text-[13px] text-red-700">{error.message}</p>}
           </div>
         </DialogHeader>
         <DialogFooter className="flex flex-row items-center justify-end gap-2 border-t border-slate-100 bg-slate-50/60 px-4 py-3">

--- a/apps/web/src/pages/admin/credentials/PersonalCredentialsTab.tsx
+++ b/apps/web/src/pages/admin/credentials/PersonalCredentialsTab.tsx
@@ -160,7 +160,7 @@ export function PersonalCredentialsTab({ standalone = false }: PersonalCredentia
     <div className="space-y-5">
       {standalone && returnTo && route.returnTo && (
         <div className="flex items-center justify-between gap-3 rounded-lg border border-slate-200 bg-white px-4 py-3">
-          <p className="text-[12.5px] text-slate-600">{t("myCredentials.returnBanner.description")}</p>
+          <p className="text-[13px] text-slate-600">{t("myCredentials.returnBanner.description")}</p>
           <Button size="sm" variant="outline" onClick={() => window.location.assign(returnTo)}>
             {t("myCredentials.returnBanner.action")}
           </Button>
@@ -174,7 +174,7 @@ export function PersonalCredentialsTab({ standalone = false }: PersonalCredentia
             <p className="text-[13px] font-medium text-amber-900">
               {t("credentialsPage.personal.banner.title", { count: missing.length })}
             </p>
-            <p className="text-[12px] leading-relaxed text-amber-800">
+            <p className="text-[13px] leading-relaxed text-amber-800">
               {t("credentialsPage.personal.banner.description")}
             </p>
           </div>
@@ -207,7 +207,7 @@ export function PersonalCredentialsTab({ standalone = false }: PersonalCredentia
                       <button
                         type="button"
                         onClick={() => setExpanded((prev) => ({ ...prev, [row.kind]: !prev[row.kind] }))}
-                        className="mt-1 inline-flex items-center text-[12px] text-slate-500 hover:text-slate-900"
+                        className="mt-1 inline-flex items-center text-[13px] text-slate-500 hover:text-slate-900"
                       >
                         {t("credentialsPage.personal.pending.refCount", { count: row.refCount })}
                         <span className="ml-1 text-slate-400">{open ? "▾" : "▸"}</span>
@@ -223,7 +223,7 @@ export function PersonalCredentialsTab({ standalone = false }: PersonalCredentia
                     </Button>
                   </div>
                   {open && (
-                    <ul className="mt-2 ml-6 list-disc space-y-0.5 text-[12px] text-slate-600">
+                    <ul className="mt-2 ml-6 list-disc space-y-0.5 text-[13px] text-slate-600">
                       {row.refs.map((ref, idx) => {
                         if (ref.source === "model") {
                           return (
@@ -259,7 +259,7 @@ export function PersonalCredentialsTab({ standalone = false }: PersonalCredentia
             <h3 className="text-[14px] font-semibold text-slate-900">
               {t("credentialsPage.personal.configured.title")}
             </h3>
-            <span className="text-[12px] text-slate-400">{credentials.length}</span>
+            <span className="text-[13px] text-slate-400">{credentials.length}</span>
           </div>
           <Button size="sm" onClick={() => setCreateOpen(true)}>
             <Plus className="h-3.5 w-3.5" />
@@ -313,11 +313,11 @@ export function PersonalCredentialsTab({ standalone = false }: PersonalCredentia
                     <div className="font-medium text-slate-900">
                       {credentialKindLabel(credential.kind, i18n.language, t("myCredentials.kind.unknown"), kindOptions.kinds)}
                     </div>
-                    <div className="mt-0.5 text-[11px] text-slate-400">
+                    <div className="mt-0.5 text-[12px] text-slate-400">
                       {t("myCredentials.table.createdAt", { date: new Date(credential.created_at).toLocaleDateString() })}
                     </div>
                   </TableCell>
-                  <TableCell className="text-[12px] text-slate-500">{fmtAgo(credential.last_used_at)}</TableCell>
+                  <TableCell className="text-[13px] text-slate-500">{fmtAgo(credential.last_used_at)}</TableCell>
                   <TableCell className="text-right">
                     <div className="inline-flex items-center gap-1.5">
                       <Button variant="ghost" size="sm" onClick={() => setEditTarget(credential)}>

--- a/apps/web/src/pages/admin/runtimes/LocalDeviceRuntimesPanel.tsx
+++ b/apps/web/src/pages/admin/runtimes/LocalDeviceRuntimesPanel.tsx
@@ -74,7 +74,7 @@ function LocalDeviceRuntimesPanelInner({ workspaceID }: { workspaceID: string })
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <p className="text-[12px] text-slate-500">
+        <p className="text-[13px] text-slate-500">
           {t("runtime.agentDaemon.intro", {
             defaultValue:
               "本地设备通过 parsar-daemon 反向连接 Parsar，让 Agent 使用这台机器上的 Claude Code / OpenCode 等 CLI。",
@@ -159,18 +159,18 @@ function DaemonRuntimeRow({
 
   return (
     <TableRow data-testid={`agent-daemon-row-${runtime.id}`}>
-      <TableCell className="font-mono text-[12px] text-slate-800">
+      <TableCell className="font-mono text-[13px] text-slate-800">
         <div className="space-y-1">
           <div>{runtime.name}</div>
-          <div className="text-[11px] text-slate-500">{shortRuntimeID(runtime.id)}</div>
+          <div className="text-[12px] text-slate-500">{shortRuntimeID(runtime.id)}</div>
         </div>
       </TableCell>
-      <TableCell className="text-[12px] text-slate-600">{runtime.hostname || "—"}</TableCell>
-      <TableCell className="text-[12px] text-slate-600">
+      <TableCell className="text-[13px] text-slate-600">{runtime.hostname || "—"}</TableCell>
+      <TableCell className="text-[13px] text-slate-600">
         <div className="space-y-1">
           <div>{runtime.version || "—"}</div>
           {activeRequests !== null && (
-            <div className="text-[11px] text-slate-500">
+            <div className="text-[12px] text-slate-500">
               {activeRequests === 0
                 ? t("runtime.agentDaemon.load.idle", { defaultValue: "空闲" })
                 : t("runtime.agentDaemon.load.active", { count: activeRequests, defaultValue: "{{count}} 个运行中" })}
@@ -184,14 +184,14 @@ function DaemonRuntimeRow({
       <TableCell>
         <div className="space-y-1">
           <DaemonStatusBadge liveness={runtime.liveness} />
-          <p className="max-w-[240px] text-[11px] leading-4 text-slate-500">{daemonStatusDetail(runtime, t)}</p>
+          <p className="max-w-[240px] text-[12px] leading-4 text-slate-500">{daemonStatusDetail(runtime, t)}</p>
         </div>
       </TableCell>
-      <TableCell className="text-[12px] text-slate-600" title={lastHeartbeatExact ?? undefined}>
+      <TableCell className="text-[13px] text-slate-600" title={lastHeartbeatExact ?? undefined}>
         {runtime.last_heartbeat_at ? (
           <div className="space-y-1">
             <div>{relativeAgo(runtime.last_heartbeat_at)}</div>
-            <div className="text-[11px] text-slate-500">{lastHeartbeatExact}</div>
+            <div className="text-[12px] text-slate-500">{lastHeartbeatExact}</div>
           </div>
         ) : (
           "—"
@@ -217,7 +217,7 @@ function AgentKindBadges({ runtime }: { runtime: Runtime }) {
   const kinds = supportedAgentKinds(runtime)
   const capabilities = daemonCapabilityLabels(runtime, t)
   if (kinds.length === 0) {
-    return <span className="text-[12px] text-slate-400">—</span>
+    return <span className="text-[13px] text-slate-400">—</span>
   }
   return (
     <div className="space-y-1.5">
@@ -233,11 +233,11 @@ function AgentKindBadges({ runtime }: { runtime: Runtime }) {
           </Badge>
         ))}
       </div>
-      <div className="text-[11px] leading-4 text-slate-500">
+      <div className="text-[12px] leading-4 text-slate-500">
         {kinds.map((kind) => formatAgentKindSnapshot(kind, t)).join(" · ")}
       </div>
       {capabilities.length > 0 && (
-        <div className="text-[11px] leading-4 text-slate-500">{capabilities.join(" · ")}</div>
+        <div className="text-[12px] leading-4 text-slate-500">{capabilities.join(" · ")}</div>
       )}
     </div>
   )
@@ -403,7 +403,7 @@ function ConfirmDeleteRuntimeDialog({
               })}
             </DialogDescription>
             {error && (
-              <p className="text-[12px] text-red-700">{error.message}</p>
+              <p className="text-[13px] text-red-700">{error.message}</p>
             )}
           </div>
         </DialogHeader>

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -1,7 +1,8 @@
 @import "tailwindcss";
 
-/* Inter variable font (rsms/inter — author-maintained, small, fast) */
-@import url("https://rsms.me/inter/inter.css");
+/* Geist + Geist Mono are loaded via <link> in index.html (see note there) —
+   not here, because Tailwind v4 inlines its own @import above this point,
+   which would make a CSS @import spec-invalid and silently dropped. */
 
 @theme {
   --animate-fade-out: fade-out 2s ease-out forwards;
@@ -13,39 +14,52 @@
 }
 
 :root {
-  color: #202124;
+  color: #121212;
   background: #ffffff;
-  /* Linear-style stack: Inter variable on top, then platform UI fonts */
-  font-family:
-    "Inter var", "Inter", ui-sans-serif, system-ui, -apple-system,
-    BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB",
-    "Microsoft YaHei", sans-serif;
-  /* Linear's OpenType features — toggles Inter's stylistic alternates */
-  font-feature-settings:
-    "cv02", "cv03", "cv04", "cv11", /* curvier a, g, i, l */
-    "ss03",                          /* alt punctuation */
-    "calt",                          /* contextual alternates */
-    "ss01";
+  /* Kimi-style type system: clean sans for everything (no serif display).
+     Inter renders Latin; Noto Sans SC renders Chinese (Inter has no CJK
+     glyphs); system fonts are the final fallback. */
+  --font-sans:
+    "Inter", "Noto Sans SC", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    system-ui, Roboto, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei",
+    "Noto Sans CJK SC", sans-serif;
+  font-family: var(--font-sans);
+  font-feature-settings: "calt", "ss01";
   font-variation-settings: normal;
+  font-optical-sizing: auto;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
   letter-spacing: -0.011em;
 }
 
-@supports (font-variation-settings: normal) {
-  :root {
-    font-family:
-      "Inter var", "Inter", ui-sans-serif, system-ui, -apple-system,
-      BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB",
-      "Microsoft YaHei", sans-serif;
-  }
+/* Display headings (page/hero titles). Kimi has no serif — titles are a
+   tight, heavy sans. Keeps the `.font-display` hook so existing markup that
+   opted in still gets the intended treatment, just sans now. */
+.font-display {
+  font-family: var(--font-sans);
+  font-weight: 700;
+  letter-spacing: -0.025em;
 }
 
-/* Slightly tighter tracking on display text (page titles, section headings).
-   Tailwind's `tracking-tight` is -0.025em which is a touch too tight for Inter. */
+/* Slightly tighter tracking on display text (page titles, section headings). */
 .tracking-display {
-  letter-spacing: -0.018em;
+  letter-spacing: -0.02em;
+}
+
+/* This is a control plane: run ids, durations, token counts. Geist Mono with
+   slashed zeros + tabular figures so 0/O never read alike and numbers stay
+   column-aligned as they tick. */
+code,
+kbd,
+pre,
+samp,
+.font-mono {
+  font-family:
+    "Geist Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+  font-feature-settings: "tnum", "zero", "ss01";
+  font-variant-numeric: tabular-nums slashed-zero;
 }
 
 * {
@@ -61,6 +75,40 @@ button,
 select,
 textarea {
   font: inherit;
+}
+
+/* Brand-tinted text selection (default is a flat grey-blue). */
+::selection {
+  background: #c7d6ff;
+  color: #0f172a;
+}
+
+/* Thin, unobtrusive scrollbars for the admin shell — the default OS bars are
+   chunky against the light-grey chrome. Firefox via scrollbar-* ; WebKit via
+   ::-webkit-scrollbar. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #cbd5e1 transparent;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  border: 3px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+  background-color: #cbd5e1;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: #94a3b8;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .conversation-app {
@@ -118,29 +166,12 @@ p {
   margin-top: 0;
 }
 
-h1 {
-  margin-bottom: 0;
-  font-size: 19px;
-  line-height: 1.25;
-}
-
-h2 {
-  margin-bottom: 0;
-  font-size: 20px;
-}
-
-h3 {
-  margin-bottom: 6px;
-  font-size: 17px;
-}
-
-h4 {
-  margin-bottom: 10px;
-  color: #475569;
-  font-size: 13px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
+/* NOTE: heading font-size/line-height are intentionally NOT set here.
+   They used to be (h1:19px, h2:20px, h3:17px, h4:13px) but these are
+   unlayered rules, so per the CSS cascade they beat every Tailwind
+   `text-*` utility (which lives in @layer utilities) regardless of
+   specificity — silently capping every page title. Sizes now come from
+   the Tailwind classes on each element. */
 
 .hero-copy {
   max-width: 820px;


### PR DESCRIPTION
## 背景

Web 控制台的字体/字号是早期逐处手填的,排查后发现几个一直存在、但容易被忽视的渲染问题。本 PR 把它系统化,并修掉两个**字体根本没按预期加载**的 bug。纯前端样式改动,无 API / 行为变更。

## 改了什么

### 1. 修复 Inter 实际从未加载(bug)
`style.css` 用 CSS `@import` 引 rsms 的 Inter,但 Tailwind v4 会把 `@import "tailwindcss"` 内联展开,顶在最前面,导致 Inter 的 `@import` 不在文件首位 —— 按 CSS 规范这是非法的,浏览器**静默丢弃**。结果全站正文一直在用系统兜底字体,而不是 Inter。
→ 改为在 `index.html` 用 `<link>` + `preconnect` 加载,Inter 才真正生效。

### 2. 中文字体此前完全失控(bug)
Inter / Geist 这类西文字体**不含任何中文字形**,所以中文一直回退到各设备的系统字体(macOS 是 PingFang,Windows 是雅黑,没装的可能是宋体)—— 每台机器长得不一样。
→ 引入 **Noto Sans SC(思源黑体)**,字体栈按 `Inter(西文)→ Noto Sans SC(中文)→ 系统` 逐字回退,保证**跨设备一致**。

### 3. 字号系统化
- 此前 `text-[12px]` 当正文用了 358 处(偏小),还混入 `12.5 / 11.5 / 13.5 / 14.5px` 等脏值。
- 统一吸附到 `11 / 12 / 13 / 14` 刻度(正文 12→13),共重写 **756 处** `text-[Npx]`,保留层级关系。

### 4. 移除遗留的无-layer 标题规则(bug)
`style.css` 里遗留的 `h1{19px}` / `h2{20px}` / `h3{17px}` 等裸元素规则没有进 `@layer`,在 CSS 级联里**永远压过** Tailwind 的 `text-*` 工具类(与具体性无关),导致页面标题字号一直改不动。移除后由组件上的 Tailwind 类接管。

### 5. 等宽 + 细节
- 等宽统一为 **Geist Mono**,对 id / 时长开启 `tabular-nums` + `slashed-zero`(数字列对齐、`0`/`O` 不混淆)。
- 登录页占位字符 "T" → 真实 logo(`favicon.png`)。
- 状态徽章新增 `pulse`(运行中呼吸点,向后兼容的可选 prop)。
- 品牌色文本选区 + 细滚动条。

## 验证
- ✅ `tsc --noEmit` 通过
- ✅ `vite build` 通过(仅既有的 chunk-size 提示,非本 PR 引入)
- 改动范围:69 个文件,全部在 `apps/web/` 下,仅 `.tsx / .css / .html`

## 影响范围
纯视觉层。无 DB / API / OpenAPI 改动,故未涉及 migration 与 `openapi.yaml`。