### PR TITLE
fix(web): 修复模型 combobox 在 Dialog 内点不开 & 运行页 tab 空态吞掉 tab bar

### DIFF
--- a/apps/web/src/lib/use-wheel-scroll.ts
+++ b/apps/web/src/lib/use-wheel-scroll.ts
@@ -1,0 +1,25 @@
+import { useEffect, type RefObject } from "react"
+
+/**
+ * Drive an element's vertical scroll from the wheel manually and swallow
+ * the event, so it never reaches Radix Dialog's react-remove-scroll or
+ * DropdownMenu's own wheel handler.
+ *
+ * React's onWheel is passive by default and dispatches after document-level
+ * capture listeners, so preventDefault/stopPropagation in JSX is unreliable
+ * inside a Dialog. Attaching non-passive with capture keeps the wheel local
+ * to this element.
+ */
+export function useWheelScroll(ref: RefObject<HTMLElement | null>) {
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const onWheel = (e: WheelEvent) => {
+      el.scrollTop += e.deltaY
+      e.preventDefault()
+      e.stopPropagation()
+    }
+    el.addEventListener("wheel", onWheel, { passive: false })
+    return () => el.removeEventListener("wheel", onWheel)
+  }, [ref])
+}

--- a/apps/web/src/pages/admin/ModelKeyCombobox.tsx
+++ b/apps/web/src/pages/admin/ModelKeyCombobox.tsx
@@ -7,13 +7,14 @@
  * search box doubles as the free-text value: whatever is typed becomes the
  * model key on Enter / "Use …", even if it matches no preset.
  */
-import { useMemo, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronsUpDown, CornerDownLeft } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Input } from "../../components/ui/input"
 import { cn } from "../../lib/utils"
