### PR TITLE
web(models): 厂商按品牌列出 + 可搜索模型选择器

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -75,6 +75,8 @@
     "createProvider": {
       "fields": {
         "providerType": "Provider type",
+        "providerSearch": "Search providers…",
+        "providerEmpty": "No matching providers",
         "baseURL": "Base URL",
         "adapterHint": "Adapter package: {{adapter}}",
         "apiKey": "API key",
@@ -99,6 +101,10 @@
         "namePlaceholder": "e.g. Claude Opus 4.5",
         "modelKey": "Model key",
         "modelKeyPlaceholder": "claude-3-5-sonnet-20241022",
+        "modelKeyCatalogHint": "Pick from this provider's known models, or type any model id.",
+        "modelKeySearch": "Search or type a model id…",
+        "modelKeyUse": "Use",
+        "modelKeyEmpty": "No matching models — type any id",
         "credentialMode": "Credential mode"
       },
       "credentialMode": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -75,6 +75,8 @@
     "createProvider": {
       "fields": {
         "providerType": "供应商类型",
+        "providerSearch": "搜索供应商…",
+        "providerEmpty": "无匹配的供应商",
         "baseURL": "服务地址",
         "adapterHint": "Adapter 包: {{adapter}}",
         "apiKey": "API Key",
@@ -99,6 +101,10 @@
         "namePlaceholder": "例：Claude Opus 4.5",
         "modelKey": "模型 Key",
         "modelKeyPlaceholder": "claude-3-5-sonnet-20241022",
+        "modelKeyCatalogHint": "可从该厂商的已知模型中选择，也可手动输入任意模型 id。",
+        "modelKeySearch": "搜索或输入模型 id…",
+        "modelKeyUse": "使用",
+        "modelKeyEmpty": "无匹配模型 —— 可直接输入任意 id",
         "credentialMode": "凭据模式"
       },
       "credentialMode": {

--- a/apps/web/src/lib/model-presets.ts
+++ b/apps/web/src/lib/model-presets.ts
@@ -1,0 +1,262 @@
+/**
+ * Hardcoded provider + model presets for the Add-Model dialog.
+ *
+ * Hand-maintained. Base URLs / model ids were seeded from models.dev
+ * (https://models.dev) but this file is the source of truth now — edit it
+ * directly to add a provider or refresh a model list. No build step.
+ *
+ * Model ids may go stale as vendors ship; the model-key combobox always
+ * lets the user type any id, so a missing preset is never a hard block.
+ * Future: a backend GET {base_url}/v1/models proxy could replace these
+ * static lists with the key's real, live model list.
+ */
+
+export interface ModelPreset {
+  id: string
+  name: string
+  /** Context window in tokens; null when unknown. */
+  context: number | null
+  /** USD per 1M tokens; null when unpriced. */
+  costIn: number | null
+  costOut: number | null
+  tool: boolean
+  reasoning: boolean
+  vision: boolean
+}
+
+export interface ProviderPreset {
+  /** models.dev provider id, used as provider_type. */
+  key: string
+  name: string
+  /** npm adapter package (== Model.adapter). */
+  adapter: string
+  /** Empty when the first-party SDK already knows the default endpoint. */
+  defaultBaseURL: string
+  docUrl: string
+  /** Gateway-style adapter -> show the custom-headers editor. */
+  customHeaders: boolean
+  /** anthropic-compatible gateway -> show the auth-scheme selector. */
+  authSchemeSelector: boolean
+  models: ModelPreset[]
+}
+
+export const PROVIDER_CATALOG: ProviderPreset[] = [
+  {
+    key: "openai",
+    name: "OpenAI",
+    adapter: "@ai-sdk/openai",
+    defaultBaseURL: "https://api.openai.com/v1",
+    docUrl: "https://platform.openai.com/docs/models",
+    customHeaders: false,
+    authSchemeSelector: false,
+    models: [
+      { id: "gpt-5.5-pro", name: "GPT-5.5 Pro", context: 1050000, costIn: 30, costOut: 180, tool: true, reasoning: true, vision: true },
+      { id: "gpt-5.5", name: "GPT-5.5", context: 1050000, costIn: 5, costOut: 30, tool: true, reasoning: true, vision: true },
+      { id: "gpt-image-2", name: "gpt-image-2", context: 0, costIn: 5, costOut: 30, tool: false, reasoning: false, vision: true },
+      { id: "gpt-5.4-nano", name: "GPT-5.4 nano", context: 400000, costIn: 0.2, costOut: 1.25, tool: true, reasoning: true, vision: true },
+      { id: "gpt-5.4-mini", name: "GPT-5.4 mini", context: 400000, costIn: 0.75, costOut: 4.5, tool: true, reasoning: true, vision: true },
+      { id: "gpt-5.4", name: "GPT-5.4", context: 1050000, costIn: 2.5, costOut: 15, tool: true, reasoning: true, vision: true },
+    ],
+  },
+  {
+    key: "anthropic",
+    name: "Anthropic Claude",
+    adapter: "@ai-sdk/anthropic",
+    defaultBaseURL: "https://api.anthropic.com",
+    docUrl: "https://docs.anthropic.com/en/docs/about-claude/models",
+    customHeaders: false,
+    authSchemeSelector: false,
+    models: [
+      { id: "claude-fable-5", name: "Claude Fable 5", context: 1000000, costIn: 10, costOut: 50, tool: true, reasoning: true, vision: true },
+      { id: "claude-opus-4-8", name: "Claude Opus 4.8", context: 1000000, costIn: 5, costOut: 25, tool: true, reasoning: true, vision: true },
+      { id: "claude-opus-4-7", name: "Claude Opus 4.7", context: 1000000, costIn: 5, costOut: 25, tool: true, reasoning: true, vision: true },
+      { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", context: 1000000, costIn: 3, costOut: 15, tool: true, reasoning: true, vision: true },
+      { id: "claude-opus-4-6", name: "Claude Opus 4.6", context: 1000000, costIn: 5, costOut: 25, tool: true, reasoning: true, vision: true },
+      { id: "claude-opus-4-5", name: "Claude Opus 4.5 (latest)", context: 200000, costIn: 5, costOut: 25, tool: true, reasoning: true, vision: true },
+    ],
+  },
+  {
+    key: "google",
+    name: "Google Gemini",
+    adapter: "@ai-sdk/google",
+    defaultBaseURL: "https://generativelanguage.googleapis.com/v1beta",
+    docUrl: "https://ai.google.dev/gemini-api/docs/models",
+    customHeaders: false,
+    authSchemeSelector: false,
+    models: [
+      { id: "gemini-3.5-flash", name: "Gemini 3.5 Flash", context: 1048576, costIn: 1.5, costOut: 9, tool: true, reasoning: true, vision: true },
+      { id: "gemini-3.1-flash-lite", name: "Gemini 3.1 Flash Lite", context: 1048576, costIn: 0.25, costOut: 1.5, tool: true, reasoning: true, vision: true },
+      { id: "gemma-4-31b-it", name: "Gemma 4 31B IT", context: 262144, costIn: null, costOut: null, tool: true, reasoning: true, vision: true },
+      { id: "gemma-4-26b-a4b-it", name: "Gemma 4 26B A4B IT", context: 262144, costIn: null, costOut: null, tool: true, reasoning: true, vision: true },
+      { id: "gemini-3.1-flash-lite-preview", name: "Gemini 3.1 Flash Lite Preview", context: 1048576, costIn: 0.25, costOut: 1.5, tool: true, reasoning: true, vision: true },
+      { id: "gemini-3.1-flash-image-preview", name: "Nano Banana 2", context: 65536, costIn: 0.5, costOut: 60, tool: false, reasoning: true, vision: true },
+    ],
+  },
+  {
+    key: "deepseek",
+    name: "DeepSeek",
+    adapter: "@ai-sdk/openai-compatible",
+    defaultBaseURL: "https://api.deepseek.com",
+    docUrl: "https://api-docs.deepseek.com/quick_start/pricing",
+    customHeaders: true,
+    authSchemeSelector: false,
+    models: [
+      { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", context: 1000000, costIn: 0.14, costOut: 0.28, tool: true, reasoning: true, vision: false },
+      { id: "deepseek-v4-pro", name: "DeepSeek V4 Pro", context: 1000000, costIn: 0.435, costOut: 0.87, tool: true, reasoning: true, vision: false },
+      { id: "deepseek-reasoner", name: "DeepSeek Reasoner", context: 1000000, costIn: 0.14, costOut: 0.28, tool: true, reasoning: true, vision: false },
+      { id: "deepseek-chat", name: "DeepSeek Chat", context: 1000000, costIn: 0.14, costOut: 0.28, tool: true, reasoning: false, vision: false },
+    ],
+  },
+  {
+    key: "moonshotai",
+    name: "Moonshot (Kimi)",
+    adapter: "@ai-sdk/openai-compatible",
+    defaultBaseURL: "https://api.moonshot.ai/v1",
+    docUrl: "https://platform.moonshot.ai/docs/api/chat",
+    customHeaders: true,
+    authSchemeSelector: false,
+    models: [
+      { id: "kimi-k2.7-code", name: "Kimi K2.7 Code", context: 262144, costIn: 0.95, costOut: 4, tool: true, reasoning: true, vision: true },
+      { id: "kimi-k2.7-code-highspeed", name: "Kimi K2.7 Code HighSpeed", context: 262144, costIn: 1.9, costOut: 8, tool: true, reasoning: true, vision: true },
+      { id: "kimi-k2.6", name: "Kimi K2.6", context: 262144, costIn: 0.95, costOut: 4, tool: true, reasoning: true, vision: true },
+      { id: "kimi-k2.5", name: "Kimi K2.5", context: 262144, costIn: 0.6, costOut: 3, tool: true, reasoning: true, vision: true },
+      { id: "kimi-k2-thinking-turbo", name: "Kimi K2 Thinking Turbo", context: 262144, costIn: 1.15, costOut: 8, tool: true, reasoning: true, vision: false },
+      { id: "kimi-k2-thinking", name: "Kimi K2 Thinking", context: 262144, costIn: 0.6, costOut: 2.5, tool: true, reasoning: true, vision: false },
+    ],
+  },
+  {
+    key: "alibaba",
+    name: "Alibaba Qwen",
+    adapter: "@ai-sdk/openai-compatible",
+    defaultBaseURL: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+    docUrl: "https://www.alibabacloud.com/help/en/model-studio/models",
+    customHeaders: true,
+    authSchemeSelector: false,
+    models: [
+      { id: "qwen3.7-plus", name: "Qwen3.7 Plus", context: 1000000, costIn: 0.5, costOut: 3, tool: true, reasoning: true, vision: true },
+      { id: "qwen3.7-max", name: "Qwen3.7 Max", context: 1000000, costIn: 2.5, costOut: 7.5, tool: true, reasoning: true, vision: false },
+      { id: "qwen3.6-flash", name: "Qwen3.6 Flash", context: 1000000, costIn: 0.1875, costOut: 1.125, tool: true, reasoning: true, vision: true },
+      { id: "qwen3.6-27b", name: "Qwen3.6 27B", context: 262144, costIn: 0.6, costOut: 3.6, tool: true, reasoning: true, vision: true },
+      { id: "qwen3.6-max-preview", name: "Qwen3.6 Max Preview", context: 262144, costIn: 1.3, costOut: 7.8, tool: true, reasoning: true, vision: false },
+      { id: "qwen3.6-35b-a3b", name: "Qwen3.6 35B-A3B", context: 262144, costIn: 0.248, costOut: 1.485, tool: true, reasoning: true, vision: true },
+    ],
+  },
+  {
+    key: "zhipuai",
+    name: "Zhipu GLM",
+    adapter: "@ai-sdk/openai-compatible",
+    defaultBaseURL: "https://open.bigmodel.cn/api/paas/v4",
+    docUrl: "https://docs.z.ai/guides/overview/pricing",
+    customHeaders: true,
+    authSchemeSelector: false,
+    models: [
+      { id: "glm-5.2", name: "GLM-5.2", context: 1000000, costIn: 1.4, costOut: 4.4, tool: true, reasoning: true, vision: false },
+      { id: "glm-5v-turbo", name: "GLM-5V-Turbo", context: 200000, costIn: 5, costOut: 22, tool: true, reasoning: true, vision: true },
+      { id: "glm-5.1", name: "GLM-5.1", context: 200000, costIn: 6, costOut: 24, tool: true, reasoning: true, vision: false },
+      { id: "glm-5", name: "GLM-5", context: 204800, costIn: 1, costOut: 3.2, tool: true, reasoning: true, vision: false },
+      { id: "glm-4.7-flash", name: "GLM-4.7-Flash", context: 200000, costIn: 0, costOut: 0, tool: true, reasoning: true, vision: false },
+      { id: "glm-4.7-flashx", name: "GLM-4.7-FlashX", context: 200000, costIn: 0.07, costOut: 0.4, tool: true, reasoning: true, vision: false },
+    ],
+  },
+  {
+    key: "xai",
+    name: "xAI Grok",
+    adapter: "@ai-sdk/xai",
+    defaultBaseURL: "https://api.x.ai/v1",
+    docUrl: "https://docs.x.ai/docs/models",
+    customHeaders: false,
+    authSchemeSelector: false,
+    models: [
+      { id: "grok-4.3", name: "Grok 4.3", context: 1000000, costIn: 1.25, costOut: 2.5, tool: true, reasoning: true, vision: true },
+      { id: "grok-build-0.1", name: "Grok Build 0.1", context: 256000, costIn: 1, costOut: 2, tool: true, reasoning: true, vision: true },
+      { id: "grok-imagine-image-quality", name: "Grok Imagine Image Quality", context: 8000, costIn: null, costOut: null, tool: false, reasoning: false, vision: true },
+      { id: "grok-4.20-multi-agent-0309", name: "Grok 4.20 Multi-Agent", context: 1000000, costIn: 1.25, costOut: 2.5, tool: false, reasoning: true, vision: true },
+      { id: "grok-4.20-0309-non-reasoning", name: "Grok 4.20 (Non-Reasoning)", context: 1000000, costIn: 1.25, costOut: 2.5, tool: true, reasoning: false, vision: true },
+      { id: "grok-4.20-0309-reasoning", name: "Grok 4.20 (Reasoning)", context: 1000000, costIn: 1.25, costOut: 2.5, tool: true, reasoning: true, vision: true },
+    ],
+  },
+  {
+    key: "mistral",
+    name: "Mistral",
+    adapter: "@ai-sdk/mistral",
+    defaultBaseURL: "https://api.mistral.ai/v1",
+    docUrl: "https://docs.mistral.ai/getting-started/models/",
+    customHeaders: false,
+    authSchemeSelector: false,
+    models: [
+      { id: "mistral-medium-2604", name: "Mistral Medium 3.5", context: 262144, costIn: 1.5, costOut: 7.5, tool: true, reasoning: true, vision: true },
+      { id: "mistral-small-latest", name: "Mistral Small (latest)", context: 256000, costIn: 0.15, costOut: 0.6, tool: true, reasoning: true, vision: true },
+      { id: "mistral-small-2603", name: "Mistral Small 4", context: 256000, costIn: 0.15, costOut: 0.6, tool: true, reasoning: true, vision: true },
+      { id: "devstral-latest", name: "Devstral 2", context: 262144, costIn: 0.4, costOut: 2, tool: true, reasoning: false, vision: false },
+      { id: "devstral-2512", name: "Devstral 2", context: 262144, costIn: 0.4, costOut: 2, tool: true, reasoning: false, vision: false },
+      { id: "labs-devstral-small-2512", name: "Devstral Small 2", context: 256000, costIn: 0, costOut: 0, tool: true, reasoning: false, vision: true },
+    ],
+  },
+  {
+    key: "groq",
+    name: "Groq",
+    adapter: "@ai-sdk/groq",
+    defaultBaseURL: "https://api.groq.com/openai/v1",
+    docUrl: "https://console.groq.com/docs/models",
+    customHeaders: false,
+    authSchemeSelector: false,
+    models: [
+      { id: "canopylabs/orpheus-v1-english", name: "Canopy Labs Orpheus V1 English", context: 4000, costIn: null, costOut: null, tool: false, reasoning: false, vision: false },
+      { id: "canopylabs/orpheus-arabic-saudi", name: "Canopy Labs Orpheus Arabic Saudi", context: 4000, costIn: null, costOut: null, tool: false, reasoning: false, vision: false },
+      { id: "openai/gpt-oss-safeguard-20b", name: "Safety GPT OSS 20B", context: 131072, costIn: 0.075, costOut: 0.3, tool: true, reasoning: true, vision: false },
+      { id: "groq/compound", name: "Compound", context: 131072, costIn: null, costOut: null, tool: false, reasoning: false, vision: false },
+      { id: "groq/compound-mini", name: "Compound Mini", context: 131072, costIn: null, costOut: null, tool: false, reasoning: false, vision: false },
+      { id: "openai/gpt-oss-120b", name: "GPT OSS 120B", context: 131072, costIn: 0.15, costOut: 0.6, tool: true, reasoning: true, vision: false },
+    ],
+  },
+  {
+    key: "openrouter",
+    name: "OpenRouter",
+    adapter: "@openrouter/ai-sdk-provider",
+    defaultBaseURL: "https://openrouter.ai/api/v1",
+    docUrl: "https://openrouter.ai/models",
+    customHeaders: false,
+    authSchemeSelector: false,
+    models: [
+      { id: "sakana/fugu-ultra", name: "Fugu Ultra", context: 1000000, costIn: 5, costOut: 30, tool: true, reasoning: true, vision: true },
+      { id: "google/gemini-3.1-flash-image", name: "Nano Banana 2 (Gemini 3.1 Flash Image)", context: 131072, costIn: 0.5, costOut: 3, tool: false, reasoning: true, vision: true },
+      { id: "google/gemini-3-pro-image", name: "Nano Banana Pro (Gemini 3 Pro Image)", context: 65536, costIn: 2, costOut: 12, tool: true, reasoning: true, vision: true },
+      { id: "cohere/north-mini-code:free", name: "North Mini Code (free)", context: 256000, costIn: 0, costOut: 0, tool: true, reasoning: true, vision: false },
+      { id: "z-ai/glm-5.2", name: "GLM-5.2", context: 1048576, costIn: 0.94, costOut: 3, tool: true, reasoning: true, vision: false },
+      { id: "openrouter/fusion", name: "Fusion", context: 1000000, costIn: null, costOut: null, tool: false, reasoning: false, vision: false },
+    ],
+  },
+  {
+    key: "minimax-coding-plan",
+    name: "MiniMax",
+    adapter: "@ai-sdk/anthropic",
+    defaultBaseURL: "https://api.minimax.io/anthropic/v1",
+    docUrl: "https://platform.minimax.io/docs/token-plan/intro",
+    customHeaders: false,
+    authSchemeSelector: false,
+    models: [
+      { id: "MiniMax-M3", name: "MiniMax-M3", context: 1000000, costIn: 0, costOut: 0, tool: true, reasoning: true, vision: true },
+      { id: "MiniMax-M2.7-highspeed", name: "MiniMax-M2.7-highspeed", context: 204800, costIn: 0, costOut: 0, tool: true, reasoning: true, vision: false },
+      { id: "MiniMax-M2.7", name: "MiniMax-M2.7", context: 204800, costIn: 0, costOut: 0, tool: true, reasoning: true, vision: false },
+      { id: "MiniMax-M2.5-highspeed", name: "MiniMax-M2.5-highspeed", context: 204800, costIn: 0, costOut: 0, tool: true, reasoning: true, vision: false },
+      { id: "MiniMax-M2.5", name: "MiniMax-M2.5", context: 204800, costIn: 0, costOut: 0, tool: true, reasoning: true, vision: false },
+      { id: "MiniMax-M2.1", name: "MiniMax-M2.1", context: 204800, costIn: 0, costOut: 0, tool: true, reasoning: true, vision: false },
+    ],
+  },
+]
+
+export function findProvider(key: string): ProviderPreset | undefined {
+  return PROVIDER_CATALOG.find((p) => p.key === key)
+}
+
+/** Short "200K · $0.14/$0.28" caption for a model, omitting null parts. */
+export function modelCaption(m: ModelPreset): string {
+  const parts: string[] = []
+  if (m.context != null) {
+    parts.push(m.context >= 1000 ? `${Math.round(m.context / 1000)}K` : String(m.context))
+  }
+  if (m.costIn != null && m.costOut != null) {
+    parts.push(`$${m.costIn}/$${m.costOut}`)
+  }
+  return parts.join(" · ")
+}

--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -30,6 +30,12 @@ import {
 } from "../../components/ui/dialog"
 import { Input } from "../../components/ui/input"
 import { CredentialKindCombobox } from "./capabilities/CredentialKindCombobox"
+import { ModelKeyCombobox } from "./ModelKeyCombobox"
+import { ProviderTypeCombobox } from "./ProviderTypeCombobox"
+import {
+  PROVIDER_CATALOG,
+  type ModelPreset,
+} from "../../lib/model-presets"
 
 function extractErrorMessage(err: unknown): string | null {
   if (!err) return null
@@ -51,24 +57,36 @@ function extractErrorMessage(err: unknown): string | null {
  * typically don't implement — they only expose `/v1/chat/completions`.
  * Use `@ai-sdk/openai-compatible` for those. Same rule lives in
  * server/internal/seed/models.go::modelSpecs.
+ *
+ * Branded providers come from the models.dev snapshot (see
+ * lib/model-catalog.ts); the two generic "custom gateway" entries are kept as
+ * fallbacks for endpoints not in the catalog (internal gateways, self-hosted).
  */
-const PROVIDER_TYPES = [
-  {
-    key: "openai",
-    adapter: "@ai-sdk/openai",
-    defaultBaseURL: "https://api.openai.com/v1",
-    customHeaders: false,
-    authSchemeSelector: false,
-    labelKey: "models.createProvider.providerTypeLabel.openai",
-  },
-  {
-    key: "anthropic",
-    adapter: "@ai-sdk/anthropic",
-    defaultBaseURL: "https://api.anthropic.com",
-    customHeaders: false,
-    authSchemeSelector: false,
-    labelKey: "models.createProvider.providerTypeLabel.anthropic",
-  },
+interface ProviderTypeOption {
+  key: string
+  adapter: string
+  defaultBaseURL: string
+  customHeaders: boolean
+  authSchemeSelector: boolean
+  /** Literal brand name (catalog) — takes precedence over labelKey. */
+  label?: string
+  /** i18n key for the generic gateway entries. */
+  labelKey?: string
+  /** Model id suggestions for the model_key datalist (catalog only). */
+  models?: ModelPreset[]
+}
+
+const CATALOG_PROVIDER_TYPES: ProviderTypeOption[] = PROVIDER_CATALOG.map((p) => ({
+  key: p.key,
+  adapter: p.adapter,
+  defaultBaseURL: p.defaultBaseURL,
+  customHeaders: p.customHeaders,
+  authSchemeSelector: p.authSchemeSelector,
+  label: p.name,
+  models: p.models,
+}))
+
+const GATEWAY_PROVIDER_TYPES: ProviderTypeOption[] = [
   {
     key: "anthropic-compatible",
     adapter: "@ai-sdk/anthropic",
@@ -78,14 +96,6 @@ const PROVIDER_TYPES = [
     labelKey: "models.createProvider.providerTypeLabel.anthropicCompatible",
   },
   {
-    key: "google",
-    adapter: "@ai-sdk/google",
-    defaultBaseURL: "https://generativelanguage.googleapis.com/v1beta",
-    customHeaders: false,
-    authSchemeSelector: false,
-    labelKey: "models.createProvider.providerTypeLabel.google",
-  },
-  {
     key: "openai-compatible",
     adapter: "@ai-sdk/openai-compatible",
     defaultBaseURL: "",
@@ -93,7 +103,12 @@ const PROVIDER_TYPES = [
     authSchemeSelector: false,
     labelKey: "models.createProvider.providerTypeLabel.openaiCompatible",
   },
-] as const
+]
+
+const PROVIDER_TYPES: ProviderTypeOption[] = [
+  ...CATALOG_PROVIDER_TYPES,
+  ...GATEWAY_PROVIDER_TYPES,
+]
 
 /* --- HeadersEditor ------------------------------------------------------
  *
@@ -374,7 +389,30 @@ export function CreateModelDialog({
   const adapter = cfg?.adapter ?? "@ai-sdk/openai-compatible"
   const showHeadersEditor = !!cfg?.customHeaders
   const showAuthSchemeSelector = !!cfg?.authSchemeSelector
+  const providerModels = cfg?.models ?? []
   const errMsg = extractErrorMessage(error)
+
+  // Resolve each provider option's display label once (literal brand name, or
+  // translated key for the generic gateways) for the searchable picker.
+  const providerChoices = useMemo(
+    () =>
+      PROVIDER_TYPES.map((p) => ({
+        key: p.key,
+        label: p.label ?? (p.labelKey ? t(p.labelKey as never) : p.key),
+        adapter: p.adapter,
+      })),
+    [t],
+  )
+
+  // Picking a catalog model id fills the key; if Display name is still empty,
+  // seed it from the model's friendly name (the user can override).
+  function handleModelKeyChange(next: string) {
+    setModelKey(next)
+    if (name.trim() === "") {
+      const hit = providerModels.find((m) => m.id === next)
+      if (hit) setName(hit.name)
+    }
+  }
 
   const activeSecrets = secrets.filter(
     (s) => s.status === "active" && s.kind === "model_provider"
@@ -470,18 +508,12 @@ export function CreateModelDialog({
               {t("models.createProvider.fields.providerType")}
               <span className="ml-0.5 text-danger">*</span>
             </label>
-            <select
+            <ProviderTypeCombobox
               id="model-provider-type"
               value={providerType}
-              onChange={(e) => handleProviderTypeChange(e.target.value)}
-              className="flex h-9 w-full rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
-            >
-              {PROVIDER_TYPES.map((p) => (
-                <option key={p.key} value={p.key}>
-                  {t(p.labelKey)}
-                </option>
-              ))}
-            </select>
+              onChange={handleProviderTypeChange}
+              options={providerChoices}
+            />
             <span className="text-xs text-fg-faint">
               {t("models.createProvider.fields.adapterHint", { adapter })}
             </span>
@@ -497,15 +529,24 @@ export function CreateModelDialog({
             mono
           />
 
-          <Field
-            id="model-key"
-            label={t("models.createModel.fields.modelKey")}
-            value={modelKey}
-            onChange={setModelKey}
-            placeholder={t("models.createModel.fields.modelKeyPlaceholder")}
-            required
-            mono
-          />
+          <div className="grid gap-1.5">
+            <label className="text-sm font-medium text-fg-muted" htmlFor="model-key">
+              {t("models.createModel.fields.modelKey")}
+              <span className="ml-0.5 text-danger">*</span>
+            </label>
+            <ModelKeyCombobox
+              id="model-key"
+              value={modelKey}
+              onChange={handleModelKeyChange}
+              models={providerModels}
+              placeholder={t("models.createModel.fields.modelKeyPlaceholder")}
+            />
+            {providerModels.length > 0 && (
+              <span className="text-xs text-fg-faint">
+                {t("models.createModel.fields.modelKeyCatalogHint")}
+              </span>
+            )}
+          </div>
 
           {/* --- Custom headers (only for *-compatible gateways) --- */}
           {showHeadersEditor && (

--- a/apps/web/src/pages/admin/ModelKeyCombobox.tsx
+++ b/apps/web/src/pages/admin/ModelKeyCombobox.tsx
@@ -1,0 +1,168 @@
+/**
+ * Model-key picker: searchable list of a provider's preset models, with
+ * free-text fallback so any model id can still be entered (presets go stale;
+ * a missing model must never block the user).
+ *
+ * Modeled on CredentialKindCombobox (Radix dropdown + Input filter), but the
+ * search box doubles as the free-text value: whatever is typed becomes the
+ * model key on Enter / "Use …", even if it matches no preset.
+ */
+import { useMemo, useState } from "react"
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
+import { Check, ChevronsUpDown, CornerDownLeft } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Input } from "../../components/ui/input"
+import { cn } from "../../lib/utils"
+import { modelCaption, type ModelPreset } from "../../lib/model-presets"
+
+interface Props {
+  value: string
+  onChange: (modelKey: string) => void
+  /** Preset models for the selected provider; empty → pure free-text input. */
+  models: ModelPreset[]
+  placeholder?: string
+  id?: string
+}
+
+export function ModelKeyCombobox({ value, onChange, models, placeholder, id }: Props) {
+  const { t } = useTranslation("admin")
+  const [search, setSearch] = useState("")
+
+  const selected = useMemo(() => models.find((m) => m.id === value), [models, value])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return models
+    return models.filter(
+      (m) => m.id.toLowerCase().includes(q) || m.name.toLowerCase().includes(q),
+    )
+  }, [models, search])
+
+  // Typed text that isn't an exact preset id → offer "Use <text>" so custom
+  // ids commit with one action.
+  const typed = search.trim()
+  const showFreeText = typed !== "" && !models.some((m) => m.id === typed)
+
+  function commit(next: string) {
+    onChange(next)
+    setSearch("")
+  }
+
+  return (
+    <DropdownMenu.Root modal={false}>
+      <DropdownMenu.Trigger asChild>
+        <button
+          id={id}
+          type="button"
+          className={cn(
+            "flex h-9 w-full items-center justify-between rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300",
+            !value && "text-fg-faint",
+          )}
+        >
+          <span className="truncate font-mono text-sm">
+            {value || placeholder || t("models.createModel.fields.modelKeyPlaceholder")}
+          </span>
+          <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-fg-faint" />
+        </button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 max-h-[320px] w-[var(--radix-dropdown-menu-trigger-width)] min-w-[280px] overflow-hidden rounded-md border border-line bg-surface p-1 shadow-lg"
+        >
+          <div className="border-b border-line-muted p-1">
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t("models.createModel.fields.modelKeySearch", "Search or type a model id…")}
+              onKeyDown={(e) => {
+                e.stopPropagation()
+                if (e.key === "Enter" && typed !== "") {
+                  e.preventDefault()
+                  commit(typed)
+                }
+              }}
+              className="h-8 font-mono text-sm"
+              autoFocus
+            />
+          </div>
+
+          <div className="max-h-[220px] overflow-auto py-1">
+            {showFreeText && (
+              <DropdownMenu.Item
+                onSelect={() => commit(typed)}
+                className="flex cursor-pointer items-center gap-2 rounded px-3 py-2 text-sm outline-none hover:bg-surface-subtle focus:bg-surface-subtle"
+              >
+                <CornerDownLeft className="h-3.5 w-3.5 shrink-0 text-fg-faint" />
+                <span className="text-fg-subtle">{t("models.createModel.fields.modelKeyUse", "Use")}</span>
+                <code className="truncate font-mono text-xs text-fg">{typed}</code>
+              </DropdownMenu.Item>
+            )}
+
+            {filtered.length === 0 && !showFreeText ? (
+              <p className="px-3 py-2 text-sm text-fg-subtle">
+                {t("models.createModel.fields.modelKeyEmpty", "No matching models — type any id")}
+              </p>
+            ) : (
+              filtered.map((m) => (
+                <ModelRow
+                  key={m.id}
+                  model={m}
+                  selected={m.id === value}
+                  onSelect={() => commit(m.id)}
+                />
+              ))
+            )}
+          </div>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+
+function ModelRow({
+  model,
+  selected,
+  onSelect,
+}: {
+  model: ModelPreset
+  selected: boolean
+  onSelect: () => void
+}) {
+  const caption = modelCaption(model)
+  return (
+    <DropdownMenu.Item
+      onSelect={() => onSelect()}
+      className={cn(
+        "flex cursor-pointer items-start justify-between gap-2 rounded px-3 py-2 outline-none",
+        selected ? "bg-surface-muted" : "hover:bg-surface-subtle focus:bg-surface-subtle",
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium text-fg">{model.name}</span>
+          {model.reasoning && (
+            <span className="rounded bg-surface-muted px-1.5 py-0.5 text-[10px] text-fg-muted">
+              reasoning
+            </span>
+          )}
+          {model.vision && (
+            <span className="rounded bg-surface-muted px-1.5 py-0.5 text-[10px] text-fg-muted">
+              vision
+            </span>
+          )}
+        </div>
+        <div className="mt-0.5 flex items-center gap-2">
+          <code className="truncate rounded bg-surface-muted px-1.5 py-0.5 font-mono text-xs text-fg-subtle">
+            {model.id}
+          </code>
+          {caption && <span className="shrink-0 text-xs text-fg-subtle">{caption}</span>}
+        </div>
+      </div>
+      {selected && <Check className="h-3.5 w-3.5 shrink-0 text-fg-muted" />}
+    </DropdownMenu.Item>
+  )
+}

--- a/apps/web/src/pages/admin/ProviderTypeCombobox.tsx
+++ b/apps/web/src/pages/admin/ProviderTypeCombobox.tsx
@@ -1,0 +1,126 @@
+/**
+ * Provider-type picker: searchable dropdown over the model-provider catalog.
+ * Select-only (provider_type must be a known key — unlike the model-key
+ * combobox there is no free-text fallback).
+ *
+ * Same Radix dropdown + Input filter shape as ModelKeyCombobox /
+ * CredentialKindCombobox.
+ */
+import { useMemo, useState } from "react"
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
+import { Check, ChevronsUpDown } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Input } from "../../components/ui/input"
+import { cn } from "../../lib/utils"
+
+export interface ProviderTypeChoice {
+  key: string
+  /** Display label (already resolved — literal brand name or translated). */
+  label: string
+  adapter: string
+}
+
+interface Props {
+  value: string
+  onChange: (key: string) => void
+  options: ProviderTypeChoice[]
+  id?: string
+}
+
+export function ProviderTypeCombobox({ value, onChange, options, id }: Props) {
+  const { t } = useTranslation("admin")
+  const [search, setSearch] = useState("")
+
+  const selected = useMemo(() => options.find((o) => o.key === value), [options, value])
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return options
+    return options.filter(
+      (o) =>
+        o.label.toLowerCase().includes(q) ||
+        o.key.toLowerCase().includes(q) ||
+        o.adapter.toLowerCase().includes(q),
+    )
+  }, [options, search])
+
+  function commit(next: string) {
+    onChange(next)
+    setSearch("")
+  }
+
+  return (
+    <DropdownMenu.Root modal={false}>
+      <DropdownMenu.Trigger asChild>
+        <button
+          id={id}
+          type="button"
+          className={cn(
+            "flex h-9 w-full items-center justify-between rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300",
+            !selected && "text-fg-faint",
+          )}
+        >
+          <span className="truncate text-sm">
+            {selected?.label ?? value ?? t("models.createProvider.fields.providerType")}
+          </span>
+          <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 text-fg-faint" />
+        </button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 max-h-[320px] w-[var(--radix-dropdown-menu-trigger-width)] min-w-[280px] overflow-hidden rounded-md border border-line bg-surface p-1 shadow-lg"
+        >
+          <div className="border-b border-line-muted p-1">
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t("models.createProvider.fields.providerSearch", "Search providers…")}
+              onKeyDown={(e) => {
+                e.stopPropagation()
+                if (e.key === "Enter" && filtered.length > 0) {
+                  e.preventDefault()
+                  commit(filtered[0].key)
+                }
+              }}
+              className="h-8 text-sm"
+              autoFocus
+            />
+          </div>
+
+          <div className="max-h-[240px] overflow-auto py-1">
+            {filtered.length === 0 ? (
+              <p className="px-3 py-2 text-sm text-fg-subtle">
+                {t("models.createProvider.fields.providerEmpty", "No matching providers")}
+              </p>
+            ) : (
+              filtered.map((o) => (
+                <DropdownMenu.Item
+                  key={o.key}
+                  onSelect={() => commit(o.key)}
+                  className={cn(
+                    "flex cursor-pointer items-center justify-between gap-2 rounded px-3 py-2 outline-none",
+                    o.key === value
+                      ? "bg-surface-muted"
+                      : "hover:bg-surface-subtle focus:bg-surface-subtle",
+                  )}
+                >
+                  <div className="min-w-0 flex-1">
+                    <span className="truncate text-sm font-medium text-fg">{o.label}</span>
+                    <code className="mt-0.5 block truncate font-mono text-xs text-fg-subtle">
+                      {o.adapter}
+                    </code>
+                  </div>
+                  {o.key === value && <Check className="h-3.5 w-3.5 shrink-0 text-fg-muted" />}
+                </DropdownMenu.Item>
+              ))
+            )}
+          </div>
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}


### PR DESCRIPTION
## 背景

「加共享模型」弹窗原本只有 5 个**通用 adapter 类型**(openai / anthropic / google / 各 compatible),且 **model key 是纯手填**——用户既选不到具体厂商(DeepSeek / Kimi / Qwen 得自己查 base_url),也得记住并手敲模型 id。

## 改了什么

### 1. 厂商按品牌列出(12 家)
OpenAI / Anthropic / Google / DeepSeek / Moonshot(Kimi) / Qwen / Zhipu / xAI / Mistral / Groq / OpenRouter / MiniMax。选厂商**自动带出 base_url**;末尾保留两个「自定义网关」项兜底内部/自托管端点。

### 2. 两个字段都改成可搜索下拉(combobox)
- **Provider type**:输入「kimi」秒筛到 Moonshot;每行显示品牌名 + adapter 包。
- **Model key**:输入实时过滤;模型行显示名称 / 上下文 / 价格 / `reasoning`·`vision` 标记。

### 3. Model key 仍可手填(不锁死)
下拉里输入未收录的 id 会出现 **「Use \<id\>」**,预设过期/缺失绝不阻塞;选中已知模型时**自动预填 Display name**。

## 数据来源 & 维护

手写静态预设 `apps/web/src/lib/model-presets.ts`,字段最初 seed 自 [models.dev](https://models.dev) 但**以本文件为准**——加厂商/刷新模型直接改它,**无构建步骤、无运行时依赖、不引 npm 包**。

> 未来增强(本 PR 未做):后端加一个 `GET {base_url}/v1/models` 代理,即可用「该 key 真实可用的模型列表」替换静态预设。`testModelConnectivity`(server/internal/dev/routes.go)已经在「带 key 调上游」,可复用那套。文件内留有 TODO 注释。

## 一处坑(已修)

两个 combobox 复用仓库现有 `CredentialKindCombobox` 的 Radix dropdown + 搜索模式。但直接照抄会有 bug:`DropdownMenu.Item` 的 `onSelect` 里 `e.preventDefault()`(那是为 inline-create 故意保持菜单打开)会让普通选择器**选中后菜单不关**,弹出层悬在上面拦截点击 ——表现为「字段已有值时列表点不动、无法重选」。修法:行选择去掉 `preventDefault`(选中即关),并设 `modal={false}` 避免嵌在 Dialog 内时的焦点/关闭层冲突。

## 验证
- ✅ `tsc --noEmit` 通过;`vite build` 通过
- ✅ Playwright 实测:选厂商→自动填 base_url;选模型→预填名称;**已有值时重开仍可选、可改**;手填任意 id 仍可提交;全程弹窗不误关
- 改动范围:6 个文件,全部 `apps/web/` 下,纯前端

## 影响范围
纯视觉/交互层。无 DB / API / OpenAPI 改动,故无 migration。