### PR TITLE
feat(web): 创建 Agent 锁定为 public 并隐藏可见性选择器

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -2133,8 +2133,6 @@
     "sharedPlaceholder": "Pick a shared secret…",
     "sharedNewQueued": "Will create: {{name}}",
     "sharedNewEdit": "Edit",
-    "publicWarning": "Public agents may be called by users without a Parsar account. Model and capability credentials must use shared secrets; personal options are disabled.",
-    "tenantHint": "Tenant agents may be called from other workspaces. Callers must configure their own credentials or the capability is disabled — use shared secrets to avoid this.",
     "modelBindingTitle": "Model credential",
     "modelBindingPersonal": "Each caller's own API key",
     "modelBindingShared": "Use a shared API key",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -2133,8 +2133,6 @@
     "sharedPlaceholder": "选择一个共享密钥…",
     "sharedNewQueued": "将创建：{{name}}",
     "sharedNewEdit": "编辑",
-    "publicWarning": "公开 Agent 的调用者可能未注册 Parsar。Model 和能力凭据都必须使用共享密钥；个人凭据选项会被禁用。",
-    "tenantHint": "跨工作区调用者需在 Parsar 配置过自己的凭据，否则该能力会被自动禁用。可改用共享密钥避免此问题。",
     "modelBindingTitle": "Model 凭据",
     "modelBindingPersonal": "调用者各自的 API key",
     "modelBindingShared": "使用共享 API key",

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -70,12 +70,10 @@ import {
   useProjectAgents,
   useSetProjectAgentStatus,
   useUpdateAgent,
-  useUpdateAgentVisibility,
   useUpdateProjectAgentProfile,
   useAgentMetrics,
   useAgentRuns,
   type AgentMetrics,
-  type AgentVisibility,
 } from "../../lib/api-agents"
 import { useModels } from "../../lib/api-models"
 import { useSandboxBinding } from "../../lib/api-sandbox"
