### PR TITLE
feat(connectors): 工作区维度的 IM 连接器(飞书/Slack/Discord)

### DIFF
--- a/apps/web/src/components/admin/channel-connectors/ChannelConnectorPanel.tsx
+++ b/apps/web/src/components/admin/channel-connectors/ChannelConnectorPanel.tsx
@@ -1,0 +1,73 @@
+import { useMemo, useState } from "react"
+
+import {
+  useWorkspaceIMConnectors,
+  readFeishuConnector,
+  readSlackConnector,
+  readDiscordConnector,
+} from "../../../lib/api-connectors"
+import { FeishuConnectorFields } from "./feishuFields"
+import { SlackConnectorFields } from "./slackFields"
+import { DiscordConnectorFields } from "./discordFields"
+import { PlatformSelector, type ConnectorPlatform } from "./PlatformSelector"
+
+interface ChannelConnectorPanelProps {
+  workspaceID: string | null
+  canEdit: boolean
+  onToast: (msg: string) => void
+}
+
+/**
+ * Top-level workspace-dimension connector configuration surface.
+ *
+ * The PlatformSelector dropdown lets the admin pick Feishu / Slack / Discord,
+ * and the panel swaps in the matching per-platform fields sub-component. The
+ * persisted config for every platform is read once from
+ * `GET /workspaces/{id}/connectors` and split per-platform; switching platforms
+ * preserves the persisted config and resets any in-flight draft, since each
+ * platform has its own validation gates and own secret fields.
+ */
+export function ChannelConnectorPanel({
+  workspaceID,
+  canEdit,
+  onToast,
+}: ChannelConnectorPanelProps) {
+  const { data } = useWorkspaceIMConnectors(workspaceID)
+  const connectors = data?.connectors
+
+  const feishuConfig = useMemo(() => readFeishuConnector(connectors), [connectors])
+  const slackConfig = useMemo(() => readSlackConnector(connectors), [connectors])
+  const discordConfig = useMemo(() => readDiscordConnector(connectors), [connectors])
+
+  const [platform, setPlatform] = useState<ConnectorPlatform>("feishu")
+
+  return (
+    <div data-testid="channel-connector-panel">
+      <PlatformSelector value={platform} onChange={setPlatform} />
+      {platform === "feishu" && (
+        <FeishuConnectorFields
+          workspaceID={workspaceID}
+          current={feishuConfig}
+          canEdit={canEdit}
+          onToast={onToast}
+        />
+      )}
+      {platform === "slack" && (
+        <SlackConnectorFields
+          workspaceID={workspaceID}
+          current={slackConfig}
+          canEdit={canEdit}
+          onToast={onToast}
+        />
+      )}
+      {platform === "discord" && (
+        <DiscordConnectorFields
+          workspaceID={workspaceID}
+          current={discordConfig}
+          canEdit={canEdit}
+          onToast={onToast}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/admin/channel-connectors/PlatformSelector.tsx
+++ b/apps/web/src/components/admin/channel-connectors/PlatformSelector.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from "react-i18next"
+
+export type ConnectorPlatform = "feishu" | "slack" | "discord"
+
+interface PlatformSelectorProps {
+  value: ConnectorPlatform
+  onChange: (next: ConnectorPlatform) => void
+  disabled?: boolean
+  testId?: string
+}
+
+/**
+ * Dropdown that lets the admin pick which IM platform's connector config to
+ * render in the ChannelConnectorPanel. Each option maps 1:1 to a per-platform
+ * fields module (feishuFields / slackFields / discordFields) and a per-platform
+ * PATCH route on the backend.
+ */
+export function PlatformSelector({
+  value,
+  onChange,
+  disabled = false,
+  testId,
+}: PlatformSelectorProps) {
+  const { t } = useTranslation("admin")
+  const options: ConnectorPlatform[] = ["feishu", "slack", "discord"]
+
+  return (
+    <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-line bg-surface px-3 py-2">
+      <label
+        htmlFor={testId ?? "channel-connector-platform"}
+        className="text-xs uppercase tracking-wider text-fg-subtle"
+      >
+        {t("connections.connector.platformSelect.label")}
+      </label>
+      <select
+        id={testId ?? "channel-connector-platform"}
+        value={value}
+        onChange={(e) => onChange(e.target.value as ConnectorPlatform)}
+        disabled={disabled}
+        className="h-8 rounded-md border border-line bg-surface px-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:cursor-not-allowed disabled:bg-surface-subtle"
+        data-testid={testId ?? "channel-connector-platform-select"}
+      >
+        {options.map((opt) => (
+          <option key={opt} value={opt}>
+            {t(`connections.connector.platformSelect.options.${opt}`)}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/apps/web/src/components/admin/channel-connectors/discordFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/discordFields.tsx
@@ -1,0 +1,357 @@
+import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Loader2, RefreshCw } from "lucide-react"
+
+import { ApiError } from "../../../lib/api-client"
+import {
+  useUpdateWorkspaceDiscordConnector,
+  type DiscordConnectorInput,
+} from "../../../lib/api-connectors"
+import { useCreateSecret } from "../../../lib/api-secrets"
+import type { CreateSecretRequest } from "../../../lib/api-types"
+import { Card, Field, SecretInput, randomHex } from "./shared"
+
+const EMPTY_CONFIG: DiscordConnectorInput = {
+  enabled: false,
+  app_id: "",
+  bot_token_ref: "",
+  public_key_ref: "",
+  intents: "",
+}
+
+const DISCORD_INTENT_OPTIONS = [
+  "GUILDS",
+  "GUILD_MESSAGES",
+  "DIRECT_MESSAGES",
+  "MESSAGE_CONTENT",
+  "GUILD_MESSAGE_REACTIONS",
+] as const
+
+type SecretInputs = {
+  botToken: string
+  publicKey: string
+}
+
+type DiscordSecretField = keyof SecretInputs
+type DiscordSecretRefKey = "bot_token_ref" | "public_key_ref"
+
+type DiscordSecretFieldSpec = {
+  refKey: DiscordSecretRefKey
+  kind: string
+  authType: string
+  payloadKey: string
+  namePrefix: string
+}
+
+const EMPTY_SECRET_INPUTS: SecretInputs = {
+  botToken: "",
+  publicKey: "",
+}
+
+const DISCORD_SECRET_FIELDS: Record<DiscordSecretField, DiscordSecretFieldSpec> = {
+  botToken: {
+    refKey: "bot_token_ref",
+    kind: "discord_bot_token",
+    authType: "bot_token",
+    payloadKey: "bot_token",
+    namePrefix: "discord-bot-token",
+  },
+  publicKey: {
+    refKey: "public_key_ref",
+    kind: "discord_public_key",
+    authType: "public_key",
+    payloadKey: "public_key",
+    namePrefix: "discord-public-key",
+  },
+}
+
+export interface DiscordConnectorFieldsProps {
+  workspaceID: string | null
+  current: DiscordConnectorInput | undefined
+  canEdit: boolean
+  onToast: (msg: string) => void
+}
+
+export function DiscordConnectorFields({
+  workspaceID,
+  current,
+  canEdit,
+  onToast,
+}: DiscordConnectorFieldsProps) {
+  const { t } = useTranslation("admin")
+  const mut = useUpdateWorkspaceDiscordConnector(workspaceID)
+  const createSecretMut = useCreateSecret(workspaceID)
+
+  const [draft, setDraft] = useState<DiscordConnectorInput>(current ?? EMPTY_CONFIG)
+  const [secretInputs, setSecretInputs] = useState<SecretInputs>({ ...EMPTY_SECRET_INPUTS })
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    setDraft(current ?? EMPTY_CONFIG)
+    setSecretInputs({ ...EMPTY_SECRET_INPUTS })
+    setErrorMsg(null)
+  }, [current])
+
+  const dirty = !configEqual(draft, current ?? EMPTY_CONFIG) || secretInputsDirty(secretInputs)
+  const saving = mut.isPending || createSecretMut.isPending
+
+  const missingRequired = draft.enabled && (
+    !draft.app_id.trim() ||
+    (!draft.bot_token_ref.trim() && !secretInputs.botToken.trim()) ||
+    (!draft.public_key_ref.trim() && !secretInputs.publicKey.trim())
+  )
+
+  const selectedIntents = parseIntents(draft.intents)
+
+  const toggleIntent = (intent: string) => {
+    setDraft((prev) => {
+      const set = new Set(parseIntents(prev.intents))
+      if (set.has(intent)) {
+        set.delete(intent)
+      } else {
+        set.add(intent)
+      }
+      return { ...prev, intents: Array.from(set).join(",") }
+    })
+  }
+
+  const onSave = async () => {
+    setErrorMsg(null)
+    try {
+      const config = await buildConfigWithSecretRefs(draft, secretInputs, async (body) => {
+        const secret = await createSecretMut.mutateAsync({ body })
+        return secret.id
+      })
+      setDraft(config)
+      setSecretInputs({ ...EMPTY_SECRET_INPUTS })
+      const change = await mut.mutateAsync({ config })
+      applyChange(setDraft, config, change.config)
+      onToast(t("connections.connector.discord.saved"))
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const code = err.envelope.code
+        if (code === "discord_app_id_in_use") {
+          setErrorMsg(t("connections.connector.discord.errors.appIdInUse"))
+          return
+        }
+        if (code === "discord_connector_incomplete") {
+          setErrorMsg(t("connections.connector.discord.errors.incomplete"))
+          return
+        }
+      }
+      setErrorMsg(err instanceof Error ? err.message : t("connections.connector.discord.errors.generic"))
+    }
+  }
+
+  const onReset = () => {
+    setDraft(current ?? EMPTY_CONFIG)
+    setSecretInputs({ ...EMPTY_SECRET_INPUTS })
+    setErrorMsg(null)
+  }
+
+  return (
+    <Card
+      title={t("connections.connector.discord.title")}
+      description={t("connections.connector.discord.description")}
+      docHref={t("connections.connector.discord.docLink.href")}
+      docLabel={t("connections.connector.discord.docLink.label")}
+    >
+      <Field
+        label={t("connections.connector.discord.fields.enabled.label")}
+        hint={t("connections.connector.discord.fields.enabled.hint")}
+      >
+        <label className="inline-flex items-center gap-2 text-sm text-fg">
+          <input
+            type="checkbox"
+            checked={draft.enabled}
+            onChange={(e) => setDraft({ ...draft, enabled: e.target.checked })}
+            disabled={!canEdit || saving}
+            data-testid="discord-enabled-input"
+          />
+          {t("connections.connector.discord.fields.enabled.toggle")}
+        </label>
+      </Field>
+
+      {draft.enabled && (
+        <>
+          <Field
+            label={t("connections.connector.discord.fields.appId.label")}
+            hint={t("connections.connector.discord.fields.appId.hint")}
+            required
+          >
+            <input
+              type="text"
+              value={draft.app_id}
+              placeholder="1234567890"
+              onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
+              disabled={!canEdit || saving}
+              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+              data-testid="discord-app-id-input"
+            />
+          </Field>
+
+          <SecretInput
+            label={t("connections.connector.discord.fields.botToken.label")}
+            hint={t("connections.connector.discord.fields.botToken.hint")}
+            savedHint={t("connections.connector.discord.fields.botToken.savedHint")}
+            savedBadge={t("connections.connector.savedBadge")}
+            value={secretInputs.botToken}
+            onChange={(v) => setSecretInputs((prev) => ({ ...prev, botToken: v }))}
+            required={!draft.bot_token_ref.trim()}
+            hasSavedValue={Boolean(draft.bot_token_ref.trim())}
+            disabled={!canEdit || saving}
+            testId="discord-bot-token-input"
+          />
+
+          <SecretInput
+            label={t("connections.connector.discord.fields.publicKey.label")}
+            hint={t("connections.connector.discord.fields.publicKey.hint")}
+            savedHint={t("connections.connector.discord.fields.publicKey.savedHint")}
+            savedBadge={t("connections.connector.savedBadge")}
+            value={secretInputs.publicKey}
+            onChange={(v) => setSecretInputs((prev) => ({ ...prev, publicKey: v }))}
+            required={!draft.public_key_ref.trim()}
+            hasSavedValue={Boolean(draft.public_key_ref.trim())}
+            disabled={!canEdit || saving}
+            testId="discord-public-key-input"
+          />
+
+          <Field
+            label={t("connections.connector.discord.fields.intents.label")}
+            hint={t("connections.connector.discord.fields.intents.hint")}
+          >
+            <div className="flex flex-wrap gap-2">
+              {DISCORD_INTENT_OPTIONS.map((intent) => {
+                const active = selectedIntents.includes(intent)
+                return (
+                  <button
+                    key={intent}
+                    type="button"
+                    onClick={() => toggleIntent(intent)}
+                    disabled={!canEdit || saving}
+                    className={`min-h-8 rounded-md border px-2.5 py-1 font-mono text-xs transition ${
+                      active
+                        ? "border-line-strong bg-surface-emphasis text-white"
+                        : "border-line bg-surface text-fg-muted hover:bg-surface-subtle"
+                    } disabled:opacity-60`}
+                    aria-pressed={active}
+                  >
+                    {intent}
+                  </button>
+                )
+              })}
+            </div>
+          </Field>
+        </>
+      )}
+
+      {!canEdit && (
+        <p className="mt-3 text-sm text-fg-faint">{t("connections.connector.adminOnly")}</p>
+      )}
+
+      {errorMsg && (
+        <p className="mt-3 text-sm text-danger" role="alert" data-testid="discord-error">
+          {errorMsg}
+        </p>
+      )}
+
+      <div className="mt-4 flex items-center justify-end gap-2">
+        {dirty && (
+          <button
+            type="button"
+            onClick={onReset}
+            disabled={saving}
+            className="inline-flex items-center gap-2 rounded-md border border-line px-3 py-1.5 text-sm text-fg-muted hover:bg-surface-subtle disabled:opacity-60"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            {t("connections.connector.actions.reset")}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!canEdit || saving || !dirty || Boolean(missingRequired)}
+          className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
+          data-testid="discord-save-button"
+        >
+          {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+          {t("connections.connector.actions.save")}
+        </button>
+      </div>
+    </Card>
+  )
+}
+
+function applyChange(
+  setDraft: (c: DiscordConnectorInput) => void,
+  sent: DiscordConnectorInput,
+  config: Record<string, unknown>,
+) {
+  const str = (k: string) => (typeof config[k] === "string" ? (config[k] as string) : "")
+  setDraft({
+    enabled: sent.enabled,
+    app_id: sent.app_id,
+    bot_token_ref: str("bot_token_ref"),
+    public_key_ref: str("public_key_ref"),
+    intents: str("intents"),
+  })
+}
+
+function parseIntents(intents: string): string[] {
+  return intents
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+function secretInputsDirty(inputs: SecretInputs): boolean {
+  return Boolean(inputs.botToken.trim() || inputs.publicKey.trim())
+}
+
+async function buildConfigWithSecretRefs(
+  draft: DiscordConnectorInput,
+  inputs: SecretInputs,
+  createSecret: (body: CreateSecretRequest) => Promise<string>,
+): Promise<DiscordConnectorInput> {
+  const next = trimConfig(draft)
+  if (!next.enabled) return next
+
+  for (const field of Object.keys(DISCORD_SECRET_FIELDS) as DiscordSecretField[]) {
+    const plaintext = inputs[field].trim()
+    if (!plaintext) continue
+    const spec = DISCORD_SECRET_FIELDS[field]
+    next[spec.refKey] = await createSecret(createDiscordSecretBody(spec, plaintext))
+  }
+
+  return next
+}
+
+function trimConfig(config: DiscordConnectorInput): DiscordConnectorInput {
+  return {
+    enabled: config.enabled,
+    app_id: config.app_id.trim(),
+    bot_token_ref: config.bot_token_ref.trim(),
+    public_key_ref: config.public_key_ref.trim(),
+    intents: parseIntents(config.intents).sort().join(","),
+  }
+}
+
+function createDiscordSecretBody(spec: DiscordSecretFieldSpec, plaintext: string): CreateSecretRequest {
+  return {
+    name: spec.namePrefix + "-" + randomHex(6),
+    kind: spec.kind,
+    provider: "discord",
+    auth_type: spec.authType,
+    payload: { [spec.payloadKey]: plaintext },
+  }
+}
+
+function configEqual(a: DiscordConnectorInput, b: DiscordConnectorInput): boolean {
+  return (
+    a.enabled === b.enabled &&
+    a.app_id === b.app_id &&
+    a.bot_token_ref === b.bot_token_ref &&
+    a.public_key_ref === b.public_key_ref &&
+    parseIntents(a.intents).sort().join(",") === parseIntents(b.intents).sort().join(",")
+  )
+}

--- a/apps/web/src/components/admin/channel-connectors/feishuFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/feishuFields.tsx
@@ -1,0 +1,374 @@
+import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Loader2, RefreshCw } from "lucide-react"
+
+import { ApiError } from "../../../lib/api-client"
+import {
+  useUpdateWorkspaceFeishuConnector,
+  type FeishuConnectorInput,
+} from "../../../lib/api-connectors"
+import { useCreateSecret } from "../../../lib/api-secrets"
+import type { CreateSecretRequest } from "../../../lib/api-types"
+import { Card, Field, SecretInput, randomHex } from "./shared"
+
+const EMPTY_CONFIG: FeishuConnectorInput = {
+  enabled: false,
+  app_id: "",
+  app_secret_ref: "",
+  verification_token_ref: "",
+  encrypt_key_ref: "",
+  bot_open_id: "",
+  event_mode: "websocket",
+}
+
+type SecretInputs = {
+  appSecret: string
+  verificationToken: string
+  encryptKey: string
+}
+
+type FeishuSecretField = keyof SecretInputs
+type FeishuSecretRefKey = "app_secret_ref" | "verification_token_ref" | "encrypt_key_ref"
+
+type FeishuSecretFieldSpec = {
+  refKey: FeishuSecretRefKey
+  kind: string
+  authType: string
+  payloadKey: string
+  namePrefix: string
+}
+
+const EMPTY_SECRET_INPUTS: SecretInputs = {
+  appSecret: "",
+  verificationToken: "",
+  encryptKey: "",
+}
+
+const FEISHU_SECRET_FIELDS: Record<FeishuSecretField, FeishuSecretFieldSpec> = {
+  appSecret: {
+    refKey: "app_secret_ref",
+    kind: "feishu_app_secret",
+    authType: "app_secret",
+    payloadKey: "app_secret",
+    namePrefix: "feishu-app-secret",
+  },
+  verificationToken: {
+    refKey: "verification_token_ref",
+    kind: "feishu_verification_token",
+    authType: "verification_token",
+    payloadKey: "verification_token",
+    namePrefix: "feishu-verification-token",
+  },
+  encryptKey: {
+    refKey: "encrypt_key_ref",
+    kind: "feishu_encrypt_key",
+    authType: "encrypt_key",
+    payloadKey: "encrypt_key",
+    namePrefix: "feishu-encrypt-key",
+  },
+}
+
+export interface FeishuConnectorFieldsProps {
+  workspaceID: string | null
+  current: FeishuConnectorInput | undefined
+  canEdit: boolean
+  onToast: (msg: string) => void
+}
+
+export function FeishuConnectorFields({
+  workspaceID,
+  current,
+  canEdit,
+  onToast,
+}: FeishuConnectorFieldsProps) {
+  const { t } = useTranslation("admin")
+  const mut = useUpdateWorkspaceFeishuConnector(workspaceID)
+  const createSecretMut = useCreateSecret(workspaceID)
+
+  const [draft, setDraft] = useState<FeishuConnectorInput>(current ?? EMPTY_CONFIG)
+  const [secretInputs, setSecretInputs] = useState<SecretInputs>({ ...EMPTY_SECRET_INPUTS })
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    setDraft(current ?? EMPTY_CONFIG)
+    setSecretInputs({ ...EMPTY_SECRET_INPUTS })
+    setErrorMsg(null)
+  }, [current])
+
+  const dirty = !configEqual(draft, current ?? EMPTY_CONFIG) || secretInputsDirty(secretInputs)
+  const saving = mut.isPending || createSecretMut.isPending
+
+  const missingRequired = draft.enabled && (
+    !draft.app_id.trim() ||
+    (!draft.app_secret_ref.trim() && !secretInputs.appSecret.trim()) ||
+    (draft.event_mode === "webhook" && !draft.verification_token_ref.trim() && !secretInputs.verificationToken.trim())
+  )
+
+  const onSave = async () => {
+    setErrorMsg(null)
+    try {
+      const config = await buildConfigWithSecretRefs(draft, secretInputs, async (body) => {
+        const secret = await createSecretMut.mutateAsync({ body })
+        return secret.id
+      })
+      setDraft(config)
+      setSecretInputs({ ...EMPTY_SECRET_INPUTS })
+      const change = await mut.mutateAsync({ config })
+      applyChange(setDraft, config, change.config)
+      onToast(t("connections.connector.feishu.saved"))
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const code = err.envelope.code
+        if (code === "feishu_app_id_in_use") {
+          setErrorMsg(t("connections.connector.feishu.errors.appIdInUse"))
+          return
+        }
+        if (code === "feishu_connector_incomplete") {
+          setErrorMsg(t("connections.connector.feishu.errors.incomplete"))
+          return
+        }
+      }
+      setErrorMsg(err instanceof Error ? err.message : t("connections.connector.feishu.errors.generic"))
+    }
+  }
+
+  const onReset = () => {
+    setDraft(current ?? EMPTY_CONFIG)
+    setSecretInputs({ ...EMPTY_SECRET_INPUTS })
+    setErrorMsg(null)
+  }
+
+  return (
+    <Card
+      title={t("connections.connector.feishu.title")}
+      description={t("connections.connector.feishu.description")}
+      docHref={t("connections.connector.feishu.docLink.href")}
+      docLabel={t("connections.connector.feishu.docLink.label")}
+    >
+      <Field
+        label={t("connections.connector.feishu.fields.enabled.label")}
+        hint={t("connections.connector.feishu.fields.enabled.hint")}
+      >
+        <label className="inline-flex items-center gap-2 text-sm text-fg">
+          <input
+            type="checkbox"
+            checked={draft.enabled}
+            onChange={(e) => setDraft({ ...draft, enabled: e.target.checked })}
+            disabled={!canEdit || saving}
+            data-testid="feishu-enabled-input"
+          />
+          {t("connections.connector.feishu.fields.enabled.toggle")}
+        </label>
+      </Field>
+
+      {draft.enabled && (
+        <>
+          <Field
+            label={t("connections.connector.feishu.fields.appId.label")}
+            hint={t("connections.connector.feishu.fields.appId.hint")}
+            required
+          >
+            <input
+              type="text"
+              value={draft.app_id}
+              placeholder="cli_xxxxxxxxxxxxxxxx"
+              onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
+              disabled={!canEdit || saving}
+              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+              data-testid="feishu-app-id-input"
+            />
+          </Field>
+
+          <SecretInput
+            label={t("connections.connector.feishu.fields.appSecret.label")}
+            hint={t("connections.connector.feishu.fields.appSecret.hint")}
+            savedHint={t("connections.connector.feishu.fields.appSecret.savedHint")}
+            savedBadge={t("connections.connector.savedBadge")}
+            value={secretInputs.appSecret}
+            onChange={(v) => setSecretInputs((prev) => ({ ...prev, appSecret: v }))}
+            required={!draft.app_secret_ref.trim()}
+            hasSavedValue={Boolean(draft.app_secret_ref.trim())}
+            disabled={!canEdit || saving}
+            testId="feishu-app-secret-input"
+          />
+
+          <SecretInput
+            label={t("connections.connector.feishu.fields.verificationToken.label")}
+            hint={t("connections.connector.feishu.fields.verificationToken.hint")}
+            savedHint={t("connections.connector.feishu.fields.verificationToken.savedHint")}
+            savedBadge={t("connections.connector.savedBadge")}
+            value={secretInputs.verificationToken}
+            onChange={(v) => setSecretInputs((prev) => ({ ...prev, verificationToken: v }))}
+            required={draft.event_mode === "webhook" && !draft.verification_token_ref.trim()}
+            hasSavedValue={Boolean(draft.verification_token_ref.trim())}
+            disabled={!canEdit || saving}
+            testId="feishu-verification-token-input"
+          />
+
+          <SecretInput
+            label={t("connections.connector.feishu.fields.encryptKey.label")}
+            hint={t("connections.connector.feishu.fields.encryptKey.hint")}
+            savedHint={t("connections.connector.feishu.fields.encryptKey.savedHint")}
+            savedBadge={t("connections.connector.savedBadge")}
+            value={secretInputs.encryptKey}
+            onChange={(v) => setSecretInputs((prev) => ({ ...prev, encryptKey: v }))}
+            required={false}
+            hasSavedValue={Boolean(draft.encrypt_key_ref.trim())}
+            disabled={!canEdit || saving}
+            testId="feishu-encrypt-key-input"
+          />
+
+          <Field
+            label={t("connections.connector.feishu.fields.botOpenId.label")}
+            hint={t("connections.connector.feishu.fields.botOpenId.hint")}
+          >
+            <input
+              type="text"
+              value={draft.bot_open_id}
+              placeholder="ou_xxxxxxxxxxxxxxxx"
+              onChange={(e) => setDraft({ ...draft, bot_open_id: e.target.value })}
+              disabled={!canEdit || saving}
+              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+              data-testid="feishu-bot-open-id-input"
+            />
+          </Field>
+
+          <Field
+            label={t("connections.connector.feishu.fields.eventMode.label")}
+            hint={t("connections.connector.feishu.fields.eventMode.hint")}
+          >
+            <div className="grid grid-cols-2 gap-2">
+              {(["websocket", "webhook"] as const).map((mode) => {
+                const active = draft.event_mode === mode
+                return (
+                  <button
+                    key={mode}
+                    type="button"
+                    onClick={() => setDraft({ ...draft, event_mode: mode })}
+                    disabled={!canEdit || saving}
+                    className={`min-h-9 rounded-md border px-3 py-1.5 text-sm font-medium transition ${
+                      active
+                        ? "border-line-strong bg-surface-emphasis text-white"
+                        : "border-line bg-surface text-fg-muted hover:bg-surface-subtle"
+                    } disabled:opacity-60`}
+                    aria-pressed={active}
+                  >
+                    {t(`connections.connector.feishu.fields.eventMode.options.${mode}`)}
+                  </button>
+                )
+              })}
+            </div>
+          </Field>
+        </>
+      )}
+
+      {!canEdit && (
+        <p className="mt-3 text-sm text-fg-faint">{t("connections.connector.adminOnly")}</p>
+      )}
+
+      {errorMsg && (
+        <p className="mt-3 text-sm text-danger" role="alert" data-testid="feishu-error">
+          {errorMsg}
+        </p>
+      )}
+
+      <div className="mt-4 flex items-center justify-end gap-2">
+        {dirty && (
+          <button
+            type="button"
+            onClick={onReset}
+            disabled={saving}
+            className="inline-flex items-center gap-2 rounded-md border border-line px-3 py-1.5 text-sm text-fg-muted hover:bg-surface-subtle disabled:opacity-60"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            {t("connections.connector.actions.reset")}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!canEdit || saving || !dirty || Boolean(missingRequired)}
+          className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
+          data-testid="feishu-save-button"
+        >
+          {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+          {t("connections.connector.actions.save")}
+        </button>
+      </div>
+    </Card>
+  )
+}
+
+function applyChange(
+  setDraft: (c: FeishuConnectorInput) => void,
+  sent: FeishuConnectorInput,
+  config: Record<string, unknown>,
+) {
+  const str = (k: string) => (typeof config[k] === "string" ? (config[k] as string) : "")
+  const mode = str("event_mode")
+  setDraft({
+    enabled: sent.enabled,
+    app_id: sent.app_id,
+    app_secret_ref: str("app_secret_ref"),
+    verification_token_ref: str("verification_token_ref"),
+    encrypt_key_ref: str("encrypt_key_ref"),
+    bot_open_id: str("bot_open_id"),
+    event_mode: mode === "webhook" ? "webhook" : "websocket",
+  })
+}
+
+function secretInputsDirty(inputs: SecretInputs): boolean {
+  return Boolean(inputs.appSecret.trim() || inputs.verificationToken.trim() || inputs.encryptKey.trim())
+}
+
+async function buildConfigWithSecretRefs(
+  draft: FeishuConnectorInput,
+  inputs: SecretInputs,
+  createSecret: (body: CreateSecretRequest) => Promise<string>,
+): Promise<FeishuConnectorInput> {
+  const next = trimConfig(draft)
+  if (!next.enabled) return next
+
+  for (const field of Object.keys(FEISHU_SECRET_FIELDS) as FeishuSecretField[]) {
+    const plaintext = inputs[field].trim()
+    if (!plaintext) continue
+    const spec = FEISHU_SECRET_FIELDS[field]
+    next[spec.refKey] = await createSecret(createFeishuSecretBody(spec, plaintext))
+  }
+
+  return next
+}
+
+function trimConfig(config: FeishuConnectorInput): FeishuConnectorInput {
+  return {
+    enabled: config.enabled,
+    app_id: config.app_id.trim(),
+    app_secret_ref: config.app_secret_ref.trim(),
+    verification_token_ref: config.verification_token_ref.trim(),
+    encrypt_key_ref: config.encrypt_key_ref.trim(),
+    bot_open_id: config.bot_open_id.trim(),
+    event_mode: config.event_mode === "webhook" ? "webhook" : "websocket",
+  }
+}
+
+function createFeishuSecretBody(spec: FeishuSecretFieldSpec, plaintext: string): CreateSecretRequest {
+  return {
+    name: spec.namePrefix + "-" + randomHex(6),
+    kind: spec.kind,
+    provider: "feishu",
+    auth_type: spec.authType,
+    payload: { [spec.payloadKey]: plaintext },
+  }
+}
+
+function configEqual(a: FeishuConnectorInput, b: FeishuConnectorInput): boolean {
+  return (
+    a.enabled === b.enabled &&
+    a.app_id === b.app_id &&
+    a.app_secret_ref === b.app_secret_ref &&
+    a.verification_token_ref === b.verification_token_ref &&
+    a.encrypt_key_ref === b.encrypt_key_ref &&
+    a.bot_open_id === b.bot_open_id &&
+    a.event_mode === b.event_mode
+  )
+}

--- a/apps/web/src/components/admin/channel-connectors/shared.tsx
+++ b/apps/web/src/components/admin/channel-connectors/shared.tsx
@@ -1,0 +1,171 @@
+/**
+ * Shared UI primitives + tiny helpers for all channel-connector panels
+ * (Feishu / Slack / Discord). Each platform-specific fields module owns its
+ * own SecretFieldSpec + config-equal logic, but the visual shell — Card,
+ * Field, SecretInput, randomHex — lives here so all three panels look the
+ * same and any tweak to spacing/colors applies uniformly.
+ */
+import type { ReactNode } from "react"
+import { CheckCircle2, ExternalLink, Loader2, QrCode, XCircle } from "lucide-react"
+
+export function Card({
+  title,
+  description,
+  docHref,
+  docLabel,
+  className,
+  children,
+}: {
+  title: string
+  description?: string
+  docHref?: string
+  docLabel?: string
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    <section className={`rounded-lg border border-line bg-surface p-4 ${className ?? ""}`}>
+      <header className="mb-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wider text-fg-subtle">{title}</h3>
+        {description && <p className="mt-1 text-sm text-fg-subtle">{description}</p>}
+        {docHref && docLabel && (
+          <a
+            href={docHref}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-info-emphasis hover:underline"
+          >
+            <ExternalLink className="h-3 w-3" />
+            {docLabel}
+          </a>
+        )}
+      </header>
+      {children}
+    </section>
+  )
+}
+
+export function Field({
+  label,
+  hint,
+  required,
+  badge,
+  children,
+}: {
+  label: string
+  hint?: string
+  required?: boolean
+  badge?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <div className="mb-3 last:mb-0">
+      <label className="mb-1 flex items-center gap-2 text-xs uppercase tracking-wider text-fg-faint">
+        <span>
+          {label}
+          {required && <span className="ml-1 text-danger">*</span>}
+        </span>
+        {badge}
+      </label>
+      {children}
+      {hint && <p className="mt-1 text-xs text-fg-subtle">{hint}</p>}
+    </div>
+  )
+}
+
+export function SecretInput({
+  label,
+  hint,
+  savedHint,
+  savedBadge,
+  value,
+  onChange,
+  required,
+  hasSavedValue,
+  disabled,
+  testId,
+}: {
+  label: string
+  hint: string
+  savedHint: string
+  savedBadge?: string
+  value: string
+  onChange: (v: string) => void
+  required: boolean
+  hasSavedValue: boolean
+  disabled: boolean
+  testId: string
+}) {
+  return (
+    <Field
+      label={label}
+      hint={hasSavedValue ? savedHint : hint}
+      required={required}
+      badge={
+        hasSavedValue ? (
+          <span
+            className="inline-flex items-center gap-1 rounded-full bg-success-subtle px-1.5 py-0.5 text-[10px] font-medium normal-case tracking-normal text-success-emphasis"
+            data-testid={`${testId}-saved-badge`}
+          >
+            <CheckCircle2 className="h-3 w-3" />
+            {savedBadge ?? "Saved"}
+          </span>
+        ) : undefined
+      }
+    >
+      <input
+        type="password"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        autoComplete="new-password"
+        placeholder={hasSavedValue ? "••••••••" : undefined}
+        className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+        data-testid={testId}
+      />
+    </Field>
+  )
+}
+
+export function randomHex(bytes: number): string {
+  const values = new Uint8Array(bytes)
+  crypto.getRandomValues(values)
+  return Array.from(values, (value) => value.toString(16).padStart(2, "0")).join("")
+}
+
+/** ProvisionStatusIcon is Feishu-specific (it has the QR device-flow). Slack
+ *  and Discord don't have an equivalent inline provisioning UI yet, but the
+ *  icon helper is generic enough that all three can reuse it once they grow
+ *  one. Keeping it exported from shared so the surface is uniform. */
+export function ProvisionStatusIcon({
+  status,
+  loading,
+  labels,
+}: {
+  status: "pending" | "success" | "error" | "expired"
+  loading: boolean
+  labels: { waiting: string; connected: string; stopped: string }
+}) {
+  if (status === "success") {
+    return (
+      <p className="inline-flex items-center gap-1 text-success">
+        <CheckCircle2 className="h-3.5 w-3.5" />
+        <span>{labels.connected}</span>
+      </p>
+    )
+  }
+  if (status === "error" || status === "expired") {
+    return (
+      <p className="inline-flex items-center gap-1 text-danger">
+        <XCircle className="h-3.5 w-3.5" />
+        <span>{labels.stopped}</span>
+      </p>
+    )
+  }
+  return (
+    <p className="inline-flex items-center gap-1 text-fg-subtle">
+      {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <QrCode className="h-3.5 w-3.5" />}
+      <span>{labels.waiting}</span>
+    </p>
+  )
+}

--- a/apps/web/src/components/admin/channel-connectors/slackFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/slackFields.tsx
@@ -1,0 +1,359 @@
+import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Loader2, RefreshCw } from "lucide-react"
+
+import { ApiError } from "../../../lib/api-client"
+import {
+  useUpdateWorkspaceSlackConnector,
+  type SlackConnectorInput,
+} from "../../../lib/api-connectors"
+import { useCreateSecret } from "../../../lib/api-secrets"
+import type { CreateSecretRequest } from "../../../lib/api-types"
+import { Card, Field, SecretInput, randomHex } from "./shared"
+
+const EMPTY_CONFIG: SlackConnectorInput = {
+  enabled: false,
+  app_id: "",
+  bot_token_ref: "",
+  app_token_ref: "",
+  signing_secret_ref: "",
+  event_mode: "socket",
+}
+
+type SecretInputs = {
+  botToken: string
+  appToken: string
+  signingSecret: string
+}
+
+type SlackSecretField = keyof SecretInputs
+type SlackSecretRefKey = "bot_token_ref" | "app_token_ref" | "signing_secret_ref"
+
+type SlackSecretFieldSpec = {
+  refKey: SlackSecretRefKey
+  kind: string
+  authType: string
+  payloadKey: string
+  namePrefix: string
+}
+
+const EMPTY_SECRET_INPUTS: SecretInputs = {
+  botToken: "",
+  appToken: "",
+  signingSecret: "",
+}
+
+const SLACK_SECRET_FIELDS: Record<SlackSecretField, SlackSecretFieldSpec> = {
+  botToken: {
+    refKey: "bot_token_ref",
+    kind: "slack_bot_token",
+    authType: "bot_token",
+    payloadKey: "bot_token",
+    namePrefix: "slack-bot-token",
+  },
+  appToken: {
+    refKey: "app_token_ref",
+    kind: "slack_app_token",
+    authType: "app_token",
+    payloadKey: "app_token",
+    namePrefix: "slack-app-token",
+  },
+  signingSecret: {
+    refKey: "signing_secret_ref",
+    kind: "slack_signing_secret",
+    authType: "signing_secret",
+    payloadKey: "signing_secret",
+    namePrefix: "slack-signing-secret",
+  },
+}
+
+export interface SlackConnectorFieldsProps {
+  workspaceID: string | null
+  current: SlackConnectorInput | undefined
+  canEdit: boolean
+  onToast: (msg: string) => void
+}
+
+export function SlackConnectorFields({
+  workspaceID,
+  current,
+  canEdit,
+  onToast,
+}: SlackConnectorFieldsProps) {
+  const { t } = useTranslation("admin")
+  const mut = useUpdateWorkspaceSlackConnector(workspaceID)
+  const createSecretMut = useCreateSecret(workspaceID)
+
+  const [draft, setDraft] = useState<SlackConnectorInput>(current ?? EMPTY_CONFIG)
+  const [secretInputs, setSecretInputs] = useState<SecretInputs>({ ...EMPTY_SECRET_INPUTS })
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    setDraft(current ?? EMPTY_CONFIG)
+    setSecretInputs({ ...EMPTY_SECRET_INPUTS })
+    setErrorMsg(null)
+  }, [current])
+
+  const dirty = !configEqual(draft, current ?? EMPTY_CONFIG) || secretInputsDirty(secretInputs)
+  const saving = mut.isPending || createSecretMut.isPending
+
+  const missingRequired = draft.enabled && (
+    !draft.app_id.trim() ||
+    (!draft.bot_token_ref.trim() && !secretInputs.botToken.trim()) ||
+    (draft.event_mode === "socket"
+      ? (!draft.app_token_ref.trim() && !secretInputs.appToken.trim())
+      : (!draft.signing_secret_ref.trim() && !secretInputs.signingSecret.trim()))
+  )
+
+  const onSave = async () => {
+    setErrorMsg(null)
+    try {
+      const config = await buildConfigWithSecretRefs(draft, secretInputs, async (body) => {
+        const secret = await createSecretMut.mutateAsync({ body })
+        return secret.id
+      })
+      setDraft(config)
+      setSecretInputs({ ...EMPTY_SECRET_INPUTS })
+      const change = await mut.mutateAsync({ config })
+      applyChange(setDraft, config, change.config)
+      onToast(t("connections.connector.slack.saved"))
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const code = err.envelope.code
+        if (code === "slack_app_id_in_use") {
+          setErrorMsg(t("connections.connector.slack.errors.appIdInUse"))
+          return
+        }
+        if (code === "slack_connector_incomplete") {
+          setErrorMsg(t("connections.connector.slack.errors.incomplete"))
+          return
+        }
+      }
+      setErrorMsg(err instanceof Error ? err.message : t("connections.connector.slack.errors.generic"))
+    }
+  }
+
+  const onReset = () => {
+    setDraft(current ?? EMPTY_CONFIG)
+    setSecretInputs({ ...EMPTY_SECRET_INPUTS })
+    setErrorMsg(null)
+  }
+
+  return (
+    <Card
+      title={t("connections.connector.slack.title")}
+      description={t("connections.connector.slack.description")}
+      docHref={t("connections.connector.slack.docLink.href")}
+      docLabel={t("connections.connector.slack.docLink.label")}
+    >
+      <Field
+        label={t("connections.connector.slack.fields.enabled.label")}
+        hint={t("connections.connector.slack.fields.enabled.hint")}
+      >
+        <label className="inline-flex items-center gap-2 text-sm text-fg">
+          <input
+            type="checkbox"
+            checked={draft.enabled}
+            onChange={(e) => setDraft({ ...draft, enabled: e.target.checked })}
+            disabled={!canEdit || saving}
+            data-testid="slack-enabled-input"
+          />
+          {t("connections.connector.slack.fields.enabled.toggle")}
+        </label>
+      </Field>
+
+      {draft.enabled && (
+        <>
+          <Field
+            label={t("connections.connector.slack.fields.appId.label")}
+            hint={t("connections.connector.slack.fields.appId.hint")}
+            required
+          >
+            <input
+              type="text"
+              value={draft.app_id}
+              placeholder="A0000000000000"
+              onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
+              disabled={!canEdit || saving}
+              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+              data-testid="slack-app-id-input"
+            />
+          </Field>
+
+          <SecretInput
+            label={t("connections.connector.slack.fields.botToken.label")}
+            hint={t("connections.connector.slack.fields.botToken.hint")}
+            savedHint={t("connections.connector.slack.fields.botToken.savedHint")}
+            savedBadge={t("connections.connector.savedBadge")}
+            value={secretInputs.botToken}
+            onChange={(v) => setSecretInputs((prev) => ({ ...prev, botToken: v }))}
+            required={!draft.bot_token_ref.trim()}
+            hasSavedValue={Boolean(draft.bot_token_ref.trim())}
+            disabled={!canEdit || saving}
+            testId="slack-bot-token-input"
+          />
+
+          {draft.event_mode === "socket" ? (
+            <SecretInput
+              label={t("connections.connector.slack.fields.appToken.label")}
+              hint={t("connections.connector.slack.fields.appToken.hint")}
+              savedHint={t("connections.connector.slack.fields.appToken.savedHint")}
+              savedBadge={t("connections.connector.savedBadge")}
+              value={secretInputs.appToken}
+              onChange={(v) => setSecretInputs((prev) => ({ ...prev, appToken: v }))}
+              required={!draft.app_token_ref.trim()}
+              hasSavedValue={Boolean(draft.app_token_ref.trim())}
+              disabled={!canEdit || saving}
+              testId="slack-app-token-input"
+            />
+          ) : (
+            <SecretInput
+              label={t("connections.connector.slack.fields.signingSecret.label")}
+              hint={t("connections.connector.slack.fields.signingSecret.hint")}
+              savedHint={t("connections.connector.slack.fields.signingSecret.savedHint")}
+              savedBadge={t("connections.connector.savedBadge")}
+              value={secretInputs.signingSecret}
+              onChange={(v) => setSecretInputs((prev) => ({ ...prev, signingSecret: v }))}
+              required={!draft.signing_secret_ref.trim()}
+              hasSavedValue={Boolean(draft.signing_secret_ref.trim())}
+              disabled={!canEdit || saving}
+              testId="slack-signing-secret-input"
+            />
+          )}
+
+          <Field
+            label={t("connections.connector.slack.fields.eventMode.label")}
+            hint={t("connections.connector.slack.fields.eventMode.hint")}
+          >
+            <div className="grid grid-cols-2 gap-2">
+              {(["socket", "events"] as const).map((mode) => {
+                const active = draft.event_mode === mode
+                return (
+                  <button
+                    key={mode}
+                    type="button"
+                    onClick={() => setDraft({ ...draft, event_mode: mode })}
+                    disabled={!canEdit || saving}
+                    className={`min-h-9 rounded-md border px-3 py-1.5 text-sm font-medium transition ${
+                      active
+                        ? "border-line-strong bg-surface-emphasis text-white"
+                        : "border-line bg-surface text-fg-muted hover:bg-surface-subtle"
+                    } disabled:opacity-60`}
+                    aria-pressed={active}
+                  >
+                    {t(`connections.connector.slack.fields.eventMode.options.${mode}`)}
+                  </button>
+                )
+              })}
+            </div>
+          </Field>
+        </>
+      )}
+
+      {!canEdit && (
+        <p className="mt-3 text-sm text-fg-faint">{t("connections.connector.adminOnly")}</p>
+      )}
+
+      {errorMsg && (
+        <p className="mt-3 text-sm text-danger" role="alert" data-testid="slack-error">
+          {errorMsg}
+        </p>
+      )}
+
+      <div className="mt-4 flex items-center justify-end gap-2">
+        {dirty && (
+          <button
+            type="button"
+            onClick={onReset}
+            disabled={saving}
+            className="inline-flex items-center gap-2 rounded-md border border-line px-3 py-1.5 text-sm text-fg-muted hover:bg-surface-subtle disabled:opacity-60"
+          >
+            <RefreshCw className="h-3.5 w-3.5" />
+            {t("connections.connector.actions.reset")}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!canEdit || saving || !dirty || Boolean(missingRequired)}
+          className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
+          data-testid="slack-save-button"
+        >
+          {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+          {t("connections.connector.actions.save")}
+        </button>
+      </div>
+    </Card>
+  )
+}
+
+function applyChange(
+  setDraft: (c: SlackConnectorInput) => void,
+  sent: SlackConnectorInput,
+  config: Record<string, unknown>,
+) {
+  const str = (k: string) => (typeof config[k] === "string" ? (config[k] as string) : "")
+  const mode = str("event_mode")
+  setDraft({
+    enabled: sent.enabled,
+    app_id: sent.app_id,
+    bot_token_ref: str("bot_token_ref"),
+    app_token_ref: str("app_token_ref"),
+    signing_secret_ref: str("signing_secret_ref"),
+    event_mode: mode === "events" ? "events" : "socket",
+  })
+}
+
+function secretInputsDirty(inputs: SecretInputs): boolean {
+  return Boolean(inputs.botToken.trim() || inputs.appToken.trim() || inputs.signingSecret.trim())
+}
+
+async function buildConfigWithSecretRefs(
+  draft: SlackConnectorInput,
+  inputs: SecretInputs,
+  createSecret: (body: CreateSecretRequest) => Promise<string>,
+): Promise<SlackConnectorInput> {
+  const next = trimConfig(draft)
+  if (!next.enabled) return next
+
+  for (const field of Object.keys(SLACK_SECRET_FIELDS) as SlackSecretField[]) {
+    const plaintext = inputs[field].trim()
+    if (!plaintext) continue
+    const spec = SLACK_SECRET_FIELDS[field]
+    next[spec.refKey] = await createSecret(createSlackSecretBody(spec, plaintext))
+  }
+
+  return next
+}
+
+function trimConfig(config: SlackConnectorInput): SlackConnectorInput {
+  return {
+    enabled: config.enabled,
+    app_id: config.app_id.trim(),
+    bot_token_ref: config.bot_token_ref.trim(),
+    app_token_ref: config.app_token_ref.trim(),
+    signing_secret_ref: config.signing_secret_ref.trim(),
+    event_mode: config.event_mode === "events" ? "events" : "socket",
+  }
+}
+
+function createSlackSecretBody(spec: SlackSecretFieldSpec, plaintext: string): CreateSecretRequest {
+  return {
+    name: spec.namePrefix + "-" + randomHex(6),
+    kind: spec.kind,
+    provider: "slack",
+    auth_type: spec.authType,
+    payload: { [spec.payloadKey]: plaintext },
+  }
+}
+
+function configEqual(a: SlackConnectorInput, b: SlackConnectorInput): boolean {
+  return (
+    a.enabled === b.enabled &&
+    a.app_id === b.app_id &&
+    a.bot_token_ref === b.bot_token_ref &&
+    a.app_token_ref === b.app_token_ref &&
+    a.signing_secret_ref === b.signing_secret_ref &&
+    a.event_mode === b.event_mode
+  )
+}

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -2597,6 +2597,161 @@
       "submit": "Create",
       "cancel": "Cancel",
       "errorGeneric": "Failed to create, please try again later"
+    },
+    "connector": {
+      "adminOnly": "Only workspace owners and admins can edit connector settings.",
+      "savedBadge": "Saved",
+      "actions": {
+        "save": "Save",
+        "reset": "Reset"
+      },
+      "platformSelect": {
+        "label": "Platform",
+        "options": {
+          "feishu": "Feishu",
+          "slack": "Slack",
+          "discord": "Discord"
+        }
+      },
+      "feishu": {
+        "title": "Feishu connector",
+        "description": "Bind one Feishu bot for this workspace. All agents reachable from this workspace share this bot.",
+        "saved": "Feishu connector saved.",
+        "docLink": {
+          "label": "Open the Feishu Open Platform to create / manage your bot",
+          "href": "https://open.feishu.cn/app"
+        },
+        "fields": {
+          "enabled": {
+            "label": "Enabled",
+            "hint": "Turn on to route Feishu messages through this bot.",
+            "toggle": "Enable Feishu bot"
+          },
+          "appId": {
+            "label": "App ID",
+            "hint": "Credentials & Basic Info page → App ID (starts with cli_)."
+          },
+          "appSecret": {
+            "label": "App secret",
+            "hint": "Credentials & Basic Info page → App Secret. Stored encrypted.",
+            "savedHint": "A saved app secret is in place (Credentials & Basic Info → App Secret). Enter a new value to replace it."
+          },
+          "verificationToken": {
+            "label": "Verification token",
+            "hint": "Event Subscriptions page → Verification Token. Required for webhook mode. Stored encrypted.",
+            "savedHint": "A saved verification token is in place (Event Subscriptions → Verification Token). Enter a new value to replace it."
+          },
+          "encryptKey": {
+            "label": "Encrypt key",
+            "hint": "Event Subscriptions page → Encrypt Key. Optional; decrypts event payloads. Stored encrypted.",
+            "savedHint": "A saved encrypt key is in place (Event Subscriptions → Encrypt Key). Enter a new value to replace it."
+          },
+          "botOpenId": {
+            "label": "Bot open ID",
+            "hint": "Optional. The bot's open_id (ou_…), from the Bot menu or contact API; used to skip self-sent messages."
+          },
+          "eventMode": {
+            "label": "Event mode",
+            "hint": "WebSocket opens a long-lived connection (works on localhost); webhook receives HTTP callbacks.",
+            "options": {
+              "websocket": "WebSocket",
+              "webhook": "Webhook"
+            }
+          }
+        },
+        "errors": {
+          "appIdInUse": "This Feishu app ID is already bound to another workspace.",
+          "incomplete": "The Feishu connector is incomplete. Fill in all required fields.",
+          "generic": "Failed to save the Feishu connector. Please try again."
+        }
+      },
+      "slack": {
+        "title": "Slack connector",
+        "description": "Bind one Slack bot for this workspace. All agents reachable from this workspace share this bot.",
+        "saved": "Slack connector saved.",
+        "docLink": {
+          "label": "Create a Slack app at api.slack.com/apps",
+          "href": "https://api.slack.com/apps"
+        },
+        "fields": {
+          "enabled": {
+            "label": "Enabled",
+            "hint": "Turn on to route Slack messages through this bot.",
+            "toggle": "Enable Slack bot"
+          },
+          "appId": {
+            "label": "App ID",
+            "hint": "Basic Information page → App Credentials → App ID (starts with A)."
+          },
+          "botToken": {
+            "label": "Bot token",
+            "hint": "OAuth & Permissions tab → Bot User OAuth Token (xoxb-…). Install the app to your workspace first. Stored encrypted.",
+            "savedHint": "A saved bot token is in place (OAuth & Permissions → Bot User OAuth Token). Enter a new xoxb token to replace it."
+          },
+          "appToken": {
+            "label": "App-level token",
+            "hint": "Basic Information → App-Level Tokens → Generate Token with the connections:write scope (xapp-…). Required for socket mode. Stored encrypted.",
+            "savedHint": "A saved app-level token is in place (Basic Information → App-Level Tokens). Enter a new xapp token to replace it."
+          },
+          "signingSecret": {
+            "label": "Signing secret",
+            "hint": "Basic Information → App Credentials → Signing Secret. Required for events mode. Stored encrypted.",
+            "savedHint": "A saved signing secret is in place (Basic Information → App Credentials → Signing Secret). Enter a new value to replace it."
+          },
+          "eventMode": {
+            "label": "Event mode",
+            "hint": "Socket opens a long-lived connection (works on localhost, needs an xapp token); events receives HTTP callbacks (needs a signing secret).",
+            "options": {
+              "socket": "Socket mode",
+              "events": "Events API"
+            }
+          }
+        },
+        "errors": {
+          "appIdInUse": "This Slack app ID is already bound to another workspace.",
+          "incomplete": "The Slack connector is incomplete. Fill in all required fields.",
+          "generic": "Failed to save the Slack connector. Please try again."
+        }
+      },
+      "discord": {
+        "title": "Discord connector",
+        "description": "Bind one Discord bot for this workspace. All agents reachable from this workspace share this bot.",
+        "saved": "Discord connector saved.",
+        "docLink": {
+          "label": "Create a Discord app in the Developer Portal",
+          "href": "https://discord.com/developers/applications"
+        },
+        "fields": {
+          "enabled": {
+            "label": "Enabled",
+            "hint": "Turn on to route Discord messages through this bot.",
+            "toggle": "Enable Discord bot"
+          },
+          "appId": {
+            "label": "Application ID",
+            "hint": "General Information page → Application ID."
+          },
+          "botToken": {
+            "label": "Bot token",
+            "hint": "Bot tab → Reset Token to reveal the bot token. Stored encrypted.",
+            "savedHint": "A saved bot token is in place (Bot tab → Token). Enter a new value to replace it."
+          },
+          "publicKey": {
+            "label": "Public key",
+            "hint": "General Information page → Public Key. Verifies interaction signatures. Stored encrypted.",
+            "savedHint": "A saved public key is in place (General Information → Public Key). Enter a new value to replace it."
+          },
+          "intents": {
+            "label": "Gateway intents",
+            "hint": "Enable matching intents under Bot → Privileged Gateway Intents (e.g. MESSAGE CONTENT) or message bodies arrive empty."
+          }
+        },
+        "errors": {
+          "appIdInUse": "This Discord application ID is already bound to another workspace.",
+          "incomplete": "The Discord connector is incomplete. Fill in all required fields.",
+          "generic": "Failed to save the Discord connector. Please try again."
+        }
+      }
     }
   },
   "specs": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -2597,6 +2597,161 @@
       "submit": "创建",
       "cancel": "取消",
       "errorGeneric": "创建失败,请稍后再试"
+    },
+    "connector": {
+      "adminOnly": "仅工作区所有者和管理员可以编辑连接器设置。",
+      "savedBadge": "已保存",
+      "actions": {
+        "save": "保存",
+        "reset": "重置"
+      },
+      "platformSelect": {
+        "label": "平台",
+        "options": {
+          "feishu": "飞书",
+          "slack": "Slack",
+          "discord": "Discord"
+        }
+      },
+      "feishu": {
+        "title": "飞书连接器",
+        "description": "为本工作区绑定一个飞书机器人。从本工作区可达的所有 Agent 共用此机器人。",
+        "saved": "飞书连接器已保存。",
+        "docLink": {
+          "label": "前往飞书开放平台创建 / 管理机器人",
+          "href": "https://open.feishu.cn/app"
+        },
+        "fields": {
+          "enabled": {
+            "label": "启用",
+            "hint": "开启后,飞书消息将通过此机器人路由。",
+            "toggle": "启用飞书机器人"
+          },
+          "appId": {
+            "label": "App ID",
+            "hint": "「凭证与基础信息」页 → App ID(以 cli_ 开头)。"
+          },
+          "appSecret": {
+            "label": "App Secret",
+            "hint": "「凭证与基础信息」页 → App Secret。加密存储。",
+            "savedHint": "已保存 App Secret(凭证与基础信息 → App Secret)。如需更换请输入新值。"
+          },
+          "verificationToken": {
+            "label": "Verification Token",
+            "hint": "「事件订阅」页 → Verification Token。webhook 模式必填。加密存储。",
+            "savedHint": "已保存 Verification Token(事件订阅 → Verification Token)。如需更换请输入新值。"
+          },
+          "encryptKey": {
+            "label": "Encrypt Key",
+            "hint": "「事件订阅」页 → Encrypt Key。可选,用于解密事件回调。加密存储。",
+            "savedHint": "已保存 Encrypt Key(事件订阅 → Encrypt Key)。如需更换请输入新值。"
+          },
+          "botOpenId": {
+            "label": "Bot open ID",
+            "hint": "可选。机器人的 open_id(以 ou_ 开头),可在机器人菜单或通讯录 API 获取,用于跳过机器人自己发的消息。"
+          },
+          "eventMode": {
+            "label": "事件模式",
+            "hint": "WebSocket 建立长连接(本地可用);webhook 通过 HTTP 回调接收。",
+            "options": {
+              "websocket": "WebSocket",
+              "webhook": "Webhook"
+            }
+          }
+        },
+        "errors": {
+          "appIdInUse": "该飞书 App ID 已绑定到另一个工作区。",
+          "incomplete": "飞书连接器信息不完整,请填写所有必填项。",
+          "generic": "保存飞书连接器失败,请重试。"
+        }
+      },
+      "slack": {
+        "title": "Slack 连接器",
+        "description": "为本工作区绑定一个 Slack 机器人。从本工作区可达的所有 Agent 共用此机器人。",
+        "saved": "Slack 连接器已保存。",
+        "docLink": {
+          "label": "前往 api.slack.com/apps 创建 Slack 应用",
+          "href": "https://api.slack.com/apps"
+        },
+        "fields": {
+          "enabled": {
+            "label": "启用",
+            "hint": "开启后,Slack 消息将通过此机器人路由。",
+            "toggle": "启用 Slack 机器人"
+          },
+          "appId": {
+            "label": "App ID",
+            "hint": "「Basic Information」页 → App Credentials → App ID(以 A 开头)。"
+          },
+          "botToken": {
+            "label": "Bot Token",
+            "hint": "「OAuth & Permissions」标签页 → Bot User OAuth Token(以 xoxb- 开头)。需先 Install to Workspace。加密存储。",
+            "savedHint": "已保存 Bot Token(OAuth & Permissions → Bot User OAuth Token)。如需更换请输入新的 xoxb 令牌。"
+          },
+          "appToken": {
+            "label": "App-Level Token",
+            "hint": "「Basic Information」→ App-Level Tokens → Generate Token,勾选 connections:write 权限(以 xapp- 开头)。socket 模式必填。加密存储。",
+            "savedHint": "已保存 App-Level Token(Basic Information → App-Level Tokens)。如需更换请输入新的 xapp 令牌。"
+          },
+          "signingSecret": {
+            "label": "Signing Secret",
+            "hint": "「Basic Information」→ App Credentials → Signing Secret。events 模式必填。加密存储。",
+            "savedHint": "已保存 Signing Secret(Basic Information → App Credentials → Signing Secret)。如需更换请输入新值。"
+          },
+          "eventMode": {
+            "label": "事件模式",
+            "hint": "Socket 建立长连接(本地可用,需 xapp 令牌);events 通过 HTTP 回调接收(需 Signing Secret)。",
+            "options": {
+              "socket": "Socket 模式",
+              "events": "Events API"
+            }
+          }
+        },
+        "errors": {
+          "appIdInUse": "该 Slack App ID 已绑定到另一个工作区。",
+          "incomplete": "Slack 连接器信息不完整,请填写所有必填项。",
+          "generic": "保存 Slack 连接器失败,请重试。"
+        }
+      },
+      "discord": {
+        "title": "Discord 连接器",
+        "description": "为本工作区绑定一个 Discord 机器人。从本工作区可达的所有 Agent 共用此机器人。",
+        "saved": "Discord 连接器已保存。",
+        "docLink": {
+          "label": "前往 Discord 开发者门户创建应用",
+          "href": "https://discord.com/developers/applications"
+        },
+        "fields": {
+          "enabled": {
+            "label": "启用",
+            "hint": "开启后,Discord 消息将通过此机器人路由。",
+            "toggle": "启用 Discord 机器人"
+          },
+          "appId": {
+            "label": "Application ID",
+            "hint": "「General Information」页 → Application ID。"
+          },
+          "botToken": {
+            "label": "Bot Token",
+            "hint": "「Bot」标签页 → Reset Token 获取机器人令牌。加密存储。",
+            "savedHint": "已保存 Bot Token(Bot 标签页 → Token)。如需更换请输入新值。"
+          },
+          "publicKey": {
+            "label": "Public Key",
+            "hint": "「General Information」页 → Public Key,用于校验交互签名。加密存储。",
+            "savedHint": "已保存 Public Key(General Information → Public Key)。如需更换请输入新值。"
+          },
+          "intents": {
+            "label": "Gateway Intents",
+            "hint": "在「Bot」→ Privileged Gateway Intents 打开对应意图(如 MESSAGE CONTENT),否则消息正文会为空。"
+          }
+        },
+        "errors": {
+          "appIdInUse": "该 Discord Application ID 已绑定到另一个工作区。",
+          "incomplete": "Discord 连接器信息不完整,请填写所有必填项。",
+          "generic": "保存 Discord 连接器失败,请重试。"
+        }
+      }
     }
   },
   "specs": {

--- a/apps/web/src/lib/api-connectors.ts
+++ b/apps/web/src/lib/api-connectors.ts
@@ -1,0 +1,218 @@
+/**
+ * Workspace-dimension IM connector hooks.
+ *
+ * A bot binds at the WORKSPACE dimension (one bot per platform per workspace),
+ * not per-agent: all agents reachable from one workspace `/list` share the bot
+ * credential. These hooks back the Connections-tab ChannelConnectorPanel.
+ *
+ * Reads `GET /workspaces/{id}/connectors` (all platforms, decoded config jsonb)
+ * and writes per-platform via `PATCH /workspaces/{id}/connector/{platform}`.
+ * Secret plaintext never travels through these types — only the `*_ref` UUIDs
+ * minted by `useCreateSecret`.
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { apiRequest, noUnreachableRetry } from "./api-client"
+
+/* --- Query keys --------------------------------------------------------- */
+
+const KEY_CONNECTORS = (workspaceID: string) =>
+  ["admin", "workspaceConnectors", workspaceID] as const
+
+/* --- Wire types --------------------------------------------------------- */
+
+export type ConnectorPlatform = "feishu" | "slack" | "discord"
+
+/** One decoded row from workspace_im_connectors. `config` holds the *_ref
+ *  UUIDs + non-secret fields; column fields (app_id/enabled) are hoisted. */
+export interface WorkspaceConnector {
+  id: string
+  workspace_id: string
+  workspace_name: string
+  platform: string
+  app_id: string
+  enabled: boolean
+  config: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+interface ListWorkspaceConnectorsResponse {
+  connectors: WorkspaceConnector[]
+}
+
+export interface WorkspaceConnectorChange {
+  id: string
+  workspace_id: string
+  platform: string
+  app_id: string
+  enabled: boolean
+  config: Record<string, unknown>
+  updated_at: string
+  noop?: boolean
+}
+
+interface UpdateWorkspaceConnectorResponse {
+  connector: WorkspaceConnectorChange
+}
+
+/** Slack connector PATCH body — mirrors updateWorkspaceSlackConnectorBody. */
+export interface SlackConnectorInput {
+  enabled: boolean
+  app_id: string
+  bot_token_ref: string
+  app_token_ref: string
+  signing_secret_ref: string
+  event_mode: "socket" | "events"
+}
+
+/** Discord connector PATCH body — mirrors updateWorkspaceDiscordConnectorBody. */
+export interface DiscordConnectorInput {
+  enabled: boolean
+  app_id: string
+  bot_token_ref: string
+  public_key_ref: string
+  intents: string
+}
+
+/** Feishu connector PATCH body — mirrors updateWorkspaceFeishuConnectorBody. */
+export interface FeishuConnectorInput {
+  enabled: boolean
+  app_id: string
+  app_secret_ref: string
+  verification_token_ref: string
+  encrypt_key_ref: string
+  bot_open_id: string
+  event_mode: "websocket" | "webhook"
+}
+
+/* --- Network ------------------------------------------------------------ */
+
+async function listWorkspaceConnectorsRequest(
+  workspaceID: string | null,
+): Promise<ListWorkspaceConnectorsResponse> {
+  if (!workspaceID) return { connectors: [] }
+  return apiRequest<ListWorkspaceConnectorsResponse>(
+    `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/connectors`,
+    { method: "GET" },
+  )
+}
+
+async function updateConnectorRequest<T>(
+  workspaceID: string,
+  platform: ConnectorPlatform,
+  body: T,
+): Promise<WorkspaceConnectorChange> {
+  const res = await apiRequest<UpdateWorkspaceConnectorResponse>(
+    `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/connector/${platform}`,
+    { method: "PATCH", body },
+  )
+  return res.connector
+}
+
+/* --- Hooks -------------------------------------------------------------- */
+
+export function useWorkspaceIMConnectors(workspaceID: string | null) {
+  return useQuery({
+    queryKey: KEY_CONNECTORS(workspaceID ?? "_none"),
+    queryFn: () => listWorkspaceConnectorsRequest(workspaceID),
+    retry: noUnreachableRetry,
+    staleTime: 15_000,
+  })
+}
+
+function useUpdateConnector<T>(
+  workspaceID: string | null,
+  platform: ConnectorPlatform,
+) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: { config: T }) => {
+      if (!workspaceID) {
+        throw new Error("no workspace selected")
+      }
+      return updateConnectorRequest<T>(workspaceID, platform, input.config)
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({
+        queryKey: KEY_CONNECTORS(workspaceID ?? "_none"),
+      })
+    },
+  })
+}
+
+export function useUpdateWorkspaceSlackConnector(workspaceID: string | null) {
+  return useUpdateConnector<SlackConnectorInput>(workspaceID, "slack")
+}
+
+export function useUpdateWorkspaceDiscordConnector(workspaceID: string | null) {
+  return useUpdateConnector<DiscordConnectorInput>(workspaceID, "discord")
+}
+
+export function useUpdateWorkspaceFeishuConnector(workspaceID: string | null) {
+  return useUpdateConnector<FeishuConnectorInput>(workspaceID, "feishu")
+}
+
+/* --- Config extractors -------------------------------------------------- */
+//
+// Pull a single platform's persisted config out of the connectors list. Each
+// returns undefined when that platform was never configured for the workspace,
+// so a field module can fall back to its EMPTY_CONFIG.
+
+function pickConnector(
+  connectors: WorkspaceConnector[] | undefined,
+  platform: ConnectorPlatform,
+): WorkspaceConnector | undefined {
+  return connectors?.find((c) => c.platform === platform)
+}
+
+function configString(config: Record<string, unknown>, key: string): string {
+  const v = config[key]
+  return typeof v === "string" ? v : ""
+}
+
+export function readSlackConnector(
+  connectors: WorkspaceConnector[] | undefined,
+): SlackConnectorInput | undefined {
+  const conn = pickConnector(connectors, "slack")
+  if (!conn) return undefined
+  const mode = configString(conn.config, "event_mode")
+  return {
+    enabled: conn.enabled,
+    app_id: conn.app_id,
+    bot_token_ref: configString(conn.config, "bot_token_ref"),
+    app_token_ref: configString(conn.config, "app_token_ref"),
+    signing_secret_ref: configString(conn.config, "signing_secret_ref"),
+    event_mode: mode === "events" ? "events" : "socket",
+  }
+}
+
+export function readDiscordConnector(
+  connectors: WorkspaceConnector[] | undefined,
+): DiscordConnectorInput | undefined {
+  const conn = pickConnector(connectors, "discord")
+  if (!conn) return undefined
+  return {
+    enabled: conn.enabled,
+    app_id: conn.app_id,
+    bot_token_ref: configString(conn.config, "bot_token_ref"),
+    public_key_ref: configString(conn.config, "public_key_ref"),
+    intents: configString(conn.config, "intents"),
+  }
+}
+
+export function readFeishuConnector(
+  connectors: WorkspaceConnector[] | undefined,
+): FeishuConnectorInput | undefined {
+  const conn = pickConnector(connectors, "feishu")
+  if (!conn) return undefined
+  const mode = configString(conn.config, "event_mode")
+  return {
+    enabled: conn.enabled,
+    app_id: conn.app_id,
+    app_secret_ref: configString(conn.config, "app_secret_ref"),
+    verification_token_ref: configString(conn.config, "verification_token_ref"),
+    encrypt_key_ref: configString(conn.config, "encrypt_key_ref"),
+    bot_open_id: configString(conn.config, "bot_open_id"),
+    event_mode: mode === "webhook" ? "webhook" : "websocket",
+  }
+}

