### PR TITLE
i18n: English defaults across server and web

### DIFF
--- a/apps/web/src/components/UserSearchCombobox.tsx
+++ b/apps/web/src/components/UserSearchCombobox.tsx
@@ -84,7 +84,7 @@ export function UserSearchCombobox({
       ? t("members.add.search.placeholder")
       : t("members.add.search.selectedCount", {
           count: selected.length,
-          defaultValue: "已选 {{count}} 人",
+          defaultValue: "{{count}} selected",
         })
 
   return (

--- a/apps/web/src/components/admin/DevicePicker.tsx
+++ b/apps/web/src/components/admin/DevicePicker.tsx
@@ -90,8 +90,8 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
               : "agents.form.devicePicker.emptyTitle",
             {
               defaultValue: hasOnlineDevices
-                ? "没有兼容当前 Agent 引擎的在线设备"
-                : "尚未连接任何 agent daemon",
+                ? "No online devices compatible with the current Agent engine"
+                : "No agent daemons connected yet",
             },
           )}
         </p>
@@ -105,7 +105,7 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
           >
             <Plus className="h-3 w-3" />
             {t("agents.form.devicePicker.addDevice", {
-              defaultValue: "接入新设备",
+              defaultValue: "Pair a new device",
             })}
           </button>
         ) : (
@@ -116,8 +116,8 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
                 : "agents.form.devicePicker.emptyDescription",
               {
                 defaultValue: hasOnlineDevices
-                  ? "请在 Runtime -> 本地设备 页面确认设备 heartbeat 已上报该 Agent 引擎，或切换到支持当前引擎的设备。"
-                  : "请先在 Runtime -> 本地设备 页面生成配对 token，并在目标机器上运行 `parsar-daemon connect --url ... --token ...` 后再回来。",
+                  ? "Open Runtime → Local devices to confirm the device has reported a heartbeat for this Agent engine, or switch to a device that supports it."
+                  : "Open Runtime → Local devices to generate a pairing token, then run `parsar-daemon connect --url ... --token ...` on the target machine before returning here.",
               },
             )}
           </p>
