### PR TITLE
docs: require English comments and docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,11 @@ baseline, web UI rules, and the required `make check` — lives in
 [`CONTRIBUTING.md`](./CONTRIBUTING.md). Read it before any
 implementation, refactor, or schema / API change.
 
+## Language
+
+Except for user-facing internationalized bilingual copy, comments and
+documentation must be written in English.
+
 ## HTTP contract (swaggo generation)
 
 `docs/openapi/openapi.yaml` is a **build artifact**, not a hand-edited

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,3 +158,6 @@ drift that only shows up on the runner.
 ## Report language
 
 Verification reports and delivery reports default to English.
+
+Except for user-facing internationalized bilingual copy, comments and
+documentation must be written in English.


### PR DESCRIPTION
## Summary
- add AGENTS.md language rule requiring English comments and documentation except user-facing bilingual i18n copy
- add the same rule to CONTRIBUTING.md near report language guidance

## Tests
- Not run per request after sandboxed `make check` failed to resolve goproxy.cn.