+import { useWheelScroll } from "../../lib/use-wheel-scroll"
 import { modelCaption, type ModelPreset } from "../../lib/model-presets"
 
 interface Props {
@@ -28,6 +29,8 @@ interface Props {
 export function ModelKeyCombobox({ value, onChange, models, placeholder, id }: Props) {
   const { t } = useTranslation("admin")
   const [search, setSearch] = useState("")
+  const listRef = useRef<HTMLDivElement>(null)
+  useWheelScroll(listRef)
 
   const selected = useMemo(() => models.find((m) => m.id === value), [models, value])
 
@@ -67,68 +70,62 @@ export function ModelKeyCombobox({ value, onChange, models, placeholder, id }: P
         </button>
       </DropdownMenu.Trigger>
 
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content
-          align="start"
-          sideOffset={4}
-          className="z-50 max-h-[320px] w-[var(--radix-dropdown-menu-trigger-width)] min-w-[280px] overflow-hidden rounded-md border border-line bg-surface p-1 shadow-lg"
-        >
-          <div className="border-b border-line-muted p-1">
-            <Input
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder={t("models.createModel.fields.modelKeySearch", "Search or type a model id…")}
-              onKeyDown={(e) => {
-                e.stopPropagation()
-                if (e.key === "Enter" && typed !== "") {
-                  e.preventDefault()
-                  commit(typed)
-                }
-              }}
-              className="h-8 font-mono text-sm"
-              autoFocus
-            />
-          </div>
-
-          {/* Radix DropdownMenu.Content owns wheel/arrow navigation and swallows
-              the wheel event, so a nested overflow-auto list scrolls only via
-              its scrollbar thumb. Re-drive the scroll here and stop the event
-              from reaching the menu so the wheel works over the 70+ presets. */}
-          <div
-            className="max-h-[220px] overflow-auto py-1"
-            onWheel={(e) => {
-              e.currentTarget.scrollTop += e.deltaY
+      {/* No Portal: when rendered inside a Radix Dialog (modal), portaling
+          to <body> lands outside the Dialog's pointer-events scope and the
+          menu never opens. Keep the content inside the DialogContent subtree. */}
+      <DropdownMenu.Content
+        align="start"
+        sideOffset={4}
+        className="z-50 max-h-[320px] w-[var(--radix-dropdown-menu-trigger-width)] min-w-[280px] overflow-hidden rounded-md border border-line bg-surface p-1 shadow-lg"
+      >
+        <div className="border-b border-line-muted p-1">
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t("models.createModel.fields.modelKeySearch", "Search or type a model id…")}
+            onKeyDown={(e) => {
               e.stopPropagation()
+              if (e.key === "Enter" && typed !== "") {
+                e.preventDefault()
+                commit(typed)
+              }
             }}
-          >
-            {showFreeText && (
-              <DropdownMenu.Item
-                onSelect={() => commit(typed)}
-                className="flex cursor-pointer items-center gap-2 rounded px-3 py-2 text-sm outline-none hover:bg-surface-subtle focus:bg-surface-subtle"
-              >
-                <CornerDownLeft className="h-3.5 w-3.5 shrink-0 text-fg-faint" />
-                <span className="text-fg-subtle">{t("models.createModel.fields.modelKeyUse", "Use")}</span>
-                <code className="truncate font-mono text-xs text-fg">{typed}</code>
-              </DropdownMenu.Item>
-            )}
+            className="h-8 font-mono text-sm"
+            autoFocus
+          />
+        </div>
 
-            {filtered.length === 0 && !showFreeText ? (
-              <p className="px-3 py-2 text-sm text-fg-subtle">
-                {t("models.createModel.fields.modelKeyEmpty", "No matching models — type any id")}
-              </p>
-            ) : (
-              filtered.map((m) => (
-                <ModelRow
-                  key={m.id}
-                  model={m}
-                  selected={m.id === value}
-                  onSelect={() => commit(m.id)}
-                />
-              ))
-            )}
-          </div>
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
+        {/* Wheel scroll driven by a non-passive listener (see useWheelScroll) —
+            an inline React onWheel is passive in a Dialog and gets eaten by
+            react-remove-scroll, so the wheel wouldn't reach the list at all. */}
+        <div ref={listRef} className="max-h-[220px] overflow-auto py-1">
+          {showFreeText && (
+            <DropdownMenu.Item
+              onSelect={() => commit(typed)}
+              className="flex cursor-pointer items-center gap-2 rounded px-3 py-2 text-sm outline-none hover:bg-surface-subtle focus:bg-surface-subtle"
+            >
+              <CornerDownLeft className="h-3.5 w-3.5 shrink-0 text-fg-faint" />
+              <span className="text-fg-subtle">{t("models.createModel.fields.modelKeyUse", "Use")}</span>
+              <code className="truncate font-mono text-xs text-fg">{typed}</code>
+            </DropdownMenu.Item>
+          )}
+
+          {filtered.length === 0 && !showFreeText ? (
+            <p className="px-3 py-2 text-sm text-fg-subtle">
+              {t("models.createModel.fields.modelKeyEmpty", "No matching models — type any id")}
+            </p>
+          ) : (
+            filtered.map((m) => (
+              <ModelRow
+                key={m.id}
+                model={m}
+                selected={m.id === value}
+                onSelect={() => commit(m.id)}
+              />
+            ))
+          )}
+        </div>
+      </DropdownMenu.Content>
     </DropdownMenu.Root>
   )
 }

--- a/apps/web/src/pages/admin/ProviderTypeCombobox.tsx
+++ b/apps/web/src/pages/admin/ProviderTypeCombobox.tsx
@@ -6,13 +6,14 @@
  * Same Radix dropdown + Input filter shape as ModelKeyCombobox /
  * CredentialKindCombobox.
  */
-import { useMemo, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronsUpDown } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Input } from "../../components/ui/input"
 import { cn } from "../../lib/utils"
+import { useWheelScroll } from "../../lib/use-wheel-scroll"
 
 export interface ProviderTypeChoice {
   key: string
@@ -31,6 +32,8 @@ interface Props {
 export function ProviderTypeCombobox({ value, onChange, options, id }: Props) {
   const { t } = useTranslation("admin")
   const [search, setSearch] = useState("")
+  const listRef = useRef<HTMLDivElement>(null)
+  useWheelScroll(listRef)
 
   const selected = useMemo(() => options.find((o) => o.key === value), [options, value])
 
@@ -68,67 +71,65 @@ export function ProviderTypeCombobox({ value, onChange, options, id }: Props) {
         </button>
       </DropdownMenu.Trigger>
 
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content
-          align="start"
-          sideOffset={4}
-          className="z-50 max-h-[320px] w-[var(--radix-dropdown-menu-trigger-width)] min-w-[280px] overflow-hidden rounded-md border border-line bg-surface p-1 shadow-lg"
-        >
-          <div className="border-b border-line-muted p-1">
-            <Input
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder={t("models.createProvider.fields.providerSearch", "Search providers…")}
-              onKeyDown={(e) => {
-                e.stopPropagation()
-                if (e.key === "Enter" && filtered.length > 0) {
-                  e.preventDefault()
-                  commit(filtered[0].key)
-                }
-              }}
-              className="h-8 text-sm"
-              autoFocus
-            />
-          </div>
-
-          {/* Radix DropdownMenu swallows wheel events; re-drive scroll so the
-              nested list responds to the wheel, not only the scrollbar thumb. */}
-          <div
-            className="max-h-[240px] overflow-auto py-1"
-            onWheel={(e) => {
-              e.currentTarget.scrollTop += e.deltaY
+      {/* No Portal: when this combobox lives inside a Radix Dialog (modal),
+          portaling to <body> lands outside the Dialog's pointer-events
+          scope and the trigger click reaches a locked layer, so the menu
+          never opens. Rendering in-place keeps the menu inside the
+          DialogContent subtree. */}
+      <DropdownMenu.Content
+        align="start"
+        sideOffset={4}
+        className="z-50 max-h-[320px] w-[var(--radix-dropdown-menu-trigger-width)] min-w-[280px] overflow-hidden rounded-md border border-line bg-surface p-1 shadow-lg"
+      >
+        <div className="border-b border-line-muted p-1">
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t("models.createProvider.fields.providerSearch", "Search providers…")}
+            onKeyDown={(e) => {
               e.stopPropagation()
+              if (e.key === "Enter" && filtered.length > 0) {
+                e.preventDefault()
+                commit(filtered[0].key)
+              }
             }}
-          >
-            {filtered.length === 0 ? (
-              <p className="px-3 py-2 text-sm text-fg-subtle">
-                {t("models.createProvider.fields.providerEmpty", "No matching providers")}
-              </p>
-            ) : (
-              filtered.map((o) => (
-                <DropdownMenu.Item
-                  key={o.key}
-                  onSelect={() => commit(o.key)}
-                  className={cn(
-                    "flex cursor-pointer items-center justify-between gap-2 rounded px-3 py-2 outline-none",
-                    o.key === value
-                      ? "bg-surface-muted"
-                      : "hover:bg-surface-subtle focus:bg-surface-subtle",
-                  )}
-                >
-                  <div className="min-w-0 flex-1">
-                    <span className="truncate text-sm font-medium text-fg">{o.label}</span>
-                    <code className="mt-0.5 block truncate font-mono text-xs text-fg-subtle">
-                      {o.adapter}
-                    </code>
-                  </div>
-                  {o.key === value && <Check className="h-3.5 w-3.5 shrink-0 text-fg-muted" />}
-                </DropdownMenu.Item>
-              ))
-            )}
-          </div>
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
+            className="h-8 text-sm"
+            autoFocus
+          />
+        </div>
+
+        {/* Wheel scroll driven by a non-passive listener (see useWheelScroll) —
+            an inline React onWheel is passive in a Dialog and gets eaten by
+            react-remove-scroll, so the wheel wouldn't reach the list at all. */}
+        <div ref={listRef} className="max-h-[240px] overflow-auto py-1">
+          {filtered.length === 0 ? (
+            <p className="px-3 py-2 text-sm text-fg-subtle">
+              {t("models.createProvider.fields.providerEmpty", "No matching providers")}
+            </p>
+          ) : (
+            filtered.map((o) => (
+              <DropdownMenu.Item
+                key={o.key}
+                onSelect={() => commit(o.key)}
+                className={cn(
+                  "flex cursor-pointer items-center justify-between gap-2 rounded px-3 py-2 outline-none",
+                  o.key === value
+                    ? "bg-surface-muted"
+                    : "hover:bg-surface-subtle focus:bg-surface-subtle",
+                )}
+              >
+                <div className="min-w-0 flex-1">
+                  <span className="truncate text-sm font-medium text-fg">{o.label}</span>
+                  <code className="mt-0.5 block truncate font-mono text-xs text-fg-subtle">
+                    {o.adapter}
+                  </code>
+                </div>
+                {o.key === value && <Check className="h-3.5 w-3.5 shrink-0 text-fg-muted" />}
+              </DropdownMenu.Item>
+            ))
+          )}
+        </div>
+      </DropdownMenu.Content>
     </DropdownMenu.Root>
   )
 }

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -441,12 +441,6 @@ export function RunsPage() {
           }
           onRetry={() => void query.refetch()}
         />
-      ) : total === 0 ? (
-        <EmptyState
-          icon={Play}
-          title={t("runs.empty.title")}
-          description={t("runs.empty.description")}
-        />
       ) : (
         <div className="space-y-4">
           <div className="flex items-center justify-between gap-3">
@@ -468,7 +462,16 @@ export function RunsPage() {
             </div>
           </div>
 
-          {filtered.length === 0 ? (
+          {total === 0 ? (
+            // Empty state must live INSIDE the tabs container so an empty
+            // 进行中 / 失败 tab doesn't take the tab bar with it — the user
+            // has to be able to click 全部 to get back.
+            <EmptyState
+              icon={Play}
+              title={t("runs.empty.title")}
+              description={t("runs.empty.description")}
+            />
+          ) : filtered.length === 0 ? (
             <EmptyState
               icon={Play}
               title={t("runs.emptyFiltered.title")}

--- a/apps/web/src/pages/admin/capabilities/CredentialKindCombobox.tsx
+++ b/apps/web/src/pages/admin/capabilities/CredentialKindCombobox.tsx
@@ -3,7 +3,7 @@
  * Invoked by EnvCredentialPicker when an env row switches to
  * mode=credential_ref. Selection is by `code`.
  */
-import { useMemo, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronsUpDown, Loader2, Plus } from "lucide-react"
 import { useTranslation } from "react-i18next"
@@ -12,6 +12,7 @@ import { ApiError } from "../../../lib/api-client"
 import { Button } from "../../../components/ui/button"
 import { Input } from "../../../components/ui/input"
 import { cn } from "../../../lib/utils"
+import { useWheelScroll } from "../../../lib/use-wheel-scroll"
 
 import { useCredentialKindsQuery } from "./api"
 import { NewCredentialKindInlineDialog } from "./NewCredentialKindInlineDialog"
@@ -39,6 +40,8 @@ export function CredentialKindCombobox({
   const kindsQ = useCredentialKindsQuery(workspaceID)
   const [search, setSearch] = useState("")
   const [createOpen, setCreateOpen] = useState(false)
+  const listRef = useRef<HTMLDivElement>(null)
+  useWheelScroll(listRef)
 
   const items = kindsQ.data?.items ?? []
   const selected = useMemo(() => items.find((k) => k.code === value), [items, value])
@@ -90,69 +93,65 @@ export function CredentialKindCombobox({
           </Button>
         </DropdownMenu.Trigger>
 
-        <DropdownMenu.Portal>
-          <DropdownMenu.Content
-            align="start"
-            sideOffset={4}
-            className="z-50 max-h-[320px] w-[var(--radix-dropdown-menu-trigger-width)] min-w-[280px] overflow-hidden rounded-md border border-line bg-surface p-1 shadow-lg"
+        {/* No Portal: when rendered inside a Radix Dialog (modal), portaling
+            to <body> lands outside the Dialog's pointer-events scope and the
+            menu never opens. Keep the content inside the DialogContent subtree. */}
+        <DropdownMenu.Content
+          align="start"
+          sideOffset={4}
+          className="z-50 max-h-[320px] w-[var(--radix-dropdown-menu-trigger-width)] min-w-[280px] overflow-hidden rounded-md border border-line bg-surface p-1 shadow-lg"
+        >
+          <div className="border-b border-line-muted p-1">
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder={t("capabilities.import.kindPicker.search", "Search…")}
+              onKeyDown={(e) => e.stopPropagation() /* keep arrow keys in input */}
+              className="h-8 text-sm"
+              autoFocus
+            />
+          </div>
+
+          {/* Wheel scroll driven by a non-passive listener (see useWheelScroll) —
+              an inline React onWheel is passive in a Dialog and gets eaten by
+              react-remove-scroll, so the wheel wouldn't reach the list at all. */}
+          <div ref={listRef} className="max-h-[200px] overflow-auto py-1">
+            {kindsQ.isLoading ? (
+              <div className="flex items-center gap-2 px-3 py-2 text-sm text-fg-subtle">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                {t("capabilities.import.kindPicker.loading", "Loading…")}
+              </div>
+            ) : errMsg ? (
+              <p className="px-3 py-2 text-sm text-danger-emphasis">{errMsg}</p>
+            ) : filtered.length === 0 ? (
+              <p className="px-3 py-2 text-sm text-fg-subtle">
+                {t("capabilities.import.kindPicker.empty", "No matching credential kinds")}
+              </p>
+            ) : (
+              filtered.map((kind) => (
+                <KindRow
+                  key={kind.id}
+                  kind={kind}
+                  selected={kind.code === value}
+                  onSelect={() => onChange(kind.code)}
+                />
+              ))
+            )}
+          </div>
+
+          <DropdownMenu.Separator className="my-1 h-px bg-surface-muted" />
+
+          <DropdownMenu.Item
+            onSelect={(e) => {
+              e.preventDefault()
+              setCreateOpen(true)
+            }}
+            className="flex cursor-pointer items-center gap-2 rounded px-3 py-2 text-sm font-medium text-fg outline-none hover:bg-surface-subtle focus:bg-surface-subtle"
           >
-            <div className="border-b border-line-muted p-1">
-              <Input
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                placeholder={t("capabilities.import.kindPicker.search", "Search…")}
-                onKeyDown={(e) => e.stopPropagation() /* keep arrow keys in input */}
-                className="h-8 text-sm"
-                autoFocus
-              />
-            </div>
-
-            {/* Radix DropdownMenu swallows wheel events; re-drive scroll so the
-                nested list responds to the wheel, not only the scrollbar thumb. */}
-            <div
-              className="max-h-[200px] overflow-auto py-1"
-              onWheel={(e) => {
-                e.currentTarget.scrollTop += e.deltaY
-                e.stopPropagation()
-              }}
-            >
-              {kindsQ.isLoading ? (
-                <div className="flex items-center gap-2 px-3 py-2 text-sm text-fg-subtle">
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  {t("capabilities.import.kindPicker.loading", "Loading…")}
-                </div>
-              ) : errMsg ? (
-                <p className="px-3 py-2 text-sm text-danger-emphasis">{errMsg}</p>
-              ) : filtered.length === 0 ? (
-                <p className="px-3 py-2 text-sm text-fg-subtle">
-                  {t("capabilities.import.kindPicker.empty", "No matching credential kinds")}
-                </p>
-              ) : (
-                filtered.map((kind) => (
-                  <KindRow
-                    key={kind.id}
-                    kind={kind}
-                    selected={kind.code === value}
-                    onSelect={() => onChange(kind.code)}
-                  />
-                ))
-              )}
-            </div>
-
-            <DropdownMenu.Separator className="my-1 h-px bg-surface-muted" />
-
-            <DropdownMenu.Item
-              onSelect={(e) => {
-                e.preventDefault()
-                setCreateOpen(true)
-              }}
-              className="flex cursor-pointer items-center gap-2 rounded px-3 py-2 text-sm font-medium text-fg outline-none hover:bg-surface-subtle focus:bg-surface-subtle"
-            >
-              <Plus className="h-3.5 w-3.5" />
-              {t("capabilities.import.kindPicker.createNew", "Create credential kind…")}
-            </DropdownMenu.Item>
-          </DropdownMenu.Content>
-        </DropdownMenu.Portal>
+            <Plus className="h-3.5 w-3.5" />
+            {t("capabilities.import.kindPicker.createNew", "Create credential kind…")}
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
       </DropdownMenu.Root>
 
       <NewCredentialKindInlineDialog


### PR DESCRIPTION
## Summary
- 三个 combobox (ProviderType / ModelKey / CredentialKind) 去掉 `DropdownMenu.Portal`：Portal 到 body 会落在 Dialog 的 pointer-events 锁定层外，触发按钮 click 直接被吞，用户点"供应商类型"完全没反应。改为就地渲染在 DialogContent 子树内。
- 新增 `useWheelScroll` hook，用非-passive 的原生 `wheel` 监听器接管列表滚动。Dialog 的 `react-remove-scroll` 会屏蔽子树的 passive wheel，JSX `onWheel` 因此拦不住事件（React 19 里默认 passive），只有原生 non-passive listener + `preventDefault` 才能把滚轮引到列表上。
- `RunsPage.tsx`：`total === 0` 的空态原本在 `<Tabs>` 外面，点"进行中/失败"没数据时整条 tab bar 会被空态替换，用户没法点回"全部"。挪到 Tabs 内部。

## Test plan
- [x] `pnpm typecheck` / `pnpm build` 通过
- [x] 部署到 10.74.2.80:18080 手动验：admin → 模型 → 新建模型，"供应商类型"能下拉、能滚轮
- [x] 同上，编辑模型 → 凭据引用绑定，`CredentialKindCombobox` 表现一致
- [x] 运行页切"进行中"/"失败"无数据时，tab bar 依然可见，能切回"全部"

🤖 Generated with [Claude Code](https://claude.com/claude-code)