### PR TITLE
fix(web): proxy /agent-daemon with WebSocket in dev

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -7,6 +7,7 @@ const devAPIURL = process.env.PARSAR_DEV_API_URL ?? process.env.VITE_PARSAR_API_
 const devProxy: ProxyOptions = {
   target: devAPIURL,
   changeOrigin: true,
+  ws: true,
   // When the upstream Go server is down, reply 503 with a JSON body so the
   // frontend recognises it as "server unreachable" instead of vite's default
   // ECONNREFUSED 404.
@@ -36,6 +37,7 @@ export default defineConfig({
     proxy: {
       '/dev': devProxy,
       '/api': devProxy,
+      '/agent-daemon': devProxy,
     },
   },
 })


### PR DESCRIPTION
## 背景

本地跑全栈时,"接入新设备"一直卡在 "Waiting for the device to connect...",daemon 无法握手。

## 根因

为了让浏览器 mock 登录能正常回跳,`PARSAR_PUBLIC_URL` 指向 Vite 源(`http://127.0.0.1:5173`)。因此服务端下发给 daemon 的 `ws_url` 是 `ws://127.0.0.1:5173/agent-daemon/ws`。但 Vite dev server 只代理了 `/api` 和 `/dev`,于是:

- daemon 的 bootstrap(`POST /agent-daemon/bootstrap`)打到了 SPA,而不是后端;
- 反向 WebSocket(`/agent-daemon/ws`)同样没有被代理,且 devProxy 没开 `ws`。

两者都拿不到后端 18080,握手失败。

## 改动

`apps/web/vite.config.ts`:

- devProxy 增加 `ws: true`,让 WebSocket 升级请求也走代理;
- 代理表新增 `'/agent-daemon': devProxy`,覆盖 daemon 的 bootstrap(HTTP)与反向 WS。

纯 dev-server 配置改动,不影响生产(生产环境后端直连,不经过 Vite)。

## 验证

本地全栈(server 18080 + Vite 5173 + Postgres)下,用 UI 一键命令接入一台设备:

| 检查 | 结果 |
|---|---|
| `install.sh` 经 5173 代理 | HTTP 200 |
| daemon 二进制 download 经 5173 代理 | HTTP 200 |
| bootstrap → `ws_url=ws://127.0.0.1:5173/agent-daemon/ws` | ok |
| `ws connected` | ✅ |
| 设备 liveness | **online**(正常心跳) |

> 注:本地要完整跑通接入,服务端还需能提供 daemon 二进制(设置 `PARSAR_DAEMON_BINARY_DIR` 指向已编译的 `parsar-daemon-<os>-<arch>`)。那属于本地运行配置,不在本 PR 范围。

## Test plan

- [ ] `pnpm --filter @parsar/web build` 通过
- [ ] 本地起 server + Vite,"接入新设备" 一键命令能让设备变为在线