--- a/apps/web/src/pages/admin/ConnectionsPage.tsx
+++ b/apps/web/src/pages/admin/ConnectionsPage.tsx
@@ -1,13 +1,23 @@
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { AdminLayout } from "../../components/layout/AdminLayout"
 import { PageHeader } from "../../components/layout/PageHeader"
 import { ScopeRequiredState } from "../../components/admin/ScopeRequiredState"
+import { ChannelConnectorPanel } from "../../components/admin/channel-connectors/ChannelConnectorPanel"
+import { useMyWorkspaces } from "../../lib/api-workspaces"
 import { useWorkspaceId } from "../../lib/workspace"
 
 export function ConnectionsPage() {
   const { t } = useTranslation("admin")
   const wsId = useWorkspaceId()
+  const { data: myWorkspaces } = useMyWorkspaces()
+  const [toast, setToast] = useState<string | null>(null)
+
+  const canEdit = useMemo(() => {
+    const role = myWorkspaces?.workspaces.find((w) => w.id === wsId)?.role
+    return role === "owner" || role === "admin"
+  }, [myWorkspaces, wsId])
 
   return (
     <AdminLayout activeMenu="connections">
@@ -15,7 +25,16 @@ export function ConnectionsPage() {
 
       {!wsId ? (
         <ScopeRequiredState scope="workspace" resourceName={t("connections.page.title")} />
-      ) : null}
+      ) : (
+        <>
+          {toast && (
+            <div className="mb-4 rounded-md border border-success-border bg-success-subtle px-3 py-2 text-sm text-success-emphasis">
+              {toast}
+            </div>
+          )}
+          <ChannelConnectorPanel workspaceID={wsId} canEdit={canEdit} onToast={setToast} />
+        </>
+      )}
     </AdminLayout>
   )
 }

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -113,6 +113,13 @@ services:
       PARSAR_MASTER_KEY: "parsar-dev-master-key-2026"
       PARSAR_FEISHU_WEBSOCKET: "true"
       PARSAR_FEISHU_OUTBOUND: "true"