@@ -1330,141 +1328,6 @@ function Stat({ label, value }: { label: string; value: string }) {
       <div className="text-xs uppercase tracking-wider text-fg-faint">{label}</div>
       <div className="mt-1 text-2xl font-semibold tabular-nums text-fg">{value}</div>
     </div>
-  )
-}
-
-/**
- * Agent visibility radio + confirmation dialog when tightening FROM
- * `public` to a stricter tier. RBAC-gated client-side; backend re-enforces.
- */
-function VisibilityCard({
-  agentID,
-  projectID,
-  current,
-  canEdit,
-  onSuccess,
-}: {
-  agentID: string
-  projectID: string | null
-  current: AgentVisibility
-  canEdit: boolean
-  onSuccess: (next: AgentVisibility) => void
-}) {
-  const { t } = useTranslation("admin")
-  const mut = useUpdateAgentVisibility(projectID)
-  const [pendingDowngrade, setPendingDowngrade] = useState<AgentVisibility | null>(null)
-  const [errorMsg, setErrorMsg] = useState<string | null>(null)
-
-  const apply = (next: AgentVisibility) => {
-    setErrorMsg(null)
-    mut.mutate(
-      { agentID, visibility: next },
-      {
-        onSuccess: () => {
-          setPendingDowngrade(null)
-          onSuccess(next)
-        },
-        onError: (err) => {
-          setErrorMsg((err as Error)?.message ?? t("agents.visibility.updateError"))
-        },
-      },
-    )
-  }
-
-  const onSelect = (next: AgentVisibility) => {
-    if (next === current) return
-    // Tightening from public kicks out external users — confirm first.
-    if (current === "public" && next !== "public") {
-      setPendingDowngrade(next)
-      return
-    }
-    apply(next)
-  }
-
-  const tiers: { value: AgentVisibility; hint: string }[] = [
-    { value: "workspace", hint: t("agents.visibility.workspaceHint") },
-    { value: "tenant", hint: t("agents.visibility.tenantHint") },
-    { value: "public", hint: t("agents.visibility.publicHint") },
-  ]
-
-  return (
-    <Card title={t("agents.table.visibility")} className="mt-4">
-      <div className="space-y-2">
-        {tiers.map((tier) => (
-          <label
-            key={tier.value}
-            className={`flex cursor-pointer items-start gap-3 rounded-md border p-3 transition-colors ${
-              current === tier.value
-                ? "border-line-strong bg-surface-subtle"
-                : "border-line hover:bg-surface-subtle"
-            } ${!canEdit ? "cursor-not-allowed opacity-60" : ""}`}
-          >
-            <input
-              type="radio"
-              name="agent-visibility"
-              value={tier.value}
-              checked={current === tier.value}
-              disabled={!canEdit || mut.isPending}
-              onChange={() => onSelect(tier.value)}
-              className="mt-1"
-            />
-            <div className="flex-1">
-              <div className="text-sm font-medium text-fg">
-                {t(`agents.visibility.${tier.value}`)}
-              </div>
-              <div className="mt-0.5 text-sm text-fg-subtle">{tier.hint}</div>
-            </div>
-          </label>
-        ))}
-      </div>
-      {!canEdit && (
-        <p className="mt-2 text-sm text-fg-faint">
-          {t("agents.visibility.ownerOnly")}
-        </p>
-      )}
-      {errorMsg && (
-        <p className="mt-2 text-sm text-danger" role="alert">
-          {errorMsg}
-        </p>
-      )}
-
-      {pendingDowngrade && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-surface-emphasis/40 px-4">
-          <div className="w-full max-w-md rounded-lg bg-surface p-5 shadow-xl">
-            <h4 className="text-base font-semibold text-fg">
-              {t("agents.visibility.downgradeWarnTitle")}
-            </h4>
-            <p className="mt-2 text-sm text-fg-muted">
-              {t("agents.visibility.downgradeWarnBody", {
-                to: t(`agents.visibility.${pendingDowngrade}`),
-              })}
-            </p>
-            <div className="mt-4 flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={() => setPendingDowngrade(null)}
-                className="rounded-md border border-line px-3 py-1.5 text-sm text-fg-muted hover:bg-surface-subtle"
-                disabled={mut.isPending}
-              >
-                {t("agents.visibility.cancel")}
-              </button>
-              <button
-                type="button"
-                onClick={() => apply(pendingDowngrade)}
-                className="rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
-                disabled={mut.isPending}
-              >
-                {mut.isPending ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  t("agents.visibility.confirmDowngrade")
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-    </Card>
   )
 }
 

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -234,6 +234,9 @@ export function CreateAgentDialog({
   /** "personal" or "shared:<secret_id>" or "shared:new:<displayName>|<plaintext>". */
   const [modelBindingChoice, setModelBindingChoice] = useState<
     | { source: "personal" }
+    // Pending pick: shared selected, no secret chosen yet — required so a workspace
+    // with zero shared secrets can still flip source → "shared" and open the form.
+    | { source: "shared" }
     | { source: "shared"; existing_secret_id: string }
     | { source: "shared"; new_secret: { display_name: string; plaintext: string } }
   >({ source: "personal" })
@@ -432,7 +435,10 @@ export function CreateAgentDialog({
       // previous clone's bindings would leak across dialog opens.
       setCredentialBindings({})
       setInitialCredentialBindings(undefined)
-      setModelBindingChoice({ source: "personal" })
+      // Create is locked to public, so personal binding is disabled — start on
+      // shared. Left as a pending pick here (secrets may still be loading); the
+      // resolver effect below upgrades it to the first existing secret if any.
+      setModelBindingChoice({ source: "shared" })
       setInlineNewSecrets([])
     } else if (agent) {
       setName(agent.name)
@@ -588,6 +594,18 @@ export function CreateAgentDialog({
   const hasModel = activeModels.length > 0
   const requiresModel = connector !== "agent_daemon" || agentEngine === "claude_code" || agentEngine === "codex" || agentEngine === "pi"
   const hasRequiredModel = !requiresModel || (hasModel && modelID !== "")
+  // Create opens model binding on a pending "shared" pick because secrets may
+  // still be loading; once they land, resolve to the first existing one. Gated
+  // on the credential_ref UI so no-credential models stay untouched; with zero
+  // secrets it stays pending and the inline new-secret form takes over.
+  useEffect(() => {
+    if (mode !== "create") return
+    if (!requiresModel || selectedModel?.credential_mode !== "credential_ref") return
+    if (modelBindingChoice.source !== "shared") return
+    if ("existing_secret_id" in modelBindingChoice || "new_secret" in modelBindingChoice) return
+    if (modelNewSecretExpanded || sharedSecrets.length === 0) return
+    setModelBindingChoice({ source: "shared", existing_secret_id: sharedSecrets[0].id })
+  }, [mode, requiresModel, selectedModel, modelBindingChoice, modelNewSecretExpanded, sharedSecrets])
   const daemonExecutionEditable = connector === "agent_daemon"
   const showExecutionChoices = mode === "create" || daemonExecutionEditable
   const showDevicePicker = connector === "agent_daemon" && executionMode === "local_device" && Boolean(workspaceID)
@@ -1141,10 +1159,12 @@ export function CreateAgentDialog({
                         className="mt-0.5"
                         checked={modelBindingChoice.source === "shared"}
                         onChange={() => {
-                          // Default selection on flip-in: existing secret if any, else open the new-secret form.
+                          // Default selection on flip-in: existing secret if any, else
+                          // mark shared "pending" so the radio selects + form renders.
                           if (sharedSecrets[0]) {
                             setModelBindingChoice({ source: "shared", existing_secret_id: sharedSecrets[0].id })
                           } else {
+                            setModelBindingChoice({ source: "shared" })
                             setModelNewSecretExpanded(true)
                             setModelNewSecretDisplayName("")
                             setModelNewSecretPlaintext("")

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -216,7 +216,7 @@ export function CreateAgentDialog({
   // picker's loading-state fallback option renders the right number
   // instead of mis-labelling the pinned row with the latest version.
   const [capabilityVersionChoices, setCapabilityVersionChoices] = useState<Record<string, { pinningMode: "latest" | "pinned"; versionID: string; pinnedVersion?: string }>>({})
-  const [visibility, setVisibility] = useState<"workspace" | "tenant" | "public">("workspace")
+  const [visibility, setVisibility] = useState<"workspace" | "tenant" | "public">("public")
   const [capabilitySearch, setCapabilitySearch] = useState("")
   const [capabilityTypeFilter, setCapabilityTypeFilter] = useState<"all" | "mcp" | "skill" | "plugin" | "system_prompt">("all")
   const [deviceID, setDeviceID] = useState("")
@@ -423,7 +423,8 @@ export function CreateAgentDialog({
       setSelectedCapabilityIDs([])
       setCapabilityVersionChoices({})
       setCapabilitySearch("")
-      setVisibility(cloneSource?.visibility ?? "workspace")
+      // Creation is locked to public; the visibility selector is hidden.
+      setVisibility("public")
       setDeviceID(cloneSource ? deviceIDFromAgent(cloneSource) : "")
       setWorkDir(cloneSource ? workDirFromAgent(cloneSource) : "")
       // Clones explicitly drop the source agent's credential bindings: the
@@ -924,39 +925,6 @@ export function CreateAgentDialog({
               <Field label={t("agents.form.fields.description")}>
                 <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t("agents.form.placeholders.description")} />
               </Field>
-              {mode === "create" && (
-                <Field label={t("agents.table.visibility")} required>
-                  <div className="grid gap-2 sm:grid-cols-3">
-                    {(["workspace", "tenant", "public"] as const).map((tier) => (
-                      <label key={tier} className={"flex cursor-pointer flex-col gap-1 rounded-md border px-3 py-2 text-sm " + (visibility === tier ? "border-line-strong bg-surface-subtle text-fg" : "border-line bg-surface text-fg-muted")}>
-                        <span className="flex items-center gap-2 font-medium">
-                          <input
-                            type="radio"
-                            name="agent-visibility"
-                            value={tier}
-                            checked={visibility === tier}
-                            onChange={() => setVisibility(tier)}
-                          />
-                          {t(`agents.visibility.${tier}` as never)}
-                        </span>
-                        <span className="pl-5 text-xs leading-4 text-fg-subtle">{t(`agents.visibility.${tier}Hint` as never)}</span>
-                      </label>
-                    ))}
-                  </div>
-                  {visibility === "public" && (
-                    <div className="mt-2 rounded-md border border-danger-border bg-danger-subtle px-3 py-2 text-xs leading-5 text-danger-emphasis">
-                      <AlertTriangle className="mr-1 inline h-3.5 w-3.5" />
-                      {t("credentialCheck.publicWarning")}
-                    </div>
-                  )}
-                  {visibility === "tenant" && (
-                    <div className="mt-2 rounded-md border border-warning-border bg-warning-subtle px-3 py-2 text-xs leading-5 text-warning-emphasis">
-                      <AlertTriangle className="mr-1 inline h-3.5 w-3.5" />
-                      {t("credentialCheck.tenantHint")}
-                    </div>
-                  )}
-                </Field>
-              )}
             </section>
           )}
 


### PR DESCRIPTION
## 背景

在 Agent 创建流程中，可见性（visibility）是个容易让人误选的字段。本次改动统一：**所有新建 Agent 一律以 `public` 创建**，并自动走"公开 Agent"的凭据绑定交互（强制共享密钥、禁用个人凭据），不再向用户暴露可见性选择。

纯前端改动 —— 后端 `store.CreateAgent` 空值默认、OpenAPI 默认、`PATCH .../visibility` 路由、`validateAgentVisibilityBindings`（422）全部不动，后端继续作为最终防线。

## 改动内容

- **`CreateAgentDialog.tsx`**：创建态 `visibility` state 锁死为 `"public"`（初始值 + 创建/克隆 open-effect）；删除第 1 步的可见性选择器 UI（单选组 + public/tenant 提示横幅）。因凭据面板与模型绑定区读取 `visibility` state，写死 public 后"公开交互逻辑"自动生效（个人凭据禁用、强制共享密钥）。编辑态 `setVisibility(agent.visibility ?? "workspace")` 保留，不受影响。
- **`AgentsPage.tsx`**：删除无 JSX 调用点的死代码组件 `VisibilityCard`（135 行）及其因此孤立的 import（`useUpdateAgentVisibility`、`type AgentVisibility`）。`api-agents.ts` 中的定义/导出有意保留（仍对应后端 live PATCH 端点）。列表只读可见性列保留。
- **i18n**：移除选择器删除后孤立的 `credentialCheck.publicWarning` / `credentialCheck.tenantHint`（en-US + zh-CN）。`agents.visibility.*` 保留 —— 其 `workspace/tenant/public` 仍被列表动态引用，其余键与保留的 visibility PATCH 能力配套。

## 验证

- [x] `make check` 通过（Go 测试 + sqlc 无漂移 + 迁移 smoke + 全包 `tsc --noEmit`），末行 `Parsar harness checks passed.`
- [x] 代码级走查：创建第 1 步无可见性选择器；提交体 create 态恒送 `visibility="public"`；个人凭据 `disabled={visibility === "public"}`、`CredentialCheckPanel` 强制共享；编辑态行为不变。
- [ ] 人工浏览器冒烟（建议 reviewer 在 `make web` 下确认创建对话框交互与列表显示 `public`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
