### PR TITLE
fix(web): enable wheel scroll in model/provider dropdowns

### DIFF
--- a/apps/web/src/pages/admin/ModelKeyCombobox.tsx
+++ b/apps/web/src/pages/admin/ModelKeyCombobox.tsx
@@ -90,7 +90,17 @@ export function ModelKeyCombobox({ value, onChange, models, placeholder, id }: P
             />
           </div>
 
-          <div className="max-h-[220px] overflow-auto py-1">
+          {/* Radix DropdownMenu.Content owns wheel/arrow navigation and swallows
+              the wheel event, so a nested overflow-auto list scrolls only via
+              its scrollbar thumb. Re-drive the scroll here and stop the event
+              from reaching the menu so the wheel works over the 70+ presets. */}
+          <div
+            className="max-h-[220px] overflow-auto py-1"
+            onWheel={(e) => {
+              e.currentTarget.scrollTop += e.deltaY
+              e.stopPropagation()
+            }}
+          >
             {showFreeText && (
               <DropdownMenu.Item
                 onSelect={() => commit(typed)}

--- a/apps/web/src/pages/admin/ProviderTypeCombobox.tsx
+++ b/apps/web/src/pages/admin/ProviderTypeCombobox.tsx
@@ -91,7 +91,15 @@ export function ProviderTypeCombobox({ value, onChange, options, id }: Props) {
             />
           </div>
 
-          <div className="max-h-[240px] overflow-auto py-1">
+          {/* Radix DropdownMenu swallows wheel events; re-drive scroll so the
+              nested list responds to the wheel, not only the scrollbar thumb. */}
+          <div
+            className="max-h-[240px] overflow-auto py-1"
+            onWheel={(e) => {
+              e.currentTarget.scrollTop += e.deltaY
+              e.stopPropagation()
+            }}
+          >
             {filtered.length === 0 ? (
               <p className="px-3 py-2 text-sm text-fg-subtle">
                 {t("models.createProvider.fields.providerEmpty", "No matching providers")}

--- a/apps/web/src/pages/admin/capabilities/CredentialKindCombobox.tsx
+++ b/apps/web/src/pages/admin/capabilities/CredentialKindCombobox.tsx
@@ -107,7 +107,15 @@ export function CredentialKindCombobox({
               />
             </div>
 
-            <div className="max-h-[200px] overflow-auto py-1">
+            {/* Radix DropdownMenu swallows wheel events; re-drive scroll so the
+                nested list responds to the wheel, not only the scrollbar thumb. */}
+            <div
+              className="max-h-[200px] overflow-auto py-1"
+              onWheel={(e) => {
+                e.currentTarget.scrollTop += e.deltaY
+                e.stopPropagation()
+              }}
+            >
               {kindsQ.isLoading ? (
                 <div className="flex items-center gap-2 px-3 py-2 text-sm text-fg-subtle">
                   <Loader2 className="h-3.5 w-3.5 animate-spin" />


### PR DESCRIPTION
## Problem
Opening the model-key dropdown (70+ presets) — and the sibling provider-type / credential-kind pickers — the list could only be scrolled by dragging the scrollbar; the mouse wheel did nothing.

## Cause
Each list lives inside a Radix `DropdownMenu.Content`, which captures wheel/arrow events for menu navigation and prevents the nested `overflow-auto` container from scrolling.

## Fix
Add an `onWheel` handler on the scroll container that applies the delta directly and stops propagation to the menu. No structural or dependency changes.

## Test
- Local `pnpm dev`, verified the wheel now scrolls all three dropdowns.
- `tsc --noEmit` passes; the 3 changed files introduce no new lint findings.