+      # Workspace-dimension IM connector reconcilers (workspace_im_connectors
+      # table → one Socket Mode / Gateway runner per workspace|app_id, hot-
+      # reloading on token rotation). Opt-in gates read in main.go
+      # (buildSlackInboundManager / buildDiscordInboundManager); both reuse
+      # PARSAR_MASTER_KEY above to decrypt the vaulted bot tokens.
+      PARSAR_SLACK_CONNECTORS: "true"
+      PARSAR_DISCORD_CONNECTORS: "true"
       # Shared default Bot credentials. Values come from a gitignored .env
       # file next to this compose (NEVER hardcode the App Secret here — this
       # file is repo-tracked). The websocket manager reads these to open the

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -17,8 +17,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
 	agentdaemonbinding "github.com/MiniMax-AI-Dev/parsar/server/internal/agentdaemon/binding"
 	agentdaemongateway "github.com/MiniMax-AI-Dev/parsar/server/internal/agentdaemon/gateway"
@@ -53,6 +51,8 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/specmemory"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/storage/oss"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 const feishuStartupFatalMessage = "PARSAR_FEISHU_APP_ID/APP_SECRET/REDIRECT_URI and PARSAR_FEISHU_VERIFICATION_TOKEN required when not in mock mode; export PARSAR_FEISHU_MOCK=true for local dev"
@@ -773,6 +773,39 @@ func main() {
 		}
 	}
 
