### PR TITLE
feat(server): docker-backed agent_daemon sandbox provider

### DIFF
--- a/apps/web/src/lib/api-agents.ts
+++ b/apps/web/src/lib/api-agents.ts
@@ -42,11 +42,20 @@ const KEY_AGENT_METRICS = (
 
 /* --- Network ------------------------------------------------------------ */
 
+// The agent-list endpoint keys rows `agent_id` (store.AgentRead) but the app
+// reads `.id`; backfill it once here, the choke point feeding useAgents.
+function normalizeAgentId(a: Agent): Agent {
+  if (a.id) return a
+  const agentID = (a as Agent & { agent_id?: string }).agent_id
+  return agentID ? { ...a, id: agentID } : a
+}
+
 async function listAgents(workspaceID: string | null): Promise<ListAgentsResponse> {
   if (!workspaceID) return { agents: [] }
-  return apiRequest<ListAgentsResponse>(
+  const res = await apiRequest<ListAgentsResponse>(
     `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/agents`
   )
+  return { ...res, agents: (res.agents ?? []).map(normalizeAgentId) }
 }
 
 async function listAgentRuns(

--- a/infra/e2b-templates/parsar-sandbox-local/.gitignore
+++ b/infra/e2b-templates/parsar-sandbox-local/.gitignore
@@ -1,0 +1,2 @@
+# Build staging dir assembled by build.sh (compiled binaries + copied hooks).
+.build/

--- a/infra/e2b-templates/parsar-sandbox-local/build.sh
+++ b/infra/e2b-templates/parsar-sandbox-local/build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Build the local docker sandbox image (parsar-sandbox:local) for the
+# docker-backed SandboxProvider (AGENT_DAEMON_SANDBOX_BACKEND=docker).
+#
+# Compiles the parsar + parsar-daemon CLIs as static linux/arm64 binaries
+# (the container runs linux/aarch64 under Docker Desktop on Apple Silicon),
+# stages them alongside the shared claude/opencode hooks, then builds the
+# image from local.Dockerfile.
+#
+# Usage: infra/e2b-templates/parsar-sandbox-local/build.sh
+# Override the tag: PARSAR_SANDBOX_LOCAL_IMAGE=foo:bar build.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/.build"
+HOOKS_SRC="${SCRIPT_DIR}/../parsar-daemon-claudecode/hooks"
+IMAGE="${PARSAR_SANDBOX_LOCAL_IMAGE:-parsar-sandbox:local}"
+TARGET_ARCH="${PARSAR_SANDBOX_LOCAL_ARCH:-arm64}"
+
+echo "[build] repo root: ${REPO_ROOT}"
+echo "[build] image tag: ${IMAGE} (linux/${TARGET_ARCH})"
+
+rm -rf "${BUILD_DIR}"
+mkdir -p "${BUILD_DIR}"
+
+echo "[build] compiling parsar-daemon + parsar (static linux/${TARGET_ARCH})"
+( cd "${REPO_ROOT}" && CGO_ENABLED=0 GOOS=linux GOARCH="${TARGET_ARCH}" GOFLAGS=-trimpath \
+    go build -ldflags='-s -w' -o "${BUILD_DIR}/parsar-daemon" ./apps/parsar-daemon/cmd/parsar-daemon )
+( cd "${REPO_ROOT}" && CGO_ENABLED=0 GOOS=linux GOARCH="${TARGET_ARCH}" GOFLAGS=-trimpath \
+    go build -ldflags='-s -w' -o "${BUILD_DIR}/parsar" ./apps/parsar/cmd/parsar )
+
+echo "[build] staging hooks from ${HOOKS_SRC}"
+cp -R "${HOOKS_SRC}" "${BUILD_DIR}/hooks"
+
+echo "[build] docker build"
+docker build --platform "linux/${TARGET_ARCH}" \
+  -f "${SCRIPT_DIR}/local.Dockerfile" \
+  -t "${IMAGE}" \
+  "${BUILD_DIR}"
+
+echo "[build] done: ${IMAGE}"
+echo "[build] run the server with:"
+echo "        AGENT_DAEMON_SANDBOX_BACKEND=docker AGENT_DAEMON_SANDBOX_DOCKER_IMAGE=${IMAGE} <server>"

--- a/infra/e2b-templates/parsar-sandbox-local/local.Dockerfile
+++ b/infra/e2b-templates/parsar-sandbox-local/local.Dockerfile
@@ -1,0 +1,40 @@
+# Local-only sandbox image for the docker-backed SandboxProvider.
+#
+# Unlike the sibling ../parsar-daemon-claudecode/e2b.Dockerfile (amd64,
+# parsar-daemon pulled from GitHub Releases), this copies host-built
+# linux/arm64 binaries so it runs natively under Docker Desktop on Apple
+# Silicon. The binaries and hooks are staged into the build context by
+# build.sh — do NOT `docker build` this file directly; run build.sh.
+#
+# Wired via: AGENT_DAEMON_SANDBOX_BACKEND=docker
+#            AGENT_DAEMON_SANDBOX_DOCKER_IMAGE=parsar-sandbox:local
+FROM e2bdev/base:latest
+
+RUN apt-get update -y \
+ && apt-get install -y --no-install-recommends curl ca-certificates jq \
+ && rm -rf /var/lib/apt/lists/*
+
+# Claude Code CLI — the daemon's connect preflight refuses to register
+# unless at least one supported agent CLI is on PATH.
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+ && CLAUDE_BIN="$(command -v claude || true)" \
+ && if [ -z "$CLAUDE_BIN" ] && [ -x /root/.local/bin/claude ]; then CLAUDE_BIN=/root/.local/bin/claude; fi \
+ && if [ -z "$CLAUDE_BIN" ]; then echo "claude install failed: no binary on PATH"; exit 1; fi \
+ && ln -sf "$CLAUDE_BIN" /usr/local/bin/claude \
+ && /usr/local/bin/claude --version
+
+COPY parsar-daemon /usr/local/bin/parsar-daemon
+COPY parsar /usr/local/bin/parsar
+RUN chmod +x /usr/local/bin/parsar-daemon /usr/local/bin/parsar \
+ && /usr/local/bin/parsar-daemon version \
+ && /usr/local/bin/parsar --version
+
+COPY hooks /opt/parsar/hooks
+RUN chmod -R a+rx /opt/parsar/hooks
+
+ENV IS_SANDBOX=1
+ENV DISABLE_TELEMETRY=1
+ENV CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+
+RUN mkdir -p /workspace
+WORKDIR /workspace

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1223,6 +1223,12 @@ func buildAgentDaemonSandboxProvider(
 	if env == nil {
 		env = os.Getenv
 	}
+	// Local-docker backend short-circuit: when AGENT_DAEMON_SANDBOX_BACKEND
+	// is "docker" this returns a container-backed provider and we skip the
+	// e2b-specific API-key/CA/pod-IP wiring below entirely.
+	if p := buildDockerAgentDaemonSandboxProvider(env, cfg, dbStore, registry, binder, selfPodID); p != nil {
+		return p
+	}
 	template := strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_TEMPLATE"))
 	if template == "" {
 		return nil

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -357,7 +357,7 @@ func main() {
 		})
 		agentDaemonRegistry := agentdaemongateway.NewRegistry()
 		agentDaemonAuth := agentdaemongateway.NewAuthenticator(dbStore)
-		publicWSURL := buildAgentDaemonWSURL(cfg)
+		publicWSURL := resolveAgentDaemonPublicWSURL(envLookup, cfg)
 		agentDaemonPodID := resolveAgentDaemonOwnerPodID(envLookup)
 		agentDaemonOwnerURL, err := resolveAgentDaemonOwnerURL(envLookup, cfg)
 		if err != nil {

--- a/server/cmd/server/sandbox_docker.go
+++ b/server/cmd/server/sandbox_docker.go
@@ -46,8 +46,11 @@ func dockerDialBackURL(serverURL string) (string, bool) {
 //   - AGENT_DAEMON_SANDBOX_DOCKER_IMAGE — local image tag to run.
 //   - AGENT_DAEMON_SANDBOX_DOCKER_NETWORK — optional docker network to join
 //     (use the compose network when the server runs as a compose service).
-//   - AGENT_DAEMON_SANDBOX_DOCKER_MEMORY / _CPUS / _PIDS_LIMIT — optional
-//     `docker run` resource caps; unset = docker defaults (unbounded).
+//   - AGENT_DAEMON_SANDBOX_DOCKER_MEMORY / _CPUS — optional `docker run`
+//     resource caps; unset = built-in default (4g / 2 CPU). Set to
+//     0/unlimited/none to remove the cap.
+//   - AGENT_DAEMON_SANDBOX_DOCKER_PIDS_LIMIT — optional pids cap; unset = no
+//     cap (docker default).
 func buildDockerAgentDaemonSandboxProvider(
 	env func(string) string,
 	cfg config.Config,
@@ -111,17 +114,42 @@ func buildDockerAgentDaemonSandboxProvider(
 	return provider
 }
 
-// dockerClientFromEnv builds the docker sandbox client, folding in the
-// optional AGENT_DAEMON_SANDBOX_DOCKER_{MEMORY,CPUS,PIDS_LIMIT} resource caps.
-// Empty env values leave the corresponding `docker run` flag off, so the
-// default (unbounded) behavior is unchanged.
+// Built-in sandbox caps used when the operator sets no override: a
+// conservative default stops one runaway sandbox starving the host (raise it
+// with the env var, or disable it with 0/unlimited). PidsLimit has no default
+// — a low pids cap breaks parallel builds (`make -j`, `go test ./...`).
+const (
+	defaultDockerMemory = "4g"
+	defaultDockerCPUs   = "2"
+)
+
+// dockerClientFromEnv builds the docker sandbox client, resolving the
+// AGENT_DAEMON_SANDBOX_DOCKER_{MEMORY,CPUS,PIDS_LIMIT} caps: memory and cpus
+// fall back to the built-in default when unset, pids stays off; see
+// resolveDockerLimit for the 0/unlimited escape hatch.
 func dockerClientFromEnv(env func(string) string, image, network string, hostGateway bool) *dockersandbox.Client {
 	return &dockersandbox.Client{
 		Image:       image,
 		Network:     network,
 		HostGateway: hostGateway,
-		Memory:      strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_DOCKER_MEMORY")),
-		CPUs:        strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_DOCKER_CPUS")),
-		PidsLimit:   strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_DOCKER_PIDS_LIMIT")),
+		Memory:      resolveDockerLimit(env("AGENT_DAEMON_SANDBOX_DOCKER_MEMORY"), defaultDockerMemory),
+		CPUs:        resolveDockerLimit(env("AGENT_DAEMON_SANDBOX_DOCKER_CPUS"), defaultDockerCPUs),
+		PidsLimit:   resolveDockerLimit(env("AGENT_DAEMON_SANDBOX_DOCKER_PIDS_LIMIT"), ""),
 	}
+}
+
+// resolveDockerLimit resolves one resource cap: empty env → built-in default;
+// "0"/"unlimited"/"none" (case-insensitive) → "" so Create omits the flag
+// (docker's unbounded default); otherwise the literal value, passed through
+// unvalidated (a bad value fails `docker run`, which Create surfaces).
+func resolveDockerLimit(raw, def string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return def
+	}
+	switch strings.ToLower(raw) {
+	case "0", "unlimited", "none":
+		return ""
+	}
+	return raw
 }

--- a/server/cmd/server/sandbox_docker.go
+++ b/server/cmd/server/sandbox_docker.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+	agentdaemonbinding "github.com/MiniMax-AI-Dev/parsar/server/internal/agentdaemon/binding"
+	agentdaemongateway "github.com/MiniMax-AI-Dev/parsar/server/internal/agentdaemon/gateway"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/config"
+	connagentdaemon "github.com/MiniMax-AI-Dev/parsar/server/internal/connector/agentdaemon"
+	dockersandbox "github.com/MiniMax-AI-Dev/parsar/server/internal/sandbox/docker"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+// dockerDialBackURL rewrites a loopback ServerURL so a sandbox container
+// can reach the host-run server. A daemon inside the container cannot dial
+// 127.0.0.1/localhost/::1 (that's the container itself); Docker exposes the
+// host as host.docker.internal. Returns the rewritten URL and whether the
+// host-gateway mapping is needed (non-loopback URLs pass through untouched).
+func dockerDialBackURL(serverURL string) (string, bool) {
+	u, err := url.Parse(strings.TrimSpace(serverURL))
+	if err != nil || u.Host == "" {
+		return serverURL, false
+	}
+	host := u.Hostname()
+	if host != "127.0.0.1" && host != "localhost" && host != "::1" {
+		return serverURL, false
+	}
+	newHost := "host.docker.internal"
+	if port := u.Port(); port != "" {
+		newHost += ":" + port
+	}
+	u.Host = newHost
+	return u.String(), true
+}
+
+// buildDockerAgentDaemonSandboxProvider wires a local-docker-backed
+// SandboxProvider for the agent_daemon connector. Returns nil when the
+// docker backend is not requested (caller falls back to the e2b builder,
+// then NoopSandboxProvider).
+//
+// Env vars:
+//   - AGENT_DAEMON_SANDBOX_BACKEND — must equal "docker" to select this.
+//   - AGENT_DAEMON_SANDBOX_DOCKER_IMAGE — local image tag to run.
+//   - AGENT_DAEMON_SANDBOX_DOCKER_NETWORK — optional docker network to join
+//     (use the compose network when the server runs as a compose service).
+func buildDockerAgentDaemonSandboxProvider(
+	env func(string) string,
+	cfg config.Config,
+	dbStore *store.Store,
+	registry *agentdaemongateway.Registry,
+	binder agentdaemonbinding.Binder,
+	selfPodID string,
+) connagentdaemon.SandboxProvider {
+	if env == nil {
+		env = os.Getenv
+	}
+	if strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_BACKEND")) != "docker" {
+		return nil
+	}
+	image := strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_DOCKER_IMAGE"))
+	if image == "" {
+		log.Bg().Warn("agent_daemon docker sandbox disabled: AGENT_DAEMON_SANDBOX_BACKEND=docker but AGENT_DAEMON_SANDBOX_DOCKER_IMAGE is empty")
+		return nil
+	}
+
+	publicURL := strings.TrimSpace(cfg.Server.PublicURL)
+	if publicURL == "" {
+		publicURL = "http://127.0.0.1:18080"
+	}
+	network := strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_DOCKER_NETWORK"))
+	serverURL, hostGateway := dockerDialBackURL(publicURL)
+	// When joined to a user-defined docker network the server is reachable
+	// by service name, so the loopback rewrite/host-gateway is unnecessary.
+	if network != "" {
+		serverURL = publicURL
+		hostGateway = false
+	}
+
+	client := &dockersandbox.Client{
+		Image:       image,
+		Network:     network,
+		HostGateway: hostGateway,
+	}
+	provider, err := connagentdaemon.NewE2BSandboxProvider(connagentdaemon.E2BProviderConfig{
+		Client:       client,
+		Store:        dbStore,
+		Registry:     registry,
+		Binder:       binder,
+		Bindings:     dbStore,
+		Template:     image,
+		Templates:    map[string]string{"standard": image},
+		DefaultSize:  "standard",
+		ServerURL:    serverURL,
+		OwnerChecker: dbStore,
+		SelfPodID:    selfPodID,
+		Log:          log.Bg(),
+	})
+	if err != nil {
+		log.Bg().Warn("agent_daemon docker sandbox provider init failed; docker backend disabled", "error", err)
+		return nil
+	}
+	log.Bg().Info("agent_daemon docker sandbox provider wired",
+		"image", image,
+		"network", network,
+		"server_url", serverURL,
+		"host_gateway", hostGateway)
+	return provider
+}

--- a/server/cmd/server/sandbox_docker.go
+++ b/server/cmd/server/sandbox_docker.go
@@ -36,6 +36,30 @@ func dockerDialBackURL(serverURL string) (string, bool) {
 	return u.String(), true
 }
 
+// resolveAgentDaemonPublicWSURL returns the ws:// URL the daemon dials after
+// bootstrap. It starts from the scheme-swapped PublicURL
+// (buildAgentDaemonWSURL) and, when the local-docker sandbox backend is active
+// without a user-defined docker network, applies the same loopback →
+// host.docker.internal rewrite used for the bootstrap ServerURL. Without it a
+// container daemon dials 127.0.0.1 — itself — never reaching the host server,
+// so the run stays unassigned. A configured network makes the server reachable
+// by service name, so the loopback URL is left intact (mirrors the gating in
+// buildDockerAgentDaemonSandboxProvider).
+func resolveAgentDaemonPublicWSURL(env func(string) string, cfg config.Config) string {
+	if env == nil {
+		env = os.Getenv
+	}
+	base := buildAgentDaemonWSURL(cfg)
+	if strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_BACKEND")) != "docker" {
+		return base
+	}
+	if strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_DOCKER_NETWORK")) != "" {
+		return base
+	}
+	rewritten, _ := dockerDialBackURL(base)
+	return rewritten
+}
+
 // buildDockerAgentDaemonSandboxProvider wires a local-docker-backed
 // SandboxProvider for the agent_daemon connector. Returns nil when the
 // docker backend is not requested (caller falls back to the e2b builder,

--- a/server/cmd/server/sandbox_docker.go
+++ b/server/cmd/server/sandbox_docker.go
@@ -46,6 +46,8 @@ func dockerDialBackURL(serverURL string) (string, bool) {
 //   - AGENT_DAEMON_SANDBOX_DOCKER_IMAGE — local image tag to run.
 //   - AGENT_DAEMON_SANDBOX_DOCKER_NETWORK — optional docker network to join
 //     (use the compose network when the server runs as a compose service).
+//   - AGENT_DAEMON_SANDBOX_DOCKER_MEMORY / _CPUS / _PIDS_LIMIT — optional
+//     `docker run` resource caps; unset = docker defaults (unbounded).
 func buildDockerAgentDaemonSandboxProvider(
 	env func(string) string,
 	cfg config.Config,
@@ -79,11 +81,7 @@ func buildDockerAgentDaemonSandboxProvider(
 		hostGateway = false
 	}
 
-	client := &dockersandbox.Client{
-		Image:       image,
-		Network:     network,
-		HostGateway: hostGateway,
-	}
+	client := dockerClientFromEnv(env, image, network, hostGateway)
 	provider, err := connagentdaemon.NewE2BSandboxProvider(connagentdaemon.E2BProviderConfig{
 		Client:       client,
 		Store:        dbStore,
@@ -106,6 +104,24 @@ func buildDockerAgentDaemonSandboxProvider(
 		"image", image,
 		"network", network,
 		"server_url", serverURL,
-		"host_gateway", hostGateway)
+		"host_gateway", hostGateway,
+		"memory", client.Memory,
+		"cpus", client.CPUs,
+		"pids_limit", client.PidsLimit)
 	return provider
+}
+
+// dockerClientFromEnv builds the docker sandbox client, folding in the
+// optional AGENT_DAEMON_SANDBOX_DOCKER_{MEMORY,CPUS,PIDS_LIMIT} resource caps.
+// Empty env values leave the corresponding `docker run` flag off, so the
+// default (unbounded) behavior is unchanged.
+func dockerClientFromEnv(env func(string) string, image, network string, hostGateway bool) *dockersandbox.Client {
+	return &dockersandbox.Client{
+		Image:       image,
+		Network:     network,
+		HostGateway: hostGateway,
+		Memory:      strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_DOCKER_MEMORY")),
+		CPUs:        strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_DOCKER_CPUS")),
+		PidsLimit:   strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_DOCKER_PIDS_LIMIT")),
+	}
 }

--- a/server/cmd/server/sandbox_docker_test.go
+++ b/server/cmd/server/sandbox_docker_test.go
@@ -7,10 +7,10 @@ func TestDockerDialBackURLRewritesLoopback(t *testing.T) {
 		wantURL     string
 		wantGateway bool
 	}{
-		"http://127.0.0.1:18080":  {"http://host.docker.internal:18080", true},
-		"http://localhost:18080":  {"http://host.docker.internal:18080", true},
-		"http://[::1]:8080":       {"http://host.docker.internal:8080", true},
-		"http://parsar-server:8080": {"http://parsar-server:8080", false},
+		"http://127.0.0.1:18080":     {"http://host.docker.internal:18080", true},
+		"http://localhost:18080":     {"http://host.docker.internal:18080", true},
+		"http://[::1]:8080":          {"http://host.docker.internal:8080", true},
+		"http://parsar-server:8080":  {"http://parsar-server:8080", false},
 		"https://public.example.com": {"https://public.example.com", false},
 	}
 	for in, want := range cases {
@@ -19,5 +19,29 @@ func TestDockerDialBackURLRewritesLoopback(t *testing.T) {
 			t.Fatalf("dockerDialBackURL(%q) = (%q, %v), want (%q, %v)",
 				in, gotURL, gotGateway, want.wantURL, want.wantGateway)
 		}
+	}
+}
+
+func TestDockerClientFromEnvReadsResourceLimits(t *testing.T) {
+	env := func(k string) string {
+		return map[string]string{
+			"AGENT_DAEMON_SANDBOX_DOCKER_MEMORY":     "2g",
+			"AGENT_DAEMON_SANDBOX_DOCKER_CPUS":       "1.5",
+			"AGENT_DAEMON_SANDBOX_DOCKER_PIDS_LIMIT": "512",
+		}[k]
+	}
+	c := dockerClientFromEnv(env, "img", "net", true)
+	if c.Image != "img" || c.Network != "net" || !c.HostGateway {
+		t.Fatalf("base fields not wired: %+v", c)
+	}
+	if c.Memory != "2g" || c.CPUs != "1.5" || c.PidsLimit != "512" {
+		t.Fatalf("resource limits not wired: %+v", c)
+	}
+}
+
+func TestDockerClientFromEnvOmitsUnsetLimits(t *testing.T) {
+	c := dockerClientFromEnv(func(string) string { return "" }, "img", "", false)
+	if c.Memory != "" || c.CPUs != "" || c.PidsLimit != "" {
+		t.Fatalf("expected empty limits when env unset, got %+v", c)
 	}
 }

--- a/server/cmd/server/sandbox_docker_test.go
+++ b/server/cmd/server/sandbox_docker_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/config"
+)
 
 func TestDockerDialBackURLRewritesLoopback(t *testing.T) {
 	cases := map[string]struct {
@@ -68,5 +72,71 @@ func TestDockerClientFromEnvEscapeHatchDisablesDefault(t *testing.T) {
 		if c.Memory != "" || c.CPUs != "" {
 			t.Fatalf("escape hatch %q: expected limits omitted, got cpus=%q memory=%q", off, c.CPUs, c.Memory)
 		}
+	}
+}
+
+func dockerBackendEnv(overrides map[string]string) func(string) string {
+	return func(k string) string {
+		if v, ok := overrides[k]; ok {
+			return v
+		}
+		return ""
+	}
+}
+
+func TestResolveAgentDaemonPublicWSURLRewritesLoopbackForDockerBackend(t *testing.T) {
+	// The in-container daemon dials PublicWSURL after bootstrap. With the local
+	// docker backend and no user-defined network, a loopback host must be
+	// rewritten to host.docker.internal (mirroring the bootstrap ServerURL
+	// rewrite) or the container would dial itself and stay 待分配.
+	var cfg config.Config
+	cfg.Server.PublicURL = "http://127.0.0.1:18090"
+	env := dockerBackendEnv(map[string]string{"AGENT_DAEMON_SANDBOX_BACKEND": "docker"})
+
+	got := resolveAgentDaemonPublicWSURL(env, cfg)
+	if want := "ws://host.docker.internal:18090/agent-daemon/ws"; got != want {
+		t.Fatalf("resolveAgentDaemonPublicWSURL = %q, want %q", got, want)
+	}
+}
+
+func TestResolveAgentDaemonPublicWSURLKeepsLoopbackWhenDockerNetworkSet(t *testing.T) {
+	// A user-defined docker network makes the server reachable by service name,
+	// so the loopback rewrite/host-gateway is unnecessary — leave PublicWSURL
+	// untouched (mirrors buildDockerAgentDaemonSandboxProvider).
+	var cfg config.Config
+	cfg.Server.PublicURL = "http://127.0.0.1:18090"
+	env := dockerBackendEnv(map[string]string{
+		"AGENT_DAEMON_SANDBOX_BACKEND":        "docker",
+		"AGENT_DAEMON_SANDBOX_DOCKER_NETWORK": "parsar_default",
+	})
+
+	got := resolveAgentDaemonPublicWSURL(env, cfg)
+	if want := "ws://127.0.0.1:18090/agent-daemon/ws"; got != want {
+		t.Fatalf("resolveAgentDaemonPublicWSURL = %q, want %q", got, want)
+	}
+}
+
+func TestResolveAgentDaemonPublicWSURLLeavesNonLoopbackUntouched(t *testing.T) {
+	// A real public host is reachable from inside the container as-is; only the
+	// scheme swap from buildAgentDaemonWSURL applies.
+	var cfg config.Config
+	cfg.Server.PublicURL = "https://parsar.example.com"
+	env := dockerBackendEnv(map[string]string{"AGENT_DAEMON_SANDBOX_BACKEND": "docker"})
+
+	got := resolveAgentDaemonPublicWSURL(env, cfg)
+	if want := "wss://parsar.example.com/agent-daemon/ws"; got != want {
+		t.Fatalf("resolveAgentDaemonPublicWSURL = %q, want %q", got, want)
+	}
+}
+
+func TestResolveAgentDaemonPublicWSURLNoRewriteWhenBackendNotDocker(t *testing.T) {
+	// Without the docker backend the rewrite must not fire: e2b/other backends
+	// keep the plain scheme-swapped PublicURL from buildAgentDaemonWSURL.
+	var cfg config.Config
+	cfg.Server.PublicURL = "http://127.0.0.1:18090"
+
+	got := resolveAgentDaemonPublicWSURL(dockerBackendEnv(nil), cfg)
+	if want := "ws://127.0.0.1:18090/agent-daemon/ws"; got != want {
+		t.Fatalf("resolveAgentDaemonPublicWSURL = %q, want %q", got, want)
 	}
 }

--- a/server/cmd/server/sandbox_docker_test.go
+++ b/server/cmd/server/sandbox_docker_test.go
@@ -39,9 +39,34 @@ func TestDockerClientFromEnvReadsResourceLimits(t *testing.T) {
 	}
 }
 
-func TestDockerClientFromEnvOmitsUnsetLimits(t *testing.T) {
+func TestDockerClientFromEnvAppliesBuiltInDefaults(t *testing.T) {
+	// With the env unset the operator still gets a safe built-in cap (2 CPU /
+	// 4GB) so one runaway sandbox can't starve the host. PidsLimit stays unset:
+	// a low pids cap is a classic build-breaker (make -j, go test ./...).
 	c := dockerClientFromEnv(func(string) string { return "" }, "img", "", false)
-	if c.Memory != "" || c.CPUs != "" || c.PidsLimit != "" {
-		t.Fatalf("expected empty limits when env unset, got %+v", c)
+	if c.CPUs != "2" || c.Memory != "4g" {
+		t.Fatalf("expected default 2 CPU / 4g, got cpus=%q memory=%q", c.CPUs, c.Memory)
+	}
+	if c.PidsLimit != "" {
+		t.Fatalf("expected pids-limit unset by default, got %q", c.PidsLimit)
+	}
+}
+
+func TestDockerClientFromEnvEscapeHatchDisablesDefault(t *testing.T) {
+	// An operator who wants docker's unbounded default back sets the env to
+	// 0/unlimited/none (case-insensitive, trimmed); the flag is then omitted
+	// rather than falling back to the built-in cap.
+	for _, off := range []string{"0", "unlimited", "none", "UNLIMITED", " None "} {
+		env := func(k string) string {
+			switch k {
+			case "AGENT_DAEMON_SANDBOX_DOCKER_MEMORY", "AGENT_DAEMON_SANDBOX_DOCKER_CPUS":
+				return off
+			}
+			return ""
+		}
+		c := dockerClientFromEnv(env, "img", "", false)
+		if c.Memory != "" || c.CPUs != "" {
+			t.Fatalf("escape hatch %q: expected limits omitted, got cpus=%q memory=%q", off, c.CPUs, c.Memory)
+		}
 	}
 }

--- a/server/cmd/server/sandbox_docker_test.go
+++ b/server/cmd/server/sandbox_docker_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+func TestDockerDialBackURLRewritesLoopback(t *testing.T) {
+	cases := map[string]struct {
+		wantURL     string
+		wantGateway bool
+	}{
+		"http://127.0.0.1:18080":  {"http://host.docker.internal:18080", true},
+		"http://localhost:18080":  {"http://host.docker.internal:18080", true},
+		"http://[::1]:8080":       {"http://host.docker.internal:8080", true},
+		"http://parsar-server:8080": {"http://parsar-server:8080", false},
+		"https://public.example.com": {"https://public.example.com", false},
+	}
+	for in, want := range cases {
+		gotURL, gotGateway := dockerDialBackURL(in)
+		if gotURL != want.wantURL || gotGateway != want.wantGateway {
+			t.Fatalf("dockerDialBackURL(%q) = (%q, %v), want (%q, %v)",
+				in, gotURL, gotGateway, want.wantURL, want.wantGateway)
+		}
+	}
+}

--- a/server/internal/sandbox/docker/client.go
+++ b/server/internal/sandbox/docker/client.go
@@ -1,0 +1,143 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/sandbox/e2b"
+)
+
+// syntheticTTL is the fake expiry GetInfo reports. Local docker containers
+// have no control-plane TTL; the provider only uses EndAt as optional
+// status metadata, so any comfortably-future value is fine.
+const syntheticTTL = 30 * 24 * time.Hour
+
+type execResult struct {
+	Stdout   string
+	Stderr   string
+	ExitCode int
+}
+
+// runnerFunc is the injection seam: production wires an os/exec-backed
+// runner, tests wire a fake so no real docker daemon is required.
+type runnerFunc func(ctx context.Context, name string, args []string, stdin io.Reader) (execResult, error)
+
+type Client struct {
+	Image       string
+	Network     string
+	HostGateway bool
+	runner      runnerFunc
+}
+
+func (c *Client) Create(ctx context.Context, input e2b.CreateInput) (e2b.Sandbox, error) {
+	args := []string{"run", "-d", "--entrypoint", "sleep"}
+	if strings.TrimSpace(c.Network) != "" {
+		args = append(args, "--network", c.Network)
+	}
+	if c.HostGateway {
+		args = append(args, "--add-host", "host.docker.internal:host-gateway")
+	}
+	for k, v := range input.Metadata {
+		args = append(args, "--label", k+"="+v)
+	}
+	for k, v := range input.Env {
+		args = append(args, "-e", k+"="+v)
+	}
+	args = append(args, c.Image, "infinity")
+
+	res, err := c.runnerOrDefault()(ctx, "docker", args, nil)
+	if err != nil {
+		return e2b.Sandbox{}, err
+	}
+	return e2b.Sandbox{SandboxID: strings.TrimSpace(res.Stdout)}, nil
+}
+
+func (c *Client) RunCommand(ctx context.Context, input e2b.RunCommandInput) (e2b.CommandResult, error) {
+	args := []string{"exec"}
+	if cwd := strings.TrimSpace(input.CWD); cwd != "" {
+		args = append(args, "-w", cwd)
+	}
+	user := strings.TrimSpace(input.User)
+	if user == "" {
+		user = "root"
+	}
+	args = append(args, "-u", user)
+	for k, v := range input.Env {
+		args = append(args, "-e", k+"="+v)
+	}
+	args = append(args, input.Sandbox.SandboxID, "/bin/bash", "-l", "-c", input.Command)
+
+	res, err := c.runnerOrDefault()(ctx, "docker", args, nil)
+	if err != nil {
+		return e2b.CommandResult{}, err
+	}
+	return e2b.CommandResult{
+		Stdout: res.Stdout,
+		Stderr: res.Stderr,
+		Status: strconv.Itoa(res.ExitCode),
+		Exited: true,
+	}, nil
+}
+
+func (c *Client) Kill(ctx context.Context, sandboxID string) error {
+	sandboxID = strings.TrimSpace(sandboxID)
+	if sandboxID == "" {
+		return errors.New("dockersandbox: sandbox id is empty")
+	}
+	_, err := c.runnerOrDefault()(ctx, "docker", []string{"rm", "-f", sandboxID}, nil)
+	return err
+}
+
+func (c *Client) Renew(_ context.Context, _ string, _ int) error {
+	return nil
+}
+
+func (c *Client) GetInfo(_ context.Context, sandboxID string) (e2b.SandboxRuntimeInfo, error) {
+	now := time.Now()
+	return e2b.SandboxRuntimeInfo{
+		SandboxID: strings.TrimSpace(sandboxID),
+		StartedAt: now,
+		EndAt:     now.Add(syntheticTTL),
+		State:     "running",
+	}, nil
+}
+
+func (c *Client) runnerOrDefault() runnerFunc {
+	if c.runner != nil {
+		return c.runner
+	}
+	return osExecRun
+}
+
+// osExecRun runs a local process. A non-zero exit is a normal result
+// (ExitCode set, err nil) so RunCommand can report it as Status; only a
+// launch failure or context cancellation returns a non-nil error.
+func osExecRun(ctx context.Context, name string, args []string, stdin io.Reader) (execResult, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	if stdin != nil {
+		cmd.Stdin = stdin
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	res := execResult{Stdout: stdout.String(), Stderr: stderr.String()}
+	if err != nil {
+		if ctx.Err() != nil {
+			return res, ctx.Err()
+		}
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			res.ExitCode = exitErr.ExitCode()
+			return res, nil
+		}
+		return res, err
+	}
+	return res, nil
+}

--- a/server/internal/sandbox/docker/client.go
+++ b/server/internal/sandbox/docker/client.go
@@ -33,7 +33,14 @@ type Client struct {
 	Image       string
 	Network     string
 	HostGateway bool
-	runner      runnerFunc
+	// Optional container resource limits, passed straight to `docker run`
+	// when non-empty (empty = flag omitted, docker's default). A malformed
+	// value makes `docker run` exit non-zero, which Create surfaces as an
+	// error, so no pre-validation is needed here.
+	Memory    string // --memory, e.g. "2g"
+	CPUs      string // --cpus, e.g. "1.5"
+	PidsLimit string // --pids-limit, e.g. "512"
+	runner    runnerFunc
 }
 
 func (c *Client) Create(ctx context.Context, input e2b.CreateInput) (e2b.Sandbox, error) {
@@ -43,6 +50,15 @@ func (c *Client) Create(ctx context.Context, input e2b.CreateInput) (e2b.Sandbox
 	}
 	if c.HostGateway {
 		args = append(args, "--add-host", "host.docker.internal:host-gateway")
+	}
+	if m := strings.TrimSpace(c.Memory); m != "" {
+		args = append(args, "--memory", m)
+	}
+	if cpus := strings.TrimSpace(c.CPUs); cpus != "" {
+		args = append(args, "--cpus", cpus)
+	}
+	if pids := strings.TrimSpace(c.PidsLimit); pids != "" {
+		args = append(args, "--pids-limit", pids)
 	}
 	for k, v := range input.Metadata {
 		args = append(args, "--label", k+"="+v)

--- a/server/internal/sandbox/docker/client.go
+++ b/server/internal/sandbox/docker/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os/exec"
 	"strconv"
@@ -55,9 +56,24 @@ func (c *Client) Create(ctx context.Context, input e2b.CreateInput) (e2b.Sandbox
 	if err != nil {
 		return e2b.Sandbox{}, err
 	}
-	return e2b.Sandbox{SandboxID: strings.TrimSpace(res.Stdout)}, nil
+	// Create is a control-plane verb: unlike RunCommand, a non-zero docker
+	// exit means the operation failed, not a payload. Surface it (with
+	// stderr) instead of returning an empty-id sandbox that reads as success.
+	if res.ExitCode != 0 {
+		return e2b.Sandbox{}, fmt.Errorf("dockersandbox: docker run failed (exit %d): %s", res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	id := strings.TrimSpace(res.Stdout)
+	if id == "" {
+		return e2b.Sandbox{}, fmt.Errorf("dockersandbox: docker run returned no container id (stderr: %s)", strings.TrimSpace(res.Stderr))
+	}
+	return e2b.Sandbox{SandboxID: id}, nil
 }
 
+// RunCommand execs into the container and returns the command's exit code as
+// Status (Create/Kill treat non-zero as failure; here it's the payload). Note
+// a docker-level launch failure — e.g. the container is gone — surfaces as
+// docker exec's own 125/126/127, indistinguishable from the command exiting
+// with those codes; callers see it as a failed command with docker's stderr.
 func (c *Client) RunCommand(ctx context.Context, input e2b.RunCommandInput) (e2b.CommandResult, error) {
 	args := []string{"exec"}
 	if cwd := strings.TrimSpace(input.CWD); cwd != "" {
@@ -90,14 +106,30 @@ func (c *Client) Kill(ctx context.Context, sandboxID string) error {
 	if sandboxID == "" {
 		return errors.New("dockersandbox: sandbox id is empty")
 	}
-	_, err := c.runnerOrDefault()(ctx, "docker", []string{"rm", "-f", sandboxID}, nil)
-	return err
+	res, err := c.runnerOrDefault()(ctx, "docker", []string{"rm", "-f", sandboxID}, nil)
+	if err != nil {
+		return err
+	}
+	if res.ExitCode != 0 {
+		// Removing an already-gone container is idempotent success; any other
+		// non-zero exit (daemon unreachable, permission denied) must surface
+		// so Release/Reap don't record a leaked container as killed.
+		if strings.Contains(res.Stderr, "No such container") {
+			return nil
+		}
+		return fmt.Errorf("dockersandbox: docker rm -f %s failed (exit %d): %s", sandboxID, res.ExitCode, strings.TrimSpace(res.Stderr))
+	}
+	return nil
 }
 
 func (c *Client) Renew(_ context.Context, _ string, _ int) error {
 	return nil
 }
 
+// GetInfo returns synthetic metadata: local containers have no control-plane,
+// so State is always "running" and EndAt a fixed future TTL. It is NOT a
+// liveness probe — a crashed container still reports "running". The provider
+// only consumes EndAt (optional status metadata), so this is sufficient.
 func (c *Client) GetInfo(_ context.Context, sandboxID string) (e2b.SandboxRuntimeInfo, error) {
 	now := time.Now()
 	return e2b.SandboxRuntimeInfo{

--- a/server/internal/sandbox/docker/client_integration_test.go
+++ b/server/internal/sandbox/docker/client_integration_test.go
@@ -1,0 +1,87 @@
+package docker
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/sandbox/e2b"
+)
+
+// TestIntegrationRealDockerLifecycle drives the real os/exec runner against a
+// live docker daemon. Skipped unless PARSAR_DOCKER_IT=1 (and the
+// parsar-sandbox:local image exists) so `go test ./...` stays hermetic.
+//
+// Run: PARSAR_DOCKER_IT=1 go test ./server/internal/sandbox/docker/ -run Integration -v
+func TestIntegrationRealDockerLifecycle(t *testing.T) {
+	if os.Getenv("PARSAR_DOCKER_IT") != "1" {
+		t.Skip("set PARSAR_DOCKER_IT=1 to run the real-docker integration test")
+	}
+	image := os.Getenv("PARSAR_DOCKER_IT_IMAGE")
+	if image == "" {
+		image = "parsar-sandbox:local"
+	}
+
+	client := &Client{Image: image}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	sb, err := client.Create(ctx, e2b.CreateInput{
+		Env:      map[string]string{"FOO": "bar"},
+		Metadata: map[string]string{"parsar.test": "it"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if strings.TrimSpace(sb.SandboxID) == "" {
+		t.Fatalf("expected non-empty container id")
+	}
+	t.Logf("created container %s", sb.SandboxID)
+
+	defer func() {
+		if err := client.Kill(context.Background(), sb.SandboxID); err != nil {
+			t.Errorf("kill: %v", err)
+		}
+		out, _ := osExecRun(context.Background(), "docker",
+			[]string{"ps", "-a", "--filter", "id=" + sb.SandboxID, "--format", "{{.ID}}"}, nil)
+		if strings.TrimSpace(out.Stdout) != "" {
+			t.Errorf("expected container removed, still present: %q", out.Stdout)
+		}
+	}()
+
+	res, err := client.RunCommand(ctx, e2b.RunCommandInput{
+		Sandbox: sb,
+		Command: "echo hi-$FOO",
+		CWD:     "/workspace",
+		Env:     map[string]string{"FOO": "bar"},
+	})
+	if err != nil {
+		t.Fatalf("run echo: %v", err)
+	}
+	if res.Status != "0" || !res.Exited {
+		t.Fatalf("expected exit 0, got status=%q exited=%v stderr=%q", res.Status, res.Exited, res.Stderr)
+	}
+	if strings.TrimSpace(res.Stdout) != "hi-bar" {
+		t.Fatalf("expected 'hi-bar', got %q", res.Stdout)
+	}
+
+	// Non-zero exit must surface as Status, not a Go error.
+	res, err = client.RunCommand(ctx, e2b.RunCommandInput{Sandbox: sb, Command: "exit 7"})
+	if err != nil {
+		t.Fatalf("run exit7 returned error, want nil: %v", err)
+	}
+	if res.Status != "7" {
+		t.Fatalf("expected status 7, got %q", res.Status)
+	}
+
+	res, err = client.RunCommand(ctx, e2b.RunCommandInput{Sandbox: sb, Command: "parsar-daemon version"})
+	if err != nil {
+		t.Fatalf("run daemon version: %v", err)
+	}
+	if res.Status != "0" {
+		t.Fatalf("expected daemon version exit 0, got %q stderr=%q", res.Status, res.Stderr)
+	}
+	t.Logf("parsar-daemon version -> %q", strings.TrimSpace(res.Stdout))
+}

--- a/server/internal/sandbox/docker/client_test.go
+++ b/server/internal/sandbox/docker/client_test.go
@@ -321,3 +321,47 @@ func TestKillToleratesMissingContainer(t *testing.T) {
 		t.Fatalf("expected nil error when container already gone, got %v", err)
 	}
 }
+
+func TestCreateAppliesResourceLimitsWhenSet(t *testing.T) {
+	var got recordedCall
+	fake := &fakeRunner{handler: func(call recordedCall) (execResult, error) {
+		got = call
+		return execResult{Stdout: "cid\n"}, nil
+	}}
+	client := &Client{
+		Image:     "img",
+		Memory:    "2g",
+		CPUs:      "1.5",
+		PidsLimit: "512",
+		runner:    fake.run,
+	}
+	if _, err := client.Create(context.Background(), e2b.CreateInput{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	joined := strings.Join(got.Args, " ")
+	for _, want := range []string{"--memory 2g", "--cpus 1.5", "--pids-limit 512"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("expected %q in args, got %v", want, got.Args)
+		}
+	}
+}
+
+func TestCreateOmitsResourceLimitsWhenUnset(t *testing.T) {
+	// Defaults must be byte-for-byte unchanged: no limit flags unless the
+	// operator opts in via env.
+	var got recordedCall
+	fake := &fakeRunner{handler: func(call recordedCall) (execResult, error) {
+		got = call
+		return execResult{Stdout: "cid\n"}, nil
+	}}
+	client := &Client{Image: "img", runner: fake.run}
+	if _, err := client.Create(context.Background(), e2b.CreateInput{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	joined := strings.Join(got.Args, " ")
+	for _, unwanted := range []string{"--memory", "--cpus", "--pids-limit"} {
+		if strings.Contains(joined, unwanted) {
+			t.Fatalf("expected no %q flag when unset, got %v", unwanted, got.Args)
+		}
+	}
+}

--- a/server/internal/sandbox/docker/client_test.go
+++ b/server/internal/sandbox/docker/client_test.go
@@ -1,0 +1,261 @@
+package docker
+
+import (
+	"context"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/sandbox/e2b"
+)
+
+type recordedCall struct {
+	Name  string
+	Args  []string
+	Stdin string
+}
+
+// fakeRunner records calls and returns canned output so unit tests never
+// touch a real docker daemon.
+type fakeRunner struct {
+	calls   []recordedCall
+	handler func(call recordedCall) (execResult, error)
+}
+
+func (f *fakeRunner) run(_ context.Context, name string, args []string, stdin io.Reader) (execResult, error) {
+	var stdinStr string
+	if stdin != nil {
+		b, _ := io.ReadAll(stdin)
+		stdinStr = string(b)
+	}
+	call := recordedCall{Name: name, Args: args, Stdin: stdinStr}
+	f.calls = append(f.calls, call)
+	if f.handler != nil {
+		return f.handler(call)
+	}
+	return execResult{}, nil
+}
+
+func containsArg(args []string, want string) bool {
+	return slices.Contains(args, want)
+}
+
+func TestCreateRunsDockerRunAndReturnsContainerID(t *testing.T) {
+	fake := &fakeRunner{
+		handler: func(recordedCall) (execResult, error) {
+			// docker run -d prints the full container ID on stdout.
+			return execResult{Stdout: "abc123def456\n"}, nil
+		},
+	}
+	client := &Client{Image: "parsar-sandbox:local", runner: fake.run}
+
+	sb, err := client.Create(context.Background(), e2b.CreateInput{})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if sb.SandboxID != "abc123def456" {
+		t.Fatalf("expected container id as sandbox id, got %q", sb.SandboxID)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("expected exactly 1 docker call, got %d", len(fake.calls))
+	}
+	call := fake.calls[0]
+	if call.Name != "docker" {
+		t.Fatalf("expected docker binary, got %q", call.Name)
+	}
+	if !containsArg(call.Args, "run") || !containsArg(call.Args, "-d") {
+		t.Fatalf("expected `docker run -d`, got args %v", call.Args)
+	}
+	if !containsArg(call.Args, "parsar-sandbox:local") {
+		t.Fatalf("expected image in args, got %v", call.Args)
+	}
+}
+
+func TestCreateKeepsContainerAliveViaEntrypointOverride(t *testing.T) {
+	fake := &fakeRunner{handler: func(recordedCall) (execResult, error) {
+		return execResult{Stdout: "cid\n"}, nil
+	}}
+	client := &Client{Image: "img", runner: fake.run}
+
+	if _, err := client.Create(context.Background(), e2b.CreateInput{}); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	call := fake.calls[0]
+	// The container must outlive `docker run` so later `docker exec` works;
+	// the e2b base image's default entrypoint is envd, which we bypass
+	// locally in favour of exec, so we override it with a keepalive.
+	if !containsArg(call.Args, "--entrypoint") {
+		t.Fatalf("expected --entrypoint override, got %v", call.Args)
+	}
+	if !strings.Contains(strings.Join(call.Args, " "), "sleep") {
+		t.Fatalf("expected keepalive command, got %v", call.Args)
+	}
+}
+
+func TestCreateAppliesNetworkHostGatewayEnvAndLabels(t *testing.T) {
+	var got recordedCall
+	fake := &fakeRunner{handler: func(call recordedCall) (execResult, error) {
+		got = call
+		return execResult{Stdout: "cid\n"}, nil
+	}}
+	client := &Client{
+		Image:       "img",
+		Network:     "parsar_default",
+		HostGateway: true,
+		runner:      fake.run,
+	}
+	_, err := client.Create(context.Background(), e2b.CreateInput{
+		Env:      map[string]string{"FOO": "bar"},
+		Metadata: map[string]string{"workspace": "ws1"},
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	joined := strings.Join(got.Args, " ")
+	if !strings.Contains(joined, "--network parsar_default") {
+		t.Fatalf("expected --network, got %v", got.Args)
+	}
+	if !strings.Contains(joined, "--add-host host.docker.internal:host-gateway") {
+		t.Fatalf("expected host-gateway mapping, got %v", got.Args)
+	}
+	if !strings.Contains(joined, "-e FOO=bar") {
+		t.Fatalf("expected env passthrough, got %v", got.Args)
+	}
+	if !strings.Contains(joined, "--label workspace=ws1") {
+		t.Fatalf("expected metadata label, got %v", got.Args)
+	}
+}
+
+func TestKillRemovesContainer(t *testing.T) {
+	fake := &fakeRunner{}
+	client := &Client{Image: "img", runner: fake.run}
+
+	if err := client.Kill(context.Background(), "cid42"); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	call := fake.calls[0]
+	if !containsArg(call.Args, "rm") || !containsArg(call.Args, "-f") || !containsArg(call.Args, "cid42") {
+		t.Fatalf("expected `docker rm -f cid42`, got %v", call.Args)
+	}
+}
+
+func TestKillEmptyIDIsError(t *testing.T) {
+	fake := &fakeRunner{}
+	client := &Client{Image: "img", runner: fake.run}
+	if err := client.Kill(context.Background(), "  "); err == nil {
+		t.Fatalf("expected error for empty sandbox id")
+	}
+	if len(fake.calls) != 0 {
+		t.Fatalf("expected no docker call for empty id, got %v", fake.calls)
+	}
+}
+
+func TestRenewIsNoOp(t *testing.T) {
+	fake := &fakeRunner{}
+	client := &Client{Image: "img", runner: fake.run}
+	if err := client.Renew(context.Background(), "cid", 60); err != nil {
+		t.Fatalf("renew: %v", err)
+	}
+	// Local containers have no control-plane TTL, so Renew must not shell
+	// out — it exists only to satisfy the E2BClient interface.
+	if len(fake.calls) != 0 {
+		t.Fatalf("expected renew to be a no-op, got calls %v", fake.calls)
+	}
+}
+
+func TestGetInfoReturnsSyntheticFutureExpiry(t *testing.T) {
+	fake := &fakeRunner{}
+	client := &Client{Image: "img", runner: fake.run}
+	before := time.Now()
+	info, err := client.GetInfo(context.Background(), "cid99")
+	if err != nil {
+		t.Fatalf("getinfo: %v", err)
+	}
+	if info.SandboxID != "cid99" {
+		t.Fatalf("expected sandbox id echoed, got %q", info.SandboxID)
+	}
+	if !info.EndAt.After(before) {
+		t.Fatalf("expected future EndAt, got %v", info.EndAt)
+	}
+	if info.State != "running" {
+		t.Fatalf("expected running state, got %q", info.State)
+	}
+}
+
+func TestOSExecRunCapturesStdoutAndZeroExit(t *testing.T) {
+	res, err := osExecRun(context.Background(), "sh", []string{"-c", "printf hello"}, nil)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if res.Stdout != "hello" {
+		t.Fatalf("stdout=%q", res.Stdout)
+	}
+	if res.ExitCode != 0 {
+		t.Fatalf("exit=%d, want 0", res.ExitCode)
+	}
+}
+
+func TestOSExecRunCapturesNonZeroExitWithoutError(t *testing.T) {
+	// A command exiting non-zero is a normal result, not a runner failure:
+	// RunCommand must surface it as CommandResult.Status, so err stays nil.
+	res, err := osExecRun(context.Background(), "sh", []string{"-c", "printf oops >&2; exit 7"}, nil)
+	if err != nil {
+		t.Fatalf("expected nil err for clean non-zero exit, got %v", err)
+	}
+	if res.ExitCode != 7 {
+		t.Fatalf("exit=%d, want 7", res.ExitCode)
+	}
+	if res.Stderr != "oops" {
+		t.Fatalf("stderr=%q", res.Stderr)
+	}
+}
+
+func TestNilRunnerFallsBackToOSExec(t *testing.T) {
+	if (&Client{}).runnerOrDefault() == nil {
+		t.Fatalf("expected non-nil default runner when none injected")
+	}
+}
+
+func TestRunCommandExecsBashWrapperAndReturnsExitStatus(t *testing.T) {
+	fake := &fakeRunner{
+		handler: func(recordedCall) (execResult, error) {
+			return execResult{Stdout: "hi\n", ExitCode: 0}, nil
+		},
+	}
+	client := &Client{Image: "img", runner: fake.run}
+
+	res, err := client.RunCommand(context.Background(), e2b.RunCommandInput{
+		Sandbox: e2b.Sandbox{SandboxID: "cid789"},
+		Command: "echo hi",
+	})
+	if err != nil {
+		t.Fatalf("run command: %v", err)
+	}
+	if res.Stdout != "hi\n" {
+		t.Fatalf("expected stdout hi, got %q", res.Stdout)
+	}
+	if !res.Exited || res.Status != "0" {
+		t.Fatalf("expected exited=true status=0, got exited=%v status=%q", res.Exited, res.Status)
+	}
+	if len(fake.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(fake.calls))
+	}
+	call := fake.calls[0]
+	if !containsArg(call.Args, "exec") {
+		t.Fatalf("expected `docker exec`, got %v", call.Args)
+	}
+	if !containsArg(call.Args, "cid789") {
+		t.Fatalf("expected container id in args, got %v", call.Args)
+	}
+	// The command must run through a login bash so PATH + profile match e2b's
+	// `/bin/bash -l -c` contract that seed/connect scripts rely on.
+	joined := strings.Join(call.Args, " ")
+	if !strings.Contains(joined, "/bin/bash -l -c") {
+		t.Fatalf("expected bash login wrapper, got %v", call.Args)
+	}
+	if call.Args[len(call.Args)-1] != "echo hi" {
+		t.Fatalf("expected raw command as final arg, got %q", call.Args[len(call.Args)-1])
+	}
+}

--- a/server/internal/sandbox/docker/client_test.go
+++ b/server/internal/sandbox/docker/client_test.go
@@ -259,3 +259,65 @@ func TestRunCommandExecsBashWrapperAndReturnsExitStatus(t *testing.T) {
 		t.Fatalf("expected raw command as final arg, got %q", call.Args[len(call.Args)-1])
 	}
 }
+
+func TestCreateReturnsErrorOnNonZeroExit(t *testing.T) {
+	// `docker run` failing (image missing, daemon down, bad --network) exits
+	// non-zero with an empty stdout. Create is a control-plane verb, so this
+	// must be a Go error — not a Sandbox{SandboxID:""} reported as success —
+	// and the error must carry docker's stderr for diagnosis.
+	fake := &fakeRunner{handler: func(recordedCall) (execResult, error) {
+		return execResult{ExitCode: 125, Stderr: "Unable to find image 'missing:tag' locally\nno such image"}, nil
+	}}
+	client := &Client{Image: "missing:tag", runner: fake.run}
+
+	sb, err := client.Create(context.Background(), e2b.CreateInput{})
+	if err == nil {
+		t.Fatalf("expected error on non-zero docker run exit, got sandbox %+v", sb)
+	}
+	if !strings.Contains(err.Error(), "no such image") {
+		t.Fatalf("expected docker stderr in error, got %q", err.Error())
+	}
+}
+
+func TestCreateReturnsErrorOnEmptyContainerID(t *testing.T) {
+	// A zero exit but blank stdout still yields no usable container id; the
+	// provider must not proceed with an empty SandboxID.
+	fake := &fakeRunner{handler: func(recordedCall) (execResult, error) {
+		return execResult{ExitCode: 0, Stdout: "  \n"}, nil
+	}}
+	client := &Client{Image: "img", runner: fake.run}
+
+	if sb, err := client.Create(context.Background(), e2b.CreateInput{}); err == nil {
+		t.Fatalf("expected error on empty container id, got sandbox %+v", sb)
+	}
+}
+
+func TestKillReturnsErrorOnNonZeroExit(t *testing.T) {
+	// A real `docker rm -f` failure (e.g. daemon unreachable) must surface so
+	// Release/Reap don't record a leaked container as successfully killed.
+	fake := &fakeRunner{handler: func(recordedCall) (execResult, error) {
+		return execResult{ExitCode: 1, Stderr: "Cannot connect to the Docker daemon at unix:///var/run/docker.sock"}, nil
+	}}
+	client := &Client{Image: "img", runner: fake.run}
+
+	err := client.Kill(context.Background(), "cid42")
+	if err == nil {
+		t.Fatalf("expected error on non-zero docker rm exit")
+	}
+	if !strings.Contains(err.Error(), "Cannot connect to the Docker daemon") {
+		t.Fatalf("expected docker stderr in error, got %q", err.Error())
+	}
+}
+
+func TestKillToleratesMissingContainer(t *testing.T) {
+	// Kill must stay idempotent: removing an already-gone container is a
+	// success, not an error, so retries/Reap don't wedge on it.
+	fake := &fakeRunner{handler: func(recordedCall) (execResult, error) {
+		return execResult{ExitCode: 1, Stderr: "Error: No such container: cid42"}, nil
+	}}
+	client := &Client{Image: "img", runner: fake.run}
+
+	if err := client.Kill(context.Background(), "cid42"); err != nil {
+		t.Fatalf("expected nil error when container already gone, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **local docker backend** for the `daemon_mode: sandbox` feature. Today `agent_daemon` provisions an **E2B cloud** sandbox; this PR lets it instead spin up a **local Docker container** by implementing the existing `E2BClient` seam against `docker run/exec/rm`. Fully opt-in and off by default.

Enabled with:

```
AGENT_DAEMON_SANDBOX_BACKEND=docker
AGENT_DAEMON_SANDBOX_DOCKER_IMAGE=parsar-sandbox:local
```

When `AGENT_DAEMON_SANDBOX_BACKEND=docker`, `buildAgentDaemonSandboxProvider` short-circuits **before** the e2b API-key / CA / pod-IP wiring and returns a container-backed `E2BSandboxProvider`. With the env unset, behavior is byte-for-byte unchanged.

## What's in it

**Go feature code**
- `server/internal/sandbox/docker/client.go` — implements the 5-method `E2BClient` interface:
  - `Create` → `docker run -d --entrypoint sleep … IMAGE infinity`
  - `RunCommand` → `docker exec [-w cwd] [-u user] … /bin/bash -l -c CMD`
  - `Kill` → `docker rm -f`
  - `Renew` → no-op (local containers have no control-plane TTL)
  - `GetInfo` → synthetic running/TTL metadata
  - Runner is an injectable seam (`runnerFunc`) so unit tests need **no docker daemon**.
- `server/cmd/server/sandbox_docker.go` — provider wiring + `dockerDialBackURL`, which rewrites a loopback server URL to `host.docker.internal` so the in-container daemon can dial back to the host.
- `server/cmd/server/main.go` — 6-line delegate at the top of `buildAgentDaemonSandboxProvider`.

**Local image tooling** (`infra/e2b-templates/parsar-sandbox-local/`)
- `local.Dockerfile` — arm64 sibling of the existing `parsar-daemon-claudecode/e2b.Dockerfile`. Copies **host-built** static `linux/arm64` binaries so it runs natively under Docker Desktop on Apple Silicon (the cloud template is amd64 + pulls the daemon from GitHub Releases).
- `build.sh` — compiles `parsar` + `parsar-daemon` (`CGO_ENABLED=0 GOOS=linux GOARCH=arm64`), stages the shared claude/opencode hooks, and builds the image. **Compiled artifacts are gitignored** (`.build/`); only source tooling is committed.

## Testing

- `client_test.go` — unit tests via the fake runner (no daemon).
- `client_integration_test.go` — real-daemon lifecycle, gated behind `PARSAR_DOCKER_IT=1`.
- `sandbox_docker_test.go` — dial-back URL rewrite.
- Validated end-to-end locally against the real server: provider wires up (`managed_sandbox_provider:true`), a real cold-start boots a container, the daemon dials back over WS and registers its device, `runtime_id` is persisted, and Kill removes the container.
- `build.sh` re-run from a clean context reproduces a working image (both binaries report their version inside the build).

## Test plan

- [ ] `go test ./server/internal/sandbox/docker/... ./server/cmd/server/...`
- [ ] `infra/e2b-templates/parsar-sandbox-local/build.sh` produces `parsar-sandbox:local`
- [ ] With the two env vars set, server logs `agent_daemon docker sandbox provider wired`
- [ ] With the env unset, e2b path is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update — end-to-end fix + unblock (post-review verification)

Two follow-up commits after verifying the feature live:

- **`fix(server): rewrite daemon PublicWSURL loopback for docker sandbox`** — the missing half of the dial-back. `dockerDialBackURL` already rewrote the *bootstrap* `ServerURL`, but the daemon also dials `PublicWSURL` **after** bootstrap; on the local docker backend with no user network that loopback must become `host.docker.internal` too, or the container dials itself and the run stays unassigned (待分配). New `resolveAgentDaemonPublicWSURL`, gated identically to the provider, + 4 table tests. Verified: newly-created agents now bind their sandbox (`runtime bound`) and the in-container daemon reports `ws connected`.

- **`fix(web): backfill agent id from agent_id in agent list`** — an **independent, pre-existing** bug surfaced while manually testing this feature (not caused by the docker sandbox work). The agent-list endpoint serializes `store.AgentRead` keyed `agent_id`, but the admin web app reads `.id`; the undefined `.id` broke agent delete (`agent_id must be a valid uuid`) and blocked agent selection / sending on the conversation page. Normalized once in `listAgents`. Happy to split into its own PR if you'd rather keep this PR server-only.
