### PR TITLE
fix(test): truncate now() to microsecond before pg timestamptz round-trip

### DIFF
--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -1765,7 +1765,12 @@ func TestGetAgentRunDetailShowsCompletedOutputMessage(t *testing.T) {
 		runtimeID,
 		managedModelID,
 	)
-	now := time.Now().UTC()
+	// Truncate to microseconds because PostgreSQL `timestamptz` stores
+	// 6 fractional-second digits (no nanoseconds). A raw time.Now() carries
+	// nanoseconds that get rounded on insert, so the post-read .Equal(now)
+	// assertion below would fail on runs where the dropped sub-microsecond
+	// bits would have rounded differently.
+	now := time.Now().UTC().Truncate(time.Microsecond)
 	if _, err := db.Exec(ctx,
 		`insert into runtimes(id, workspace_id, type, name, liveness, provider, version, hostname, config, last_heartbeat_at, created_at, updated_at)
 		 values ($1::uuid, $2::uuid, 'agent_daemon', 'Mac Mini Runner', 'online', 'agent_daemon', '1.2.3', 'test.local', '{"supported_agent_kinds":["claude_code","opencode"],"daemon_capabilities":{"streaming":true,"permissions":true,"usage":true,"resume":false,"artifacts":false}}'::jsonb, $3, $3, $3)`,


### PR DESCRIPTION
## Why

\`TestGetAgentRunDetailShowsCompletedOutputMessage\` is flaky on CI (e.g. PR #15 run [28413928016](https://github.com/MiniMax-AI-Dev/parsar/actions/runs/28413928029)):

\`\`\`
--- FAIL: TestGetAgentRunDetailShowsCompletedOutputMessage (0.21s)
    store_test.go:1837: unexpected runtime heartbeat: …
      LastHeartbeatAt:2026-06-30 01:30:46.337103 +0000 UTC …
\`\`\`

Root cause: the test does

\`\`\`go
now := time.Now().UTC()                                  // nanosecond precision
… insert with $3 = now …
… assert detail.Runtime.LastHeartbeatAt.Equal(now)
\`\`\`

PostgreSQL \`timestamptz\` stores **6 fractional-second digits** (microseconds, no nanoseconds). When \`now\` carries non-zero sub-microsecond bits they get rounded on insert, and the round-trip \`.Equal(now)\` is then a coin flip — passes ~9 runs out of 10, fires on the unlucky one.

## What

Truncate \`now\` to \`time.Microsecond\` before insert + assertion. One line.

The sibling test at \`store_test.go:1867\` (\`TestRecordAgentRunExecutionSnapshotFreezesRuntimeRead\`) already does exactly this — so the fix is adopting the established pattern, not inventing one.

## Test plan

- [x] 10 fresh \`go test -run TestGetAgentRunDetailShowsCompletedOutputMessage -count=1 ./server/internal/store\` runs — all pass.
- [ ] CI \`check\` job goes green on this PR.

## Out of scope

A grep shows another ~7 occurrences of raw \`time.Now().UTC()\` in the same file that *might* be at the same risk (lines 177, 195, 236, 266, 275, 303, 306, 791). None of them appeared in the recent flake reports, so leaving them for a follow-up sweep instead of a blast-radius change in a hot-fix PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)