+	// Slack workspace-dimension reconciler. Opt-in via PARSAR_SLACK_CONNECTORS=
+	// true. Reads workspace_im_connectors and keeps one Socket Mode runner per
+	// workspace|app_id, hot-reloading on token rotation — the DB-driven twin of
+	// the env-gated buildSlackRunner above.
+	if dbStore != nil {
+		if mgr, err := buildSlackInboundManager(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL); err != nil {
+			log.Bg().Error("slack connectors reconciler init failed", "error", err)
+			os.Exit(1)
+		} else if mgr != nil {
+			go func() {
+				if err := mgr.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+					log.Bg().Error("slack connectors reconciler exited", "error", err)
+				}
+			}()
+		}
+	}
+
+	// Discord workspace-dimension reconciler. Opt-in via PARSAR_DISCORD_CONNECTORS=
+	// true. Reads workspace_im_connectors and keeps one Gateway WebSocket runner
+	// per workspace|app_id — the DB-driven twin of buildDiscordRunner.
+	if dbStore != nil {
+		if mgr, err := buildDiscordInboundManager(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL); err != nil {
+			log.Bg().Error("discord connectors reconciler init failed", "error", err)
+			os.Exit(1)
+		} else if mgr != nil {
+			go func() {
+				if err := mgr.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+					log.Bg().Error("discord connectors reconciler exited", "error", err)
+				}
+			}()
+		}
+	}
+
 	// Feishu outbound poll worker. Opt-in via PARSAR_FEISHU_OUTBOUND=true.
 	// Poll interval default 10s; override via
 	// PARSAR_FEISHU_OUTBOUND_POLL_SECONDS for load-shedding.
