### PR TITLE
remove TOFU first-owner-on-first-login

### DIFF
--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -26,7 +26,7 @@ export function SetupPage() {
 
   const [email, setEmail] = useState("")
   const [name, setName] = useState("")
-  const [workspace, setWorkspace] = useState("")
+  const [workspace, setWorkspace] = useState("My Workspace")
   const [password, setPassword] = useState("")
 
   const submitting = register.isPending

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -56,13 +56,8 @@ services:
       start_period: 10s
 
   # One-shot: run migrations, then (optionally) provision the first owner.
-  # Two ways to get an owner:
-  #   1. Set PARSAR_OWNER_EMAIL — bootstrap pre-seeds that owner here. In
-  #      real-Feishu mode set it to the email Feishu returns for YOU.
-  #   2. Leave PARSAR_OWNER_EMAIL unset — bootstrap is SKIPPED and the first
-  #      person to log in (mock or real Feishu) auto-claims first-owner via
-  #      PARSAR_BOOTSTRAP_ON_FIRST_LOGIN (TOFU) on the parsar-server below.
-  #      No email to know in advance, no `down -v` dance.
+  # Set PARSAR_OWNER_EMAIL to pre-seed an owner via CLI bootstrap; leave
+  # unset to use the web registration form (POST /api/v1/bootstrap).
   # Tolerates exit code 2 (store.ErrBootstrapClosed) so re-running `up` is
   # idempotent. Binaries live on $PATH at /usr/local/bin (WORKDIR is
   # /var/lib/parsar), so they are invoked by bare name, NOT ./parsar-migrate.
@@ -128,7 +123,7 @@ services:
             --name="Local Admin" \
           || [ "$$?" -eq 2 ]
         else
-          echo "[parsar-init] PARSAR_OWNER_EMAIL unset — skipping bootstrap; first login will claim owner (TOFU)"
+          echo "[parsar-init] PARSAR_OWNER_EMAIL unset — skipping bootstrap; use the web registration form"
         fi
     restart: "no"
 
@@ -160,10 +155,6 @@ services:
       #   PARSAR_FEISHU_APP_SECRET=xxx
       #   PARSAR_FEISHU_VERIFICATION_TOKEN=xxx      # any non-empty value
       #
-      # You do NOT need PARSAR_OWNER_EMAIL: with PARSAR_BOOTSTRAP_ON_FIRST_LOGIN
-      # (below, default true) the first real Feishu login auto-claims owner, so
-      # no email-to-know-in-advance and no `down -v` dance. (Set OWNER_EMAIL
-      # only if you want a specific pre-seeded owner.)
       #
       # No PARSAR_MASTER_KEY / PARSAR_COOKIE_SECURE needed: a loopback
       # PARSAR_PUBLIC_URL (127.0.0.1) keeps Profile()==ProfileDev even with
@@ -189,14 +180,6 @@ services:
       # callbacks AND the minted one-line connect command line up. Kept in
       # sync with the published port via the same variable.
       PARSAR_PUBLIC_URL: "http://${PARSAR_HOST_IP:-127.0.0.1}:${PARSAR_LOCAL_PORT:-18080}"
-      # TOFU first-owner: when no PARSAR_OWNER_EMAIL was pre-seeded above, the
-      # first successful login (mock admin@example.com, or the real Feishu
-      # identity) claims first-owner — creating its workspace + owner
-      # membership on the fly. Default true for this local stack; set false to
-      # require the explicit CLI/token bootstrap path instead. No-op once any
-      # owner exists (see maybeProvisionFirstOwner in
-      # server/internal/dev/oauth_handlers.go).
-      PARSAR_BOOTSTRAP_ON_FIRST_LOGIN: "${PARSAR_BOOTSTRAP_ON_FIRST_LOGIN:-true}"
       # Inter-pod owner-routing URL. The server refuses to boot until this
       # resolves (no fallback to PublicURL/127.0.0.1, which are unsafe under
       # multi-replica load balancing — see resolveAgentDaemonOwnerURL in

--- a/docs/deploy/lan-deploy.md
+++ b/docs/deploy/lan-deploy.md
@@ -30,7 +30,7 @@ functionality".
 
 ```
 clone the repo → create a Feishu app → prepare .env → build images (server + sandbox)
-→ docker compose up → first user logs in via Feishu (TOFU Owner) → create Agent
+→ docker compose up → first user registers via web form (Owner) → create Agent
 → pair device / @Bot in Feishu groups
 ```
 
@@ -246,7 +246,7 @@ sudo docker compose -f docker-compose.local.yml up -d
 
 **Startup order (automatic):**
 1. `postgres` — PostgreSQL 16, wait for healthcheck.
-2. `parsar-init` — master-key validation + database migration + first-run onboarding (TOFU mode; bootstrap skipped).
+2. `parsar-init` — master-key validation + database migration.
 3. `parsar-server` — binds `0.0.0.0:18080`; Feishu WebSocket inbound + outbound worker start automatically.
 
 > **First run will fatal-exit — that is intentional.**
@@ -274,14 +274,12 @@ sudo docker logs parsar-local-server 2>&1 | grep "feishu.*inbound.*ready"
 
 ---
 
-## 7. First login — Owner claim (TOFU)
+## 7. First login — Register the Owner
 
 1. Open `http://YOUR_IP:18080` in your browser.
-2. Click **Feishu login** → Feishu authorization page → log in with your Feishu account.
-3. The first user to log in **automatically becomes the Workspace Owner**.
-
-> **Make sure you personally log in first.** TOFU is irreversible — the first
-> user through the door is the Owner.
+2. The system detects no owner exists and shows the **registration form**.
+3. Fill in your name, email, password, and workspace name → submit.
+4. You are now the **Workspace Owner**.
 
 ---
 
@@ -442,7 +440,7 @@ sudo docker compose -f docker-compose.local.yml up -d
 curl http://YOUR_IP:18080/healthz   # 200
 curl http://YOUR_IP:18080/readyz    # 200
 
-# 5. Browser http://YOUR_IP:18080 → Feishu login (first user = Owner)
+# 5. Browser http://YOUR_IP:18080 → register first user (Owner)
 #    → create Agent (sandbox mode) → bind default Bot
 #    → @Bot in a Feishu group / pair a device → verified
 ```

--- a/scripts/dev-server-up.sh
+++ b/scripts/dev-server-up.sh
@@ -170,16 +170,8 @@ OWNER_URL="${PARSAR_AGENT_DAEMON_OWNER_URL:-http://127.0.0.1:${PORT}}"
 FEISHU_WEBSOCKET="${PARSAR_FEISHU_WEBSOCKET:-true}"
 FEISHU_OUTBOUND="${PARSAR_FEISHU_OUTBOUND:-true}"
 MASTER_KEY="${PARSAR_MASTER_KEY:-parsar-dev-master-key-2026}"
-# TOFU first-owner: with no owner pre-seeded (this script does NOT run
-# parsar-bootstrap), the first successful Feishu OIDC login auto-claims
-# first-owner (workspace + owner membership) — no PARSAR_OWNER_EMAIL to know
-# in advance. Defaults ON here; no-op once any owner exists. NOTE: to actually
-# exercise a REAL Feishu login you must run with PARSAR_FEISHU_MOCK=false (and
-# usually PARSAR_DEV_AUTH=false, else the web UI takes the X-Parsar-Dev-User-ID
-# header bypass and never goes through the login flow).
-BOOTSTRAP_FIRST_LOGIN="${PARSAR_BOOTSTRAP_ON_FIRST_LOGIN:-true}"
 tmux new-session -d -s "${TMUX_SESSION}" \
-  "PARSAR_ADDR=:${PORT} DATABASE_URL='${DATABASE_URL}' PARSAR_DEV_AUTH=${PARSAR_DEV_AUTH} PARSAR_FEISHU_MOCK=${FEISHU_MOCK} PARSAR_FEISHU_WEBSOCKET=${FEISHU_WEBSOCKET} PARSAR_FEISHU_OUTBOUND=${FEISHU_OUTBOUND} PARSAR_MASTER_KEY='${MASTER_KEY}' PARSAR_BOOTSTRAP_ON_FIRST_LOGIN=${BOOTSTRAP_FIRST_LOGIN} PARSAR_AGENT_DAEMON_OWNER_URL='${OWNER_URL}' '${BIN_PATH}' 2>&1 | tee '${LOG_PATH}'"
+  "PARSAR_ADDR=:${PORT} DATABASE_URL='${DATABASE_URL}' PARSAR_DEV_AUTH=${PARSAR_DEV_AUTH} PARSAR_FEISHU_MOCK=${FEISHU_MOCK} PARSAR_FEISHU_WEBSOCKET=${FEISHU_WEBSOCKET} PARSAR_FEISHU_OUTBOUND=${FEISHU_OUTBOUND} PARSAR_MASTER_KEY='${MASTER_KEY}' PARSAR_AGENT_DAEMON_OWNER_URL='${OWNER_URL}' '${BIN_PATH}' 2>&1 | tee '${LOG_PATH}'"
 
 # ── readiness probe ──────────────────────────────────────────────────
 echo -n "[dev-server-up] waiting for :${PORT} "

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -651,28 +651,16 @@ func main() {
 				// where the server serves the SPA; `make dev` points
 				// at the Vite origin (e.g. http://127.0.0.1:5173/).
 				loginRedirect := strings.TrimSpace(cfg.Gateway.Feishu.LoginRedirectURL)
-				// TOFU first-owner: wire the bootstrapper only when the
-				// operator opted in. Default off keeps production on the
-				// CLI/token bootstrap path (profile not fork). When on and
-				// the system has no owner yet, the first Feishu OIDC login
-				// claims first-owner — no PARSAR_OWNER_EMAIL pre-seed needed.
-				var oauthBootstrapper dev.OAuthBootstrapper
-				bootstrapOnFirstLogin := dbStore != nil && truthy(envLookup("PARSAR_BOOTSTRAP_ON_FIRST_LOGIN"))
-				if bootstrapOnFirstLogin {
-					oauthBootstrapper = dbStore
-				}
 				opts = append(opts, dev.WithOAuthHandlers(dev.OAuthHandlerDeps{
-					Feishu:                 feishuClient,
-					Sessions:               sessionStore,
-					Store:                  dbStore,
-					Bootstrapper:           oauthBootstrapper,
-					BootstrapWorkspaceName: strings.TrimSpace(envLookup("PARSAR_BOOTSTRAP_WORKSPACE_NAME")),
-					CookieSecure:           cookieSecure,
-					LoginRedirectURL:       loginRedirect,
+					Feishu:           feishuClient,
+					Sessions:         sessionStore,
+					Store:            dbStore,
+					CookieSecure:     cookieSecure,
+					LoginRedirectURL: loginRedirect,
 				}))
 				log.Bg().Info("feishu OIDC handlers registered",
 					"mode", feishuDecision.Mode, "mock", feishuClient.IsMock(), "cookie_secure", cookieSecure,
-					"login_redirect", loginRedirect, "bootstrap_on_first_login", bootstrapOnFirstLogin)
+					"login_redirect", loginRedirect)
 			}
 		}
 	}

--- a/server/internal/dev/oauth_handlers.go
+++ b/server/internal/dev/oauth_handlers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"errors"
 	"fmt"
 
 	"net/http"
@@ -24,22 +23,6 @@ type OAuthRuntimeStore interface {
 	UpsertOAuthUser(ctx context.Context, in store.UpsertOAuthUserInput) (store.UpsertOAuthUserResult, error)
 }
 
-// OAuthBootstrapper is the optional first-owner (TOFU — trust-on-first-use)
-// surface. When wired, the very first successful Feishu OIDC login on a
-// system that has no workspace owner yet auto-provisions that user as the
-// first owner (workspace + owner membership), so operators need NOT pre-seed
-// PARSAR_OWNER_EMAIL before starting. Kept separate from OAuthRuntimeStore so
-// the existing narrow fakes (dev/oauth_handlers_test.go) keep compiling; nil
-// disables the behavior entirely. *store.Store satisfies this.
-type OAuthBootstrapper interface {
-	ActiveWorkspaceOwnerCount(ctx context.Context) (int64, error)
-	ProvisionFirstOwner(ctx context.Context, in store.ProvisionFirstOwnerInput) (store.ProvisionFirstOwnerResult, error)
-}
-
-// defaultBootstrapWorkspaceName is used when OAuthHandlerDeps.BootstrapWorkspaceName
-// is empty. ProvisionFirstOwner requires a non-empty workspace name.
-const defaultBootstrapWorkspaceName = "My Workspace"
-
 // CookieStateName is the short-lived CSRF cookie name.
 const CookieStateName = "parsar_oauth_state"
 
@@ -55,16 +38,6 @@ type OAuthHandlerDeps struct {
 	Feishu   feishu.Client
 	Sessions auth.SessionStore
 	Store    OAuthRuntimeStore
-
-	// Bootstrapper enables first-owner-on-first-login (TOFU). Optional:
-	// nil leaves the callback behaving exactly as before (login creates a
-	// user + session but no workspace). Wired only when
-	// PARSAR_BOOTSTRAP_ON_FIRST_LOGIN is truthy (see main.go).
-	Bootstrapper OAuthBootstrapper
-
-	// BootstrapWorkspaceName names the workspace created for the first
-	// owner. Empty falls back to defaultBootstrapWorkspaceName.
-	BootstrapWorkspaceName string
 
 	// CookieSecure drives the Secure attribute on issued cookies.
 	CookieSecure bool
@@ -200,12 +173,6 @@ func feishuCallbackHandler(deps OAuthHandlerDeps) http.HandlerFunc {
 			return
 		}
 
-		// TOFU: if enabled and the system has no owner yet, the first
-		// successful login claims first-owner. Best-effort — never blocks
-		// the login (a failure here leaves the user logged-in but without a
-		// workspace, exactly the pre-TOFU behavior).
-		maybeProvisionFirstOwner(r.Context(), deps, profile, now)
-
 		sessionID, err := deps.Sessions.Create(r.Context(), auth.CreateSessionInput{
 			UserID:    upsert.UserID,
 			UserAgent: r.UserAgent(),
@@ -223,50 +190,6 @@ func feishuCallbackHandler(deps OAuthHandlerDeps) http.HandlerFunc {
 
 		http.Redirect(w, r, deps.loginRedirectURL(), http.StatusFound)
 	}
-}
-
-// maybeProvisionFirstOwner implements TOFU first-owner-on-first-login. It is
-// a no-op when the feature is disabled (deps.Bootstrapper == nil) or the
-// system already has an owner. Errors are logged, never returned: the login
-// must still succeed even if provisioning fails (the user simply lands
-// without a workspace, the pre-TOFU behavior). ProvisionFirstOwner is itself
-// advisory-locked and re-checks the owner count, so a concurrent race that
-// loses returns store.ErrBootstrapClosed — treated as a benign skip here.
-func maybeProvisionFirstOwner(ctx context.Context, deps OAuthHandlerDeps, profile feishu.UserProfile, now time.Time) {
-	if deps.Bootstrapper == nil {
-		return
-	}
-	count, err := deps.Bootstrapper.ActiveWorkspaceOwnerCount(ctx)
-	if err != nil {
-		log.Bg().Warn("first-login owner: owner count check failed — skipping", "error", err, "email", profile.Email)
-		return
-	}
-	if count > 0 {
-		return // system already has an owner; nothing to claim.
-	}
-	wsName := strings.TrimSpace(deps.BootstrapWorkspaceName)
-	if wsName == "" {
-		wsName = defaultBootstrapWorkspaceName
-	}
-	res, err := deps.Bootstrapper.ProvisionFirstOwner(ctx, store.ProvisionFirstOwnerInput{
-		Email:         profile.Email,
-		Name:          profile.Name,
-		WorkspaceName: wsName,
-		Now:           now,
-	})
-	if err != nil {
-		if errors.Is(err, store.ErrBootstrapClosed) {
-			// Lost the race to another concurrent first login — fine.
-			log.Bg().Info("first-login owner: another login already claimed owner — skipping", "email", profile.Email)
-			return
-		}
-		log.Bg().Warn("first-login owner: provision failed — login proceeds without workspace",
-			"error", err, "email", profile.Email)
-		return
-	}
-	log.Bg().Info("first-login owner provisioned",
-		"user_id", res.UserID, "workspace_id", res.WorkspaceID,
-		"workspace_slug", res.WorkspaceSlug, "email", profile.Email)
 }
 
 // authLogoutHandler is POST /api/v1/auth/logout. Revokes the session and

--- a/server/internal/dev/oauth_handlers_test.go
+++ b/server/internal/dev/oauth_handlers_test.go
@@ -2,7 +2,6 @@ package dev
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -81,38 +80,6 @@ func (s *stubOAuthStore) UpsertOAuthUser(_ context.Context, in store.UpsertOAuth
 	}
 	return store.UpsertOAuthUserResult{
 		UserID: uid, Email: in.Email, Name: in.Name, Created: s.created,
-	}, nil
-}
-
-// stubBootstrapper fakes the TOFU first-owner surface. ownerCount seeds
-// ActiveWorkspaceOwnerCount; provisionErr (if set) is returned by
-// ProvisionFirstOwner. provisionCalls + lastProvision record invocations so
-// tests can assert the callback did / did not provision.
-type stubBootstrapper struct {
-	mu             sync.Mutex
-	ownerCount     int64
-	countErr       error
-	provisionErr   error
-	provisionCalls int
-	lastProvision  store.ProvisionFirstOwnerInput
-}
-
-func (s *stubBootstrapper) ActiveWorkspaceOwnerCount(_ context.Context) (int64, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.ownerCount, s.countErr
-}
-
-func (s *stubBootstrapper) ProvisionFirstOwner(_ context.Context, in store.ProvisionFirstOwnerInput) (store.ProvisionFirstOwnerResult, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.provisionCalls++
-	s.lastProvision = in
-	if s.provisionErr != nil {
-		return store.ProvisionFirstOwnerResult{}, s.provisionErr
-	}
-	return store.ProvisionFirstOwnerResult{
-		UserID: "00000000-0000-0000-0000-0000deadbeef", WorkspaceID: "ws-1", WorkspaceSlug: "ws-1", WorkspaceName: in.WorkspaceName,
 	}, nil
 }
 
@@ -334,123 +301,4 @@ func TestLogoutIdempotentWithoutCookie(t *testing.T) {
 	}
 }
 
-// newMockFeishu builds a mock Feishu client wired to the callback route.
-func newMockFeishu() feishu.Client {
-	return feishu.NewMockClient(func(k string) string {
-		if k == feishu.EnvRedirectURI {
-			return "/api/v1/auth/feishu/callback"
-		}
-		return ""
-	})
-}
 
-// driveMockCallback runs start (to mint the state cookie) then callback,
-// returning the callback recorder. Mirrors the inline dance the happy-path
-// tests use.
-func driveMockCallback(t *testing.T, r http.Handler) *httptest.ResponseRecorder {
-	t.Helper()
-	rec1 := httptest.NewRecorder()
-	r.ServeHTTP(rec1, httptest.NewRequest(http.MethodGet, "/api/v1/auth/feishu/start", nil))
-	state := strings.SplitN(strings.TrimPrefix(rec1.Header().Get("Set-Cookie"), CookieStateName+"="), ";", 2)[0]
-	if state == "" {
-		t.Fatal("could not extract state cookie")
-	}
-	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/feishu/callback?code=mock&state="+state, nil)
-	req.AddCookie(&http.Cookie{Name: CookieStateName, Value: state})
-	r.ServeHTTP(rec, req)
-	return rec
-}
-
-// TestFeishuCallbackFirstLoginProvisionsOwner: with a Bootstrapper wired and
-// zero existing owners, the first login must claim first-owner — provisioning
-// a workspace for the just-logged-in identity (TOFU).
-func TestFeishuCallbackFirstLoginProvisionsOwner(t *testing.T) {
-	sessions := newStubSessions()
-	boot := &stubBootstrapper{ownerCount: 0}
-	r := buildOAuthRouter(t, OAuthHandlerDeps{
-		Feishu:                 newMockFeishu(),
-		Sessions:               sessions,
-		Store:                  &stubOAuthStore{userID: "00000000-0000-0000-0000-0000deadbeef"},
-		Bootstrapper:           boot,
-		BootstrapWorkspaceName: "Local Workspace",
-	})
-
-	rec := driveMockCallback(t, r)
-	if rec.Code != http.StatusFound {
-		t.Fatalf("status = %d, want 302", rec.Code)
-	}
-	if boot.provisionCalls != 1 {
-		t.Fatalf("ProvisionFirstOwner called %d times, want 1", boot.provisionCalls)
-	}
-	if boot.lastProvision.Email != "admin@example.com" {
-		t.Fatalf("provisioned email = %q, want admin@example.com", boot.lastProvision.Email)
-	}
-	if boot.lastProvision.WorkspaceName != "Local Workspace" {
-		t.Fatalf("provisioned workspace name = %q, want Local Workspace", boot.lastProvision.WorkspaceName)
-	}
-	if sessions.calls != 1 {
-		t.Fatalf("session.Create called %d times, want 1 (login must still succeed)", sessions.calls)
-	}
-}
-
-// TestFeishuCallbackDefaultsWorkspaceName: empty BootstrapWorkspaceName falls
-// back to the package default rather than passing an empty name (which
-// ProvisionFirstOwner would reject).
-func TestFeishuCallbackDefaultsWorkspaceName(t *testing.T) {
-	boot := &stubBootstrapper{ownerCount: 0}
-	r := buildOAuthRouter(t, OAuthHandlerDeps{
-		Feishu:       newMockFeishu(),
-		Sessions:     newStubSessions(),
-		Store:        &stubOAuthStore{},
-		Bootstrapper: boot,
-	})
-	if rec := driveMockCallback(t, r); rec.Code != http.StatusFound {
-		t.Fatalf("status = %d, want 302", rec.Code)
-	}
-	if boot.lastProvision.WorkspaceName != defaultBootstrapWorkspaceName {
-		t.Fatalf("workspace name = %q, want default %q", boot.lastProvision.WorkspaceName, defaultBootstrapWorkspaceName)
-	}
-}
-
-// TestFeishuCallbackSkipsProvisionWhenOwnerExists: a system that already has
-// an owner must NOT re-provision — later logins are ordinary users.
-func TestFeishuCallbackSkipsProvisionWhenOwnerExists(t *testing.T) {
-	boot := &stubBootstrapper{ownerCount: 1}
-	r := buildOAuthRouter(t, OAuthHandlerDeps{
-		Feishu:       newMockFeishu(),
-		Sessions:     newStubSessions(),
-		Store:        &stubOAuthStore{},
-		Bootstrapper: boot,
-	})
-	rec := driveMockCallback(t, r)
-	if rec.Code != http.StatusFound {
-		t.Fatalf("status = %d, want 302", rec.Code)
-	}
-	if boot.provisionCalls != 0 {
-		t.Fatalf("ProvisionFirstOwner called %d times, want 0 (owner already exists)", boot.provisionCalls)
-	}
-}
-
-// TestFeishuCallbackProvisionErrorDoesNotBlockLogin: a provisioning failure is
-// best-effort — the login must still succeed (302 + session), matching the
-// pre-TOFU "logged-in but no workspace" fallback.
-func TestFeishuCallbackProvisionErrorDoesNotBlockLogin(t *testing.T) {
-	sessions := newStubSessions()
-	boot := &stubBootstrapper{ownerCount: 0, provisionErr: errProvisionBoom}
-	r := buildOAuthRouter(t, OAuthHandlerDeps{
-		Feishu:       newMockFeishu(),
-		Sessions:     sessions,
-		Store:        &stubOAuthStore{},
-		Bootstrapper: boot,
-	})
-	rec := driveMockCallback(t, r)
-	if rec.Code != http.StatusFound {
-		t.Fatalf("status = %d, want 302 despite provision error", rec.Code)
-	}
-	if sessions.calls != 1 {
-		t.Fatalf("session.Create called %d times, want 1 (login must not be blocked)", sessions.calls)
-	}
-}
-
-var errProvisionBoom = errors.New("boom")


### PR DESCRIPTION
## Summary
- Remove the TOFU first-owner-on-first-login path.
- Keep the email registration/bootstrap path as the owner creation flow.
- Update local compose/dev-server/docs wiring around the removed behavior.

## Verification
- Not completed. `make check` was started but interrupted at the user request before completion.