@@ -137,7 +137,7 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
       >
         <option value="">
           {t("agents.form.devicePicker.placeholder", {
-            defaultValue: "请选择 device...",
+            defaultValue: "Pick a device…",
           })}
         </option>
         {selectableDevices.map((r) => (
@@ -152,11 +152,11 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
           onClick={onAddDevice}
           disabled={disabled}
           data-testid="device-picker-add"
-          title={t("agents.form.devicePicker.addDevice", { defaultValue: "接入新设备" })}
+          title={t("agents.form.devicePicker.addDevice", { defaultValue: "Pair a new device" })}
           className="inline-flex h-9 shrink-0 items-center gap-1 rounded-md border border-line bg-surface px-3 text-sm text-fg-muted shadow-sm hover:bg-surface-subtle disabled:cursor-not-allowed disabled:opacity-50"
         >
           <Plus className="h-3 w-3" />
-          {t("agents.form.devicePicker.addDevice", { defaultValue: "接入新设备" })}
+          {t("agents.form.devicePicker.addDevice", { defaultValue: "Pair a new device" })}
         </button>
       )}
     </div>

--- a/apps/web/src/components/admin/PairDaemonDialog.tsx
+++ b/apps/web/src/components/admin/PairDaemonDialog.tsx
@@ -86,12 +86,12 @@ export function PairDaemonDialog({
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>
-            {t("runtime.agentDaemon.pair.title", { defaultValue: "接入新设备" })}
+            {t("runtime.agentDaemon.pair.title", { defaultValue: "Pair a new device" })}
           </DialogTitle>
           <DialogDescription>
             {t("runtime.agentDaemon.pair.description", {
               defaultValue:
-                "为这台设备生成一次性 token,然后在目标机器上运行 parsar-daemon connect。daemon 会主动通过 WebSocket 连回 Parsar。",
+                "Generate a one-time token for this device, then run parsar-daemon connect on the target machine. The daemon will dial back to Parsar over WebSocket.",
             })}
           </DialogDescription>
         </DialogHeader>
@@ -100,7 +100,7 @@ export function PairDaemonDialog({
           <div className="space-y-3">
             <label className="block text-sm">
               <span className="mb-1 block text-fg-muted">
-                {t("runtime.agentDaemon.pair.nameLabel", { defaultValue: "设备名称" })}
+                {t("runtime.agentDaemon.pair.nameLabel", { defaultValue: "Device name" })}
               </span>
               <input
                 className="w-full rounded border border-line-strong px-2 py-1 font-mono text-sm"
@@ -112,22 +112,22 @@ export function PairDaemonDialog({
             </label>
             <div className="rounded-md border border-success-border bg-success-subtle px-3 py-2 text-sm text-success-emphasis">
               <p className="mb-1 font-medium">
-                {t("runtime.agentDaemon.pair.safetyTitle", { defaultValue: "连接说明" })}
+                {t("runtime.agentDaemon.pair.safetyTitle", { defaultValue: "How the connection works" })}
               </p>
               <ul className="space-y-1 pl-4">
                 <li>
                   {t("runtime.agentDaemon.pair.safetyOutbound", {
-                    defaultValue: "由本机主动出站连接,无需开放任何入站端口",
+                    defaultValue: "This host opens an outbound connection — no inbound ports required.",
                   })}
                 </li>
                 <li>
                   {t("runtime.agentDaemon.pair.safetyClaude", {
-                    defaultValue: "Agent CLI、文件和密钥都留在这台机器上",
+                    defaultValue: "Agent CLI, files, and secrets stay on this machine.",
                   })}
                 </li>
                 <li>
                   {t("runtime.agentDaemon.pair.safetyOnce", {
-                    defaultValue: "Token 仅显示一次,关闭窗口后无法恢复",
+                    defaultValue: "The token is shown once — it cannot be recovered after this dialog closes.",
                   })}
                 </li>
               </ul>
@@ -139,7 +139,7 @@ export function PairDaemonDialog({
             )}
             <DialogFooter>
               <Button variant="outline" size="sm" onClick={close}>
-                {t("common.actions.cancel", { defaultValue: "取消" })}
+                {t("common.actions.cancel", { defaultValue: "Cancel" })}
               </Button>
               <Button
                 size="sm"
@@ -149,10 +149,10 @@ export function PairDaemonDialog({
               >
                 {create.isPending
                   ? t("runtime.agentDaemon.pair.minting", {
-                      defaultValue: "生成中…",
+                      defaultValue: "Generating…",
                     })
                   : t("runtime.agentDaemon.pair.mint", {
-                      defaultValue: "生成连接命令",
+                      defaultValue: "Generate connection command",
                     })}
               </Button>
             </DialogFooter>
@@ -162,18 +162,18 @@ export function PairDaemonDialog({
             <p className="text-sm text-success">
               {t("runtime.agentDaemon.pair.successOneLine", {
                 defaultValue:
-                  "在 {{name}} 上执行这一条命令即可连接（自动下载并连接,无需手动安装二进制):",
+                  "Run this one command on {{name}} to connect (it downloads and connects automatically — no binary to install manually):",
                 name: result.runtimeName,
               })}
             </p>
             <DaemonCommandBlock
               command={buildOneLineCommand(result.token, result.runtimeName)}
               label={t("runtime.agentDaemon.pair.oneLineLabel", {
-                defaultValue: "复制并在目标机器上运行",
+                defaultValue: "Copy and run on the target machine",
               })}
               description={t("runtime.agentDaemon.pair.oneLineHint", {
                 defaultValue:
-                  "目标机器需已安装 Claude Code / OpenCode / Codex 之一;成功后这台设备会变为「在线」",
+                  "The target machine must have one of Claude Code / OpenCode / Codex installed. Once connected, this device flips to “Online”.",
               })}
               onCopy={copyToClipboard}
               testId="agent-daemon-pair-copy-oneline"
@@ -183,21 +183,21 @@ export function PairDaemonDialog({
                 <>
                   <span className="h-2 w-2 shrink-0 rounded-full bg-success" />
                   <span className="text-success">
-                    {t("runtime.agentDaemon.pair.connected", { defaultValue: "设备已连接" })}
+                    {t("runtime.agentDaemon.pair.connected", { defaultValue: "Device connected" })}
                   </span>
                 </>
               ) : (
                 <>
                   <span className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-warning" />
                   <span className="text-fg-muted">
-                    {t("runtime.agentDaemon.pair.waitingConnection", { defaultValue: "等待设备连接…" })}
+                    {t("runtime.agentDaemon.pair.waitingConnection", { defaultValue: "Waiting for the device to connect…" })}
                   </span>
                 </>
               )}
             </div>
             <DialogFooter>
               <Button size="sm" onClick={close} data-testid="agent-daemon-pair-done">
-                {t("common.actions.done", { defaultValue: "完成" })}
+                {t("common.actions.done", { defaultValue: "Done" })}
               </Button>
             </DialogFooter>
           </div>
@@ -233,10 +233,10 @@ function DaemonCommandBlock({
           onClick={() => onCopy(command)}
           className="inline-flex shrink-0 items-center gap-1 rounded border border-line bg-surface px-2 py-1 text-xs text-fg-muted hover:bg-surface-muted"
           data-testid={testId}
-          title={t("runtime.agentDaemon.pair.copyCommand", { defaultValue: "复制命令" })}
+          title={t("runtime.agentDaemon.pair.copyCommand", { defaultValue: "Copy command" })}
         >
           <Copy className="h-3 w-3" />
-          {t("runtime.agentDaemon.pair.copy", { defaultValue: "复制" })}
+          {t("runtime.agentDaemon.pair.copy", { defaultValue: "Copy" })}
         </button>
       </div>
       <code className="block break-all rounded bg-surface p-2 font-mono text-xs leading-relaxed text-fg-emphasis">

--- a/apps/web/src/components/conversation/StepDisplay.tsx
+++ b/apps/web/src/components/conversation/StepDisplay.tsx
@@ -235,8 +235,8 @@ export function WorkingSteps({
             type="button"
             onClick={onCancel}
             disabled={cancelling}
-            aria-label={t("conversations.steps.cancelAria", { defaultValue: "取消当前任务" })}
-            title={t("conversations.steps.cancelAria", { defaultValue: "取消当前任务" })}
+            aria-label={t("conversations.steps.cancelAria", { defaultValue: "Cancel current task" })}
+            title={t("conversations.steps.cancelAria", { defaultValue: "Cancel current task" })}
             className="rounded p-0.5 text-fg-faint transition-colors hover:bg-surface-muted hover:text-danger disabled:opacity-40"
           >
             {cancelling ? (

--- a/apps/web/src/components/ui/error-state.tsx
+++ b/apps/web/src/components/ui/error-state.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, RefreshCw } from "lucide-react"
 import type { ReactNode } from "react"
+import { useTranslation } from "react-i18next"
 import { cn } from "../../lib/utils"
 import { Button } from "./button"
 
@@ -13,13 +14,15 @@ interface ErrorStateProps {
 }
 
 export function ErrorState({
-  title = "无法加载数据",
+  title,
   description,
   hint,
   onRetry,
   action,
   className,
 }: ErrorStateProps) {
+  const { t } = useTranslation("common")
+  const resolvedTitle = title ?? t("errors.loadFailed", { defaultValue: "Failed to load" })
   return (
     <div
       className={cn(
@@ -32,7 +35,7 @@ export function ErrorState({
           <AlertTriangle className="h-4 w-4" />
         </div>
         <div className="space-y-1">
-          <p className="font-medium text-danger-emphasis">{title}</p>
+          <p className="font-medium text-danger-emphasis">{resolvedTitle}</p>
           {description && <p className="text-danger-emphasis">{description}</p>}
           {hint && <p className="text-xs text-danger">{hint}</p>}
         </div>
@@ -42,7 +45,7 @@ export function ErrorState({
           {onRetry && (
             <Button size="sm" variant="outline" onClick={onRetry}>
               <RefreshCw className="h-3.5 w-3.5" />
-              重试
+              {t("actions.retry", { defaultValue: "Retry" })}
             </Button>
           )}
           {action}

--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -836,14 +836,14 @@ function ChatStream({ conversationId, agent, sidebarFolded }: { conversationId: 
                   cancelConvMut.mutate({ conversationID: conversationId, reason: "user_clicked_cancel_all" })
                 }}
                 className="h-7 gap-1 px-2 text-xs text-danger hover:text-danger-emphasis"
-                title={t("conversations.detail.cancelAllAria", { defaultValue: "取消该会话所有进行中的任务" })}
+                title={t("conversations.detail.cancelAllAria", { defaultValue: "Cancel all in-flight tasks in this conversation" })}
               >
                 {cancelConvMut.isPending ? (
                   <Loader2 className="h-3 w-3 animate-spin" strokeWidth={2.5} />
                 ) : (
                   <X className="h-3 w-3" strokeWidth={2.5} />
                 )}
-                {t("conversations.detail.cancelAll", { defaultValue: "取消全部" })}
+                {t("conversations.detail.cancelAll", { defaultValue: "Cancel all" })}
               </Button>
             )}
           </div>
@@ -1286,8 +1286,8 @@ function ComposerForm({
             type="button"
             onClick={onCancelActiveRun}
             disabled={cancelling}
-            aria-label={t("conversations.composer.stopAria", { defaultValue: "停止生成" })}
-            title={t("conversations.composer.stopAria", { defaultValue: "停止生成" })}
+            aria-label={t("conversations.composer.stopAria", { defaultValue: "Stop" })}
+            title={t("conversations.composer.stopAria", { defaultValue: "Stop" })}
             className={cn(
               "flex h-10 w-10 shrink-0 items-center justify-center rounded-md transition-colors",
               "bg-surface-inverse text-white hover:bg-surface-emphasis",

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -189,7 +189,7 @@ export function CreateAgentDialog({
   onOpenChange,
   onSubmit,
 }: CreateAgentDialogProps) {
-  const { t, i18n } = useTranslation("admin")
+  const { t } = useTranslation("admin")
   const { t: tc } = useTranslation("common")
   const queryClient = useQueryClient()
   const [name, setName] = useState("")
@@ -406,7 +406,7 @@ export function CreateAgentDialog({
       // source (with a "副本/Copy" name suffix). URL params still win — the
       // connector-wizard return-to flow relies on them.
       const cloneSource = agent
-      const cloneSuffix = cloneSource?.name ? ` (${i18n.language.startsWith("zh") ? "副本" : "Copy"})` : ""
+      const cloneSuffix = cloneSource?.name ? " (Copy)" : ""
       setName(params.get("agent_name") ?? (cloneSource ? `${cloneSource.name}${cloneSuffix}` : ""))
       setDescription(params.get("agent_description") ?? cloneSource?.description ?? "")
       setExecutionMode(cloneSource ? executionModeFromAgent(cloneSource) : "sandbox")

--- a/apps/web/src/pages/admin/MembersPage.tsx
+++ b/apps/web/src/pages/admin/MembersPage.tsx
@@ -517,7 +517,7 @@ function AddMemberDialog({
                     success: successCount,
                     failed: failures.length,
                     defaultValue:
-                      "成功 {{success}} 个,失败 {{failed}} 个",
+                      "{{success}} succeeded, {{failed}} failed",
                   })}
                 </p>
                 <ul className="space-y-0.5">
@@ -550,12 +550,12 @@ function AddMemberDialog({
                 ? t("members.add.submitting", {
                     done: progress?.done ?? 0,
                     total: progress?.total ?? 0,
-                    defaultValue: "添加中 ({{done}}/{{total}})…",
+                    defaultValue: "Adding ({{done}}/{{total}})…",
                   })
                 : selected.length > 1
                   ? t("members.add.submitMany", {
                       count: selected.length,
-                      defaultValue: "添加 {{count}} 个",
+                      defaultValue: "Add {{count}}",
                     })
                   : t("members.add.submit")}
             </Button>

--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -647,7 +647,7 @@ function CloudDaemonRuntimesPanel({
   if (error) {
     return (
       <ErrorState
-        title={t("runtime.cloud.daemonRuntimes.errors.loadFailed", { defaultValue: "无法加载沙盒内 Daemon" })}
+        title={t("runtime.cloud.daemonRuntimes.errors.loadFailed", { defaultValue: "Failed to load sandbox daemons" })}
         description={error instanceof Error ? error.message : String(error)}
         onRetry={onRefresh}
       />
@@ -661,17 +661,17 @@ function CloudDaemonRuntimesPanel({
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-line-muted px-4 py-3">
         <div>
           <h3 className="text-base font-medium text-fg">
-            {t("runtime.cloud.daemonRuntimes.title", { defaultValue: "沙盒内 Daemon" })}
+            {t("runtime.cloud.daemonRuntimes.title", { defaultValue: "Sandbox daemons" })}
           </h3>
           <p className="mt-0.5 max-w-3xl text-sm leading-relaxed text-fg-subtle">
             {t("runtime.cloud.daemonRuntimes.description", {
               count: runtimes.length,
-              defaultValue: "运行在云端沙盒里的 parsar-daemon 进程。它们属于云端沙盒，不是本地设备。",
+              defaultValue: "parsar-daemon processes running inside cloud sandboxes — these belong to the sandbox, not a physical device.",
             })}
           </p>
         </div>
         <Button size="sm" variant="outline" onClick={onRefresh}>
-          {t("runtime.list.actions.refresh", { defaultValue: "刷新" })}
+          {t("runtime.list.actions.refresh", { defaultValue: "Refresh" })}
         </Button>
       </div>
       <Table>
@@ -679,10 +679,10 @@ function CloudDaemonRuntimesPanel({
           <TableRow>
             <TableHead>{t("runtime.cloud.daemonRuntimes.table.runtime", { defaultValue: "Runtime" })}</TableHead>
             <TableHead>{t("runtime.cloud.daemonRuntimes.table.projectAgent", { defaultValue: "Project Agent" })}</TableHead>
-            <TableHead>{t("runtime.cloud.daemonRuntimes.table.kind", { defaultValue: "沙盒类型" })}</TableHead>
-            <TableHead>{t("runtime.cloud.daemonRuntimes.table.agentEngines", { defaultValue: "Agent 引擎" })}</TableHead>
-            <TableHead>{t("runtime.cloud.daemonRuntimes.table.status", { defaultValue: "状态" })}</TableHead>
-            <TableHead>{t("runtime.cloud.daemonRuntimes.table.heartbeat", { defaultValue: "最后心跳" })}</TableHead>
+            <TableHead>{t("runtime.cloud.daemonRuntimes.table.kind", { defaultValue: "Sandbox type" })}</TableHead>
+            <TableHead>{t("runtime.cloud.daemonRuntimes.table.agentEngines", { defaultValue: "Agent engines" })}</TableHead>
+            <TableHead>{t("runtime.cloud.daemonRuntimes.table.status", { defaultValue: "Status" })}</TableHead>
+            <TableHead>{t("runtime.cloud.daemonRuntimes.table.heartbeat", { defaultValue: "Last heartbeat" })}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -721,13 +721,13 @@ function RuntimeLivenessBadge({ runtime }: { runtime: Runtime }) {
   const { t } = useTranslation("admin")
   switch (runtime.liveness) {
     case "online":
-      return <Badge variant="success" dot>{t("runtime.agentDaemon.status.online", { defaultValue: "在线" })}</Badge>
+      return <Badge variant="success" dot>{t("runtime.agentDaemon.status.online", { defaultValue: "Online" })}</Badge>
     case "pending_pairing":
-      return <Badge variant="warning">{t("runtime.agentDaemon.status.pending_pairing", { defaultValue: "等待配对" })}</Badge>
+      return <Badge variant="warning">{t("runtime.agentDaemon.status.pending_pairing", { defaultValue: "Pairing" })}</Badge>
     case "error":
-      return <Badge variant="destructive">{t("runtime.agentDaemon.status.error", { defaultValue: "错误" })}</Badge>
+      return <Badge variant="destructive">{t("runtime.agentDaemon.status.error", { defaultValue: "Error" })}</Badge>
     default:
-      return <Badge variant="neutral">{t("runtime.agentDaemon.status.offline", { defaultValue: "离线" })}</Badge>
+      return <Badge variant="neutral">{t("runtime.agentDaemon.status.offline", { defaultValue: "Offline" })}</Badge>
   }
 }
 

--- a/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
@@ -142,11 +142,11 @@ export function AddCapabilityVersionDialog({
         ? t("capabilities.errors.nameTooLong")
         : null
   const versionError = !trimmedVersion
-    ? t("capabilities.errors.versionRequired", { defaultValue: "请填写新版本号" })
+    ? t("capabilities.errors.versionRequired", { defaultValue: "Please enter a new version" })
     : versionConflict
       ? t("capabilities.errors.versionMustBump", {
           version: latestVersion?.version ?? "",
-          defaultValue: "新版本号必须不同于当前最新版本（{{version}}）",
+          defaultValue: "The new version must differ from the current latest ({{version}}).",
         })
       : null
 
@@ -270,7 +270,7 @@ export function AddCapabilityVersionDialog({
           <InfoBanner>
             {t("capabilities.versions.add.prefillFromLatest", {
               version: latestVersion?.version ?? "",
-              defaultValue: "已用上一版（{{version}}）的内容预填。修改后会作为新版本提交。",
+              defaultValue: "Pre-filled with the previous version ({{version}}). Edits will be submitted as a new version.",
             })}
           </InfoBanner>
         )}
@@ -278,7 +278,7 @@ export function AddCapabilityVersionDialog({
           <InfoBanner>
             {t("capabilities.versions.add.reuseExistingZip", {
               filename: inheritedOssLabel,
-              defaultValue: "当前版本的包：{{filename}}。如不重新上传，新版本将复用此包。",
+              defaultValue: "Current version package: {{filename}}. If you do not re-upload, the new version will reuse this package.",
             })}
           </InfoBanner>
         )}
@@ -288,7 +288,7 @@ export function AddCapabilityVersionDialog({
               keys: inheritedInlineSecrets
                 .map((e) => `${e.server}.${e.envKey}`)
                 .join(", "),
-              defaultValue: "上一版的 inline secret（{{keys}}）已隐藏。如需保留，请重新输入明文；或改成已托管的凭据。",
+              defaultValue: "Previous-version inline secrets ({{keys}}) are hidden. Re-enter them in plaintext to keep, or switch to managed credentials.",
             })}
           </WarningBanner>
         )}

--- a/apps/web/src/pages/admin/capabilities/CredentialKindCombobox.tsx
+++ b/apps/web/src/pages/admin/capabilities/CredentialKindCombobox.tsx
@@ -79,7 +79,7 @@ export function CredentialKindCombobox({
                 ? selected.display_name
                 : value
                   ? value
-                  : t("capabilities.import.kindPicker.placeholder", "选择凭据类型")}
+                  : t("capabilities.import.kindPicker.placeholder", "Select a credential kind")}
               {selected && (
                 <code className="ml-2 rounded bg-surface-muted px-1.5 py-0.5 font-mono text-xs text-fg-subtle">
                   {selected.code}
@@ -100,7 +100,7 @@ export function CredentialKindCombobox({
               <Input
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                placeholder={t("capabilities.import.kindPicker.search", "搜索…")}
+                placeholder={t("capabilities.import.kindPicker.search", "Search…")}
                 onKeyDown={(e) => e.stopPropagation() /* keep arrow keys in input */}
                 className="h-8 text-sm"
                 autoFocus
@@ -111,13 +111,13 @@ export function CredentialKindCombobox({
               {kindsQ.isLoading ? (
                 <div className="flex items-center gap-2 px-3 py-2 text-sm text-fg-subtle">
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  {t("capabilities.import.kindPicker.loading", "加载中…")}
+                  {t("capabilities.import.kindPicker.loading", "Loading…")}
                 </div>
               ) : errMsg ? (
                 <p className="px-3 py-2 text-sm text-danger-emphasis">{errMsg}</p>
               ) : filtered.length === 0 ? (
                 <p className="px-3 py-2 text-sm text-fg-subtle">
-                  {t("capabilities.import.kindPicker.empty", "没有匹配的凭据类型")}
+                  {t("capabilities.import.kindPicker.empty", "No matching credential kinds")}
                 </p>
               ) : (
                 filtered.map((kind) => (
@@ -141,7 +141,7 @@ export function CredentialKindCombobox({
               className="flex cursor-pointer items-center gap-2 rounded px-3 py-2 text-sm font-medium text-fg outline-none hover:bg-surface-subtle focus:bg-surface-subtle"
             >
               <Plus className="h-3.5 w-3.5" />
-              {t("capabilities.import.kindPicker.createNew", "新建凭据类型…")}
+              {t("capabilities.import.kindPicker.createNew", "Create credential kind…")}
             </DropdownMenu.Item>
           </DropdownMenu.Content>
         </DropdownMenu.Portal>

--- a/apps/web/src/pages/admin/capabilities/EnvCredentialPicker.tsx
+++ b/apps/web/src/pages/admin/capabilities/EnvCredentialPicker.tsx
@@ -35,8 +35,8 @@ interface Props {
 type CredentialMode = Exclude<EnvMode, "literal">
 
 const MODE_OPTIONS: { value: CredentialMode; labelKey: string; fallback: string }[] = [
-  { value: "inline_secret", labelKey: "capabilities.import.envMode.inlineSecret", fallback: "团队共享密钥" },
-  { value: "credential_ref", labelKey: "capabilities.import.envMode.credentialRef", fallback: "个人凭据" },
+  { value: "inline_secret", labelKey: "capabilities.import.envMode.inlineSecret", fallback: "Team shared secret" },
+  { value: "credential_ref", labelKey: "capabilities.import.envMode.credentialRef", fallback: "Personal credential" },
 ]
 
 function startsWithEnvPlaceholder(value: string | undefined): boolean {
@@ -85,13 +85,13 @@ export function EnvCredentialPicker({
             {envKey}
           </code>
           <span className="shrink-0 rounded bg-warning-subtle px-1.5 py-0.5 text-xs font-medium text-warning">
-            {t("capabilities.import.envBadge.credential", "凭据")}
+            {t("capabilities.import.envBadge.credential", "Credential")}
           </span>
         </div>
 
         <div className="space-y-1.5">
           <div className="text-xs font-medium text-fg-subtle">
-            {t("capabilities.import.envMode.label", "凭据来源")}
+            {t("capabilities.import.envMode.label", "Credential source")}
           </div>
           <ModeToggle value={activeMode} onChange={setMode} />
         </div>
@@ -107,14 +107,14 @@ export function EnvCredentialPicker({
               className="font-mono text-sm"
               placeholder={t(
                 "capabilities.import.envValue.inlineSecretPlaceholder",
-                "粘贴团队共用 token，导入时加密保存",
+                "Paste a team-shared token; we encrypt it on import.",
               )}
             />
             <p className="flex items-center gap-1.5 text-xs text-success">
               <Lock className="h-3 w-3" />
               {t(
                 "capabilities.import.envValue.inlineSecretNote",
-                "适合团队共用的服务账号 token；提交后配置里只保留密钥引用，不保存明文。",
+                "Best for shared service-account tokens. The config only stores a reference; plaintext is never persisted.",
               )}
             </p>
           </div>
@@ -132,7 +132,7 @@ export function EnvCredentialPicker({
               <KeyRound className="h-3 w-3" />
               {t(
                 "capabilities.import.envValue.credentialRefNote",
-                "适合 GitLab PAT 这类个人 token；运行时使用调用者在「我的凭据」里绑定的值。",
+                "Best for personal tokens like a GitLab PAT — at runtime we use the caller's value from My Credentials.",
               )}
             </p>
           </div>

--- a/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
@@ -240,27 +240,27 @@ export function ImportCapabilityDialog({
       >
         <DialogHeader>
           <DialogTitle>
-            {t("capabilities.import.dialog.title", "导入能力")}
+            {t("capabilities.import.dialog.title", "Import capability")}
           </DialogTitle>
           <DialogDescription>
             {kind === "skill"
               ? t(
                   "capabilities.import.dialog.descriptionSkill",
-                  "粘贴 SKILL.md 或上传 zip 包。Skill 的名称和描述由 frontmatter 决定,正文会作为 instruction 注入模型。",
+                  "Paste a SKILL.md or upload a zip. The Skill name and description come from the frontmatter; the body is injected into the model as the instruction.",
                 )
               : kind === "plugin"
                 ? t(
                     "capabilities.import.dialog.descriptionPlugin",
-                    "上传 .claude-plugin 打包好的 zip,服务端会校验 manifest 并解析。",
+                    "Upload a .claude-plugin zip. The server validates the manifest and parses it.",
                   )
                 : kind === "system_prompt"
                   ? t(
                       "capabilities.import.dialog.descriptionSystemPrompt",
-                      "把一段 system prompt 注册成可复用的能力。Append 模式拼在用户 system prompt 前;Override 模式完全替换。",
+                      "Register a system prompt as a reusable capability. Append prepends to the user system prompt; Override replaces it entirely.",
                     )
                   : t(
                       "capabilities.import.dialog.description",
-                      "粘贴第三方 MCP 配置(JSON / TOML),会自动解析并预览。普通 env 值原样导入;只有 env 值以 $ 开头时才会提示凭据处理。",
+                      "Paste a third-party MCP config (JSON / TOML); we parse and preview it. Plain env values are imported as-is; only env values starting with $ trigger the credential prompt.",
                     )}
           </DialogDescription>
         </DialogHeader>
@@ -288,7 +288,7 @@ export function ImportCapabilityDialog({
           {kind !== "skill" && (
             <div className="mt-4 grid gap-3 md:grid-cols-2">
               <Field
-                label={t("capabilities.import.dialog.name", "名称")}
+                label={t("capabilities.import.dialog.name", "Name")}
                 required
               >
                 <Input
@@ -299,19 +299,19 @@ export function ImportCapabilityDialog({
                   }}
                   placeholder={t(
                     "capabilities.import.dialog.namePlaceholder",
-                    "如 github-mcp",
+                    "e.g. github-mcp",
                   )}
                 />
               </Field>
               <Field
-                label={t("capabilities.import.dialog.descriptionLabel", "描述")}
+                label={t("capabilities.import.dialog.descriptionLabel", "Description")}
               >
                 <Input
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                   placeholder={t(
                     "capabilities.import.dialog.descriptionPlaceholder",
-                    "用一句话说明这个能力做什么,Claude 会用它判断是否调用",
+                    "One sentence describing what this capability does — Claude uses it to decide when to invoke.",
                   )}
                 />
               </Field>
@@ -388,13 +388,13 @@ export function ImportCapabilityDialog({
             disabled={commitMut.isPending || createMut.isPending}
             onClick={() => onOpenChange(false)}
           >
-            {t("capabilities.actions.cancel", "取消")}
+            {t("capabilities.actions.cancel", "Cancel")}
           </Button>
           <Button size="sm" disabled={!canSubmit} onClick={submit}>
             {(commitMut.isPending || createMut.isPending) && (
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
             )}
-            {t("capabilities.import.dialog.submit", "导入")}
+            {t("capabilities.import.dialog.submit", "Import")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/pages/admin/capabilities/ImportMCPForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportMCPForm.tsx
@@ -111,7 +111,7 @@ export function ImportMCPForm({
               ? err.envelope.message
               : err instanceof Error
                 ? err.message
-                : t("capabilities.import.preview.errorFallback", "解析失败")
+                : t("capabilities.import.preview.errorFallback", "Failed to parse")
             setErrorMessage(msg)
             setWarnings([])
             onChange(null)
@@ -164,7 +164,7 @@ export function ImportMCPForm({
         <p className="text-xs text-fg-subtle">
           {t(
             "capabilities.import.mcp.pasteHelp",
-            "支持 Claude Code (env) / OpenCode (environment) JSON 与 Codex TOML。也可以只粘贴 mcpServers 内层对象。",
+            "Supports Claude Code (env) / OpenCode (environment) JSON and Codex TOML. You can also paste just the inner mcpServers object.",
           )}
         </p>
       </div>
@@ -242,7 +242,7 @@ function FormatPicker({
   return (
     <div className="flex items-center gap-2 text-sm">
       <span className="font-medium text-fg-muted">
-        {t("capabilities.import.mcp.format", "格式")}
+        {t("capabilities.import.mcp.format", "Format")}
       </span>
       <div className="flex overflow-hidden rounded-md border border-line bg-surface-subtle">
         {options.map((opt) => {
@@ -338,7 +338,7 @@ function ServerCard({
 
       {credentialEnvEntries.length === 0 ? (
         <p className="mt-2 text-sm text-fg-subtle">
-          {t("capabilities.import.envEmpty.noCredentialPlaceholders", "无需要处理的凭据")}
+          {t("capabilities.import.envEmpty.noCredentialPlaceholders", "No credential placeholders to fill")}
         </p>
       ) : (
         <div className="mt-2 space-y-2">

--- a/apps/web/src/pages/admin/capabilities/ImportPluginForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportPluginForm.tsx
@@ -97,12 +97,12 @@ export function ImportPluginForm({
   const acceptFile = async (picked: File) => {
     setLocalErr(null)
     if (!picked.name.toLowerCase().endsWith(ACCEPTED_EXT)) {
-      setLocalErr(t("capabilities.import.plugin.errors.notZip", "请选择 .zip 文件"))
+      setLocalErr(t("capabilities.import.plugin.errors.notZip", "Please choose a .zip file"))
       return
     }
     if (picked.size > MAX_BYTES) {
       setLocalErr(
-        t("capabilities.import.plugin.errors.tooLarge", "文件超过 32 MiB,服务端会拒绝"),
+        t("capabilities.import.plugin.errors.tooLarge", "File exceeds 32 MiB — the server will reject it"),
       )
       return
     }
@@ -168,7 +168,7 @@ export function ImportPluginForm({
     <div className="grid gap-4 md:grid-cols-2">
       <div className="grid gap-3">
         <span className="text-sm font-medium text-fg-muted">
-          {t("capabilities.import.plugin.uploadLabel", "上传 Plugin zip")}
+          {t("capabilities.import.plugin.uploadLabel", "Upload Plugin zip")}
         </span>
         {!file ? (
           <label
@@ -179,10 +179,10 @@ export function ImportPluginForm({
           >
             <Upload className="h-5 w-5 text-fg-subtle" />
             <span className="text-sm text-fg-muted">
-              {t("capabilities.import.plugin.dropHint", "拖拽或点击上传 .zip 文件")}
+              {t("capabilities.import.plugin.dropHint", "Drag or click to upload a .zip file")}
             </span>
             <span className="text-xs text-fg-subtle">
-              {t("capabilities.import.plugin.sizeHint", "最大 32 MiB")}
+              {t("capabilities.import.plugin.sizeHint", "Up to 32 MiB")}
             </span>
             <input
               id="plugin-zip-input"
@@ -210,8 +210,8 @@ export function ImportPluginForm({
                       <span className="inline-flex items-center gap-1 text-fg-muted">
                         <Loader2 className="h-3 w-3 animate-spin" />
                         {presignMut.isPending
-                          ? t("capabilities.import.plugin.uploading", "上传中…")
-                          : t("capabilities.import.plugin.validating", "校验中…")}
+                          ? t("capabilities.import.plugin.uploading", "Uploading…")
+                          : t("capabilities.import.plugin.validating", "Validating…")}
                       </span>
                     </>
                   )}
@@ -223,7 +223,7 @@ export function ImportPluginForm({
               size="sm"
               onClick={reset}
               disabled={busy}
-              aria-label={t("capabilities.actions.cancel", "取消")}
+              aria-label={t("capabilities.actions.cancel", "Cancel")}
             >
               <X className="h-4 w-4" />
             </Button>
@@ -243,11 +243,11 @@ export function ImportPluginForm({
       {/* ---- validation preview pane ----------------------------------- */}
       <div className="grid gap-3">
         <span className="text-sm font-medium text-fg-muted">
-          {t("capabilities.import.plugin.previewLabel", "校验结果")}
+          {t("capabilities.import.plugin.previewLabel", "Validation result")}
         </span>
         {!validation && !busy && (
           <div className="rounded-md border border-dashed border-line-strong bg-surface-subtle px-3 py-6 text-center text-sm text-fg-subtle">
-            {t("capabilities.import.plugin.previewEmpty", "上传一个 zip 文件后在这里看到校验结果")}
+            {t("capabilities.import.plugin.previewEmpty", "Upload a zip file to see the validation result here")}
           </div>
         )}
         {validation && <ValidationPanel validation={validation} preview={previewMut.data ?? null} />}
@@ -290,11 +290,11 @@ function ValidationPanel({
     <div className="grid gap-3 rounded-md border border-line bg-surface p-3">
       {validation.valid ? (
         <div className="rounded-md border border-success-border bg-success-subtle px-3 py-1.5 text-sm text-success-emphasis">
-          {t("capabilities.import.plugin.passed", "校验通过")}
+          {t("capabilities.import.plugin.passed", "Validation passed")}
         </div>
       ) : (
         <div className="rounded-md border border-danger-border bg-danger-subtle px-3 py-1.5 text-sm text-danger-emphasis">
-          {t("capabilities.import.plugin.failed", "校验失败,请修复后重新上传")}
+          {t("capabilities.import.plugin.failed", "Validation failed — fix the issues and upload again")}
         </div>
       )}
 
@@ -322,7 +322,7 @@ function ValidationPanel({
       {errors.length > 0 && (
         <div>
           <p className="mb-1 text-xs font-medium uppercase tracking-wide text-danger-emphasis">
-            {t("capabilities.import.plugin.errorsHeader", "错误")}
+            {t("capabilities.import.plugin.errorsHeader", "Errors")}
           </p>
           <ul className="ml-4 list-disc space-y-0.5 text-sm text-danger-emphasis">
             {errors.map((e, i) => (
@@ -335,7 +335,7 @@ function ValidationPanel({
       {warnings.length > 0 && (
         <div>
           <p className="mb-1 text-xs font-medium uppercase tracking-wide text-warning">
-            {t("capabilities.import.plugin.warningsHeader", "警告")}
+            {t("capabilities.import.plugin.warningsHeader", "Warnings")}
           </p>
           <ul className="ml-4 list-disc space-y-0.5 text-sm text-warning-emphasis">
             {warnings.map((wn, i) => (

--- a/apps/web/src/pages/admin/capabilities/ImportPreview.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportPreview.tsx
@@ -40,14 +40,14 @@ export function ImportPreview({
     <div className="space-y-2">
       {status === "idle" && (
         <p className="rounded-md border border-dashed border-line bg-surface-subtle px-3 py-2 text-sm text-fg-subtle">
-          {t("capabilities.import.preview.idle", "在左侧粘贴内容后,这里会显示解析结果")}
+          {t("capabilities.import.preview.idle", "Paste content on the left to see the parsed result here")}
         </p>
       )}
 
       {status === "loading" && (
         <p className="inline-flex items-center gap-2 rounded-md border border-line bg-surface-subtle px-3 py-2 text-sm text-fg-muted">
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          {t("capabilities.import.preview.loading", "正在解析…")}
+          {t("capabilities.import.preview.loading", "Parsing…")}
         </p>
       )}
 
@@ -80,7 +80,7 @@ export function ImportPreview({
         <div className="space-y-1 rounded-md border border-warning-border bg-warning-subtle px-3 py-2 text-sm text-warning-emphasis">
           <div className="flex items-center gap-1.5 font-medium">
             <AlertTriangle className="h-3.5 w-3.5" />
-            {t("capabilities.import.preview.warnings", "解析提示")}
+            {t("capabilities.import.preview.warnings", "Parse warnings")}
           </div>
           <ul className="list-disc space-y-0.5 pl-5">
             {warnings.map((w, i) => (

--- a/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
@@ -107,7 +107,7 @@ export function ImportSkillForm({
           },
           onError: (err) => {
             setPasteError(
-              formatErr(err, t("capabilities.import.preview.errorFallback", "解析失败")),
+              formatErr(err, t("capabilities.import.preview.errorFallback", "Failed to parse")),
             )
             setPasteWarnings([])
             onChange(null)
@@ -151,12 +151,12 @@ export function ImportSkillForm({
   const acceptZip = async (picked: File) => {
     setZipError(null)
     if (!picked.name.toLowerCase().endsWith(".zip")) {
-      setZipError(t("capabilities.import.skill.errors.notZip", "请选择 .zip 文件"))
+      setZipError(t("capabilities.import.skill.errors.notZip", "Please choose a .zip file"))
       return
     }
     if (picked.size > ZIP_MAX_BYTES) {
       setZipError(
-        t("capabilities.import.skill.errors.tooLarge", "文件超过 8 MiB,服务端会拒绝"),
+        t("capabilities.import.skill.errors.tooLarge", "File exceeds 8 MiB — the server will reject it"),
       )
       return
     }
@@ -195,7 +195,7 @@ export function ImportSkillForm({
     } catch (err) {
       if (myReq !== requestSeq.current) return
       setZipError(
-        formatErr(err, t("capabilities.import.preview.errorFallback", "解析失败")),
+        formatErr(err, t("capabilities.import.preview.errorFallback", "Failed to parse")),
       )
       onChange(null)
       onOssKeyChange(null)
@@ -266,7 +266,7 @@ export function ImportSkillForm({
           {source === "paste" ? (
             <>
               <p className="text-sm font-medium text-fg-muted">
-                {t("capabilities.import.skill.markdown", "Markdown 内容")}
+                {t("capabilities.import.skill.markdown", "Markdown content")}
               </p>
               <textarea
                 value={raw}
@@ -284,23 +284,23 @@ export function ImportSkillForm({
               <p className="text-xs text-fg-subtle">
                 {t(
                   "capabilities.import.skill.pasteHelp",
-                  "支持带 YAML frontmatter 的 Markdown。name + description 来自 frontmatter,正文作为 instruction 注入到模型。",
+                  "Supports Markdown with YAML frontmatter. name + description come from the frontmatter; the body is injected into the model as the instruction.",
                 )}
               </p>
             </>
           ) : (
             <>
               <p className="text-sm font-medium text-fg-muted">
-                {t("capabilities.import.skill.zipLabel", "上传 Skill zip")}
+                {t("capabilities.import.skill.zipLabel", "Upload Skill zip")}
               </p>
               <SkillZipDropzone
                 file={zipFile}
                 busy={busy}
                 busyLabel={
                   presignMut.isPending
-                    ? t("capabilities.import.skill.uploading", "上传中…")
+                    ? t("capabilities.import.skill.uploading", "Uploading…")
                     : previewMut.isPending
-                      ? t("capabilities.import.skill.parsing", "解析中…")
+                      ? t("capabilities.import.skill.parsing", "Parsing…")
                       : undefined
                 }
                 onPick={(f) => void acceptZip(f)}
@@ -310,7 +310,7 @@ export function ImportSkillForm({
               <p className="text-xs text-fg-subtle">
                 {t(
                   "capabilities.import.skill.zipHelp",
-                  "zip 内需包含 SKILL.md(可在根目录或一层子目录)。references/、scripts/ 等子目录会一并导入。",
+                  "The zip must contain a SKILL.md (at the root or one level deep). references/ and scripts/ subdirectories are imported alongside it.",
                 )}
               </p>
             </>
@@ -364,18 +364,18 @@ function SourceModeSwitch({
     <div
       className="inline-flex items-center gap-1 self-start rounded-md border border-line bg-surface-subtle p-0.5"
       role="tablist"
-      aria-label={t("capabilities.import.skill.source.label", "导入方式")}
+      aria-label={t("capabilities.import.skill.source.label", "Import method")}
     >
       <ModeButton
         active={value === "paste"}
         icon={<ClipboardPaste className="h-3.5 w-3.5" />}
-        label={t("capabilities.import.skill.source.paste", "粘贴 Markdown")}
+        label={t("capabilities.import.skill.source.paste", "Paste Markdown")}
         onClick={() => onChange("paste")}
       />
       <ModeButton
         active={value === "zip"}
         icon={<FileArchive className="h-3.5 w-3.5" />}
-        label={t("capabilities.import.skill.source.zip", "上传 zip")}
+        label={t("capabilities.import.skill.source.zip", "Upload zip")}
         onClick={() => onChange("zip")}
       />
     </div>
@@ -430,7 +430,7 @@ function SinglePreviewCard({
        *  surfaces it on the "ready" card, repeating it here was noisy. */}
 
       {skill.trigger && (
-        <Field label={t("capabilities.import.skill.trigger", "触发条件")}>
+        <Field label={t("capabilities.import.skill.trigger", "Trigger")}>
           <code className="block whitespace-pre-wrap rounded bg-surface-subtle px-2 py-1.5 font-mono text-xs text-fg-muted">
             {skill.trigger}
           </code>
@@ -438,7 +438,7 @@ function SinglePreviewCard({
       )}
 
       <Field
-        label={t("capabilities.import.skill.instruction", "Instruction(注入到模型)")}
+        label={t("capabilities.import.skill.instruction", "Instruction (injected into the model)")}
       >
         <pre className="max-h-[280px] overflow-auto whitespace-pre-wrap rounded bg-surface-subtle px-2 py-1.5 font-mono text-xs leading-relaxed text-fg-muted">
           {skill.instruction}

--- a/apps/web/src/pages/admin/capabilities/ImportSystemPromptForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportSystemPromptForm.tsx
@@ -30,7 +30,7 @@ export function ImportSystemPromptForm({ value, onChange }: Props) {
   return (
     <div className="space-y-4">
       <Field
-        label={t("capabilities.import.systemPrompt.versionLabel", "版本号")}
+        label={t("capabilities.import.systemPrompt.versionLabel", "Version")}
         required
       >
         <Input
@@ -40,7 +40,7 @@ export function ImportSystemPromptForm({ value, onChange }: Props) {
         />
       </Field>
 
-      <Field label={t("capabilities.import.systemPrompt.modeLabel", "注入模式")} required>
+      <Field label={t("capabilities.import.systemPrompt.modeLabel", "Injection mode")} required>
         <div className="flex gap-4 text-sm">
           <label className="inline-flex items-center gap-2">
             <input
@@ -50,7 +50,7 @@ export function ImportSystemPromptForm({ value, onChange }: Props) {
               checked={value.mode === "append"}
               onChange={() => set({ mode: "append" })}
             />
-            {t("capabilities.import.systemPrompt.modeAppend", "Append（拼到用户 system prompt 前）")}
+            {t("capabilities.import.systemPrompt.modeAppend", "Append (prepended to the user system prompt)")}
           </label>
           <label className="inline-flex items-center gap-2">
             <input
@@ -60,19 +60,19 @@ export function ImportSystemPromptForm({ value, onChange }: Props) {
               checked={value.mode === "override"}
               onChange={() => set({ mode: "override" })}
             />
-            {t("capabilities.import.systemPrompt.modeOverride", "Override（完全替换）")}
+            {t("capabilities.import.systemPrompt.modeOverride", "Override (replaces the default system prompt)")}
           </label>
         </div>
       </Field>
 
-      <Field label={t("capabilities.import.systemPrompt.promptLabel", "Prompt 内容")} required>
+      <Field label={t("capabilities.import.systemPrompt.promptLabel", "Prompt content")} required>
         <textarea
           className="min-h-[260px] w-full rounded-md border border-line bg-surface p-3 font-mono text-sm leading-relaxed text-fg-emphasis focus:outline-none focus:ring-2 focus:ring-slate-300"
           value={value.prompt}
           onChange={(e) => set({ prompt: e.target.value })}
           placeholder={t(
             "capabilities.import.systemPrompt.promptPlaceholder",
-            "在这里写你想注入到 agent 的 system prompt 文本。Override 模式会替换默认 system prompt;append 模式会拼到用户自己写的 system_prompt 前面。",
+            "Write the system prompt text you want injected into the agent. Override replaces the default system prompt; append prepends it to the user-supplied system_prompt.",
           )}
         />
       </Field>

--- a/apps/web/src/pages/admin/capabilities/NewCredentialKindInlineDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/NewCredentialKindInlineDialog.tsx
@@ -88,7 +88,7 @@ export function NewCredentialKindInlineDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>{t("capabilities.import.newKind.title", "新建凭据类型")}</DialogTitle>
+          <DialogTitle>{t("capabilities.import.newKind.title", "New credential kind")}</DialogTitle>
         </DialogHeader>
 
         <div className="space-y-3">
@@ -96,7 +96,7 @@ export function NewCredentialKindInlineDialog({
             label={t("capabilities.import.newKind.code.label", "Code")}
             help={t(
               "capabilities.import.newKind.code.help",
-              "小写字母 + 数字 + 下划线,如 linear_api_key",
+              "Lowercase letters, digits, and underscores — e.g. linear_api_key",
             )}
             required
           >
@@ -110,14 +110,14 @@ export function NewCredentialKindInlineDialog({
               <p className="text-xs text-danger">
                 {t(
                   "capabilities.import.newKind.code.invalid",
-                  "code 必须以小写字母开头,只能包含小写字母、数字、下划线",
+                  "code must start with a lowercase letter and contain only lowercase letters, digits, and underscores",
                 )}
               </p>
             )}
           </Field>
 
           <Field
-            label={t("capabilities.import.newKind.displayName.label", "显示名")}
+            label={t("capabilities.import.newKind.displayName.label", "Display name")}
             required
           >
             <Input
@@ -127,13 +127,13 @@ export function NewCredentialKindInlineDialog({
             />
           </Field>
 
-          <Field label={t("capabilities.import.newKind.description.label", "说明")}>
+          <Field label={t("capabilities.import.newKind.description.label", "Description")}>
             <Input
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder={t(
                 "capabilities.import.newKind.description.placeholder",
-                "可选,告诉用户去哪里获取这个 token",
+                "Optional — tell users where to get this token",
               )}
             />
           </Field>
@@ -159,7 +159,7 @@ export function NewCredentialKindInlineDialog({
           </Button>
           <Button size="sm" disabled={disabled} onClick={submit}>
             {mut.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            {t("capabilities.import.newKind.submit", "新建")}
+            {t("capabilities.import.newKind.submit", "Create")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/pages/admin/capabilities/SkillFileTree.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillFileTree.tsx
@@ -52,7 +52,7 @@ export function SkillFileTree({ skill }: Props) {
       {grouped.other.length > 0 && (
         <GroupCard
           icon={<FolderOpen className="h-4 w-4 text-fg-subtle" />}
-          title={t("capabilities.import.skill.fileTree.other", "其它文件")}
+          title={t("capabilities.import.skill.fileTree.other", "Other files")}
           files={grouped.other}
         />
       )}
@@ -78,7 +78,7 @@ function SkillMdCard({ skill }: { skill: CanonicalSkillSpec }) {
           <FileText className="h-4 w-4 shrink-0 text-success" />
           <code className="font-mono text-sm text-fg">SKILL.md</code>
           <span className="ml-auto rounded-full bg-success-subtle px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-success-emphasis">
-            {t("capabilities.import.skill.fileTree.entry", "入口")}
+            {t("capabilities.import.skill.fileTree.entry", "Entry")}
           </span>
         </CollapsibleTrigger>
         <CollapsibleContent>

--- a/apps/web/src/pages/admin/capabilities/SkillZipDropzone.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillZipDropzone.tsx
@@ -72,11 +72,11 @@ export function SkillZipDropzone({
           <Upload className="h-5 w-5 text-fg-subtle" />
           <span className="text-sm text-fg-muted">
             {isDragActive
-              ? t("capabilities.import.skill.dropActive", "松开导入 .zip")
-              : t("capabilities.import.skill.dropHint", "拖拽或点击上传 .zip(SKILL.md + references / scripts)")}
+              ? t("capabilities.import.skill.dropActive", "Release to import the .zip")
+              : t("capabilities.import.skill.dropHint", "Drag or click to upload a .zip (SKILL.md + references / scripts)")}
           </span>
           <span className="text-xs text-fg-subtle">
-            {t("capabilities.import.skill.sizeHint", "最大 8 MiB")}
+            {t("capabilities.import.skill.sizeHint", "Up to 8 MiB")}
           </span>
         </div>
         {localError && (
@@ -105,7 +105,7 @@ export function SkillZipDropzone({
                   {" · "}
                   <span className="inline-flex items-center gap-1 text-fg-muted">
                     <Loader2 className="h-3 w-3 animate-spin" />
-                    {busyLabel ?? t("capabilities.import.skill.uploading", "上传中…")}
+                    {busyLabel ?? t("capabilities.import.skill.uploading", "Uploading…")}
                   </span>
                 </>
               )}
@@ -117,7 +117,7 @@ export function SkillZipDropzone({
           size="sm"
           onClick={onClear}
           disabled={busy}
-          aria-label={t("capabilities.actions.cancel", "取消")}
+          aria-label={t("capabilities.actions.cancel", "Cancel")}
         >
           <X className="h-4 w-4" />
         </Button>

--- a/apps/web/src/pages/admin/runtimes/LocalDeviceRuntimesPanel.tsx
+++ b/apps/web/src/pages/admin/runtimes/LocalDeviceRuntimesPanel.tsx
@@ -60,7 +60,7 @@ function LocalDeviceRuntimesPanelInner({ workspaceID }: { workspaceID: string })
     return (
       <ErrorState
         title={t("runtime.agentDaemon.errors.loadFailed", {
-          defaultValue: "无法加载本地设备列表",
+          defaultValue: "Failed to load local devices",
         })}
         description={(listQ.error as Error).message}
         onRetry={() => void listQ.refetch()}
@@ -77,7 +77,7 @@ function LocalDeviceRuntimesPanelInner({ workspaceID }: { workspaceID: string })
         <p className="text-sm text-fg-subtle">
           {t("runtime.agentDaemon.intro", {
             defaultValue:
-              "本地设备通过 parsar-daemon 反向连接 Parsar，让 Agent 使用这台机器上的 Claude Code / OpenCode 等 CLI。",
+              "Local devices dial back to Parsar through parsar-daemon, letting Agents use the Claude Code / OpenCode CLIs installed on this machine.",
           })}
         </p>
         <Button
@@ -86,14 +86,14 @@ function LocalDeviceRuntimesPanelInner({ workspaceID }: { workspaceID: string })
           onClick={() => setPairOpen(true)}
           data-testid="agent-daemon-pair-button"
         >
-          {t("runtime.agentDaemon.actions.pair", { defaultValue: "接入新设备" })}
+          {t("runtime.agentDaemon.actions.pair", { defaultValue: "Pair a new device" })}
         </Button>
       </div>
 
       {runtimes.length === 0 ? (
         <div className="rounded-md border border-dashed border-line bg-surface-subtle/60 p-6 text-center text-sm text-fg-subtle">
           {t("runtime.agentDaemon.empty", {
-            defaultValue: "尚未接入任何本地设备。点击右上角按钮生成连接命令。",
+            defaultValue: "No local devices paired yet. Use the button above to generate a pairing command.",
           })}
         </div>
       ) : (
@@ -101,12 +101,12 @@ function LocalDeviceRuntimesPanelInner({ workspaceID }: { workspaceID: string })
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>{t("runtime.agentDaemon.table.name", { defaultValue: "名称" })}</TableHead>
-                <TableHead>{t("runtime.agentDaemon.table.hostname", { defaultValue: "主机名" })}</TableHead>
-                <TableHead>{t("runtime.agentDaemon.table.version", { defaultValue: "版本" })}</TableHead>
-                <TableHead>{t("runtime.agentDaemon.table.agentEngines", { defaultValue: "Agent 引擎" })}</TableHead>
-                <TableHead>{t("runtime.agentDaemon.table.status", { defaultValue: "状态" })}</TableHead>
-                <TableHead>{t("runtime.agentDaemon.table.heartbeat", { defaultValue: "最后心跳" })}</TableHead>
+                <TableHead>{t("runtime.agentDaemon.table.name", { defaultValue: "Name" })}</TableHead>
+                <TableHead>{t("runtime.agentDaemon.table.hostname", { defaultValue: "Hostname" })}</TableHead>
+                <TableHead>{t("runtime.agentDaemon.table.version", { defaultValue: "Version" })}</TableHead>
+                <TableHead>{t("runtime.agentDaemon.table.agentEngines", { defaultValue: "Agent engines" })}</TableHead>
+                <TableHead>{t("runtime.agentDaemon.table.status", { defaultValue: "Status" })}</TableHead>
+                <TableHead>{t("runtime.agentDaemon.table.heartbeat", { defaultValue: "Last heartbeat" })}</TableHead>
                 <TableHead className="w-[60px]" />
               </TableRow>
             </TableHeader>
@@ -172,8 +172,8 @@ function DaemonRuntimeRow({
           {activeRequests !== null && (
             <div className="text-xs text-fg-subtle">
               {activeRequests === 0
-                ? t("runtime.agentDaemon.load.idle", { defaultValue: "空闲" })
-                : t("runtime.agentDaemon.load.active", { count: activeRequests, defaultValue: "{{count}} 个运行中" })}
+                ? t("runtime.agentDaemon.load.idle", { defaultValue: "Idle" })
+                : t("runtime.agentDaemon.load.active", { count: activeRequests, defaultValue: "{{count}} running" })}
             </div>
           )}
         </div>
@@ -202,7 +202,7 @@ function DaemonRuntimeRow({
           type="button"
           onClick={onDelete}
           className="inline-flex h-7 w-7 items-center justify-center rounded text-fg-faint hover:bg-danger-subtle hover:text-danger"
-          title={t("runtime.agentDaemon.actions.delete", { defaultValue: "删除设备" })}
+          title={t("runtime.agentDaemon.actions.delete", { defaultValue: "Delete device" })}
           data-testid={`agent-daemon-delete-${runtime.id}`}
         >
           <Trash2 className="h-3.5 w-3.5" />
@@ -272,12 +272,12 @@ function formatAgentKindTitle(kind: SupportedAgentKind, t: TFunction<"admin">): 
 function formatAgentKindSnapshot(kind: SupportedAgentKind, t: TFunction<"admin">): string {
   const label = formatAgentKindLabel(kind.kind)
   if (!kind.available) {
-    return t("runtime.agentDaemon.agentKind.notDetected", { label, defaultValue: "{{label}} 未检测到" })
+    return t("runtime.agentDaemon.agentKind.notDetected", { label, defaultValue: "{{label}} not detected" })
   }
   if (kind.version) {
     return t("runtime.agentDaemon.agentKind.version", { label, version: kind.version, defaultValue: "{{label}} {{version}}" })
   }
-  return t("runtime.agentDaemon.agentKind.usable", { label, defaultValue: "{{label}} 可用" })
+  return t("runtime.agentDaemon.agentKind.usable", { label, defaultValue: "{{label}} available" })
 }
 
 function DaemonStatusBadge({
@@ -290,25 +290,25 @@ function DaemonStatusBadge({
     case "online":
       return (
         <Badge variant="success" dot>
-          {t("runtime.agentDaemon.status.online", { defaultValue: "在线" })}
+          {t("runtime.agentDaemon.status.online", { defaultValue: "Online" })}
         </Badge>
       )
     case "pending_pairing":
       return (
         <Badge variant="warning">
-          {t("runtime.agentDaemon.status.pending_pairing", { defaultValue: "等待配对" })}
+          {t("runtime.agentDaemon.status.pending_pairing", { defaultValue: "Pairing" })}
         </Badge>
       )
     case "error":
       return (
         <Badge variant="destructive">
-          {t("runtime.agentDaemon.status.error", { defaultValue: "错误" })}
+          {t("runtime.agentDaemon.status.error", { defaultValue: "Error" })}
         </Badge>
       )
     default:
       return (
         <Badge variant="neutral">
-          {t("runtime.agentDaemon.status.offline", { defaultValue: "离线" })}
+          {t("runtime.agentDaemon.status.offline", { defaultValue: "Offline" })}
         </Badge>
       )
   }
@@ -341,21 +341,21 @@ function daemonStatusDetail(runtime: Runtime, t: TFunction<"admin">): string {
   const availableKinds = kinds.filter((kind) => kind.available)
   switch (runtime.liveness) {
     case "pending_pairing":
-      return t("runtime.agentDaemon.detail.pendingPairing", { defaultValue: "等待执行 parsar-daemon connect 完成配对。" })
+      return t("runtime.agentDaemon.detail.pendingPairing", { defaultValue: "Waiting for parsar-daemon connect to complete pairing." })
     case "offline":
       return kinds.length === 0
-        ? t("runtime.agentDaemon.detail.offlineNoSnapshot", { defaultValue: "还没收到 capability 快照；请先确认设备上的 parsar-daemon 已连上。" })
-        : t("runtime.agentDaemon.detail.offlineWithSnapshot", { defaultValue: "最近心跳中断；可在设备上运行 parsar-daemon status 或 parsar-daemon logs 排查。" })
+        ? t("runtime.agentDaemon.detail.offlineNoSnapshot", { defaultValue: "No capability snapshot yet — make sure parsar-daemon is connected on the device." })
+        : t("runtime.agentDaemon.detail.offlineWithSnapshot", { defaultValue: "Recent heartbeats lost — run parsar-daemon status or parsar-daemon logs on the device to diagnose." })
     case "error":
-      return t("runtime.agentDaemon.detail.error", { defaultValue: "daemon 上报错误；请在设备上运行 parsar-daemon logs 查看最近错误。" })
+      return t("runtime.agentDaemon.detail.error", { defaultValue: "Daemon reported an error — run parsar-daemon logs on the device to inspect." })
     case "online":
       if (kinds.length > 0 && availableKinds.length === 0) {
-        return t("runtime.agentDaemon.detail.onlineNoCli", { defaultValue: "WebSocket 在线，但本机没有可用的 Agent CLI。" })
+        return t("runtime.agentDaemon.detail.onlineNoCli", { defaultValue: "WebSocket connected, but no Agent CLI is installed on this host." })
       }
       if (activeRequests > 0) {
-        return t("runtime.agentDaemon.detail.onlineActive", { count: activeRequests, defaultValue: "当前有 {{count}} 个运行在执行。" })
+        return t("runtime.agentDaemon.detail.onlineActive", { count: activeRequests, defaultValue: "{{count}} run(s) currently executing." })
       }
-      return t("runtime.agentDaemon.detail.onlineIdle", { defaultValue: "在线，等待新请求。" })
+      return t("runtime.agentDaemon.detail.onlineIdle", { defaultValue: "Online, waiting for new requests." })
     default:
       return "—"
   }
@@ -394,12 +394,12 @@ function ConfirmDeleteRuntimeDialog({
             <DialogTitle className="text-sm">
               {t("runtime.agentDaemon.delete.title", {
                 name: targetName,
-                defaultValue: "删除设备「{{name}}」",
+                defaultValue: "Delete device {{name}}",
               })}
             </DialogTitle>
             <DialogDescription className="text-sm leading-relaxed">
               {t("runtime.agentDaemon.delete.description", {
-                defaultValue: "删除后该设备将无法接收新任务，已有运行不受影响。此操作不可撤销。",
+                defaultValue: "Once deleted, this device can no longer accept new tasks; running tasks are unaffected. This action cannot be undone.",
               })}
             </DialogDescription>
             {error && (
@@ -414,7 +414,7 @@ function ConfirmDeleteRuntimeDialog({
             onClick={onCancel}
             disabled={pending}
           >
-            {t("common.actions.cancel", { defaultValue: "取消" })}
+            {t("common.actions.cancel", { defaultValue: "Cancel" })}
           </Button>
           <Button
             variant="destructive"
@@ -423,7 +423,7 @@ function ConfirmDeleteRuntimeDialog({
             disabled={pending}
           >
             {pending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            {t("runtime.agentDaemon.delete.confirm", { defaultValue: "删除" })}
+            {t("runtime.agentDaemon.delete.confirm", { defaultValue: "Delete" })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/server/internal/connector/agentdaemon/connector.go
+++ b/server/internal/connector/agentdaemon/connector.go
@@ -136,7 +136,7 @@ type Config struct {
 
 	// SandboxBindingReader, when non-nil, lets the connector
 	// distinguish spawning / failed / never-attempted sandbox states
-	// for the user-facing "未绑定 Runtime" message instead of using a
+	// for the user-facing "no Runtime bound" message instead of using a
 	// generic line. Nil keeps legacy behaviour for tests.
 	SandboxBindingReader SandboxBindingReader
 
@@ -409,8 +409,8 @@ func (c *Connector) streamPrompt(ctx context.Context, in connector.PromptInput, 
 		// in the web UI).
 		if isSandboxMode(in) && c.systemMessages != nil {
 			notice := fmt.Sprintf(
-				"⚠️ 当前沙箱 %s 不可用，可能因长时间空闲被回收或网络异常。"+
-					"等待几分钟看是否恢复；若需立即重置，可在 Agent 设置中删除并重新创建该 Agent。",
+				"⚠️ Sandbox %s is unavailable — likely reclaimed after idle timeout or a network issue. "+
+					"Wait a few minutes for it to recover, or delete and recreate the Agent in its settings to reset immediately.",
 				bind.DeviceID,
 			)
 			if _, sysErr := c.systemMessages.CreateSandboxOfflineNotice(ctx, store.CreateSandboxOfflineNoticeInput{
@@ -952,33 +952,33 @@ func isSandboxMode(in connector.PromptInput) bool {
 // never-attempted so the message matches reality.
 //
 // SandboxBindingReader is optional; a nil reader falls back to a
-// generic "正在准备" line under sandbox mode (the settings page
+// generic "preparing" line under sandbox mode (the settings page
 // pointer no longer applies under the eager-Acquire flow).
 func (c *Connector) unboundRuntimeMessage(ctx context.Context, in connector.PromptInput) string {
 	if !isSandboxMode(in) {
-		return "Agent 未绑定 Runtime,请在 Agent 设置页选择一个 Runtime 后重试。"
+		return "This Agent has no Runtime bound. Pick one in the Agent settings and retry."
 	}
 	if c.sandboxBindings == nil {
-		return "Agent 沙箱正在准备,请稍后再发。"
+		return "This Agent's sandbox is preparing — please retry shortly."
 	}
 	bindingRow, found, err := c.sandboxBindings.GetActiveSandboxBindingForAgent(ctx, in.WorkspaceID, in.ProjectAgentID)
 	if err != nil {
 		c.log.Warn("agent_daemon: sandbox binding lookup for unbound-runtime hint failed",
 			"err", err, "project_agent_id", in.ProjectAgentID)
-		return "Agent 沙箱正在准备,请稍后再发。"
+		return "This Agent's sandbox is preparing — please retry shortly."
 	}
 	if !found {
-		return "Agent 尚未准备运行环境,请联系管理员重建 Agent。"
+		return "This Agent has no runtime yet — ask an admin to rebuild it."
 	}
 	switch bindingRow.Status {
 	case store.SandboxBindingStatusKilledError:
-		return "Agent 沙箱准备失败,请在 Agent 设置页点击 Rebuild 重试。"
+		return "This Agent's sandbox failed to start — click Rebuild in the Agent settings to retry."
 	case store.SandboxBindingStatusKilled, store.SandboxBindingStatusKilledOrphaned:
-		return "Agent 沙箱已被回收,请在 Agent 设置页点击 Rebuild 重试。"
+		return "This Agent's sandbox was reclaimed — click Rebuild in the Agent settings to retry."
 	default:
 		// spawning / killing / running-but-runtime_id-not-yet-written
 		// are all transient.
-		return "Agent 沙箱正在准备(约需 10 秒),请稍后再发。"
+		return "This Agent's sandbox is starting up (~10s) — please retry shortly."
 	}
 }
 

--- a/server/internal/connector/agentdaemon/connector_test.go
+++ b/server/internal/connector/agentdaemon/connector_test.go
@@ -976,8 +976,8 @@ func TestStreamPrompt_LocalModeConfiguredDeviceBindsWithWorkdirKey(t *testing.T)
 // ephemeral path but is disconnected from the default first-prompt flow.
 //
 // Sandbox-mode agents that hit dispatch before runtime_id is written
-// see a sandbox-aware hint ("沙箱正在准备") instead of the generic
-// "未绑定 Runtime" copy.
+// see a sandbox-aware hint ("sandbox is preparing") instead of the generic
+// "no Runtime bound" copy.
 func TestStreamPrompt_SandboxModeIsNoLongerAutoAcquired(t *testing.T) {
 	reg := gateway.NewRegistry()
 	sb := &stubSandboxProvider{deviceID: "dev-sbx-abc"}
@@ -1002,7 +1002,7 @@ func TestStreamPrompt_SandboxModeIsNoLongerAutoAcquired(t *testing.T) {
 	// Sandbox-mode unbound surfaces a sandbox-preparation hint — the
 	// createAgent goroutine is racing to write runtime_id back, and a
 	// user retry in ~10s should land on a healthy binding.
-	if !contains(gotErr.Error, "沙箱") {
+	if !contains(gotErr.Error, "sandbox is preparing") {
 		t.Fatalf("expected sandbox-preparation hint, got %q", gotErr.Error)
 	}
 	// And nothing got bound.
@@ -1032,7 +1032,7 @@ func TestStreamPrompt_SandboxModeProviderDisabled_StillRefusesAutoAcquire(t *tes
 	if gotErr == nil || gotDone == nil {
 		t.Fatalf("expected EventError + EventDone, got err=%v done=%v", gotErr, gotDone)
 	}
-	if !contains(gotErr.Error, "沙箱") {
+	if !contains(gotErr.Error, "sandbox is preparing") {
 		t.Fatalf("expected sandbox-preparation hint, got %q", gotErr.Error)
 	}
 }

--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -148,7 +148,7 @@ func (c *Connector) injectManagedModel(ctx context.Context, in connector.PromptI
 	//                                         (per-user for credential_ref;
 	//                                         a no-op for inline_secret).
 	// store.ResolveModelRuntimeForUser still rejects credential_ref + empty
-	// initiator — that surfaces the "缺凭据" notice via the err branch below.
+	// initiator — that surfaces the "missing credentials" notice via the err branch below.
 	// Mirrors capability_runtime.resolveCredentialValues: binding wins over
 	// initiator presence, never the other way.
 	modelBinding, hasModelBinding := ParseModelCredentialBinding(in.AgentConfig, in.ProjectAgentConfig)
@@ -806,12 +806,12 @@ func buildModelCredentialCapabilityName(mr store.ModelRuntime) string {
 	modelKey := strings.TrimSpace(mr.ModelKey)
 	switch {
 	case provider != "" && modelKey != "":
-		return "模型 · " + provider + "/" + modelKey
+		return "Model · " + provider + "/" + modelKey
 	case modelKey != "":
-		return "模型 · " + modelKey
+		return "Model · " + modelKey
 	case strings.TrimSpace(mr.ModelName) != "":
-		return "模型 · " + strings.TrimSpace(mr.ModelName)
+		return "Model · " + strings.TrimSpace(mr.ModelName)
 	default:
-		return "模型"
+		return "Model"
 	}
 }

--- a/server/internal/connector/agentdaemon/model_injection_test.go
+++ b/server/internal/connector/agentdaemon/model_injection_test.go
@@ -814,22 +814,22 @@ func TestBuildModelCredentialCapabilityName_Fallbacks(t *testing.T) {
 		{
 			name: "provider and model_key",
 			mr:   store.ModelRuntime{ProviderType: "anthropic", ModelKey: "claude-sonnet-4-5"},
-			want: "模型 · anthropic/claude-sonnet-4-5",
+			want: "Model · anthropic/claude-sonnet-4-5",
 		},
 		{
 			name: "only model_key",
 			mr:   store.ModelRuntime{ModelKey: "claude-sonnet-4-5"},
-			want: "模型 · claude-sonnet-4-5",
+			want: "Model · claude-sonnet-4-5",
 		},
 		{
 			name: "only model_name",
 			mr:   store.ModelRuntime{ModelName: "Claude Sonnet 4.5"},
-			want: "模型 · Claude Sonnet 4.5",
+			want: "Model · Claude Sonnet 4.5",
 		},
 		{
 			name: "no identifiers",
 			mr:   store.ModelRuntime{},
-			want: "模型",
+			want: "Model",
 		},
 	}
 	for _, tc := range cases {

--- a/server/internal/connector/agentdaemon/remote_http.go
+++ b/server/internal/connector/agentdaemon/remote_http.go
@@ -128,7 +128,7 @@ func (s HTTPRemoteStreamer) StreamPromptRemote(ctx context.Context, owner store.
 
 // SubmitPermissionRemote POSTs the verdict to the owner pod's internal
 // submit-permission endpoint. Errors surface to the feishu webhook
-// handler as "更新失败" toasts so the user can retry.
+// handler as "update failed" toasts so the user can retry.
 func (s HTTPRemoteStreamer) SubmitPermissionRemote(ctx context.Context, owner store.AgentDaemonDeviceOwnerRead, decision connector.PermissionDecision) error {
 	body, err := json.Marshal(remoteSubmitPermissionRequest{Generation: owner.Generation, Decision: decision})
 	if err != nil {

--- a/server/internal/connector/agentdaemon/sandbox_provider.go
+++ b/server/internal/connector/agentdaemon/sandbox_provider.go
@@ -105,7 +105,7 @@ type SandboxProvider interface {
 	//
 	// info.ExpiresAt is populated best-effort by querying e2b for the
 	// live TTL; a transient e2b error leaves it zero and the admin
-	// handler renders zero as "未知".
+	// handler renders zero as "unknown".
 	SandboxStatus(ctx context.Context, projectAgentID string) (connector.SandboxInfo, bool, error)
 
 	// Release tears down the sandbox associated with a project_agent.

--- a/server/internal/store/system_messages.go
+++ b/server/internal/store/system_messages.go
@@ -80,7 +80,7 @@ func (s *Store) CreateCapabilityCredentialOwnerNoticeOnce(ctx context.Context, i
 		return false, fmt.Errorf("capability credential notice: marshal metadata: %w", err)
 	}
 	now := time.Now().UTC()
-	content := fmt.Sprintf("此 Agent 当前使用 @%s 的凭据进行外部调用。同 Conversation 中其他成员的请求也会用这份凭据。", displayName)
+	content := fmt.Sprintf("This Agent is currently using @%s's credentials for external calls. Other members' requests in the same conversation will use these credentials too.", displayName)
 	rows, err := sqlc.New(s.db).CreateSystemMessageOnce(ctx, sqlc.CreateSystemMessageOnceParams{
 		ID:             mustUUID(newID()),
 		WorkspaceID:    mustUUID(conversation.WorkspaceID),
@@ -166,8 +166,8 @@ func (s *Store) CreateSandboxOfflineNotice(ctx context.Context, input CreateSand
 	}
 	content := strings.TrimSpace(input.Content)
 	if content == "" {
-		content = "⚠️ 当前沙箱不可用，可能因长时间空闲被回收或网络异常。" +
-			"等待几分钟看是否恢复；若需立即重置，可在 Agent 设置中删除并重新创建该 Agent。"
+		content = "⚠️ Sandbox is unavailable — likely reclaimed after idle timeout or a network issue. " +
+			"Wait a few minutes for it to recover, or delete and recreate the Agent in its settings to reset immediately."
 	}
 	// Dedicated sqlc query — does NOT reuse runtime_error's INSERT
 	// because that one hard-codes kind='error' + folds


### PR DESCRIPTION
## Why

The product positions itself \"for engineering teams\", but several layers were still leaking Chinese to English-locale users. Most visible offender: the chat error \"Agent 尚未准备运行环境,请联系管理员重建 Agent。\" — emitted directly from the Go server with no i18n in sight.

## What

**Server** — user-facing strings rewritten in English; test assertions and surrounding comments updated to match.

- \`internal/connector/agentdaemon/connector.go\` — 7 messages (sandbox preparing / unavailable / no Runtime / rebuild prompts)
- \`internal/connector/agentdaemon/model_injection.go\` — 4 \"Model · …\" labels
- \`internal/store/system_messages.go\` — 2 system-message bodies (sandbox offline notice, credential-owner notice)
- \`internal/connector/agentdaemon/connector_test.go\` + \`model_injection_test.go\` — assertions

**Web** — i18n fallback discipline.

- \`t(key, { defaultValue: \"…\" })\` — 74 occurrences flipped to English
- \`t(key, \"…\")\` shorthand — 61 occurrences flipped to English
- ~25 strings that bypassed i18n entirely (DevicePicker, PairDaemonDialog, EnvCredentialPicker, error-state, capability import dialogs) — either routed through i18n with an English fallback or rewritten in place

**Net behaviour**: English users see English everywhere. Chinese users still see Chinese for any string with a populated zh-CN catalog entry — \`defaultValue\` only renders when the catalog key is missing.

## Verification

- [x] \`go test ./server/...\` — all packages pass
- [x] \`pnpm --filter @parsar/web typecheck\` — clean
- [x] \`pnpm --filter @parsar/web build\` — clean
- [ ] Visual smoke: chat error in a fresh-state agent shows the English copy
- [ ] Visual smoke: settings → general → language toggle still swaps zh ↔ en for keys with catalog entries

## Known follow-ups (not in this PR)

- Feishu cards (\`internal/gateway/feishu_cards.go\` 64 strings, \`feishuinbound/manager.go\` 52) — they target a Chinese-locale Feishu audience by default and need a proper outbound-message i18n protocol, not a blind English rewrite. Tracking separately.
- \`golang.org/x/text/message\` catalog + per-user \`locale\` field on the server is the right long-term shape; this PR is the bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)