@@ -1402,6 +1435,7 @@ func buildFeishuWebSocketManager(env func(string) string, dbStore *store.Store, 
 		PermissionRouter:          inboundPermissionRouter{registry: connectorReg},
 		PromptForUserChoiceRouter: inboundPromptForUserChoiceRouter{registry: connectorReg},
 		JoinURLBuilder:            feishuJoinURLBuilder,
+		Connectors:                dbStore,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("feishu websocket inbound: init manager: %w", err)
@@ -1609,6 +1643,154 @@ func buildDiscordRunner(env func(string) string, dbStore *store.Store, connector
 	return runner, nil
 }
 
+// buildSlackInboundManager constructs the workspace-dimension Slack Socket Mode
+// reconciler: it scans workspace_im_connectors for enabled slack rows and keeps
+// one Socket Mode runner per workspace|app_id, hot-reloading on token rotation.
+// This is the DB-driven multi-tenant twin of buildSlackRunner's single env bot.
+// Opt-in via PARSAR_SLACK_CONNECTORS=true; requires PARSAR_MASTER_KEY (vault
+// seal) since each bot's tokens are decrypted from the secret vault.
+//
+// The card-action router and the app_id credential resolver are built once and
+// shared across every per-bot adapter the NewAdapter factory mints — both
+// resolve by store lookup (card payload / app_id), not by a captured token, so a
+// single instance serves all workspace bots.
+func buildSlackInboundManager(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string) (*slackrunner.Manager, error) {
+	if !truthy(env("PARSAR_SLACK_CONNECTORS")) {
+		return nil, nil
+	}
+	masterKey := strings.TrimSpace(env("PARSAR_MASTER_KEY"))
+	if masterKey == "" {
+		return nil, errors.New("PARSAR_SLACK_CONNECTORS=true requires PARSAR_MASTER_KEY (same value the secret vault was sealed with)")
+	}
+	secretsSvc, err := secrets.New(masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("slack connectors: init secrets service: %w", err)
+	}
+
+	var slackJoinURLBuilder func(string) string
+	if strings.TrimSpace(publicURL) != "" {
+		root := strings.TrimRight(strings.TrimSpace(publicURL), "/")
+		slackJoinURLBuilder = func(workspaceID string) string {
+			return root + "/join-workspace?id=" + workspaceID + "&from=slack"
+		}
+	}
+
+	actionMgr, err := inbound.NewManager(inbound.Options{
+		Store:                     dbStore,
+		Secrets:                   secretsSvc,
+		Logger:                    slogFeishuInboundLogger{},
+		JoinURLBuilder:            slackJoinURLBuilder,
+		PermissionRouter:          inboundPermissionRouter{registry: connectorReg},
+		PromptForUserChoiceRouter: inboundPromptForUserChoiceRouter{registry: connectorReg},
+		Connectors:                dbStore,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("slack connectors: init action manager: %w", err)
+	}
+	sharedOpts := []slackchannel.Option{slackchannel.WithActionRouter(actionMgr.CardActionRouter())}
+	resolver, err := buildSlackCredentialResolver(env, dbStore)
+	if err != nil {
+		return nil, fmt.Errorf("slack connectors: build credential resolver: %w", err)
+	}
+	if resolver != nil {
+		sharedOpts = append(sharedOpts, slackchannel.WithCredentialResolver(resolver))
+	}
+
+	newAdapter := func(appID, botToken, appToken string) *slackchannel.Channel {
+		return slackchannel.New(slackchannel.Config{
+			AppID:    appID,
+			BotToken: botToken,
+			AppToken: appToken,
+		}, sharedOpts...)
+	}
+
+	mgr, err := slackrunner.NewManager(slackrunner.ManagerConfig{
+		Store:       dbStore,
+		RouterStore: dbStore,
+		Secrets:     secretsSvc,
+		NewAdapter:  newAdapter,
+		GateConfig:  gatewaypkg.GateConfig{JoinURLBuilder: slackJoinURLBuilder},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("slack connectors: init manager: %w", err)
+	}
+	log.Bg().Info("slack connectors reconciler configured")
+	return mgr, nil
+}
+
+// buildDiscordInboundManager is the Discord twin of buildSlackInboundManager: it
+// scans workspace_im_connectors for enabled discord rows and keeps one Gateway
+// WebSocket runner per workspace|app_id. Opt-in via PARSAR_DISCORD_CONNECTORS=
+// true; requires PARSAR_MASTER_KEY. Discord uses one bot token (no app token),
+// so the NewAdapter factory takes only (appID, botToken). A MemoryPickStore is
+// injected per adapter so select-change interactions fold into the Submit click.
+func buildDiscordInboundManager(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string) (*discordrunner.Manager, error) {
+	if !truthy(env("PARSAR_DISCORD_CONNECTORS")) {
+		return nil, nil
+	}
+	masterKey := strings.TrimSpace(env("PARSAR_MASTER_KEY"))
+	if masterKey == "" {
+		return nil, errors.New("PARSAR_DISCORD_CONNECTORS=true requires PARSAR_MASTER_KEY (same value the secret vault was sealed with)")
+	}
+	secretsSvc, err := secrets.New(masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("discord connectors: init secrets service: %w", err)
+	}
+
+	var discordJoinURLBuilder func(string) string
+	if strings.TrimSpace(publicURL) != "" {
+		root := strings.TrimRight(strings.TrimSpace(publicURL), "/")
+		discordJoinURLBuilder = func(workspaceID string) string {
+			return root + "/join-workspace?id=" + workspaceID + "&from=discord"
+		}
+	}
+
+	actionMgr, err := inbound.NewManager(inbound.Options{
+		Store:                     dbStore,
+		Secrets:                   secretsSvc,
+		Logger:                    slogFeishuInboundLogger{},
+		JoinURLBuilder:            discordJoinURLBuilder,
+		PermissionRouter:          inboundPermissionRouter{registry: connectorReg},
+		PromptForUserChoiceRouter: inboundPromptForUserChoiceRouter{registry: connectorReg},
+		Connectors:                dbStore,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("discord connectors: init action manager: %w", err)
+	}
+	sharedActionRouter := actionMgr.CardActionRouter()
+	resolver, err := buildDiscordCredentialResolver(env, dbStore)
+	if err != nil {
+		return nil, fmt.Errorf("discord connectors: build credential resolver: %w", err)
+	}
+
+	newAdapter := func(appID, botToken string) *discordchannel.Channel {
+		opts := []discordchannel.Option{
+			discordchannel.WithPickStore(discordchannel.NewMemoryPickStore()),
+			discordchannel.WithActionRouter(sharedActionRouter),
+		}
+		if resolver != nil {
+			opts = append(opts, discordchannel.WithCredentialResolver(resolver))
+		}
+		return discordchannel.New(discordchannel.Config{
+			AppID:    appID,
+			BotToken: botToken,
+		}, opts...)
+	}
+
+	mgr, err := discordrunner.NewManager(discordrunner.ManagerConfig{
+		Store:       dbStore,
+		RouterStore: dbStore,
+		Secrets:     secretsSvc,
+		NewAdapter:  newAdapter,
+		GateConfig:  gatewaypkg.GateConfig{JoinURLBuilder: discordJoinURLBuilder},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("discord connectors: init manager: %w", err)
+	}
+	log.Bg().Info("discord connectors reconciler configured")
+	return mgr, nil
+}
+
 // inboundPermissionRouter adapts the connector registry to the
 // inbound.PermissionRouter interface. The Feishu inbound
 // package can't depend on `connector` directly, so this adapter
@@ -1808,11 +1990,15 @@ func buildSlackCredentialResolver(env func(string) string, dbStore *store.Store)
 		strings.TrimSpace(env("PARSAR_SLACK_APP_ID")),
 		strings.TrimSpace(env("PARSAR_SLACK_BOT_TOKEN")),
 	)
-	return slackchannel.NewDBCredentialResolver(
+	legacy := slackchannel.NewDBCredentialResolver(
 		slackBotSecretLookupAdapter{store: dbStore},
 		secretsSvc,
 		fallback,
-	), nil
+	)
+	// Layer the workspace-dimension (app_id) resolver in front so a connector
+	// configured via the admin panel resolves first; legacy team_id/env is the
+	// fallback.
+	return wrapWithWorkspaceConnectorResolver(env, dbStore, "slack", legacy)
 }
 
 // discordBotSecretLookupAdapter bridges *store.Store to the discord channel's
@@ -1851,11 +2037,99 @@ func buildDiscordCredentialResolver(env func(string) string, dbStore *store.Stor
 		strings.TrimSpace(env("PARSAR_DISCORD_APP_ID")),
 		strings.TrimSpace(env("PARSAR_DISCORD_BOT_TOKEN")),
 	)
-	return discordchannel.NewDBCredentialResolver(
+	legacy := discordchannel.NewDBCredentialResolver(
 		discordBotSecretLookupAdapter{store: dbStore},
 		secretsSvc,
 		fallback,
-	), nil
+	)
+	return wrapWithWorkspaceConnectorResolver(env, dbStore, "discord", legacy)
+}
+
+// workspaceConnectorResolver is the workspace-dimension bot-token resolver.
+// It keys on the platform app_id (the join key into workspace_im_connectors
+// that is known at config-save time, unlike team_id/guild_id), reads the
+// connector's config.bot_token_ref, fetches that vault secret and decrypts
+// it per call so a rotated token takes effect without a restart. Any miss
+// (empty app_id, no enabled connector, missing ref) falls through to the
+// legacy team_id/guild_id (+ env) resolver, so existing deployments keep
+// working unchanged.
+type workspaceConnectorResolver struct {
+	store    *store.Store
+	secrets  *secrets.Service
+	platform string // "slack" | "discord"
+	tokenRef string // config key holding the secret id (e.g. "bot_token_ref")
+	fallback channel.CredentialResolver
+}
+
+func (r *workspaceConnectorResolver) Resolve(ctx context.Context, botID string) (channel.Credential, error) {
+	appID := strings.TrimSpace(botID)
+	if appID == "" {
+		return r.fallbackResolve(ctx, botID)
+	}
+	conn, err := r.store.GetWorkspaceConnectorByAppID(ctx, r.platform, appID)
+	if err != nil {
+		// botID may be a legacy team_id/guild_id rather than an app_id, or no
+		// workspace connector exists yet — defer to the legacy resolver.
+		return r.fallbackResolve(ctx, botID)
+	}
+	secretID, _ := conn.Config[r.tokenRef].(string)
+	secretID = strings.TrimSpace(secretID)
+	if secretID == "" {
+		return r.fallbackResolve(ctx, botID)
+	}
+	payload, err := r.store.GetSecretPayload(ctx, conn.WorkspaceID, secretID)
+	if err != nil {
+		return r.fallbackResolve(ctx, botID)
+	}
+	decrypted, err := r.secrets.Decrypt(payload.EncryptedPayload)
+	if err != nil {
+		return channel.Credential{}, fmt.Errorf("%s channel: decrypt bot token for app_id %s: %w", r.platform, appID, err)
+	}
+	token := strings.TrimSpace(botTokenFromPayload(decrypted))
+	if token == "" {
+		return channel.Credential{}, fmt.Errorf("%s channel: connector secret for app_id %s has no token value", r.platform, appID)
+	}
+	return channel.Credential{AppID: appID, AppSecret: token}, nil
+}
+
+func (r *workspaceConnectorResolver) fallbackResolve(ctx context.Context, botID string) (channel.Credential, error) {
+	if r.fallback == nil {
+		return channel.Credential{}, fmt.Errorf("%s channel: no workspace connector for app_id %q and no fallback resolver", r.platform, strings.TrimSpace(botID))
+	}
+	return r.fallback.Resolve(ctx, botID)
+}
+
+// botTokenFromPayload reads a bot token out of a decrypted secret payload
+// using the same key precedence the rest of the codebase uses for shared
+// credentials (api_key → token → access_token → value).
+func botTokenFromPayload(payload map[string]any) string {
+	for _, key := range []string{"bot_token", "api_key", "token", "access_token", "value"} {
+		if v, ok := payload[key].(string); ok && strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// wrapWithWorkspaceConnectorResolver layers the workspace-dimension (app_id)
+// resolver in front of an existing platform resolver. Returns the input
+// unchanged when no master key / store is available (resolver stays legacy).
+func wrapWithWorkspaceConnectorResolver(env func(string) string, dbStore *store.Store, platform string, legacy channel.CredentialResolver) (channel.CredentialResolver, error) {
+	masterKey := strings.TrimSpace(env("PARSAR_MASTER_KEY"))
+	if masterKey == "" || dbStore == nil {
+		return legacy, nil
+	}
+	secretsSvc, err := secrets.New(masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("%s workspace connector resolver: init secrets service: %w", platform, err)
+	}
+	return &workspaceConnectorResolver{
+		store:    dbStore,
+		secrets:  secretsSvc,
+		platform: platform,
+		tokenRef: "bot_token_ref",
+		fallback: legacy,
+	}, nil
 }
 
 // buildOutboundChannels assembles the neutral outbound channel registry the

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -4715,3 +4715,68 @@ order by created_at desc
 limit @item_limit;
 
 
+
+-- ============================================================
+-- workspace_im_connectors — workspace 维度 IM 连接器(feishu/slack/discord)
+-- 见 migration 000002。凭据密文在 secrets(vault),本表 config 只存
+-- *_ref 与非敏感字段。app_id 是 workspace-bot 的通用 join key。
+-- ============================================================
+
+-- name: UpsertWorkspaceIMConnector :one
+-- 按 (workspace_id, platform) 唯一约束 upsert。冲突时更新 app_id /
+-- enabled / config / updated_at,保留 id / created_by / created_at。
+-- 若 (platform, app_id) 撞了别的 workspace,会触发 uk_wic_platform_appid
+-- 唯一冲突并报错(由 store 层映射成 *_app_id_in_use)。
+insert into workspace_im_connectors (
+  id, workspace_id, platform, app_id, enabled, config, created_by, created_at, updated_at
+) values (
+  @id::uuid, @workspace_id::uuid, @platform::text, @app_id::text,
+  @enabled::boolean, @config, nullif(@created_by::text, '')::uuid, @now, @now
+)
+on conflict (workspace_id, platform) where deleted_at is null
+do update set
+  app_id     = excluded.app_id,
+  enabled    = excluded.enabled,
+  config     = excluded.config,
+  updated_at = excluded.updated_at
+returning
+  id::text, workspace_id::text, platform, app_id, enabled, config,
+  created_at, updated_at;
+
+-- name: GetWorkspaceIMConnectors :many
+-- 拉取某 workspace 全部平台的有效连接器(前端面板初始化用)。
+select
+  id::text, workspace_id::text, platform, app_id, enabled, config,
+  created_at, updated_at
+from workspace_im_connectors
+where workspace_id = @workspace_id::uuid
+  and deleted_at is null
+order by platform;
+
+-- name: GetWorkspaceConnectorByAppID :one
+-- 出站 resolver 按 (platform, app_id) 反查启用的连接器,取 config 里的
+-- *_ref 解密 token。
+select
+  c.id::text, c.workspace_id::text, w.name as workspace_name,
+  c.platform, c.app_id, c.enabled, c.config, c.created_at, c.updated_at
+from workspace_im_connectors c
+join workspaces w on w.id = c.workspace_id
+where c.platform = @platform::text
+  and c.app_id = @app_id::text
+  and c.enabled = true
+  and c.deleted_at is null
+limit 1;
+
+-- name: ListWorkspaceConnectorsByPlatform :many
+-- 入站 reconciler 按平台扫描所有启用的连接器,为每条 (workspace_id,
+-- app_id) 维持一条长连接。
+select
+  c.id::text, c.workspace_id::text, w.name as workspace_name,
+  c.platform, c.app_id, c.enabled, c.config, c.created_at, c.updated_at
+from workspace_im_connectors c
+join workspaces w on w.id = c.workspace_id
+where c.platform = @platform::text
+  and c.enabled = true
+  and c.app_id <> ''
+  and c.deleted_at is null
+order by c.workspace_id, c.app_id;

--- a/server/internal/db/sqlc/models.go
+++ b/server/internal/db/sqlc/models.go
@@ -795,6 +795,28 @@ type Workspace struct {
 	DeletedAt pgtype.Timestamptz `json:"deleted_at"`
 }
 
+// workspace 维度的 IM 连接器绑定(feishu/slack/discord 统一存储)
+type WorkspaceImConnector struct {
+	// 连接器主键
+	ID pgtype.UUID `json:"id"`
+	// 所属 workspace
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	// IM 平台: feishu / slack / discord
+	Platform string `json:"platform"`
+	// 平台应用 ID(配置时即可知, workspace-bot 的通用 join key)
+	AppID string `json:"app_id"`
+	// 是否启用(启用后 reconciler 才会为其建立入站连接)
+	Enabled bool `json:"enabled"`
+	// 非敏感配置 + 密钥引用(*_ref 指向 secrets.id; 含 event_mode/intents 等)
+	Config []byte `json:"config"`
+	// 创建人
+	CreatedBy pgtype.UUID        `json:"created_by"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
+	// 软删除时间戳; NULL=有效
+	DeletedAt pgtype.Timestamptz `json:"deleted_at"`
+}
+
 // workspace 成员与角色表(含申请状态机)
 type WorkspaceMember struct {
 	ID pgtype.UUID `json:"id"`

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -6225,6 +6225,106 @@ func (q *Queries) GetUserDisplayName(ctx context.Context, id pgtype.UUID) (strin
 	return display_name, err
 }
 
+const getWorkspaceConnectorByAppID = `-- name: GetWorkspaceConnectorByAppID :one
+select
+  c.id::text, c.workspace_id::text, w.name as workspace_name,
+  c.platform, c.app_id, c.enabled, c.config, c.created_at, c.updated_at
+from workspace_im_connectors c
+join workspaces w on w.id = c.workspace_id
+where c.platform = $1::text
+  and c.app_id = $2::text
+  and c.enabled = true
+  and c.deleted_at is null
+limit 1
+`
+
+type GetWorkspaceConnectorByAppIDParams struct {
+	Platform string `json:"platform"`
+	AppID    string `json:"app_id"`
+}
+
+type GetWorkspaceConnectorByAppIDRow struct {
+	CID           string             `json:"c_id"`
+	CWorkspaceID  string             `json:"c_workspace_id"`
+	WorkspaceName string             `json:"workspace_name"`
+	Platform      string             `json:"platform"`
+	AppID         string             `json:"app_id"`
+	Enabled       bool               `json:"enabled"`
+	Config        []byte             `json:"config"`
+	CreatedAt     pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
+}
+
+// 出站 resolver 按 (platform, app_id) 反查启用的连接器,取 config 里的
+// *_ref 解密 token。
+func (q *Queries) GetWorkspaceConnectorByAppID(ctx context.Context, arg GetWorkspaceConnectorByAppIDParams) (GetWorkspaceConnectorByAppIDRow, error) {
+	row := q.db.QueryRow(ctx, getWorkspaceConnectorByAppID, arg.Platform, arg.AppID)
+	var i GetWorkspaceConnectorByAppIDRow
+	err := row.Scan(
+		&i.CID,
+		&i.CWorkspaceID,
+		&i.WorkspaceName,
+		&i.Platform,
+		&i.AppID,
+		&i.Enabled,
+		&i.Config,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getWorkspaceIMConnectors = `-- name: GetWorkspaceIMConnectors :many
+select
+  id::text, workspace_id::text, platform, app_id, enabled, config,
+  created_at, updated_at
+from workspace_im_connectors
+where workspace_id = $1::uuid
+  and deleted_at is null
+order by platform
+`
+
+type GetWorkspaceIMConnectorsRow struct {
+	ID          string             `json:"id"`
+	WorkspaceID string             `json:"workspace_id"`
+	Platform    string             `json:"platform"`
+	AppID       string             `json:"app_id"`
+	Enabled     bool               `json:"enabled"`
+	Config      []byte             `json:"config"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+}
+
+// 拉取某 workspace 全部平台的有效连接器(前端面板初始化用)。
+func (q *Queries) GetWorkspaceIMConnectors(ctx context.Context, workspaceID pgtype.UUID) ([]GetWorkspaceIMConnectorsRow, error) {
+	rows, err := q.db.Query(ctx, getWorkspaceIMConnectors, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetWorkspaceIMConnectorsRow{}
+	for rows.Next() {
+		var i GetWorkspaceIMConnectorsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.WorkspaceID,
+			&i.Platform,
+			&i.AppID,
+			&i.Enabled,
+			&i.Config,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getWorkspaceMemberRole = `-- name: GetWorkspaceMemberRole :one
 select role
 from workspace_members
@@ -9517,6 +9617,63 @@ func (q *Queries) ListUserWorkspaces(ctx context.Context, arg ListUserWorkspaces
 	return items, nil
 }
 
+const listWorkspaceConnectorsByPlatform = `-- name: ListWorkspaceConnectorsByPlatform :many
+select
+  c.id::text, c.workspace_id::text, w.name as workspace_name,
+  c.platform, c.app_id, c.enabled, c.config, c.created_at, c.updated_at
+from workspace_im_connectors c
+join workspaces w on w.id = c.workspace_id
+where c.platform = $1::text
+  and c.enabled = true
+  and c.app_id <> ''
+  and c.deleted_at is null
+order by c.workspace_id, c.app_id
+`
+
+type ListWorkspaceConnectorsByPlatformRow struct {
+	CID           string             `json:"c_id"`
+	CWorkspaceID  string             `json:"c_workspace_id"`
+	WorkspaceName string             `json:"workspace_name"`
+	Platform      string             `json:"platform"`
+	AppID         string             `json:"app_id"`
+	Enabled       bool               `json:"enabled"`
+	Config        []byte             `json:"config"`
+	CreatedAt     pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
+}
+
+// 入站 reconciler 按平台扫描所有启用的连接器,为每条 (workspace_id,
+// app_id) 维持一条长连接。
+func (q *Queries) ListWorkspaceConnectorsByPlatform(ctx context.Context, platform string) ([]ListWorkspaceConnectorsByPlatformRow, error) {
+	rows, err := q.db.Query(ctx, listWorkspaceConnectorsByPlatform, platform)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListWorkspaceConnectorsByPlatformRow{}
+	for rows.Next() {
+		var i ListWorkspaceConnectorsByPlatformRow
+		if err := rows.Scan(
+			&i.CID,
+			&i.CWorkspaceID,
+			&i.WorkspaceName,
+			&i.Platform,
+			&i.AppID,
+			&i.Enabled,
+			&i.Config,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listWorkspaceMarketplaceInstalls = `-- name: ListWorkspaceMarketplaceInstalls :many
 select distinct
   c.id::text as capability_id,
@@ -12458,6 +12615,81 @@ func (q *Queries) UpsertUserByEmail(ctx context.Context, arg UpsertUserByEmailPa
 		&i.CreatedAt,
 		&i.UpdatedAt,
 		&i.Created,
+	)
+	return i, err
+}
+
+const upsertWorkspaceIMConnector = `-- name: UpsertWorkspaceIMConnector :one
+
+insert into workspace_im_connectors (
+  id, workspace_id, platform, app_id, enabled, config, created_by, created_at, updated_at
+) values (
+  $1::uuid, $2::uuid, $3::text, $4::text,
+  $5::boolean, $6, nullif($7::text, '')::uuid, $8, $8
+)
+on conflict (workspace_id, platform) where deleted_at is null
+do update set
+  app_id     = excluded.app_id,
+  enabled    = excluded.enabled,
+  config     = excluded.config,
+  updated_at = excluded.updated_at
+returning
+  id::text, workspace_id::text, platform, app_id, enabled, config,
+  created_at, updated_at
+`
+
+type UpsertWorkspaceIMConnectorParams struct {
+	ID          pgtype.UUID        `json:"id"`
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
+	Platform    string             `json:"platform"`
+	AppID       string             `json:"app_id"`
+	Enabled     bool               `json:"enabled"`
+	Config      []byte             `json:"config"`
+	CreatedBy   string             `json:"created_by"`
+	Now         pgtype.Timestamptz `json:"now"`
+}
+
+type UpsertWorkspaceIMConnectorRow struct {
+	ID          string             `json:"id"`
+	WorkspaceID string             `json:"workspace_id"`
+	Platform    string             `json:"platform"`
+	AppID       string             `json:"app_id"`
+	Enabled     bool               `json:"enabled"`
+	Config      []byte             `json:"config"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+}
+
+// ============================================================
+// workspace_im_connectors — workspace 维度 IM 连接器(feishu/slack/discord)
+// 见 migration 000002。凭据密文在 secrets(vault),本表 config 只存
+// *_ref 与非敏感字段。app_id 是 workspace-bot 的通用 join key。
+// ============================================================
+// 按 (workspace_id, platform) 唯一约束 upsert。冲突时更新 app_id /
+// enabled / config / updated_at,保留 id / created_by / created_at。
+// 若 (platform, app_id) 撞了别的 workspace,会触发 uk_wic_platform_appid
+// 唯一冲突并报错(由 store 层映射成 *_app_id_in_use)。
+func (q *Queries) UpsertWorkspaceIMConnector(ctx context.Context, arg UpsertWorkspaceIMConnectorParams) (UpsertWorkspaceIMConnectorRow, error) {
+	row := q.db.QueryRow(ctx, upsertWorkspaceIMConnector,
+		arg.ID,
+		arg.WorkspaceID,
+		arg.Platform,
+		arg.AppID,
+		arg.Enabled,
+		arg.Config,
+		arg.CreatedBy,
+		arg.Now,
+	)
+	var i UpsertWorkspaceIMConnectorRow
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Platform,
+		&i.AppID,
+		&i.Enabled,
+		&i.Config,
+		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }

--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -189,6 +189,14 @@ type RuntimeStore interface {
 	RejectJoinRequest(ctx context.Context, input store.ReviewJoinRequestInput) (store.WorkspaceMemberRead, error)
 	WithdrawOwnJoinRequest(ctx context.Context, workspaceID, userID string, now time.Time) error
 
+	// workspace 维度 IM 连接器(feishu/slack/discord 统一存储)。
+	// GET 面板初始化 + 三个平台的 upsert 写入。读取走 member 网关、
+	// 写入走 owner/admin 网关(见路由注册)。
+	GetWorkspaceIMConnectors(ctx context.Context, workspaceID string) ([]store.WorkspaceConnectorRead, error)
+	UpsertWorkspaceSlackConnector(ctx context.Context, input store.UpsertWorkspaceSlackConnectorInput, actorID string) (store.WorkspaceConnectorChange, error)
+	UpsertWorkspaceDiscordConnector(ctx context.Context, input store.UpsertWorkspaceDiscordConnectorInput, actorID string) (store.WorkspaceConnectorChange, error)
+	UpsertWorkspaceFeishuConnector(ctx context.Context, input store.UpsertWorkspaceFeishuConnectorInput, actorID string) (store.WorkspaceConnectorChange, error)
+
 	// 定时任务(scheduled tasks)
 	ListScheduledTasksByProjectAgent(ctx context.Context, projectAgentID string) ([]store.ScheduledTaskRead, error)
 	ListScheduledTasksByProject(ctx context.Context, projectID string, limit, offset int32) (store.ListScheduledTasksByProjectResult, error)
@@ -538,6 +546,13 @@ func RegisterRoutesWithStore(r chi.Router, runtimeStore RuntimeStore, opts ...Ro
 			r.Patch("/agents/{agentID}/visibility", updateAgentVisibility(runtimeStore))
 			r.Get("/agents/{agentID}/connector/feishu/diagnostics", getAgentFeishuConnectorDiagnostics(runtimeStore))
 			r.Patch("/agents/{agentID}/connector/feishu", updateAgentFeishuConnector(runtimeStore))
+			// Workspace-dimension IM connectors (feishu/slack/discord).
+			// Read = any member; write = owner/admin (a misconfigured bot
+			// can leak the workspace to the internet).
+			r.Get("/workspaces/{workspaceID}/connectors", gateWorkspaceMember(runtimeStore, listWorkspaceConnectors(runtimeStore)))
+			r.Patch("/workspaces/{workspaceID}/connector/slack", gateWorkspaceOwnerOrAdmin(runtimeStore, updateWorkspaceSlackConnector(runtimeStore)))
+			r.Patch("/workspaces/{workspaceID}/connector/discord", gateWorkspaceOwnerOrAdmin(runtimeStore, updateWorkspaceDiscordConnector(runtimeStore)))
+			r.Patch("/workspaces/{workspaceID}/connector/feishu", gateWorkspaceOwnerOrAdmin(runtimeStore, updateWorkspaceFeishuConnector(runtimeStore)))
 			r.Post("/agents/{agentID}/connector/feishu/provision/begin", beginAgentFeishuProvisioning(runtimeStore, cfg.feishuRegistration))
 			r.Post("/agents/{agentID}/connector/feishu/provision/poll", pollAgentFeishuProvisioning(runtimeStore, cfg.feishuRegistration))
 			r.Delete("/agents/{agentID}", deleteAgent(runtimeStore))
@@ -2284,6 +2299,158 @@ func updateAgentFeishuConnector(runtimeStore RuntimeStore) http.HandlerFunc {
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"feishu_connector": change})
+	}
+}
+
+// ============================================================
+// Workspace-dimension IM connectors (feishu / slack / discord)
+// ------------------------------------------------------------
+// Bound to the workspace, NOT to an agent: the same dimension as the
+// /list a user picks an agent from after @-summoning the shared bot.
+// Credentials live in the vault; the table stores only *_ref UUIDs +
+// non-secret fields. RBAC is enforced by the route gate middleware
+// (member for GET, owner/admin for PATCH), so the handlers trust the
+// URL workspaceID.
+// ============================================================
+
+type updateWorkspaceSlackConnectorBody struct {
+	Enabled          bool   `json:"enabled"`
+	AppID            string `json:"app_id"`
+	BotTokenRef      string `json:"bot_token_ref"`
+	AppTokenRef      string `json:"app_token_ref"`
+	SigningSecretRef string `json:"signing_secret_ref"`
+	EventMode        string `json:"event_mode"`
+}
+
+type updateWorkspaceDiscordConnectorBody struct {
+	Enabled      bool   `json:"enabled"`
+	AppID        string `json:"app_id"`
+	BotTokenRef  string `json:"bot_token_ref"`
+	PublicKeyRef string `json:"public_key_ref"`
+	Intents      string `json:"intents"`
+}
+
+type updateWorkspaceFeishuConnectorBody struct {
+	Enabled              bool   `json:"enabled"`
+	AppID                string `json:"app_id"`
+	AppSecretRef         string `json:"app_secret_ref"`
+	VerificationTokenRef string `json:"verification_token_ref"`
+	EncryptKeyRef        string `json:"encrypt_key_ref"`
+	BotOpenID            string `json:"bot_open_id"`
+	EventMode            string `json:"event_mode"`
+}
+
+// listWorkspaceConnectors returns all platforms' connector rows for the
+// workspace, decoded (config jsonb → map). Backs the admin panel's
+// initial state. Never exposes secret plaintext (only *_ref UUIDs).
+func listWorkspaceConnectors(runtimeStore RuntimeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
+		connectors, err := runtimeStore.GetWorkspaceIMConnectors(r.Context(), workspaceID)
+		if err != nil {
+			writeStoreAgentError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"connectors": connectors})
+	}
+}
+
+func updateWorkspaceSlackConnector(runtimeStore RuntimeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
+		var req updateWorkspaceSlackConnectorBody
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+			return
+		}
+		change, err := runtimeStore.UpsertWorkspaceSlackConnector(r.Context(), store.UpsertWorkspaceSlackConnectorInput{
+			WorkspaceID:      workspaceID,
+			Enabled:          req.Enabled,
+			AppID:            req.AppID,
+			BotTokenRef:      req.BotTokenRef,
+			AppTokenRef:      req.AppTokenRef,
+			SigningSecretRef: req.SigningSecretRef,
+			EventMode:        req.EventMode,
+		}, actorIDFromRequest(r))
+		if err != nil {
+			switch {
+			case errors.Is(err, store.ErrSlackConnectorIncomplete):
+				writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "slack_connector_incomplete", "detail": err.Error()})
+				return
+			case errors.Is(err, store.ErrSlackAppIDInUse):
+				writeJSON(w, http.StatusConflict, map[string]string{"error": "slack_app_id_in_use", "detail": err.Error()})
+				return
+			}
+			writeStoreAgentError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"connector": change})
+	}
+}
+
+func updateWorkspaceDiscordConnector(runtimeStore RuntimeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
+		var req updateWorkspaceDiscordConnectorBody
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+			return
+		}
+		change, err := runtimeStore.UpsertWorkspaceDiscordConnector(r.Context(), store.UpsertWorkspaceDiscordConnectorInput{
+			WorkspaceID:  workspaceID,
+			Enabled:      req.Enabled,
+			AppID:        req.AppID,
+			BotTokenRef:  req.BotTokenRef,
+			PublicKeyRef: req.PublicKeyRef,
+			Intents:      req.Intents,
+		}, actorIDFromRequest(r))
+		if err != nil {
+			switch {
+			case errors.Is(err, store.ErrDiscordConnectorIncomplete):
+				writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "discord_connector_incomplete", "detail": err.Error()})
+				return
+			case errors.Is(err, store.ErrDiscordAppIDInUse):
+				writeJSON(w, http.StatusConflict, map[string]string{"error": "discord_app_id_in_use", "detail": err.Error()})
+				return
+			}
+			writeStoreAgentError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"connector": change})
+	}
+}
+
+func updateWorkspaceFeishuConnector(runtimeStore RuntimeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
+		var req updateWorkspaceFeishuConnectorBody
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+			return
+		}
+		change, err := runtimeStore.UpsertWorkspaceFeishuConnector(r.Context(), store.UpsertWorkspaceFeishuConnectorInput{
+			WorkspaceID:          workspaceID,
+			Enabled:              req.Enabled,
+			AppID:                req.AppID,
+			AppSecretRef:         req.AppSecretRef,
+			VerificationTokenRef: req.VerificationTokenRef,
+			EncryptKeyRef:        req.EncryptKeyRef,
+			BotOpenID:            req.BotOpenID,
+			EventMode:            req.EventMode,
+		}, actorIDFromRequest(r))
+		if err != nil {
+			switch {
+			case errors.Is(err, store.ErrFeishuConnectorIncomplete):
+				writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "feishu_connector_incomplete", "detail": err.Error()})
+				return
+			case errors.Is(err, store.ErrFeishuAppIDInUse):
+				writeJSON(w, http.StatusConflict, map[string]string{"error": "feishu_app_id_in_use", "detail": err.Error()})
+				return
+			}
+			writeStoreAgentError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"connector": change})
 	}
 }
 

--- a/server/internal/dev/routes_test.go
+++ b/server/internal/dev/routes_test.go
@@ -4482,3 +4482,19 @@ func (stubRuntimeStore) RejectJoinRequest(ctx context.Context, input store.Revie
 func (stubRuntimeStore) WithdrawOwnJoinRequest(ctx context.Context, workspaceID, userID string, now time.Time) error {
 	return nil
 }
+
+func (stubRuntimeStore) GetWorkspaceIMConnectors(ctx context.Context, workspaceID string) ([]store.WorkspaceConnectorRead, error) {
+	return nil, nil
+}
+
+func (stubRuntimeStore) UpsertWorkspaceSlackConnector(ctx context.Context, input store.UpsertWorkspaceSlackConnectorInput, actorID string) (store.WorkspaceConnectorChange, error) {
+	return store.WorkspaceConnectorChange{}, nil
+}
+
+func (stubRuntimeStore) UpsertWorkspaceDiscordConnector(ctx context.Context, input store.UpsertWorkspaceDiscordConnectorInput, actorID string) (store.WorkspaceConnectorChange, error) {
+	return store.WorkspaceConnectorChange{}, nil
+}
+
+func (stubRuntimeStore) UpsertWorkspaceFeishuConnector(ctx context.Context, input store.UpsertWorkspaceFeishuConnectorInput, actorID string) (store.WorkspaceConnectorChange, error) {
+	return store.WorkspaceConnectorChange{}, nil
+}

--- a/server/internal/gateway/channel/channel.go
+++ b/server/internal/gateway/channel/channel.go
@@ -76,6 +76,13 @@ type ReplyTarget struct {
 	// single-tenant deployments and the Feishu path, which resolve a static
 	// credential and ignore this field.
 	TenantKey string
+	// SourceAppID is the platform application id captured on the inbound
+	// side (Slack/Discord/Feishu app_id). Unlike TenantKey it is known at
+	// config-save time, so it is the join key into workspace_im_connectors
+	// the outbound resolver uses to fetch the per-workspace bot token. A
+	// workspace-dimension resolver prefers this over TenantKey; empty for
+	// legacy single-tenant / env-credential paths.
+	SourceAppID string
 }
 
 // Card is a platform-native rendered payload (Feishu interactive card,

--- a/server/internal/gateway/channel/discord/outbound.go
+++ b/server/internal/gateway/channel/discord/outbound.go
@@ -82,12 +82,16 @@ func defaultSenderFactory(token string) discordSender {
 }
 
 // senderFor resolves the bot token and builds a sender via the injected
-// factory. Per-call resolution keeps token rotation hot. The target's TenantKey
-// (Discord guild_id) is passed as the resolver botID so a multi-guild
-// deployment mints the per-guild token; the static/env resolver ignores it and
-// returns the one configured token.
+// factory. Per-call resolution keeps token rotation hot. The resolver botID
+// is the workspace-bot's app_id when inbound captured one (SourceAppID) —
+// the join key into workspace_im_connectors — falling back to the legacy
+// TenantKey (Discord guild_id) and finally the channel's static appID. The
+// static/env resolver ignores the key and returns its one token.
 func (c *Channel) senderFor(ctx context.Context, target channel.ReplyTarget) (discordSender, error) {
-	botID := strings.TrimSpace(target.TenantKey)
+	botID := strings.TrimSpace(target.SourceAppID)
+	if botID == "" {
+		botID = strings.TrimSpace(target.TenantKey)
+	}
 	if botID == "" {
 		botID = c.appID
 	}

--- a/server/internal/gateway/channel/slack/outbound.go
+++ b/server/internal/gateway/channel/slack/outbound.go
@@ -74,12 +74,16 @@ func defaultSenderFactory(token string) slackSender {
 }
 
 // senderFor resolves the bot token and builds a sender via the injected
-// factory. Per-call resolution keeps token rotation hot. The target's
-// TenantKey (Slack team_id) is passed as the resolver botID so a
-// multi-workspace deployment mints the per-team token; the static/env
-// resolver ignores it and returns the one configured token.
+// factory. Per-call resolution keeps token rotation hot. The resolver botID
+// is the workspace-bot's app_id when the inbound side captured one
+// (SourceAppID) — the join key into workspace_im_connectors — falling back
+// to the legacy TenantKey (Slack team_id) and finally the channel's static
+// appID. The static/env resolver ignores the key and returns its one token.
 func (c *Channel) senderFor(ctx context.Context, target channel.ReplyTarget) (slackSender, error) {
-	botID := strings.TrimSpace(target.TenantKey)
+	botID := strings.TrimSpace(target.SourceAppID)
+	if botID == "" {
+		botID = strings.TrimSpace(target.TenantKey)
+	}
 	if botID == "" {
 		botID = c.appID
 	}

--- a/server/internal/gateway/inbound/discordrunner/manager.go
+++ b/server/internal/gateway/inbound/discordrunner/manager.go
@@ -1,0 +1,331 @@
+// manager.go is the multi-tenant reconciler that turns workspace_im_connectors
+// rows into live Gateway WebSocket runners — the Discord twin of slackrunner's
+// Manager and inbound.Manager's Feishu websocket loop.
+//
+// Where Runner (runner.go) drives ONE env-gated gateway socket, Manager drives
+// N: it ticks every refresh interval, lists every enabled Discord connector
+// (ListWorkspaceConnectorsByPlatform), decrypts each one's bot token out of the
+// vault, and keeps exactly one Runner per workspace|app_id key. Connectors that
+// disappear (disabled, deleted, app_id changed) have their runner stopped; a
+// token rotation is detected by a per-handle fingerprint and triggers a
+// stop+restart so the new credential takes effect without a process restart.
+//
+// Unlike Slack there is no separate app-level socket token: the bot token is the
+// only credential the Gateway IDENTIFY needs. The adapter (with its
+// action/credential routing + pick store) is built by an injected NewAdapter
+// factory so this package stays free of the connector/inbound wiring that lives
+// in main.
+package discordrunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway"
+	discordchannel "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel/discord"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/router"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+// ConnectorStore is the read surface the reconciler needs: the per-platform
+// connector list and the vault secret payloads its *_ref UUIDs point at.
+// *store.Store satisfies it.
+type ConnectorStore interface {
+	ListWorkspaceConnectorsByPlatform(ctx context.Context, platform string) ([]store.WorkspaceConnectorRead, error)
+	GetSecretPayload(ctx context.Context, workspaceID, secretID string) (store.SecretPayload, error)
+}
+
+// SecretDecrypter mirrors the small subset of *secrets.Service the reconciler
+// uses to turn an encrypted vault payload into its plaintext token fields.
+type SecretDecrypter interface {
+	Decrypt(envelopeJSON []byte) (map[string]any, error)
+}
+
+// ManagerConfig configures Manager. Store, Secrets and NewAdapter are required.
+type ManagerConfig struct {
+	// Store reads the connector rows and their secret payloads.
+	Store ConnectorStore
+	// RouterStore is handed to every Runner as the shared inbound router store.
+	RouterStore router.Store
+	// Secrets decrypts the bot token payload.
+	Secrets SecretDecrypter
+	// NewAdapter builds a Discord adapter for one workspace bot. main injects it
+	// so the action-router / credential-resolver / pick-store wiring stays out of
+	// this package.
+	NewAdapter func(appID, botToken string) *discordchannel.Channel
+	// GateConfig feeds the visibility rejection cards each runner renders.
+	GateConfig gateway.GateConfig
+	// Logger is optional (defaults to log.Bg()).
+	Logger *slog.Logger
+	// RefreshInterval defaults to 30s, capped at 10m.
+	RefreshInterval time.Duration
+}
+
+// Manager reconciles configured Discord connectors and keeps one Gateway
+// WebSocket Runner per workspace|app_id. Run blocks until ctx is cancelled.
+type Manager struct {
+	store      ConnectorStore
+	router     router.Store
+	secrets    SecretDecrypter
+	newAdapter func(appID, botToken string) *discordchannel.Channel
+	gateCfg    gateway.GateConfig
+	log        *slog.Logger
+	refresh    time.Duration
+
+	mu      sync.Mutex
+	clients map[string]*discordClientHandle
+}
+
+// discordClientHandle is one live runner plus the state needed to stop it and
+// to detect a token rotation (fingerprint) on the next reconcile.
+type discordClientHandle struct {
+	key         string
+	appID       string
+	cancel      context.CancelFunc
+	fingerprint string
+}
+
+// NewManager validates config and returns an inert manager (Run starts the
+// loop). Mirrors slackrunner.NewManager.
+func NewManager(cfg ManagerConfig) (*Manager, error) {
+	if cfg.Store == nil {
+		return nil, errors.New("discord runner manager: Store is required")
+	}
+	if cfg.RouterStore == nil {
+		return nil, errors.New("discord runner manager: RouterStore is required")
+	}
+	if cfg.Secrets == nil {
+		return nil, errors.New("discord runner manager: Secrets decrypter is required")
+	}
+	if cfg.NewAdapter == nil {
+		return nil, errors.New("discord runner manager: NewAdapter factory is required")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = log.Bg()
+	}
+	refresh := cfg.RefreshInterval
+	if refresh <= 0 {
+		refresh = 30 * time.Second
+	}
+	if refresh > 10*time.Minute {
+		refresh = 10 * time.Minute
+	}
+	return &Manager{
+		store:      cfg.Store,
+		router:     cfg.RouterStore,
+		secrets:    cfg.Secrets,
+		newAdapter: cfg.NewAdapter,
+		gateCfg:    cfg.GateConfig,
+		log:        logger,
+		refresh:    refresh,
+		clients:    make(map[string]*discordClientHandle),
+	}, nil
+}
+
+// Run starts the reconcile loop. It returns ctx.Err() on normal shutdown.
+func (m *Manager) Run(ctx context.Context) error {
+	m.log.Info("discord gateway inbound manager starting", "refresh_interval", m.refresh.String())
+	defer m.stopAll()
+
+	if err := m.Reconcile(ctx); err != nil {
+		m.log.Warn("discord gateway inbound initial reconcile failed", "err", err.Error())
+	}
+	ticker := time.NewTicker(m.refresh)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			m.log.Info("discord gateway inbound manager stopping", "reason", ctx.Err().Error())
+			return ctx.Err()
+		case <-ticker.C:
+			if err := m.Reconcile(ctx); err != nil {
+				m.log.Warn("discord gateway inbound reconcile failed", "err", err.Error())
+			}
+		}
+	}
+}
+
+// Reconcile starts missing runners, restarts ones whose token rotated, and
+// stops runners for connectors that were disabled/removed.
+func (m *Manager) Reconcile(ctx context.Context) error {
+	conns, err := m.store.ListWorkspaceConnectorsByPlatform(ctx, "discord")
+	if err != nil {
+		return err
+	}
+
+	wanted := make(map[string]struct{}, len(conns))
+	for _, conn := range conns {
+		appID := strings.TrimSpace(conn.AppID)
+		if !conn.Enabled || appID == "" {
+			continue
+		}
+		botRef := configString(conn.Config, "bot_token_ref")
+		if botRef == "" {
+			m.log.Warn("discord gateway inbound: connector missing bot_token_ref",
+				"workspace_id", conn.WorkspaceID, "app_id", appID)
+			continue
+		}
+		key := clientKey(conn.WorkspaceID, appID)
+		wanted[key] = struct{}{}
+		if m.upToDate(key, botRef) {
+			continue
+		}
+		m.stopByKey(key)
+		if err := m.startClient(ctx, conn, key, botRef); err != nil {
+			m.log.Warn("discord gateway inbound: start client failed",
+				"workspace_id", conn.WorkspaceID, "app_id", appID, "err", err.Error())
+		}
+	}
+
+	m.mu.Lock()
+	stale := make([]*discordClientHandle, 0)
+	for key, h := range m.clients {
+		if _, ok := wanted[key]; !ok {
+			stale = append(stale, h)
+			delete(m.clients, key)
+		}
+	}
+	m.mu.Unlock()
+	for _, h := range stale {
+		m.stopHandle(h)
+	}
+	return nil
+}
+
+// upToDate reports whether a running handle for key already matches fingerprint
+// (same token ref), so the reconcile can skip a needless restart.
+func (m *Manager) upToDate(key, fingerprint string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	h, ok := m.clients[key]
+	return ok && h.fingerprint == fingerprint
+}
+
+func (m *Manager) startClient(ctx context.Context, conn store.WorkspaceConnectorRead, key, botRef string) error {
+	appID := strings.TrimSpace(conn.AppID)
+	botToken, err := m.loadToken(ctx, conn.WorkspaceID, botRef)
+	if err != nil {
+		return fmt.Errorf("load bot token: %w", err)
+	}
+	adapter := m.newAdapter(appID, botToken)
+	runner, err := New(Config{
+		BotToken:   botToken,
+		Channel:    adapter,
+		Store:      m.router,
+		GateConfig: m.gateCfg,
+		Logger:     m.log,
+	})
+	if err != nil {
+		return err
+	}
+
+	clientCtx, cancel := context.WithCancel(ctx)
+	handle := &discordClientHandle{key: key, appID: appID, cancel: cancel, fingerprint: botRef}
+
+	m.mu.Lock()
+	if _, exists := m.clients[key]; exists {
+		m.mu.Unlock()
+		cancel()
+		return nil
+	}
+	m.clients[key] = handle
+	m.mu.Unlock()
+
+	go func() {
+		if err := runner.Run(clientCtx); err != nil && !errors.Is(err, context.Canceled) {
+			m.log.Warn("discord gateway inbound client exited",
+				"workspace_id", conn.WorkspaceID, "app_id", appID, "err", err.Error())
+		}
+	}()
+	m.log.Info("discord gateway inbound client started", "workspace_id", conn.WorkspaceID, "app_id", appID)
+	return nil
+}
+
+// stopByKey stops and removes a running handle for key, if present.
+func (m *Manager) stopByKey(key string) {
+	m.mu.Lock()
+	h, ok := m.clients[key]
+	if ok {
+		delete(m.clients, key)
+	}
+	m.mu.Unlock()
+	if ok {
+		m.stopHandle(h)
+	}
+}
+
+func (m *Manager) stopHandle(h *discordClientHandle) {
+	if h == nil {
+		return
+	}
+	h.cancel()
+	m.log.Info("discord gateway inbound client stopped", "app_id", h.appID)
+}
+
+func (m *Manager) stopAll() {
+	m.mu.Lock()
+	handles := make([]*discordClientHandle, 0, len(m.clients))
+	for key, h := range m.clients {
+		handles = append(handles, h)
+		delete(m.clients, key)
+	}
+	m.mu.Unlock()
+	for _, h := range handles {
+		m.stopHandle(h)
+	}
+}
+
+// loadToken reads a secret payload by id and returns its plaintext token using
+// the shared key precedence (api_key → token → access_token → value).
+func (m *Manager) loadToken(ctx context.Context, workspaceID, secretID string) (string, error) {
+	secretID = strings.TrimSpace(secretID)
+	if secretID == "" {
+		return "", errors.New("empty secret ref")
+	}
+	payload, err := m.store.GetSecretPayload(ctx, workspaceID, secretID)
+	if err != nil {
+		return "", fmt.Errorf("read secret payload: %w", err)
+	}
+	decrypted, err := m.secrets.Decrypt(payload.EncryptedPayload)
+	if err != nil {
+		return "", fmt.Errorf("decrypt secret: %w", err)
+	}
+	token := tokenFromPayload(decrypted)
+	if token == "" {
+		return "", errors.New("secret payload missing token value")
+	}
+	return token, nil
+}
+
+// clientKey is the per-runner identity: workspace|app_id (the Feishu manager's
+// key shape).
+func clientKey(workspaceID, appID string) string {
+	return strings.TrimSpace(workspaceID) + "|" + strings.TrimSpace(appID)
+}
+
+// configString reads a trimmed string field out of a decoded connector config.
+func configString(config map[string]any, key string) string {
+	if config == nil {
+		return ""
+	}
+	v, _ := config[key].(string)
+	return strings.TrimSpace(v)
+}
+
+// tokenFromPayload extracts a token from a decrypted secret payload using the
+// shared key precedence used elsewhere for bot credentials.
+func tokenFromPayload(payload map[string]any) string {
+	for _, key := range []string{"bot_token", "api_key", "token", "access_token", "value"} {
+		if v, ok := payload[key].(string); ok && strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}

--- a/server/internal/gateway/inbound/manager.go
+++ b/server/internal/gateway/inbound/manager.go
@@ -151,6 +151,18 @@ type SecretDecrypter interface {
 	Encrypt(payload map[string]any) ([]byte, error)
 }
 
+// ConnectorReader is the optional workspace_im_connectors source (the new,
+// three-platform-unified storage). When set, Reconcile opens websocket clients
+// for workspace-dimension Feishu connectors (new-table-first), and handleMessage
+// routes their inbound as a workspace-scoped shared bot when the legacy
+// agents.config lookup misses. Nil-tolerant: an unset reader leaves the manager
+// legacy-only (agents.config), so existing deployments and the manager's test
+// fakes are unaffected.
+type ConnectorReader interface {
+	ListWorkspaceConnectorsByPlatform(ctx context.Context, platform string) ([]store.WorkspaceConnectorRead, error)
+	GetWorkspaceConnectorByAppID(ctx context.Context, platform, appID string) (store.WorkspaceConnectorRead, error)
+}
+
 // DefaultSharedBotConfig describes the instance-level default Feishu Bot.
 // It is not stored on any Agent; Agents without their own dedicated Bot
 // connector are selected through this shared entry point.
@@ -200,6 +212,13 @@ type Options struct {
 	// visibility=workspace rejection card surfaces as a "申请加入" link.
 	// Nil falls back to "请联系上述管理员加入".
 	JoinURLBuilder func(workspaceID string) string
+
+	// Connectors, when non-nil, is the workspace_im_connectors source. It
+	// makes Reconcile new-table-first for Feishu (workspace-dimension bots
+	// open a websocket alongside the legacy agents.config ones) and lets
+	// handleMessage route a workspace-bot inbound as a shared bot when the
+	// legacy app_id lookup misses. Nil keeps the manager legacy-only.
+	Connectors ConnectorReader
 }
 
 // Manager reconciles configured websocket Bots and keeps one SDK WS client per
@@ -222,6 +241,10 @@ type Manager struct {
 	pfucRouter PromptForUserChoiceRouter
 
 	joinURLBuilder func(workspaceID string) string
+
+	// connectors is the optional workspace_im_connectors source (nil =
+	// legacy agents.config only). See ConnectorReader.
+	connectors ConnectorReader
 
 	mu      sync.Mutex
 	clients map[string]*clientHandle
@@ -281,6 +304,7 @@ func NewManager(opts Options) (*Manager, error) {
 		permRouter:     opts.PermissionRouter,
 		pfucRouter:     opts.PromptForUserChoiceRouter,
 		joinURLBuilder: opts.JoinURLBuilder,
+		connectors:     opts.Connectors,
 		clients:        make(map[string]*clientHandle),
 	}, nil
 }
@@ -327,6 +351,35 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 		}
 	}
 
+	// New-table-first: workspace_im_connectors is the three-platform unified
+	// store. A Feishu connector configured via the admin panel opens a
+	// workspace-scoped shared-bot websocket here; its app_id is remembered so
+	// the legacy agents.config loop below skips a duplicate socket for the same
+	// bot (new table wins).
+	newTableAppIDs := map[string]struct{}{}
+	if m.connectors != nil {
+		conns, err := m.connectors.ListWorkspaceConnectorsByPlatform(ctx, "feishu")
+		if err != nil {
+			m.logger.Warn("feishu websocket inbound: list workspace connectors failed", "err", err.Error())
+		}
+		for _, conn := range conns {
+			route, cfg, ok := m.workspaceFeishuRoute(conn)
+			if !ok {
+				continue
+			}
+			appID := strings.TrimSpace(cfg.AppID)
+			newTableAppIDs[appID] = struct{}{}
+			key := clientKey(conn.WorkspaceID, appID)
+			wanted[key] = struct{}{}
+			if m.hasClient(key) {
+				continue
+			}
+			if err := m.startClient(ctx, route, cfg, key); err != nil {
+				m.logger.Warn("feishu websocket inbound: start workspace connector client failed", "workspace_id", conn.WorkspaceID, "app_id", appID, "err", err.Error())
+			}
+		}
+	}
+
 	for _, route := range routes {
 		cfg, ok, err := gateway.DecodeFeishuConnectorConfig(route.Config)
 		if err != nil {
@@ -339,6 +392,11 @@ func (m *Manager) Reconcile(ctx context.Context) error {
 		appID := strings.TrimSpace(cfg.AppID)
 		if appID == "" || strings.TrimSpace(cfg.AppSecretRef) == "" {
 			m.logger.Warn("feishu websocket inbound: connector missing app_id or app_secret_ref", "agent_id", route.AgentID)
+			continue
+		}
+		// New table wins: skip the legacy socket when the same app_id is already
+		// owned by a workspace_im_connectors row.
+		if _, claimed := newTableAppIDs[appID]; claimed {
 			continue
 		}
 		key := clientKey(route.WorkspaceID, appID)
@@ -537,6 +595,12 @@ func (m *Manager) handleMessage(ctx context.Context, appID string, event *larkim
 	host, err := r.GetAgentByFeishuAppID(ctx, inbound.AppID)
 	if err != nil {
 		if errors.Is(err, gateway.ErrFeishuRouterUnknownAgent) {
+			// New-table fallback: a workspace_im_connectors Feishu bot has no
+			// agents.config row, so the legacy lookup misses. Resolve it from
+			// the workspace connector table and dispatch via the shared path.
+			if handled := m.handleWorkspaceFeishuInbound(ctx, &inbound); handled {
+				return nil
+			}
 			m.logger.Warn("feishu websocket inbound: unknown app_id", "app_id", inbound.AppID)
 			return nil
 		}
@@ -719,6 +783,58 @@ func (m *Manager) handleMessage(ctx context.Context, appID string, event *larkim
 	}
 	m.logger.Info("feishu websocket inbound accepted", "app_id", inbound.AppID, "message_id", inbound.MessageID, "agent_id", decision.Agent.AgentID)
 	return nil
+}
+
+// handleWorkspaceFeishuInbound dispatches an inbound whose app_id has no legacy
+// agents.config route but does have a workspace_im_connectors row. It mirrors
+// the isDefaultSharedBotApp shared path, but the synthetic route is scoped to
+// the connector's workspace. Returns false (not handled) when there is no
+// workspace connector for the app_id, so the caller logs the unknown-app_id
+// warning and drops the message as before.
+func (m *Manager) handleWorkspaceFeishuInbound(ctx context.Context, inbound *gateway.FeishuInboundEvent) bool {
+	if m.connectors == nil {
+		return false
+	}
+	conn, err := m.connectors.GetWorkspaceConnectorByAppID(ctx, "feishu", inbound.AppID)
+	if err != nil {
+		// No workspace connector for this app_id (the common miss case), or a
+		// transient read error — either way this manager can't route it.
+		return false
+	}
+	route, _, ok := m.workspaceFeishuRoute(conn)
+	if !ok {
+		return false
+	}
+	host := routeFromStore(route)
+	botOpenID := botOpenIDFromConfig(host.Config)
+	filterEv := gateway.NeutralFromFeishuEvent(*inbound)
+	if gateway.IsSelfSender(filterEv, botOpenID) {
+		m.logger.Info("feishu websocket inbound: workspace shared self message skipped", "app_id", inbound.AppID, "message_id", inbound.MessageID)
+		return true
+	}
+	if gateway.ShouldSkipGroupWithoutMention(ctx, neutralThreadHist{m.store}, filterEv, botOpenID) {
+		m.logger.Info("feishu websocket inbound: workspace shared group message without bot mention skipped", "app_id", inbound.AppID, "message_id", inbound.MessageID)
+		return true
+	}
+	m.enrichInboundAttachments(ctx, host, inbound)
+	neutral := gateway.NeutralFromFeishuEvent(*inbound)
+	reply := neutralReplyBridge(m, *inbound)
+	quoted := neutralQuotedChainBridge(m, inbound)
+	outcome, err := sharedrouter.HandleInbound(ctx, m.store, host, neutral, reply, quoted, m.gateConfig())
+	if err != nil {
+		m.logger.Warn("feishu websocket inbound: handle workspace shared bot failed", "app_id", inbound.AppID, "message_id", inbound.MessageID, "err", err.Error())
+		return true
+	}
+	if outcome.Accepted && outcome.InboundMessageID != "" {
+		if rAppID, rAppSecret, secErr := m.resolveImmediateReplyCredentials(ctx, host, *inbound); secErr == nil {
+			m.asyncAddTypingReaction(outcome.InboundMessageID, inbound.MessageID, rAppID, rAppSecret)
+		} else {
+			m.logger.Warn("feishu websocket inbound: skip typing reaction, credential resolve failed",
+				"app_id", inbound.AppID, "external_message_id", inbound.MessageID, "err", secErr.Error())
+		}
+	}
+	m.logger.Info("feishu websocket workspace shared bot handled", "app_id", inbound.AppID, "message_id", inbound.MessageID, "accepted", outcome.Accepted, "replied", outcome.Replied, "reason", outcome.Reason, "agent_id", outcome.AgentID)
+	return true
 }
 
 // neutralReplyBridge adapts the manager's Feishu-typed sendImmediateText to
@@ -2120,6 +2236,60 @@ func (m *Manager) defaultSharedRouteAndConfig() (store.FeishuAgentRoute, gateway
 
 func (m *Manager) isDefaultSharedBotApp(appID string) bool {
 	return m.defaultBot.configured() && strings.TrimSpace(appID) == m.defaultBot.AppID
+}
+
+// workspaceFeishuRoute turns a workspace_im_connectors Feishu row into the
+// synthetic shared-bot route + config the websocket loop and the shared-routing
+// path consume. A workspace bot is inherently shared (its agents are picked from
+// /list), so RoutingMode is "shared" and Visibility is public — the same shape
+// defaultSharedRouteAndConfig builds, but scoped to the connector's workspace
+// and backed by its vault app_secret_ref. ok=false skips a row that is disabled,
+// not websocket-mode, or missing app_id / app_secret_ref.
+func (m *Manager) workspaceFeishuRoute(conn store.WorkspaceConnectorRead) (store.FeishuAgentRoute, gateway.FeishuConnectorConfig, bool) {
+	appID := strings.TrimSpace(conn.AppID)
+	if !conn.Enabled || appID == "" {
+		return store.FeishuAgentRoute{}, gateway.FeishuConnectorConfig{}, false
+	}
+	if !strings.EqualFold(connectorConfigString(conn.Config, "event_mode"), "websocket") {
+		return store.FeishuAgentRoute{}, gateway.FeishuConnectorConfig{}, false
+	}
+	secretRef := connectorConfigString(conn.Config, "app_secret_ref")
+	if secretRef == "" {
+		m.logger.Warn("feishu websocket inbound: workspace connector missing app_secret_ref", "workspace_id", conn.WorkspaceID, "app_id", appID)
+		return store.FeishuAgentRoute{}, gateway.FeishuConnectorConfig{}, false
+	}
+	cfg := gateway.FeishuConnectorConfig{
+		Enabled:              true,
+		AppID:                appID,
+		AppSecretRef:         secretRef,
+		VerificationTokenRef: connectorConfigString(conn.Config, "verification_token_ref"),
+		EncryptKeyRef:        connectorConfigString(conn.Config, "encrypt_key_ref"),
+		BotOpenID:            connectorConfigString(conn.Config, "bot_open_id"),
+		EventMode:            "websocket",
+		RoutingMode:          "shared",
+	}
+	raw, _ := json.Marshal(map[string]any{
+		"connectors": map[string]any{"feishu": cfg},
+	})
+	route := store.FeishuAgentRoute{
+		WorkspaceID:   conn.WorkspaceID,
+		WorkspaceName: conn.WorkspaceName,
+		AgentName:     "Workspace Feishu Bot",
+		AgentSlug:     "workspace-feishu-bot",
+		Visibility:    string(gateway.VisibilityPublic),
+		Config:        raw,
+	}
+	return route, cfg, true
+}
+
+// connectorConfigString reads a trimmed string field out of a decoded
+// workspace connector config map.
+func connectorConfigString(config map[string]any, key string) string {
+	if config == nil {
+		return ""
+	}
+	v, _ := config[key].(string)
+	return strings.TrimSpace(v)
 }
 
 func clientKey(workspaceID, appID string) string {

--- a/server/internal/gateway/inbound/slackrunner/manager.go
+++ b/server/internal/gateway/inbound/slackrunner/manager.go
@@ -1,0 +1,355 @@
+// manager.go is the multi-tenant reconciler that turns workspace_im_connectors
+// rows into live Socket Mode runners — the Slack twin of inbound.Manager's
+// Feishu websocket loop.
+//
+// Where Runner (runner.go) drives ONE env-gated socket, Manager drives N: it
+// ticks every refresh interval, lists every enabled Slack connector
+// (ListWorkspaceConnectorsByPlatform), decrypts each one's bot/app token out of
+// the vault, and keeps exactly one Runner per workspace|app_id key. Connectors
+// that disappear (disabled, deleted, app_id changed) have their runner stopped;
+// a token rotation is detected by a per-handle fingerprint and triggers a
+// stop+restart so the new credential takes effect without a process restart.
+//
+// Only Socket Mode connectors (event_mode=socket, the default) get a runner —
+// an events-API connector would need an inbound HTTP webhook, which this
+// reconciler does not own. The adapter (with its action/credential routing) is
+// built by an injected NewAdapter factory so this package stays free of the
+// connector/inbound wiring that lives in main.
+package slackrunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway"
+	slackchannel "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel/slack"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/router"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+// ConnectorStore is the read surface the reconciler needs: the per-platform
+// connector list and the vault secret payloads its *_ref UUIDs point at.
+// *store.Store satisfies it.
+type ConnectorStore interface {
+	ListWorkspaceConnectorsByPlatform(ctx context.Context, platform string) ([]store.WorkspaceConnectorRead, error)
+	GetSecretPayload(ctx context.Context, workspaceID, secretID string) (store.SecretPayload, error)
+}
+
+// SecretDecrypter mirrors the small subset of *secrets.Service the reconciler
+// uses to turn an encrypted vault payload into its plaintext token fields.
+type SecretDecrypter interface {
+	Decrypt(envelopeJSON []byte) (map[string]any, error)
+}
+
+// ManagerConfig configures Manager. Store, Secrets and NewAdapter are required.
+type ManagerConfig struct {
+	// Store reads the connector rows and their secret payloads.
+	Store ConnectorStore
+	// RouterStore is handed to every Runner as the shared inbound router store.
+	RouterStore router.Store
+	// Secrets decrypts the bot/app token payloads.
+	Secrets SecretDecrypter
+	// NewAdapter builds a Slack adapter for one workspace bot. main injects it
+	// so the action-router / credential-resolver wiring (which needs the
+	// connector registry and secret vault) stays out of this package.
+	NewAdapter func(appID, botToken, appToken string) *slackchannel.Channel
+	// GateConfig feeds the visibility rejection cards each runner renders.
+	GateConfig gateway.GateConfig
+	// Logger is optional (defaults to log.Bg()).
+	Logger *slog.Logger
+	// RefreshInterval defaults to 30s, capped at 10m.
+	RefreshInterval time.Duration
+}
+
+// Manager reconciles configured Slack connectors and keeps one Socket Mode
+// Runner per workspace|app_id. Run blocks until ctx is cancelled.
+type Manager struct {
+	store      ConnectorStore
+	router     router.Store
+	secrets    SecretDecrypter
+	newAdapter func(appID, botToken, appToken string) *slackchannel.Channel
+	gateCfg    gateway.GateConfig
+	log        *slog.Logger
+	refresh    time.Duration
+
+	mu      sync.Mutex
+	clients map[string]*slackClientHandle
+}
+
+// slackClientHandle is one live runner plus the state needed to stop it and to
+// detect a token rotation (fingerprint) on the next reconcile.
+type slackClientHandle struct {
+	key         string
+	appID       string
+	cancel      context.CancelFunc
+	fingerprint string
+}
+
+// NewManager validates config and returns an inert manager (Run starts the
+// loop). Mirrors inbound.NewManager.
+func NewManager(cfg ManagerConfig) (*Manager, error) {
+	if cfg.Store == nil {
+		return nil, errors.New("slack runner manager: Store is required")
+	}
+	if cfg.RouterStore == nil {
+		return nil, errors.New("slack runner manager: RouterStore is required")
+	}
+	if cfg.Secrets == nil {
+		return nil, errors.New("slack runner manager: Secrets decrypter is required")
+	}
+	if cfg.NewAdapter == nil {
+		return nil, errors.New("slack runner manager: NewAdapter factory is required")
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = log.Bg()
+	}
+	refresh := cfg.RefreshInterval
+	if refresh <= 0 {
+		refresh = 30 * time.Second
+	}
+	if refresh > 10*time.Minute {
+		refresh = 10 * time.Minute
+	}
+	return &Manager{
+		store:      cfg.Store,
+		router:     cfg.RouterStore,
+		secrets:    cfg.Secrets,
+		newAdapter: cfg.NewAdapter,
+		gateCfg:    cfg.GateConfig,
+		log:        logger,
+		refresh:    refresh,
+		clients:    make(map[string]*slackClientHandle),
+	}, nil
+}
+
+// Run starts the reconcile loop. It returns ctx.Err() on normal shutdown.
+func (m *Manager) Run(ctx context.Context) error {
+	m.log.Info("slack socket mode inbound manager starting", "refresh_interval", m.refresh.String())
+	defer m.stopAll()
+
+	if err := m.Reconcile(ctx); err != nil {
+		m.log.Warn("slack socket mode inbound initial reconcile failed", "err", err.Error())
+	}
+	ticker := time.NewTicker(m.refresh)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			m.log.Info("slack socket mode inbound manager stopping", "reason", ctx.Err().Error())
+			return ctx.Err()
+		case <-ticker.C:
+			if err := m.Reconcile(ctx); err != nil {
+				m.log.Warn("slack socket mode inbound reconcile failed", "err", err.Error())
+			}
+		}
+	}
+}
+
+// Reconcile starts missing runners, restarts ones whose token rotated, and
+// stops runners for connectors that were disabled/removed.
+func (m *Manager) Reconcile(ctx context.Context) error {
+	conns, err := m.store.ListWorkspaceConnectorsByPlatform(ctx, "slack")
+	if err != nil {
+		return err
+	}
+
+	wanted := make(map[string]struct{}, len(conns))
+	for _, conn := range conns {
+		appID := strings.TrimSpace(conn.AppID)
+		if !conn.Enabled || appID == "" {
+			continue
+		}
+		// Only Socket Mode connectors get a runner; events-API connectors need
+		// an inbound HTTP webhook this reconciler does not own.
+		if normalizeEventMode(conn.Config) != "socket" {
+			continue
+		}
+		botRef := configString(conn.Config, "bot_token_ref")
+		appRef := configString(conn.Config, "app_token_ref")
+		if botRef == "" || appRef == "" {
+			m.log.Warn("slack socket mode inbound: connector missing bot_token_ref or app_token_ref",
+				"workspace_id", conn.WorkspaceID, "app_id", appID)
+			continue
+		}
+		key := clientKey(conn.WorkspaceID, appID)
+		fingerprint := botRef + "|" + appRef
+		wanted[key] = struct{}{}
+		if m.upToDate(key, fingerprint) {
+			continue
+		}
+		// Either missing or rotated: stop a stale instance then (re)start.
+		m.stopByKey(key)
+		if err := m.startClient(ctx, conn, key, botRef, appRef, fingerprint); err != nil {
+			m.log.Warn("slack socket mode inbound: start client failed",
+				"workspace_id", conn.WorkspaceID, "app_id", appID, "err", err.Error())
+		}
+	}
+
+	m.mu.Lock()
+	stale := make([]*slackClientHandle, 0)
+	for key, h := range m.clients {
+		if _, ok := wanted[key]; !ok {
+			stale = append(stale, h)
+			delete(m.clients, key)
+		}
+	}
+	m.mu.Unlock()
+	for _, h := range stale {
+		m.stopHandle(h)
+	}
+	return nil
+}
+
+// upToDate reports whether a running handle for key already matches fingerprint
+// (same token refs), so the reconcile can skip a needless restart.
+func (m *Manager) upToDate(key, fingerprint string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	h, ok := m.clients[key]
+	return ok && h.fingerprint == fingerprint
+}
+
+func (m *Manager) startClient(ctx context.Context, conn store.WorkspaceConnectorRead, key, botRef, appRef, fingerprint string) error {
+	appID := strings.TrimSpace(conn.AppID)
+	botToken, err := m.loadToken(ctx, conn.WorkspaceID, botRef)
+	if err != nil {
+		return fmt.Errorf("load bot token: %w", err)
+	}
+	appToken, err := m.loadToken(ctx, conn.WorkspaceID, appRef)
+	if err != nil {
+		return fmt.Errorf("load app token: %w", err)
+	}
+	adapter := m.newAdapter(appID, botToken, appToken)
+	runner, err := New(Config{
+		BotToken:   botToken,
+		AppToken:   appToken,
+		Channel:    adapter,
+		Store:      m.router,
+		GateConfig: m.gateCfg,
+		Logger:     m.log,
+	})
+	if err != nil {
+		return err
+	}
+
+	clientCtx, cancel := context.WithCancel(ctx)
+	handle := &slackClientHandle{key: key, appID: appID, cancel: cancel, fingerprint: fingerprint}
+
+	m.mu.Lock()
+	if _, exists := m.clients[key]; exists {
+		m.mu.Unlock()
+		cancel()
+		return nil
+	}
+	m.clients[key] = handle
+	m.mu.Unlock()
+
+	go func() {
+		if err := runner.Run(clientCtx); err != nil && !errors.Is(err, context.Canceled) {
+			m.log.Warn("slack socket mode inbound client exited",
+				"workspace_id", conn.WorkspaceID, "app_id", appID, "err", err.Error())
+		}
+	}()
+	m.log.Info("slack socket mode inbound client started", "workspace_id", conn.WorkspaceID, "app_id", appID)
+	return nil
+}
+
+// stopByKey stops and removes a running handle for key, if present.
+func (m *Manager) stopByKey(key string) {
+	m.mu.Lock()
+	h, ok := m.clients[key]
+	if ok {
+		delete(m.clients, key)
+	}
+	m.mu.Unlock()
+	if ok {
+		m.stopHandle(h)
+	}
+}
+
+func (m *Manager) stopHandle(h *slackClientHandle) {
+	if h == nil {
+		return
+	}
+	h.cancel()
+	m.log.Info("slack socket mode inbound client stopped", "app_id", h.appID)
+}
+
+func (m *Manager) stopAll() {
+	m.mu.Lock()
+	handles := make([]*slackClientHandle, 0, len(m.clients))
+	for key, h := range m.clients {
+		handles = append(handles, h)
+		delete(m.clients, key)
+	}
+	m.mu.Unlock()
+	for _, h := range handles {
+		m.stopHandle(h)
+	}
+}
+
+// loadToken reads a secret payload by id and returns its plaintext token using
+// the shared key precedence (api_key → token → access_token → value).
+func (m *Manager) loadToken(ctx context.Context, workspaceID, secretID string) (string, error) {
+	secretID = strings.TrimSpace(secretID)
+	if secretID == "" {
+		return "", errors.New("empty secret ref")
+	}
+	payload, err := m.store.GetSecretPayload(ctx, workspaceID, secretID)
+	if err != nil {
+		return "", fmt.Errorf("read secret payload: %w", err)
+	}
+	decrypted, err := m.secrets.Decrypt(payload.EncryptedPayload)
+	if err != nil {
+		return "", fmt.Errorf("decrypt secret: %w", err)
+	}
+	token := tokenFromPayload(decrypted)
+	if token == "" {
+		return "", errors.New("secret payload missing token value")
+	}
+	return token, nil
+}
+
+// clientKey is the per-runner identity: workspace|app_id (the Feishu manager's
+// key shape).
+func clientKey(workspaceID, appID string) string {
+	return strings.TrimSpace(workspaceID) + "|" + strings.TrimSpace(appID)
+}
+
+// configString reads a trimmed string field out of a decoded connector config.
+func configString(config map[string]any, key string) string {
+	if config == nil {
+		return ""
+	}
+	v, _ := config[key].(string)
+	return strings.TrimSpace(v)
+}
+
+// normalizeEventMode reads config.event_mode, defaulting to "socket" (the only
+// mode the reconciler runs).
+func normalizeEventMode(config map[string]any) string {
+	switch strings.ToLower(configString(config, "event_mode")) {
+	case "events", "events_api", "http", "webhook":
+		return "events"
+	default:
+		return "socket"
+	}
+}
+
+// tokenFromPayload extracts a token from a decrypted secret payload using the
+// shared key precedence used elsewhere for bot credentials.
+func tokenFromPayload(payload map[string]any) string {
+	for _, key := range []string{"bot_token", "app_token", "api_key", "token", "access_token", "value"} {
+		if v, ok := payload[key].(string); ok && strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}

--- a/server/internal/gateway/inflight/inflight_neutral.go
+++ b/server/internal/gateway/inflight/inflight_neutral.go
@@ -86,6 +86,10 @@ func (w *Worker) handleNeutralInflightConversation(ctx context.Context, c store.
 		// multi-workspace adapter resolves the per-tenant bot token at send
 		// time. Empty for Feishu and single-tenant Slack, which ignore it.
 		TenantKey: c.TenantKey,
+		// SourceAppID is the workspace-bot app_id captured on inbound — the
+		// join key into workspace_im_connectors. The workspace-dimension
+		// resolver prefers it over TenantKey; empty for env-credential paths.
+		SourceAppID: c.SourceAppID,
 	}
 
 	if isCompleted || isFailed {

--- a/server/internal/store/workspace_im_connectors.go
+++ b/server/internal/store/workspace_im_connectors.go
@@ -1,0 +1,461 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
+)
+
+// ============================================================
+// workspace_im_connectors — workspace 维度的 IM 连接器(feishu/slack/
+// discord)。见 migration 000002 与 db/queries/store.sql。
+//
+// 设计要点:
+//   - 凭据密文存在 secrets(vault),本表 config(jsonb) 只存 *_ref(UUID
+//     指针)与非敏感字段(event_mode / intents 等)。
+//   - app_id 是 workspace-bot 的通用 join key:配置保存时即可知,而
+//     team_id(Slack)/guild_id(Discord)只有 Bot 入驻后才知道。
+//   - (workspace_id, platform) 唯一 → 每个 workspace 每平台至多一个连接器;
+//     (platform, app_id) 唯一 → 同一 app_id 不能被两个 workspace 占用,
+//     冲突时 pg 报 23505,被映射成 *_app_id_in_use。
+// ============================================================
+
+const auditWorkspaceIMConnectorUpdated = "workspace.im_connector.updated"
+
+// 连接器配置不完整 / app_id 冲突的错误哨兵。HTTP 层把它们映射成
+// 422 *_connector_incomplete 与 409 *_app_id_in_use。
+var (
+	ErrSlackConnectorIncomplete   = errors.New("slack connector enabled requires app_id, bot_token_ref, and (socket: app_token_ref / events: signing_secret_ref)")
+	ErrSlackAppIDInUse            = errors.New("another workspace has already registered this Slack bot app_id")
+	ErrDiscordConnectorIncomplete = errors.New("discord connector enabled requires app_id and bot_token_ref")
+	ErrDiscordAppIDInUse          = errors.New("another workspace has already registered this Discord bot app_id")
+)
+
+// WorkspaceConnectorChange 是三个 Upsert 方法的统一返回值。Config 已去掉
+// 列字段(id/workspace_id/platform/app_id/enabled),只剩 *_ref 与模式。
+type WorkspaceConnectorChange struct {
+	ID          string         `json:"id"`
+	WorkspaceID string         `json:"workspace_id"`
+	Platform    string         `json:"platform"`
+	AppID       string         `json:"app_id"`
+	Enabled     bool           `json:"enabled"`
+	Config      map[string]any `json:"config"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+
+	// Noop=true 表示新配置与旧配置逐字段相等,handler 仍返回 200 但抑制审计。
+	Noop bool `json:"noop,omitempty"`
+}
+
+// ------------------------------------------------------------
+// Snapshots — 每平台 config 子树的扁平视图(含列字段以便逐字段比对 noop)。
+// ------------------------------------------------------------
+
+// WorkspaceSlackConnectorSnapshot mirrors a Slack connector's config plus
+// its column fields (Enabled/AppID) for noop comparison.
+type WorkspaceSlackConnectorSnapshot struct {
+	Enabled          bool   `json:"enabled"`
+	AppID            string `json:"app_id"`
+	BotTokenRef      string `json:"bot_token_ref"`
+	AppTokenRef      string `json:"app_token_ref"`
+	SigningSecretRef string `json:"signing_secret_ref"`
+	EventMode        string `json:"event_mode"`
+}
+
+func (s WorkspaceSlackConnectorSnapshot) isZero() bool {
+	return !s.Enabled && s.AppID == "" && s.BotTokenRef == "" && s.AppTokenRef == "" &&
+		s.SigningSecretRef == "" && (s.EventMode == "" || s.EventMode == "socket")
+}
+
+// toConfigMap returns only the jsonb-stored fields (column fields excluded).
+func (s WorkspaceSlackConnectorSnapshot) toConfigMap() map[string]any {
+	return map[string]any{
+		"bot_token_ref":      s.BotTokenRef,
+		"app_token_ref":      s.AppTokenRef,
+		"signing_secret_ref": s.SigningSecretRef,
+		"event_mode":         normalizeSlackEventMode(s.EventMode),
+	}
+}
+
+// WorkspaceDiscordConnectorSnapshot mirrors a Discord connector's config plus
+// its column fields.
+type WorkspaceDiscordConnectorSnapshot struct {
+	Enabled      bool   `json:"enabled"`
+	AppID        string `json:"app_id"`
+	BotTokenRef  string `json:"bot_token_ref"`
+	PublicKeyRef string `json:"public_key_ref"`
+	Intents      string `json:"intents"`
+}
+
+func (s WorkspaceDiscordConnectorSnapshot) isZero() bool {
+	return !s.Enabled && s.AppID == "" && s.BotTokenRef == "" && s.PublicKeyRef == "" && s.Intents == ""
+}
+
+func (s WorkspaceDiscordConnectorSnapshot) toConfigMap() map[string]any {
+	return map[string]any{
+		"bot_token_ref":  s.BotTokenRef,
+		"public_key_ref": s.PublicKeyRef,
+		"intents":        s.Intents,
+	}
+}
+
+// WorkspaceFeishuConnectorSnapshot mirrors a Feishu connector's config plus
+// column fields. Distinct from the agent-dimension FeishuConnectorSnapshot.
+type WorkspaceFeishuConnectorSnapshot struct {
+	Enabled              bool   `json:"enabled"`
+	AppID                string `json:"app_id"`
+	AppSecretRef         string `json:"app_secret_ref"`
+	VerificationTokenRef string `json:"verification_token_ref"`
+	EncryptKeyRef        string `json:"encrypt_key_ref"`
+	BotOpenID            string `json:"bot_open_id"`
+	EventMode            string `json:"event_mode"`
+}
+
+func (s WorkspaceFeishuConnectorSnapshot) isZero() bool {
+	return !s.Enabled && s.AppID == "" && s.AppSecretRef == "" && s.VerificationTokenRef == "" &&
+		s.EncryptKeyRef == "" && s.BotOpenID == "" && (s.EventMode == "" || s.EventMode == "webhook")
+}
+
+func (s WorkspaceFeishuConnectorSnapshot) toConfigMap() map[string]any {
+	return map[string]any{
+		"app_secret_ref":         s.AppSecretRef,
+		"verification_token_ref": s.VerificationTokenRef,
+		"encrypt_key_ref":        s.EncryptKeyRef,
+		"bot_open_id":            s.BotOpenID,
+		"event_mode":             normalizeFeishuEventMode(s.EventMode),
+	}
+}
+
+func normalizeSlackEventMode(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "events", "events_api", "http", "webhook":
+		return "events"
+	default:
+		return "socket"
+	}
+}
+
+// ------------------------------------------------------------
+// Inputs
+// ------------------------------------------------------------
+
+type UpsertWorkspaceSlackConnectorInput struct {
+	WorkspaceID      string
+	Enabled          bool
+	AppID            string
+	BotTokenRef      string // xoxb-... secret ref
+	AppTokenRef      string // xapp-... secret ref (socket mode)
+	SigningSecretRef string // signing secret ref (events api mode)
+	EventMode        string // socket (default) | events
+}
+
+type UpsertWorkspaceDiscordConnectorInput struct {
+	WorkspaceID  string
+	Enabled      bool
+	AppID        string // discord application id
+	BotTokenRef  string
+	PublicKeyRef string // optional — interactions endpoint verification
+	Intents      string // optional non-secret gateway intents bitmask/list
+}
+
+type UpsertWorkspaceFeishuConnectorInput struct {
+	WorkspaceID          string
+	Enabled              bool
+	AppID                string
+	AppSecretRef         string
+	VerificationTokenRef string
+	EncryptKeyRef        string // optional — only when event encryption is on
+	BotOpenID            string // optional — dedup self-sent messages
+	EventMode            string // websocket | webhook
+}
+
+// ------------------------------------------------------------
+// Upserts
+// ------------------------------------------------------------
+
+// UpsertWorkspaceSlackConnector writes the Slack connector for a workspace.
+// When Enabled, app_id + bot_token_ref are required plus app_token_ref
+// (socket) or signing_secret_ref (events) → ErrSlackConnectorIncomplete.
+// app_id collisions across workspaces surface as ErrSlackAppIDInUse.
+func (s *Store) UpsertWorkspaceSlackConnector(ctx context.Context, input UpsertWorkspaceSlackConnectorInput, actorID string) (WorkspaceConnectorChange, error) {
+	snap := WorkspaceSlackConnectorSnapshot{
+		Enabled:          input.Enabled,
+		AppID:            strings.TrimSpace(input.AppID),
+		BotTokenRef:      strings.TrimSpace(input.BotTokenRef),
+		AppTokenRef:      strings.TrimSpace(input.AppTokenRef),
+		SigningSecretRef: strings.TrimSpace(input.SigningSecretRef),
+		EventMode:        normalizeSlackEventMode(input.EventMode),
+	}
+	if snap.Enabled {
+		if snap.AppID == "" || snap.BotTokenRef == "" {
+			return WorkspaceConnectorChange{}, ErrSlackConnectorIncomplete
+		}
+		if snap.EventMode == "socket" && snap.AppTokenRef == "" {
+			return WorkspaceConnectorChange{}, ErrSlackConnectorIncomplete
+		}
+		if snap.EventMode == "events" && snap.SigningSecretRef == "" {
+			return WorkspaceConnectorChange{}, ErrSlackConnectorIncomplete
+		}
+	}
+	return s.upsertWorkspaceConnector(ctx, workspaceConnectorUpsert{
+		platform:    "slack",
+		workspaceID: input.WorkspaceID,
+		appID:       snap.AppID,
+		enabled:     snap.Enabled,
+		config:      snap.toConfigMap(),
+		actorID:     actorID,
+		appIDInUse:  ErrSlackAppIDInUse,
+	})
+}
+
+// UpsertWorkspaceDiscordConnector writes the Discord connector for a workspace.
+func (s *Store) UpsertWorkspaceDiscordConnector(ctx context.Context, input UpsertWorkspaceDiscordConnectorInput, actorID string) (WorkspaceConnectorChange, error) {
+	snap := WorkspaceDiscordConnectorSnapshot{
+		Enabled:      input.Enabled,
+		AppID:        strings.TrimSpace(input.AppID),
+		BotTokenRef:  strings.TrimSpace(input.BotTokenRef),
+		PublicKeyRef: strings.TrimSpace(input.PublicKeyRef),
+		Intents:      strings.TrimSpace(input.Intents),
+	}
+	if snap.Enabled {
+		if snap.AppID == "" || snap.BotTokenRef == "" {
+			return WorkspaceConnectorChange{}, ErrDiscordConnectorIncomplete
+		}
+	}
+	return s.upsertWorkspaceConnector(ctx, workspaceConnectorUpsert{
+		platform:    "discord",
+		workspaceID: input.WorkspaceID,
+		appID:       snap.AppID,
+		enabled:     snap.Enabled,
+		config:      snap.toConfigMap(),
+		actorID:     actorID,
+		appIDInUse:  ErrDiscordAppIDInUse,
+	})
+}
+
+// UpsertWorkspaceFeishuConnector writes the Feishu connector for a workspace.
+// Reuses ErrFeishuConnectorIncomplete / ErrFeishuAppIDInUse sentinels.
+func (s *Store) UpsertWorkspaceFeishuConnector(ctx context.Context, input UpsertWorkspaceFeishuConnectorInput, actorID string) (WorkspaceConnectorChange, error) {
+	snap := WorkspaceFeishuConnectorSnapshot{
+		Enabled:              input.Enabled,
+		AppID:                strings.TrimSpace(input.AppID),
+		AppSecretRef:         strings.TrimSpace(input.AppSecretRef),
+		VerificationTokenRef: strings.TrimSpace(input.VerificationTokenRef),
+		EncryptKeyRef:        strings.TrimSpace(input.EncryptKeyRef),
+		BotOpenID:            strings.TrimSpace(input.BotOpenID),
+		EventMode:            normalizeFeishuEventMode(input.EventMode),
+	}
+	if snap.Enabled {
+		if snap.AppID == "" || snap.AppSecretRef == "" || (snap.EventMode != "websocket" && snap.VerificationTokenRef == "") {
+			return WorkspaceConnectorChange{}, ErrFeishuConnectorIncomplete
+		}
+	}
+	return s.upsertWorkspaceConnector(ctx, workspaceConnectorUpsert{
+		platform:    "feishu",
+		workspaceID: input.WorkspaceID,
+		appID:       snap.AppID,
+		enabled:     snap.Enabled,
+		config:      snap.toConfigMap(),
+		actorID:     actorID,
+		appIDInUse:  ErrFeishuAppIDInUse,
+	})
+}
+
+// workspaceConnectorUpsert is the shared driver behind the three typed
+// Upsert methods. Keeps validation in the typed wrappers, persistence here.
+type workspaceConnectorUpsert struct {
+	platform    string
+	workspaceID string
+	appID       string
+	enabled     bool
+	config      map[string]any
+	actorID     string
+	appIDInUse  error // sentinel returned on (platform, app_id) collision
+}
+
+func (s *Store) upsertWorkspaceConnector(ctx context.Context, u workspaceConnectorUpsert) (WorkspaceConnectorChange, error) {
+	wsID := strings.TrimSpace(u.workspaceID)
+	if wsID == "" {
+		return WorkspaceConnectorChange{}, fmt.Errorf("%w: empty workspace_id", ErrUnknownWorkspace)
+	}
+	wsUUID, err := uuid(wsID)
+	if err != nil {
+		return WorkspaceConnectorChange{}, err
+	}
+
+	// Read the current row (if any) for noop detection + before/after audit.
+	oldAppID, oldEnabled, oldConfig, hadRow, err := s.currentWorkspaceConnector(ctx, wsUUID, u.platform)
+	if err != nil {
+		return WorkspaceConnectorChange{}, err
+	}
+
+	now := time.Now().UTC()
+	encoded, err := json.Marshal(nonNilMap(u.config))
+	if err != nil {
+		return WorkspaceConnectorChange{}, err
+	}
+
+	row, err := sqlc.New(s.db).UpsertWorkspaceIMConnector(ctx, sqlc.UpsertWorkspaceIMConnectorParams{
+		ID:          mustUUID(newID()),
+		WorkspaceID: wsUUID,
+		Platform:    u.platform,
+		AppID:       u.appID,
+		Enabled:     u.enabled,
+		Config:      encoded,
+		CreatedBy:   strings.TrimSpace(u.actorID),
+		Now:         timestamptz(now),
+	})
+	if err != nil {
+		if isUniqueViolation(err) {
+			return WorkspaceConnectorChange{}, fmt.Errorf("%w: platform=%s app_id=%s", u.appIDInUse, u.platform, u.appID)
+		}
+		return WorkspaceConnectorChange{}, err
+	}
+
+	newConfig := decodeJSONMap(row.Config)
+	noop := hadRow && oldEnabled == row.Enabled && oldAppID == row.AppID && jsonMapEqual(oldConfig, newConfig)
+
+	change := WorkspaceConnectorChange{
+		ID:          row.ID,
+		WorkspaceID: row.WorkspaceID,
+		Platform:    row.Platform,
+		AppID:       row.AppID,
+		Enabled:     row.Enabled,
+		Config:      newConfig,
+		UpdatedAt:   pgTime(row.UpdatedAt),
+		Noop:        noop,
+	}
+	if !change.Noop {
+		// Audit payload omits *_ref values; only presence/booleans.
+		s.emitAgentAudit(now, u.actorID, auditWorkspaceIMConnectorUpdated, "workspace_im_connector", change.ID, change.WorkspaceID, "", map[string]any{
+			"platform":    change.Platform,
+			"old_enabled": oldEnabled,
+			"new_enabled": change.Enabled,
+			"old_app_id":  oldAppID,
+			"new_app_id":  change.AppID,
+		})
+	}
+	return change, nil
+}
+
+// currentWorkspaceConnector returns the existing connector row's app_id /
+// enabled / config for the given platform, or hadRow=false when absent.
+func (s *Store) currentWorkspaceConnector(ctx context.Context, wsUUID pgtype.UUID, platform string) (appID string, enabled bool, config map[string]any, hadRow bool, err error) {
+	rows, err := sqlc.New(s.db).GetWorkspaceIMConnectors(ctx, wsUUID)
+	if err != nil {
+		return "", false, nil, false, err
+	}
+	for _, r := range rows {
+		if r.Platform == platform {
+			return r.AppID, r.Enabled, decodeJSONMap(r.Config), true, nil
+		}
+	}
+	return "", false, map[string]any{}, false, nil
+}
+
+// ------------------------------------------------------------
+// Reads
+// ------------------------------------------------------------
+
+// WorkspaceConnectorRead is the decoded view of one connector row.
+type WorkspaceConnectorRead struct {
+	ID            string         `json:"id"`
+	WorkspaceID   string         `json:"workspace_id"`
+	WorkspaceName string         `json:"workspace_name"`
+	Platform      string         `json:"platform"`
+	AppID         string         `json:"app_id"`
+	Enabled       bool           `json:"enabled"`
+	Config        map[string]any `json:"config"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+}
+
+// GetWorkspaceIMConnectors returns all platforms' connectors for a workspace
+// (drives the admin panel's initial state).
+func (s *Store) GetWorkspaceIMConnectors(ctx context.Context, workspaceID string) ([]WorkspaceConnectorRead, error) {
+	wsUUID, err := uuid(strings.TrimSpace(workspaceID))
+	if err != nil {
+		return nil, err
+	}
+	rows, err := sqlc.New(s.db).GetWorkspaceIMConnectors(ctx, wsUUID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]WorkspaceConnectorRead, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, WorkspaceConnectorRead{
+			ID:          r.ID,
+			WorkspaceID: r.WorkspaceID,
+			Platform:    r.Platform,
+			AppID:       r.AppID,
+			Enabled:     r.Enabled,
+			Config:      decodeJSONMap(r.Config),
+			CreatedAt:   pgTime(r.CreatedAt),
+			UpdatedAt:   pgTime(r.UpdatedAt),
+		})
+	}
+	return out, nil
+}
+
+// GetWorkspaceConnectorByAppID resolves one enabled connector by (platform,
+// app_id) — the outbound resolver's reverse lookup to fetch the token ref.
+func (s *Store) GetWorkspaceConnectorByAppID(ctx context.Context, platform, appID string) (WorkspaceConnectorRead, error) {
+	row, err := sqlc.New(s.db).GetWorkspaceConnectorByAppID(ctx, sqlc.GetWorkspaceConnectorByAppIDParams{
+		Platform: strings.TrimSpace(platform),
+		AppID:    strings.TrimSpace(appID),
+	})
+	if err != nil {
+		return WorkspaceConnectorRead{}, err
+	}
+	return WorkspaceConnectorRead{
+		ID:            row.CID,
+		WorkspaceID:   row.CWorkspaceID,
+		WorkspaceName: row.WorkspaceName,
+		Platform:      row.Platform,
+		AppID:         row.AppID,
+		Enabled:       row.Enabled,
+		Config:        decodeJSONMap(row.Config),
+		CreatedAt:     pgTime(row.CreatedAt),
+		UpdatedAt:     pgTime(row.UpdatedAt),
+	}, nil
+}
+
+// ListWorkspaceConnectorsByPlatform returns every enabled connector for a
+// platform (with a non-empty app_id) — the inbound reconcilers' scan source.
+func (s *Store) ListWorkspaceConnectorsByPlatform(ctx context.Context, platform string) ([]WorkspaceConnectorRead, error) {
+	rows, err := sqlc.New(s.db).ListWorkspaceConnectorsByPlatform(ctx, strings.TrimSpace(platform))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]WorkspaceConnectorRead, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, WorkspaceConnectorRead{
+			ID:            r.CID,
+			WorkspaceID:   r.CWorkspaceID,
+			WorkspaceName: r.WorkspaceName,
+			Platform:      r.Platform,
+			AppID:         r.AppID,
+			Enabled:       r.Enabled,
+			Config:        decodeJSONMap(r.Config),
+			CreatedAt:     pgTime(r.CreatedAt),
+			UpdatedAt:     pgTime(r.UpdatedAt),
+		})
+	}
+	return out, nil
+}
+
+// jsonMapEqual compares two decoded jsonb maps by their canonical JSON
+// encoding — enough for noop detection on flat *_ref/string configs.
+func jsonMapEqual(a, b map[string]any) bool {
+	ab, err1 := json.Marshal(nonNilMap(a))
+	bb, err2 := json.Marshal(nonNilMap(b))
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return string(ab) == string(bb)
+}

--- a/server/migrations/000002_workspace_im_connectors.sql
+++ b/server/migrations/000002_workspace_im_connectors.sql
@@ -1,0 +1,64 @@
+-- +goose Up
+-- ==============================================================
+-- 000002_workspace_im_connectors — workspace 维度的 IM 连接器绑定
+-- ==============================================================
+-- 背景:
+--   共享 Bot 的绑定应当落在 workspace 维度(用户 @ 召唤机器人后从
+--   /list 里挑选 Agent,同一 workspace 下所有 Agent 共享同一个 Bot
+--   凭据),而不是 per-agent。历史上 Feishu 连接器配置被塞进
+--   agents.config->'connectors'->'feishu',是 agent 维度;本表把三个
+--   平台(feishu/slack/discord)统一收敛到 workspace 维度。
+--
+-- 设计:
+--   * app_id 是 workspace-bot 的通用 join key —— 它在保存配置时即可知;
+--     team_id(Slack)/guild_id(Discord)只有 Bot 入驻后才知道。
+--   * 凭据密文仍存在 secrets(vault),本表 config 只存 *_ref(UUID 指针)
+--     与非敏感字段(event_mode / intents 等)。
+--   * 入站 reconciler 按 (workspace_id, app_id) 维持一条长连接;
+--     出站 resolver 按 (platform, app_id) 反查解密 token。
+-- ==============================================================
+CREATE TABLE IF NOT EXISTS workspace_im_connectors (
+  id           uuid PRIMARY KEY,
+  workspace_id uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  platform     text NOT NULL
+    CHECK (platform IN ('feishu', 'slack', 'discord')),
+  app_id       text NOT NULL,
+  enabled      boolean NOT NULL DEFAULT false,
+  config       jsonb NOT NULL DEFAULT '{}',
+  created_by   uuid REFERENCES users(id),
+  created_at   timestamptz NOT NULL,
+  updated_at   timestamptz NOT NULL,
+  deleted_at   timestamptz
+);
+
+-- 一个 workspace 每个平台至多一个有效连接器(共享 Bot 语义)。
+CREATE UNIQUE INDEX IF NOT EXISTS uk_wic_ws_platform
+  ON workspace_im_connectors(workspace_id, platform)
+  WHERE deleted_at IS NULL;
+
+-- 同一个 app_id 不能被两个 workspace 同时占用(入站路由唯一性)。
+-- 仅对已填写 app_id 的有效行生效。
+CREATE UNIQUE INDEX IF NOT EXISTS uk_wic_platform_appid
+  ON workspace_im_connectors(platform, app_id)
+  WHERE deleted_at IS NULL AND app_id <> '';
+
+-- reconciler 按 platform 扫描所有启用的连接器。
+CREATE INDEX IF NOT EXISTS idx_wic_platform_enabled
+  ON workspace_im_connectors(platform)
+  WHERE deleted_at IS NULL AND enabled = true;
+
+COMMENT ON TABLE  workspace_im_connectors IS 'workspace 维度的 IM 连接器绑定(feishu/slack/discord 统一存储)';
+COMMENT ON COLUMN workspace_im_connectors.id           IS '连接器主键';
+COMMENT ON COLUMN workspace_im_connectors.workspace_id IS '所属 workspace';
+COMMENT ON COLUMN workspace_im_connectors.platform     IS 'IM 平台: feishu / slack / discord';
+COMMENT ON COLUMN workspace_im_connectors.app_id       IS '平台应用 ID(配置时即可知, workspace-bot 的通用 join key)';
+COMMENT ON COLUMN workspace_im_connectors.enabled      IS '是否启用(启用后 reconciler 才会为其建立入站连接)';
+COMMENT ON COLUMN workspace_im_connectors.config       IS '非敏感配置 + 密钥引用(*_ref 指向 secrets.id; 含 event_mode/intents 等)';
+COMMENT ON COLUMN workspace_im_connectors.created_by   IS '创建人';
+COMMENT ON COLUMN workspace_im_connectors.deleted_at   IS '软删除时间戳; NULL=有效';
+COMMENT ON INDEX  uk_wic_ws_platform     IS '同一 workspace 每个平台至多一个有效连接器';
+COMMENT ON INDEX  uk_wic_platform_appid  IS '同一 app_id 不能被两个 workspace 占用';
+COMMENT ON INDEX  idx_wic_platform_enabled IS 'reconciler 按平台扫描启用的连接器';
+
+-- +goose Down
+DROP TABLE IF EXISTS workspace_im_connectors;


### PR DESCRIPTION
                                                                
  feat(connectors): 工作区维度的 IM 连接器(飞书/Slack/Discord)                                                          
                                 
  在工作区维度为每个平台绑定一个机器人,通过新增的                                                                       
  workspace_im_connectors 表存储,以 app_id 作为统一关联键。     
                                                                                                                        
  后端:                          
  - 新增迁移、sqlc 查询、store 方法,以及 owner/admin 鉴权的                                                             
    PATCH/GET 路由                                                                                                      
  - 新增 Slack/Discord 多租户 reconciler(对齐飞书 manager),
    按 workspace|app_id 维护一个 runner,令牌轮换时热重载                                                                
  - 出站令牌解析改为按 app_id 查找                                                                                      
                                                                                                                        
  前端:                                                                                                                 
  - 用工作区维度的连接器面板替换原先被掏空的 Connections 标签页                                                         
  - 每个平台顶部带机器人注册网址                                                                                        
  - 每个字段附来源指引(去哪个 tab/页面找对应的值)                                                                       
  - 鉴权必填项校验                                                                                                      
  - 保存后显示掩码 + 「已保存」徽标,绝不回显密钥明文