### PR TITLE
ci: add check / actionlint / shellcheck workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,38 @@
+
+# The CI of the CI. Every workflow YAML in this directory is itself
+# code — a malformed `if` expression, a typo in `needs:`, or a matrix
+# value that does not exist will pass `yaml.safe_load` but blow up at
+# runtime, sometimes hours after merge. actionlint catches that class
+# of mistake locally-equivalent on every PR that touches workflows.
+#
+# Version pinned (no `main`, no `@latest`): actionlint occasionally
+# tightens rules between releases, so a silent upgrade could turn a
+# green PR red overnight. Bump in a dedicated PR.
+name: actionlint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        run: bash <(curl -sSf https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.7.12
+      - name: Run actionlint
+        run: ./actionlint -color

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,44 @@
+# The single source of truth for "what does CI run" lives in the Makefile
+# (`make check`). That target chains sqlc generate, go test, the migration
+# drift check (which spins up postgres via docker compose), and the pnpm
+# typecheck. Re-expressing those steps in YAML would inevitably drift from
+# the Makefile and break local/CI parity, so this workflow deliberately
+# stays thin: install toolchains, then delegate to `make check`.
+name: check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.30.3
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: make check

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,50 @@
+name: shellcheck
+
+# Bash is the glue holding this project together: dev-stack.sh, check.sh,
+# dev-env.sh, the e2e drivers and the daemon installer all live in scripts/
+# and get exercised by humans on macOS and by CI on Linux. Low-level shell
+# mistakes — unquoted $vars, `[ ]` vs `[[ ]]`, accidental word-splitting,
+# missing `set -e` guards — are notoriously hard to debug once they trip in
+# the middle of a long dev session, and shellcheck is the cheapest possible
+# guard rail against them.
+#
+# We deliberately run with `severity: error` only. Warnings and info-level
+# findings are useful but plentiful; gating CI on them would turn this job
+# into noise and train the team to ignore it. Errors are rare and almost
+# always real bugs, so an error-only signal stays high quality.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "scripts/**"
+      - "**.sh"
+      - ".github/workflows/shellcheck.yml"
+  pull_request:
+    paths:
+      - "scripts/**"
+      - "**.sh"
+      - ".github/workflows/shellcheck.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: shellcheck-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: ./scripts
+          severity: error


### PR DESCRIPTION
## Summary
- **check** — 直接调 `make check`，避免 YAML 与本地脚本双写漂移
- **actionlint** — 钉版本 1.7.12，校验 workflow YAML 本身
- **shellcheck** — 仅 error 级别，保留 warning/info 作为开发者自查

三个 workflow 本地全绿（YAML + actionlint 双验证）。

## 暂缓的三个 workflow
寡人发现的红线归到独立后续 PR，避免本 PR 一上线就红：
- `build.yml` 的 race job — feishuoutbound 8 个测试报真 race
- `openapi.yml` — `docs/openapi/openapi.yaml` 140 redocly errors
- `govulncheck.yml` — pgx v5.7.6 / x/net v0.50.0 各 1 个被实际调用的 CVE

## Test plan
- [x] 本地 ruby YAML.load_file 解析全部通过
- [x] 本地 actionlint 1.7.12 扫描三份 workflow PASS
- [ ] CI 三个 job 都通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)