### PR TITLE
fix(ci): give pg_isready a real readiness window in check-migrations

### DIFF
--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -28,15 +28,26 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/dev-env.sh"
 docker compose -f docker-compose.dev.yml down -v --remove-orphans >/dev/null 2>&1 || true
 docker compose -f docker-compose.dev.yml up -d postgres >/dev/null
 
-for _ in {1..30}; do
+# Wait for Postgres to actually accept connections. pg_isready can return
+# 0 (accepting) only after the entrypoint finishes initdb and the
+# postmaster binds 5432 — on cold cache CI that takes 5–15s. We poll
+# up to 60s and treat any non-zero exit as "not yet". The previous
+# loop double-checked outside the loop, which raced the initdb window
+# (#12 follow-up: CI hit "Postgres did not become ready" 1.5s after
+# Started because the very first probe transient-failed and a second
+# probe was issued before postmaster was up).
+pg_ready=0
+for _ in $(seq 1 60); do
   if docker compose -f docker-compose.dev.yml exec -T postgres pg_isready -U "$PARSAR_PG_USER" -d "$PARSAR_PG_DB" >/dev/null 2>&1; then
+    pg_ready=1
     break
   fi
   sleep 1
 done
 
-if ! docker compose -f docker-compose.dev.yml exec -T postgres pg_isready -U "$PARSAR_PG_USER" -d "$PARSAR_PG_DB" >/dev/null 2>&1; then
-  echo "Postgres did not become ready" >&2
+if [[ "$pg_ready" -ne 1 ]]; then
+  echo "Postgres did not become ready within 60s" >&2
+  docker compose -f docker-compose.dev.yml logs --tail=80 postgres >&2 || true
   exit 1
 fi
 


### PR DESCRIPTION
## Why

CI on `main` (run [28413467116](https://github.com/MiniMax-AI-Dev/parsar/actions/runs/28413467116/job/84191259972)) failed with:

\`\`\`
Container parsar-postgres-1  Started     # 01:17:53.99
Postgres did not become ready           # 01:17:55.49
make: *** [Makefile:51: check] Error 1
\`\`\`

**1.5 seconds** between container Started and failure — the 30-iteration ×1s loop in \`scripts/check-migrations.sh\` never iterated. Two coupled bugs:

1. **Redundant outside re-check races initdb.** The script's loop breaks on the first successful \`pg_isready\`, then re-runs the SAME probe outside the loop and treats failure as fatal. The window between those two probes is small (~milliseconds), but right after a successful probe Postgres may flush a checkpoint and briefly reject the next connection — coin flip on cold-cache CI runners.
2. **30s ceiling is tight.** \`postgres:16-alpine\` cold pull + initdb on a free GitHub runner regularly takes 10–20s before \`pg_isready\` first returns 0.

## What

- Drop the duplicated outside check. Track success with a \`pg_ready\` flag inside the loop; trust that result.
- Raise the ceiling from 30s to 60s.
- On failure, dump the last 80 lines of the Postgres container log to stderr so the next CI red gives us something to debug from instead of one line.

Same pattern is replicated in \`scripts/dev-all.sh\`, \`scripts/e2e-http-agent.sh\`, \`scripts/e2e-feishu-gateway.sh\` — those are dev/e2e entry points not on the critical CI path, so leaving them for a follow-up. Happy to fold them in if the reviewer prefers a sweep PR.

## Test plan

- [x] \`scripts/check-migrations.sh\` still passes locally (single run; the failure mode is timing-dependent on cold cache).
- [ ] Re-run \`Run check\` on this PR's commit and confirm green.
- [ ] If it goes red again, the new \`docker compose logs --tail=80 postgres\` output will tell us whether the ceiling is still too short or initdb itself is failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)