### PR TITLE
ci: guard migration immutability and monotonic numbering

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -1,0 +1,56 @@
+# Guards two invariants on server/migrations/ that used to be enforced
+# only by convention:
+#
+#   1. Migration files that already exist on main are immutable. Once a
+#      file lands on main, prod has run it; editing the SQL only
+#      affects future fresh installs, silently splitting the schema.
+#   2. New migrations must be numbered strictly above the current head
+#      on main. goose orders files by their NNNNNN_ prefix — inserting
+#      a file below the head is a no-op on any DB that has already
+#      migrated past it.
+#
+# The check runs in scripts/verify-migration-order.sh; keeping the
+# logic in a shell script means humans can reproduce a failure
+# locally with `bash scripts/verify-migration-order.sh origin/main`
+# instead of squinting at CI logs.
+
+name: migrations
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'server/migrations/**'
+      - 'scripts/verify-migration-order.sh'
+      - '.github/workflows/migrations.yml'
+  pull_request:
+    paths:
+      - 'server/migrations/**'
+      - 'scripts/verify-migration-order.sh'
+      - '.github/workflows/migrations.yml'
+
+concurrency:
+  group: migrations-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify-order:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Need enough history for `git diff origin/main...HEAD` and
+          # `git ls-tree origin/main`. actions/checkout defaults to a
+          # shallow clone of HEAD only, which would leave origin/main
+          # unresolvable.
+          fetch-depth: 0
+
+      - name: Fetch base ref
+        run: git fetch --no-tags --depth=1 origin main
+
+      - name: Verify migration order and immutability
+        run: bash scripts/verify-migration-order.sh origin/main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,12 @@ Before reporting completion, you must run:
 make check
 ```
 
-- Any DB change must ship with a migration.
+- Any DB change must ship with a migration. Migrations are immutable
+  the moment they land on `main` — prod has already applied them, so
+  editing an existing file only mutates fresh installs. To change
+  schema, add a **new** migration numbered strictly above the current
+  head; CI (`.github/workflows/migrations.yml`) rejects edits to
+  landed files and numeric regressions.
 - API contracts live on the handler: every `http.HandlerFunc` factory
   must carry a swaggo annotation block (`@Summary`, `@Tags`, `@Param`,
   `@Success/@Failure`, `@Router`) directly above the `func`. After

--- a/scripts/verify-migration-order.sh
+++ b/scripts/verify-migration-order.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Enforce two invariants on server/migrations/ against a base ref:
+#   1. No file that exists on the base ref may be modified — once a
+#      migration lands on main, prod has run it and any edit only
+#      affects fresh installs, splitting the schema.
+#   2. Every newly-added migration's numeric prefix (NNNNNN_*) must be
+#      strictly greater than the maximum prefix present on the base
+#      ref. Gaps are fine (5 -> 10); regressions are not, because
+#      goose orders files by that prefix and would silently skip a
+#      migration inserted below the current head.
+#
+# Usage: verify-migration-order.sh [base-ref]
+# Default base ref: origin/main.
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+MIG_DIR="server/migrations"
+
+if ! git rev-parse --verify --quiet "${BASE_REF}" >/dev/null; then
+  echo "verify-migration-order: base ref '${BASE_REF}' not found; run 'git fetch origin main' first." >&2
+  exit 2
+fi
+
+# Name-status diff scoped to migration SQL. -M0 disables rename detection
+# so a rename shows up as delete+add (which we treat as a modification
+# of the deleted file, i.e. failure — you can't retitle a landed
+# migration either).
+added=()
+modified=()
+while IFS=$'\t' read -r status path extra; do
+  [[ -z "${status}" ]] && continue
+  # Rename/copy lines have status=R100 and two tab-separated paths;
+  # the new path is in $extra. We only care about the old path here
+  # because it counts as a removal of a landed file.
+  case "${status}" in
+    A)   added+=("${path}") ;;
+    M|T) modified+=("${path}") ;;
+    D)   modified+=("${path}") ;;
+    R*|C*)
+      modified+=("${path}")
+      if [[ -n "${extra}" ]]; then
+        added+=("${extra}")
+      fi
+      ;;
+    *)   modified+=("${path}") ;;
+  esac
+done < <(git diff --name-status -M0 "${BASE_REF}"...HEAD -- "${MIG_DIR}/*.sql")
+
+fail=0
+
+if ((${#modified[@]} > 0)); then
+  fail=1
+  echo "::error::Migrations that already exist on ${BASE_REF} were modified or removed:"
+  for f in "${modified[@]}"; do
+    echo "  - ${f}"
+  done
+  echo "Migrations become immutable the moment they land on main — prod has"
+  echo "already applied them. To change schema, add a NEW migration with the"
+  echo "next number instead of editing history."
+fi
+
+extract_num() {
+  local base="${1##*/}"
+  local num="${base%%_*}"
+  if [[ ! "${num}" =~ ^[0-9]+$ ]]; then
+    echo "verify-migration-order: cannot parse numeric prefix from '${1}'" >&2
+    return 1
+  fi
+  # Strip leading zeros without invoking octal parsing.
+  printf '%d\n' "$((10#${num}))"
+}
+
+# Highest prefix on the base ref. If there are no migrations there yet,
+# treat the floor as 0 so the first migration ever can be numbered 1.
+base_max=0
+while IFS= read -r f; do
+  [[ -z "${f}" ]] && continue
+  n=$(extract_num "${f}") || exit 3
+  ((n > base_max)) && base_max=${n}
+done < <(git ls-tree -r --name-only "${BASE_REF}" -- "${MIG_DIR}" | grep -E '\.sql$' || true)
+
+if ((${#added[@]} > 0)); then
+  # New migrations must land strictly above base_max AND must not
+  # collide with each other. Sort them numerically and walk upwards.
+  entries=""
+  for f in "${added[@]}"; do
+    n=$(extract_num "${f}") || exit 3
+    entries+="${n}:${f}"$'\n'
+  done
+  sorted=()
+  while IFS= read -r line; do
+    [[ -z "${line}" ]] && continue
+    sorted+=("${line}")
+  done < <(printf '%s' "${entries}" | sort -t: -k1,1n)
+
+  prev=${base_max}
+  for entry in "${sorted[@]}"; do
+    n="${entry%%:*}"
+    f="${entry#*:}"
+    if ((n <= prev)); then
+      fail=1
+      if ((n <= base_max)); then
+        echo "::error::New migration ${f} (prefix ${n}) is not above the current head on ${BASE_REF} (max ${base_max})."
+        echo "  goose applies files in lexicographic order — a lower-numbered file"
+        echo "  inserted below the head will be skipped on any DB that has already"
+        echo "  migrated past it. Renumber to $((base_max + 1)) or later."
+      else
+        echo "::error::New migration ${f} (prefix ${n}) collides with another added migration."
+      fi
+    fi
+    prev=${n}
+  done
+fi
+
+if ((fail != 0)); then
+  exit 1
+fi
+
+echo "Migration order check passed."
+if ((${#added[@]} > 0)); then
+  echo "  Base head: ${base_max}. Added: ${added[*]}."
+else
+  echo "  No migration changes in this diff."
+fi


### PR DESCRIPTION
## Summary

Adds a CI check for `server/migrations/` that enforces two invariants
we currently rely on convention for:

1. **History is immutable.** Any migration file already present on
   `main` cannot be modified, renamed, or deleted by a PR. Once a file
   lands on `main`, prod has already applied it — later edits only
   diverge fresh-install schema from prod schema.
2. **New migrations must strictly extend the head.** A PR's newly
   added migrations must all have numeric prefixes greater than the
   maximum on `main`. Gaps (5 -> 10) are allowed; regressions
   (`000004_*` added when head is `000005`) are not, because goose
   applies files in lexicographic order and would silently skip a
   below-head file on any DB already past it.

Delivered as:

- `scripts/verify-migration-order.sh` — the actual check; runs against
  any base ref (`origin/main` by default) so it reproduces locally.
- `.github/workflows/migrations.yml` — thin runner, scoped by `paths:`
  to migration SQL, the script, and this workflow.
- `CONTRIBUTING.md` — one-liner recording the immutability rule under
  Required checks.

## Failure scenarios & fix

- **You edited `000003_foo.sql`.** CI fails with
  `Migrations that already exist on origin/main were modified…`.
  Revert the edit and add a **new** migration (`000006_fix_foo.sql`)
  containing the corrective `ALTER`/`UPDATE`.
- **You added `000004_bar.sql` but head is `000005`.** CI fails with
  `prefix 4 is not above the current head`. Renumber the file to
  `000006_bar.sql` (or higher) — goose skips a below-head file on any
  DB that has already migrated past it.

## Test plan

Verified locally on macOS bash 3.2 against four scenarios:

- [x] Clean diff (no migration changes) -> pass.
- [x] Commit that appends to `000003_capability_blob_storage.sql` ->
      exits 1, prints the immutability error.
- [x] Commit that adds `000004_late_add.sql` when head is `000005` ->
      exits 1, prints the regression error.
- [x] Commit that adds `000006_new_thing.sql` -> pass. Same for a gap
      (`000012_gap.sql`).
- [x] `shellcheck scripts/verify-migration-order.sh` -> zero findings.

Once merged, CI runs on any PR touching `server/migrations/**`,
`scripts/verify-migration-order.sh`, or this workflow.