### PR TITLE
chore(web): hide unbuilt inbox nav item

### DIFF
--- a/apps/web/src/components/layout/AdminLayout.tsx
+++ b/apps/web/src/components/layout/AdminLayout.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 import { cn } from "../../lib/utils"
 import { useAdminView, type AdminView } from "../../lib/admin-router"
 import {
-  MessageSquare, Play, Inbox,
+  MessageSquare, Play,
   CalendarClock,
   Bot, Wrench, Database, Plug,
   Users, Settings,
@@ -44,7 +44,6 @@ const menuGroups: MenuGroup[] = [
       { id: "conversations", itemKey: "conversations", icon: MessageSquare },
       { id: "runs", itemKey: "runs", icon: Play },
       { id: "scheduled", itemKey: "scheduled", icon: CalendarClock },
-      { id: "approvals", itemKey: "approvals", icon: Inbox },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- 收件箱（inbox / `approvals`）目前仍是占位页（"页面建设中"），没有接后端、无实际功能。
- 从侧边栏「协作」组移除该菜单项，并清理 `AdminLayout.tsx` 中不再使用的 `Inbox` import。
- 保留 `AdminRouter.tsx` 的 `approvals` 路由与 `StubPage`，以后要做审批收件箱时加回一行菜单项即可恢复。

## Test plan
- [x] `pnpm typecheck`（apps/web）通过
- [ ] 本地启动，确认侧边栏「协作」组只剩 对话 / 运行 / 定时任务，收件箱不再展示