### PR TITLE
feat(gateway): Slack/Discord 已激活话题续聊与飞书对齐

### DIFF
--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -132,6 +132,9 @@ type RuntimeStore interface {
 	// to let users continue a 话题 (thread) conversation without re-
 	// @mentioning the bot on every message.
 	HasFeishuThreadInboundHistory(ctx context.Context, externalChatID, threadID string) (bool, error)
+	// HasThreadInboundHistory is the platform-scoped form used by the shared
+	// router's neutral inbound gate.
+	HasThreadInboundHistory(ctx context.Context, platform, externalChatID, threadKey string) (bool, error)
 	DeleteAgent(ctx context.Context, agentID string, actorID string) (store.DeleteAgentResult, int64, error)
 	CreateSecret(ctx context.Context, input store.CreateSecretInput, encryptedPayload []byte) (store.SecretRead, error)
 	ListSecrets(ctx context.Context, workspaceID string, limit int32) ([]store.SecretRead, error)

--- a/server/internal/dev/routes_test.go
+++ b/server/internal/dev/routes_test.go
@@ -2485,6 +2485,10 @@ func (stubRuntimeStore) HasFeishuThreadInboundHistory(_ context.Context, _, _ st
 	return false, nil
 }
 
+func (stubRuntimeStore) HasThreadInboundHistory(_ context.Context, _, _, _ string) (bool, error) {
+	return false, nil
+}
+
 func (stubRuntimeStore) DeleteAgent(ctx context.Context, agentID string, actorID string) (store.DeleteAgentResult, int64, error) {
 	if agentID == "00000000-0000-0000-0000-000000000999" {
 		return store.DeleteAgentResult{}, 2, store.ErrInFlightAgentRuns

--- a/server/internal/gateway/channel/discord/event.go
+++ b/server/internal/gateway/channel/discord/event.go
@@ -13,11 +13,12 @@
 // the bot id. Like Feishu/Slack this is a pure decode: bot-loop and mention
 // gating are the shared manager's policy, not the adapter's.
 //
-// Thread handling is deferred (Capabilities.Threads is false in 5a): a Discord
-// thread is itself a channel, so a message posted in a thread already carries the
-// thread as its channel_id and routes correctly without a separate
-// ExternalThreadID. Filling the thread/root slots (so ThreadKey groups a thread
-// on its parent) lands when native thread creation is enabled.
+// Normalize stays a pure decoder and does NOT classify threads: a message in a
+// thread already carries the thread as its channel_id, so it routes correctly on
+// channel_id alone. Populating the thread/root slots (so ThreadKey groups a
+// thread's follow-ups for no-@mention continuation) needs the live session to
+// tell a thread channel from a regular one, so it lives in the runner's
+// enrichThread step, not here.
 package discord
 
 import (

--- a/server/internal/gateway/inbound/discordrunner/runner.go
+++ b/server/internal/gateway/inbound/discordrunner/runner.go
@@ -24,9 +24,10 @@
 // round-trip via the adapter's Reply transport. Component (button / select /
 // modal) deliveries route through the adapter's HandleAction; the rendered card
 // is sent back via InteractionRespond. discordgo owns reconnection, so a dropped
-// socket resumes without runner involvement. Thread continuation without a fresh
-// @mention is deferred (history lookup is nil here), so group/channel messages
-// always require an explicit @mention. The MESSAGE_CONTENT gateway intent is
+// socket resumes without runner involvement. Thread continuation is enabled: a
+// Discord thread is itself a channel, so a follow-up in a thread the bot was
+// already activated in routes without a fresh @mention (history-backed, mirroring
+// the Feishu 话题 path). The MESSAGE_CONTENT gateway intent is
 // privileged and must be enabled in the Discord Developer Portal or message
 // bodies arrive empty.
 package discordrunner
@@ -58,9 +59,12 @@ const maxSeen = 4096
 // gatewayIntents is the privileged-aware intent set the runner identifies with:
 // guild + DM message delivery, plus MESSAGE_CONTENT so the bot actually receives
 // message bodies (without it content arrives empty for non-mention messages).
+// IntentGuilds populates the session's channel/thread State cache so thread
+// continuation can classify a channel id without a REST round-trip.
 // MESSAGE_CONTENT is a privileged intent and must be toggled on in the Discord
 // Developer Portal for the bot.
-const gatewayIntents = discordgo.IntentGuildMessages |
+const gatewayIntents = discordgo.IntentGuilds |
+	discordgo.IntentGuildMessages |
 	discordgo.IntentDirectMessages |
 	discordgo.IntentMessageContent
 
@@ -102,6 +106,14 @@ type Runner struct {
 	// method value assigns directly.
 	respond func(i *discordgo.Interaction, resp *discordgo.InteractionResponse, opts ...discordgo.RequestOption) error
 
+	// isThread reports whether a channel id refers to a Discord thread (public /
+	// private / news thread) rather than a regular channel. A thread's own id is
+	// the stable session key, so a message in it carries the thread as its root —
+	// grouping every follow-up into one conversation without a re-@mention. Pulled
+	// out as a field so tests inject a deterministic classifier; New wires the
+	// session-State-backed resolver.
+	isThread func(channelID string) bool
+
 	mu   sync.Mutex
 	seen map[string]struct{}
 }
@@ -140,7 +152,30 @@ func New(cfg Config) (*Runner, error) {
 		respond:   session.InteractionRespond,
 		seen:      make(map[string]struct{}),
 	}
+	r.isThread = r.channelIsThread
 	return r, nil
+}
+
+// channelIsThread classifies a Discord channel id as a thread (public / private
+// / news thread) or not, preferring the session's State cache (populated by the
+// IntentGuilds intent) and falling back to a REST lookup on a cache miss. A
+// lookup failure classifies as not-a-thread so the mention gate stays strict
+// rather than admitting a non-mention message on a bad read.
+func (r *Runner) channelIsThread(channelID string) bool {
+	channelID = strings.TrimSpace(channelID)
+	if channelID == "" {
+		return false
+	}
+	if r.session.State != nil {
+		if ch, err := r.session.State.Channel(channelID); err == nil && ch != nil {
+			return ch.IsThread()
+		}
+	}
+	ch, err := r.session.Channel(channelID)
+	if err != nil || ch == nil {
+		return false
+	}
+	return ch.IsThread()
 }
 
 // Run resolves the bot identity (once, if not pre-set), registers the gateway
@@ -228,9 +263,15 @@ func (r *Runner) handleMessage(ctx context.Context, payload []byte) error {
 	if gateway.IsSelfSender(event, r.botUserID) {
 		return nil
 	}
-	// Group/channel messages must @mention the bot. hist is nil in 5c, so thread
-	// continuation without a mention is not yet auto-admitted.
-	if gateway.ShouldSkipGroupWithoutMention(ctx, nil, event, r.botUserID) {
+	// A Discord thread is itself a channel: a message in it carries the thread as
+	// channel_id. Stamping that id into the root slot gives every message in the
+	// thread a shared ThreadKey, so the activating @mention and its follow-ups
+	// group into one conversation and history-backed continuation can match.
+	r.enrichThread(&event)
+	// Group/channel messages must @mention the bot, unless the message lands in a
+	// thread the bot was already activated in — then it's a 话题续聊 and no fresh
+	// @mention is required (mirrors the Feishu path).
+	if gateway.ShouldSkipGroupWithoutMention(ctx, discordThreadHist{r.store}, event, r.botUserID) {
 		return nil
 	}
 	outcome, err := router.HandleInbound(ctx, r.store, r.host, event, r.reply, nil, r.gateCfg)
@@ -242,6 +283,40 @@ func (r *Runner) handleMessage(ctx context.Context, payload []byte) error {
 		"accepted", outcome.Accepted,
 		"reason", outcome.Reason)
 	return nil
+}
+
+// enrichThread stamps a Discord thread channel's own id into the event's thread
+// and root slots. It runs before the mention gate so both the activating
+// @mention and later follow-ups in the thread share a ThreadKey (the thread id),
+// which is what history-backed continuation and conversation grouping key on. It
+// is a no-op for DMs, for a message already carrying a thread id, and for a
+// regular (non-thread) channel — there each message stays its own root, so a
+// plain-channel reply still needs an explicit @mention.
+func (r *Runner) enrichThread(event *gateway.InboundEvent) {
+	if event == nil || r.isThread == nil {
+		return
+	}
+	if strings.EqualFold(strings.TrimSpace(event.ChatType), "dm") {
+		return
+	}
+	channelID := strings.TrimSpace(event.ExternalChatID)
+	if channelID == "" || strings.TrimSpace(event.ExternalRootID) != "" {
+		return
+	}
+	if !r.isThread(channelID) {
+		return
+	}
+	event.ExternalThreadID = channelID
+	event.ExternalRootID = channelID
+}
+
+// discordThreadHist binds the runner's store to the discord platform so the
+// neutral gate's platform-agnostic ThreadHistoryLookup resolves 话题续聊 history
+// against discord conversations only.
+type discordThreadHist struct{ store router.Store }
+
+func (h discordThreadHist) HasThreadInboundHistory(ctx context.Context, externalChatID, threadKey string) (bool, error) {
+	return h.store.HasThreadInboundHistory(ctx, string(channel.PlatformDiscord), externalChatID, threadKey)
 }
 
 // handleInteraction is the pure dispatch core for component/modal callbacks: it

--- a/server/internal/gateway/inbound/discordrunner/runner_test.go
+++ b/server/internal/gateway/inbound/discordrunner/runner_test.go
@@ -17,8 +17,14 @@ import (
 // unusedStore satisfies router.Store via a nil embedded interface: any method
 // call panics. The skip-path tests assert routing is short-circuited before
 // router.HandleInbound, so the store must never be touched — a panic here is a
-// loud test failure.
+// loud test failure. HasThreadInboundHistory is the one real method: the mention
+// gate consults it on every group message, and a no-history (false) answer keeps
+// the skip-path tests exercising the mention-required branch.
 type unusedStore struct{ router.Store }
+
+func (unusedStore) HasThreadInboundHistory(context.Context, string, string, string) (bool, error) {
+	return false, nil
+}
 
 // --- fixtures: MESSAGE_CREATE payloads the adapter's Normalize accepts --------
 
@@ -52,6 +58,9 @@ func newTestRunner(t *testing.T) *Runner {
 		t.Fatalf("New: %v", err)
 	}
 	r.botUserID = "BOT" // pre-set so handleMessage skips the @me round-trip
+	// Default to "not a thread" so the mention gate stays strict and no test
+	// reaches the live discordgo channel lookup New wires by default.
+	r.isThread = func(string) bool { return false }
 	return r
 }
 
@@ -169,6 +178,7 @@ func newRoutedRunner(t *testing.T, router *fakeActionRouter) *Runner {
 		t.Fatalf("New: %v", err)
 	}
 	r.botUserID = "BOT"
+	r.isThread = func(string) bool { return false }
 	return r
 }
 
@@ -277,4 +287,121 @@ func TestAnswer_UpdateMessageVsDefer(t *testing.T) {
 	if gotData != nil {
 		t.Errorf("empty ack must carry no data, got %+v", gotData)
 	}
+}
+
+// --- thread continuation -----------------------------------------------------
+
+// errRoutingReached is the sentinel a threadHistoryStore returns from the first
+// routing lookup, so a test can prove the mention gate admitted a non-@ message
+// (routing was entered) without standing up a full routing store.
+var errRoutingReached = errors.New("routing reached")
+
+// threadHistoryStore admits a non-@ message past the mention gate by reporting
+// thread history, then halts HandleInbound at its first store lookup
+// (FindUserIDByPlatformSubject) with errRoutingReached — network-free proof that
+// the gate passed. Every other router.Store method panics via the nil embed.
+type threadHistoryStore struct {
+	router.Store
+	hasHistory bool
+	sawLookup  bool
+}
+
+func (s *threadHistoryStore) HasThreadInboundHistory(_ context.Context, _, _, _ string) (bool, error) {
+	return s.hasHistory, nil
+}
+
+func (s *threadHistoryStore) FindUserIDByPlatformSubject(_ context.Context, _, _ string) (string, error) {
+	s.sawLookup = true
+	return "", errRoutingReached
+}
+
+func newRunnerWithStore(t *testing.T, st router.Store, isThread bool) *Runner {
+	t.Helper()
+	r, err := New(Config{
+		BotToken: "bot-test",
+		Channel:  discordchannel.New(discordchannel.Config{AppID: "A123", BotToken: "bot-test"}),
+		Store:    st,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	r.botUserID = "BOT"
+	r.isThread = func(string) bool { return isThread }
+	return r
+}
+
+// TestHandleMessage_ContinuesActivatedThread: a non-@ message posted in a thread
+// the bot was already activated in (history present) skips the mention gate and
+// enters routing — the Discord twin of the Feishu 话题续聊 rule.
+func TestHandleMessage_ContinuesActivatedThread(t *testing.T) {
+	st := &threadHistoryStore{hasHistory: true}
+	r := newRunnerWithStore(t, st, true)
+	err := r.handleMessage(context.Background(), []byte(channelNoMention))
+	if !errors.Is(err, errRoutingReached) {
+		t.Fatalf("a non-@ message in an activated thread must reach routing, got err=%v", err)
+	}
+	if !st.sawLookup {
+		t.Fatal("expected routing to be entered (FindUserIDByPlatformSubject called)")
+	}
+}
+
+// TestHandleMessage_SkipsThreadWithoutHistory: the same thread message, but with
+// no prior activation, still requires an @mention — the gate drops it before
+// routing.
+func TestHandleMessage_SkipsThreadWithoutHistory(t *testing.T) {
+	st := &threadHistoryStore{hasHistory: false}
+	r := newRunnerWithStore(t, st, true)
+	if err := r.handleMessage(context.Background(), []byte(channelNoMention)); err != nil {
+		t.Fatalf("handleMessage: %v", err)
+	}
+	if st.sawLookup {
+		t.Fatal("a thread with no prior history must not route a non-@ message")
+	}
+}
+
+// TestEnrichThread covers the thread/root stamping: a thread channel gets its id
+// mirrored into both slots (a shared ThreadKey); a regular channel, a DM, an
+// already-rooted event, and a runner with no resolver are all left untouched.
+func TestEnrichThread(t *testing.T) {
+	t.Run("thread channel stamps both slots", func(t *testing.T) {
+		r := newRunnerWithStore(t, unusedStore{}, true)
+		ev := gateway.InboundEvent{ExternalChatID: "th-1", ChatType: "channel"}
+		r.enrichThread(&ev)
+		if ev.ExternalThreadID != "th-1" || ev.ExternalRootID != "th-1" {
+			t.Fatalf("thread = %q root = %q, want both th-1", ev.ExternalThreadID, ev.ExternalRootID)
+		}
+		if ev.ThreadKey() != "th-1" {
+			t.Fatalf("ThreadKey = %q, want th-1", ev.ThreadKey())
+		}
+	})
+
+	t.Run("regular channel untouched", func(t *testing.T) {
+		r := newRunnerWithStore(t, unusedStore{}, false)
+		ev := gateway.InboundEvent{ExternalChatID: "c1", ExternalMessageID: "m1", ChatType: "channel"}
+		r.enrichThread(&ev)
+		if ev.ExternalRootID != "" || ev.ExternalThreadID != "" {
+			t.Fatalf("regular channel must not be stamped, got thread=%q root=%q", ev.ExternalThreadID, ev.ExternalRootID)
+		}
+		if ev.ThreadKey() != "m1" {
+			t.Fatalf("ThreadKey = %q, want the message id m1", ev.ThreadKey())
+		}
+	})
+
+	t.Run("dm untouched even in a thread channel", func(t *testing.T) {
+		r := newRunnerWithStore(t, unusedStore{}, true)
+		ev := gateway.InboundEvent{ExternalChatID: "d1", ChatType: "dm"}
+		r.enrichThread(&ev)
+		if ev.ExternalRootID != "" {
+			t.Fatalf("dm must not be stamped, got root=%q", ev.ExternalRootID)
+		}
+	})
+
+	t.Run("already-rooted untouched", func(t *testing.T) {
+		r := newRunnerWithStore(t, unusedStore{}, true)
+		ev := gateway.InboundEvent{ExternalChatID: "th-2", ExternalRootID: "orig", ChatType: "channel"}
+		r.enrichThread(&ev)
+		if ev.ExternalRootID != "orig" {
+			t.Fatalf("existing root must be preserved, got %q", ev.ExternalRootID)
+		}
+	})
 }

--- a/server/internal/gateway/inbound/manager.go
+++ b/server/internal/gateway/inbound/manager.go
@@ -95,6 +95,9 @@ type Storer interface {
 	// HasFeishuThreadInboundHistory backs the "话题续聊不必再 @" rule in
 	// isGroupMessageWithoutBotMention.
 	HasFeishuThreadInboundHistory(ctx context.Context, externalChatID, threadID string) (bool, error)
+	// HasThreadInboundHistory is the platform-scoped form used by the shared
+	// router's neutral inbound gate.
+	HasThreadInboundHistory(ctx context.Context, platform, externalChatID, threadKey string) (bool, error)
 
 	// ResolveAgentNameForConversation returns the per-card header title
 	// for inbound paths without an agent_run in hand. Returns empty on

--- a/server/internal/gateway/inbound/manager_test.go
+++ b/server/internal/gateway/inbound/manager_test.go
@@ -562,6 +562,12 @@ func (f *inboundFakeStore) HasFeishuThreadInboundHistory(_ context.Context, _, _
 	return f.threadHistory, nil
 }
 
+func (f *inboundFakeStore) HasThreadInboundHistory(_ context.Context, _, _, _ string) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.threadHistory, nil
+}
+
 // ResolveAgentNameForConversation is the no-op stub for the title-
 // fallback path used by patch + immediate-reply notice paths.
 // Tests that care can populate inboundFakeStore.agentNameByConversation;

--- a/server/internal/gateway/inbound/slackrunner/runner.go
+++ b/server/internal/gateway/inbound/slackrunner/runner.go
@@ -16,9 +16,9 @@
 // the rendered replace_original card is POSTed to the interaction's
 // response_url (the Socket Mode ack envelope does NOT update the source message
 // for a block_actions click), while the envelope itself is bare-acked.
-// Slash-command routing is still deferred. Thread continuation without a fresh
-// @mention is also deferred (history lookup is nil here), so group/channel
-// messages always require an explicit @mention.
+// Slash-command routing is still deferred. Thread continuation is enabled:
+// a follow-up in a thread the bot was already activated in routes without a
+// fresh @mention (history-backed, mirroring the Feishu 话题 path).
 package slackrunner
 
 import (
@@ -221,6 +221,15 @@ func (r *Runner) dispatch(ctx context.Context, evt socketmode.Event) {
 	}
 }
 
+// slackThreadHist binds the runner's store to the slack platform so the
+// neutral gate's platform-agnostic ThreadHistoryLookup resolves 话题续聊
+// history against slack conversations only.
+type slackThreadHist struct{ store router.Store }
+
+func (h slackThreadHist) HasThreadInboundHistory(ctx context.Context, externalChatID, threadKey string) (bool, error) {
+	return h.store.HasThreadInboundHistory(ctx, string(channel.PlatformSlack), externalChatID, threadKey)
+}
+
 // handleEvent is the pure dispatch core: decode → dedup → neutral gates →
 // route. It takes the raw event_callback payload (not the socket Event) so it
 // is unit-testable with a captured webhook JSON and no live websocket.
@@ -239,9 +248,10 @@ func (r *Runner) handleEvent(ctx context.Context, payload []byte) error {
 	if gateway.IsSelfSender(event, r.botUserID) {
 		return nil
 	}
-	// Group/channel messages must @mention the bot. hist is nil in N4, so
-	// thread continuation without a mention is not yet auto-admitted.
-	if gateway.ShouldSkipGroupWithoutMention(ctx, nil, event, r.botUserID) {
+	// Group/channel messages must @mention the bot, unless the message lands
+	// in a thread the bot was already activated in — then it's a 话题续聊 and
+	// no fresh @mention is required (mirrors the Feishu path).
+	if gateway.ShouldSkipGroupWithoutMention(ctx, slackThreadHist{r.store}, event, r.botUserID) {
 		return nil
 	}
 	outcome, err := router.HandleInbound(ctx, r.store, r.host, event, r.reply, nil, r.gateCfg)

--- a/server/internal/gateway/inbound/slackrunner/runner_test.go
+++ b/server/internal/gateway/inbound/slackrunner/runner_test.go
@@ -18,8 +18,14 @@ import (
 // unusedStore satisfies router.Store via a nil embedded interface: any method
 // call panics. The skip-path tests assert routing is short-circuited before
 // router.HandleInbound, so the store must never be touched — a panic here is a
-// loud test failure.
+// loud test failure. HasThreadInboundHistory is the one real method: the mention
+// gate consults it on every group message, and a no-history (false) answer keeps
+// the skip-path tests exercising the mention-required branch.
 type unusedStore struct{ router.Store }
+
+func (unusedStore) HasThreadInboundHistory(context.Context, string, string, string) (bool, error) {
+	return false, nil
+}
 
 // --- fixtures: event_callback envelopes the adapter's Normalize accepts ------
 
@@ -45,6 +51,15 @@ const reactionEnvelope = `{
   "type":"event_callback","team_id":"T1","api_app_id":"A123",
   "event":{"type":"reaction_added","user":"U8","reaction":"thumbsup",
     "item":{"type":"message","channel":"C1","ts":"1700000000.000100"}}
+}`
+
+// channelThreadReply is a public-channel message with no @mention that lands in
+// an existing thread (thread_ts set) — the reply the history-backed continuation
+// gate must admit once the bot was activated in that thread.
+const channelThreadReply = `{
+  "type":"event_callback","team_id":"T1","api_app_id":"A123",
+  "event":{"type":"message","user":"U7","text":"more please","ts":"1700000012.000300",
+    "thread_ts":"1700000009.000000","channel":"C5","channel_type":"channel","event_ts":"1700000012.000300"}
 }`
 
 func newTestRunner(t *testing.T) *Runner {
@@ -335,5 +350,75 @@ func TestPostToResponseURL_PostsJSONBody(t *testing.T) {
 	defer fail.Close()
 	if err := postToResponseURL(context.Background(), fail.URL, body); err == nil {
 		t.Fatal("a non-2xx response_url status must surface as an error")
+	}
+}
+
+// --- thread continuation -----------------------------------------------------
+
+// errRoutingReached is the sentinel a threadHistoryStore returns from the first
+// routing lookup, so a test can prove the mention gate admitted a non-@ message
+// (routing was entered) without standing up a full routing store.
+var errRoutingReached = errors.New("routing reached")
+
+// threadHistoryStore admits a non-@ message past the mention gate by reporting
+// thread history, then halts HandleInbound at its first store lookup
+// (FindUserIDByPlatformSubject) with errRoutingReached — network-free proof that
+// the gate passed. Every other router.Store method panics via the nil embed.
+type threadHistoryStore struct {
+	router.Store
+	hasHistory bool
+	sawLookup  bool
+}
+
+func (s *threadHistoryStore) HasThreadInboundHistory(_ context.Context, _, _, _ string) (bool, error) {
+	return s.hasHistory, nil
+}
+
+func (s *threadHistoryStore) FindUserIDByPlatformSubject(_ context.Context, _, _ string) (string, error) {
+	s.sawLookup = true
+	return "", errRoutingReached
+}
+
+func newRunnerWithStore(t *testing.T, st router.Store) *Runner {
+	t.Helper()
+	r, err := New(Config{
+		BotToken: "xoxb-test",
+		AppToken: "xapp-test",
+		Channel:  slackchannel.New(slackchannel.Config{AppID: "A123", BotToken: "xoxb-test", AppToken: "xapp-test"}),
+		Store:    st,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	r.botUserID = "UBOT"
+	return r
+}
+
+// TestHandleEvent_ContinuesActivatedThread: a non-@ reply in a thread the bot was
+// already activated in (history present) skips the mention gate and enters
+// routing — aligning Slack with the Feishu 话题续聊 rule.
+func TestHandleEvent_ContinuesActivatedThread(t *testing.T) {
+	st := &threadHistoryStore{hasHistory: true}
+	r := newRunnerWithStore(t, st)
+	err := r.handleEvent(context.Background(), []byte(channelThreadReply))
+	if !errors.Is(err, errRoutingReached) {
+		t.Fatalf("a non-@ reply in an activated thread must reach routing, got err=%v", err)
+	}
+	if !st.sawLookup {
+		t.Fatal("expected routing to be entered (FindUserIDByPlatformSubject called)")
+	}
+}
+
+// TestHandleEvent_SkipsThreadWithoutHistory: the same thread reply, but with no
+// prior activation, still requires an @mention — the gate drops it before
+// routing.
+func TestHandleEvent_SkipsThreadWithoutHistory(t *testing.T) {
+	st := &threadHistoryStore{hasHistory: false}
+	r := newRunnerWithStore(t, st)
+	if err := r.handleEvent(context.Background(), []byte(channelThreadReply)); err != nil {
+		t.Fatalf("handleEvent: %v", err)
+	}
+	if st.sawLookup {
+		t.Fatal("a thread with no prior history must not route a non-@ reply")
 	}
 }

--- a/server/internal/gateway/router/router.go
+++ b/server/internal/gateway/router/router.go
@@ -33,6 +33,9 @@ type Store interface {
 	// queued/running run on that conversation.
 	FindConversationByExternalRef(ctx context.Context, gateway, externalChatID, externalThreadID string) (string, error)
 	CancelAllInflightForConversation(ctx context.Context, conversationID, reason string) ([]store.SupersededRun, error)
+	// Backs the "已激活话题续聊不必再 @" rule: reports whether the bot has
+	// previously accepted an inbound message in this (platform, chat, thread).
+	HasThreadInboundHistory(ctx context.Context, platform, externalChatID, threadKey string) (bool, error)
 }
 
 type ReplyFunc func(ctx context.Context, host gateway.FeishuRouteAgent, event gateway.InboundEvent, text string) error

--- a/server/internal/gateway/router/router_test.go
+++ b/server/internal/gateway/router/router_test.go
@@ -35,6 +35,9 @@ type fakeSharedStore struct {
 	cancelledRunsByConversation map[string][]store.SupersededRun
 	// cancelCalls records (conversation_id, reason) pairs for assertions.
 	cancelCalls []struct{ ConversationID, Reason string }
+	// threadHistory seeds HasThreadInboundHistory keyed by
+	// (platform|chat|thread); absence returns false.
+	threadHistory map[string]bool
 }
 
 func newFakeSharedStore() *fakeSharedStore {
@@ -186,6 +189,10 @@ func (f *fakeSharedStore) CancelAllInflightForConversation(ctx context.Context, 
 		return nil, nil
 	}
 	return f.cancelledRunsByConversation[conversationID], nil
+}
+
+func (f *fakeSharedStore) HasThreadInboundHistory(_ context.Context, platform, externalChatID, threadKey string) (bool, error) {
+	return f.threadHistory[platform+"|"+externalChatID+"|"+threadKey], nil
 }
 
 func TestHandleInboundListRepliesWithSelectableAgents(t *testing.T) {

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -2562,16 +2562,17 @@ limit 1`, gateway, externalChatID).Scan(&id, &slotRaw)
 	return id, slot, nil
 }
 
-// HasFeishuThreadInboundHistory reports whether the bot has previously
-// accepted an inbound message in the given (chat_id, thread_key) pair on
-// the feishu gateway. Used by the inbound mention gate to allow follow-up
-// messages in a Feishu 话题 without requiring @mention on every reply.
-// Returns false (no error) when either argument is empty. Caller passes
-// the thread *key* (FeishuInboundEvent.ThreadKey()), not the message_id.
-func (s *Store) HasFeishuThreadInboundHistory(ctx context.Context, externalChatID, threadKey string) (bool, error) {
+// HasThreadInboundHistory reports whether the bot has previously accepted an
+// inbound message in the given (chat_id, thread_key) pair on the named
+// gateway platform. Used by the inbound mention gate to allow follow-up
+// messages within an already-activated thread without requiring @mention on
+// every reply. Returns false (no error) when any argument is empty. Caller
+// passes the thread *key* (InboundEvent.ThreadKey()), not the message_id.
+func (s *Store) HasThreadInboundHistory(ctx context.Context, platform, externalChatID, threadKey string) (bool, error) {
+	platform = strings.TrimSpace(platform)
 	externalChatID = strings.TrimSpace(externalChatID)
 	threadKey = strings.TrimSpace(threadKey)
-	if externalChatID == "" || threadKey == "" {
+	if platform == "" || externalChatID == "" || threadKey == "" {
 		return false, nil
 	}
 	var exists bool
@@ -2579,15 +2580,21 @@ func (s *Store) HasFeishuThreadInboundHistory(ctx context.Context, externalChatI
 select exists (
   select 1
   from conversations c
-  where c.platform = 'feishu'
-    and c.external_id = $1
-    and c.external_thread_id = $2
+  where c.platform = $1
+    and c.external_id = $2
+    and c.external_thread_id = $3
     and c.deleted_at is null
-)`, externalChatID, threadKey).Scan(&exists)
+)`, platform, externalChatID, threadKey).Scan(&exists)
 	if err != nil {
 		return false, err
 	}
 	return exists, nil
+}
+
+// HasFeishuThreadInboundHistory is the Feishu-scoped shorthand for
+// HasThreadInboundHistory, kept for the existing Feishu inbound gate call site.
+func (s *Store) HasFeishuThreadInboundHistory(ctx context.Context, externalChatID, threadKey string) (bool, error) {
+	return s.HasThreadInboundHistory(ctx, "feishu", externalChatID, threadKey)
 }
 
 func (s *Store) ConfigureDevConversationExternalRef(ctx context.Context, input ConfigureDevConversationExternalRefInput) (ConfigureDevConversationExternalRefResult, error) {


### PR DESCRIPTION
## 概述

在已被 @ 激活的话题/线程内,后续非 @ 消息不再需要重新 @ 机器人,与飞书话题续聊语义一致。

- **store**:新增平台维度 `HasThreadInboundHistory(ctx, platform, chatID, threadKey)`,飞书方法改为其薄封装
- **router/manager/dev**:Store 接口补齐该方法声明及各测试假实现
- **slack**:新增 `slackThreadHist` 适配器,门控由 `nil` 换为真实历史查询
- **discord**:加 `IntentGuilds`,新增 `channelIsThread`/`enrichThread` 判定线程,并把线程 channel_id 写入 root/thread 槽位,使 `ThreadKey` 归并线程消息

## 限制

agent 仍拿不到全量群消息,仅放行已激活话题内的后续消息。

## 测试

`gateway/... dev/... store/...` 全绿。`make check` 中唯一失败项 `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation` 经 stash 验证为 origin/main 上的既有失败,与本改动无关。