### PR TITLE
Improve connections platform setup flow

### DIFF
--- a/apps/web/src/components/admin/channel-connectors/ChannelConnectorPanel.tsx
+++ b/apps/web/src/components/admin/channel-connectors/ChannelConnectorPanel.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
 
 import {
   useWorkspaceIMConnectors,
@@ -6,12 +7,16 @@ import {
   readSlackConnector,
   readDiscordConnector,
   readTeamsConnector,
+  type ConnectorPlatform,
+  type DiscordConnectorInput,
+  type FeishuConnectorInput,
+  type SlackConnectorInput,
+  type TeamsConnectorInput,
 } from "../../../lib/api-connectors"
 import { FeishuConnectorFields } from "./feishuFields"
 import { SlackConnectorFields } from "./slackFields"
 import { DiscordConnectorFields } from "./discordFields"
 import { TeamsConnectorFields } from "./teamsFields"
-import { PlatformSelector, type ConnectorPlatform } from "./PlatformSelector"
 
 interface ChannelConnectorPanelProps {
   workspaceID: string | null
@@ -19,21 +24,16 @@ interface ChannelConnectorPanelProps {
   onToast: (msg: string) => void
 }
 
-/**
- * Top-level workspace-dimension connector configuration surface.
- *
- * The PlatformSelector dropdown lets the admin pick Feishu / Slack / Discord,
- * and the panel swaps in the matching per-platform fields sub-component. The
- * persisted config for every platform is read once from
- * `GET /workspaces/{id}/connectors` and split per-platform; switching platforms
- * preserves the persisted config and resets any in-flight draft, since each
- * platform has its own validation gates and own secret fields.
- */
+const PLATFORMS: ConnectorPlatform[] = ["feishu", "slack", "discord", "teams"]
+
+type ConnectorStatus = "enabled" | "configured" | "incomplete" | "notConfigured"
+
 export function ChannelConnectorPanel({
   workspaceID,
   canEdit,
   onToast,
 }: ChannelConnectorPanelProps) {
+  const { t } = useTranslation("admin")
   const { data } = useWorkspaceIMConnectors(workspaceID)
   const connectors = data?.connectors
 
@@ -44,41 +44,185 @@ export function ChannelConnectorPanel({
 
   const [platform, setPlatform] = useState<ConnectorPlatform>("feishu")
 
+  const platformSummaries = useMemo(
+    () =>
+      PLATFORMS.map((option) => {
+        const config = configForPlatform(option, {
+          feishu: feishuConfig,
+          slack: slackConfig,
+          discord: discordConfig,
+          teams: teamsConfig,
+        })
+        const appID = config?.app_id.trim() ?? ""
+        const complete = isPlatformComplete(option, config)
+        const status = platformStatus(config, complete)
+        return { platform: option, appID, status }
+      }),
+    [discordConfig, feishuConfig, slackConfig, teamsConfig],
+  )
+
   return (
-    <div data-testid="channel-connector-panel">
-      <PlatformSelector value={platform} onChange={setPlatform} />
-      {platform === "feishu" && (
-        <FeishuConnectorFields
-          workspaceID={workspaceID}
-          current={feishuConfig}
-          canEdit={canEdit}
-          onToast={onToast}
-        />
-      )}
-      {platform === "slack" && (
-        <SlackConnectorFields
-          workspaceID={workspaceID}
-          current={slackConfig}
-          canEdit={canEdit}
-          onToast={onToast}
-        />
-      )}
-      {platform === "discord" && (
-        <DiscordConnectorFields
-          workspaceID={workspaceID}
-          current={discordConfig}
-          canEdit={canEdit}
-          onToast={onToast}
-        />
-      )}
-      {platform === "teams" && (
-        <TeamsConnectorFields
-          workspaceID={workspaceID}
-          current={teamsConfig}
-          canEdit={canEdit}
-          onToast={onToast}
-        />
-      )}
+    <div
+      className="grid gap-4 xl:grid-cols-[minmax(0,360px)_minmax(0,1fr)]"
+      data-testid="channel-connector-panel"
+    >
+      <section className="min-w-0">
+        <div className="mb-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wider text-fg-subtle">
+            {t("connections.connector.platformList.title")}
+          </h2>
+          <p className="mt-1 text-sm text-fg-faint">
+            {t("connections.connector.platformList.description")}
+          </p>
+        </div>
+        <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-1">
+          {platformSummaries.map((summary) => {
+            const active = summary.platform === platform
+            return (
+              <button
+                key={summary.platform}
+                type="button"
+                onClick={() => setPlatform(summary.platform)}
+                className={`min-w-0 rounded-md border px-3 py-3 text-left transition ${
+                  active
+                    ? "border-line-strong bg-surface text-fg shadow-sm"
+                    : "border-line bg-surface text-fg-muted hover:bg-surface-subtle"
+                }`}
+                aria-current={active ? "true" : undefined}
+                data-testid={`connector-platform-${summary.platform}`}
+              >
+                <div className="flex min-w-0 items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">
+                      {t(`connections.connector.platformSelect.options.${summary.platform}`)}
+                    </p>
+                    <p className="mt-1 truncate font-mono text-xs text-fg-faint">
+                      {summary.appID || t("connections.connector.platformList.noAppId")}
+                    </p>
+                  </div>
+                  <span
+                    className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${statusClass(
+                      summary.status,
+                    )}`}
+                  >
+                    {t(`connections.connector.platformList.status.${summary.status}`)}
+                  </span>
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </section>
+
+      <div className="min-w-0">
+        {platform === "feishu" && (
+          <FeishuConnectorFields
+            workspaceID={workspaceID}
+            current={feishuConfig}
+            canEdit={canEdit}
+            onToast={onToast}
+          />
+        )}
+        {platform === "slack" && (
+          <SlackConnectorFields
+            workspaceID={workspaceID}
+            current={slackConfig}
+            canEdit={canEdit}
+            onToast={onToast}
+          />
+        )}
+        {platform === "discord" && (
+          <DiscordConnectorFields
+            workspaceID={workspaceID}
+            current={discordConfig}
+            canEdit={canEdit}
+            onToast={onToast}
+          />
+        )}
+        {platform === "teams" && (
+          <TeamsConnectorFields
+            workspaceID={workspaceID}
+            current={teamsConfig}
+            canEdit={canEdit}
+            onToast={onToast}
+          />
+        )}
+      </div>
     </div>
   )
+}
+
+function configForPlatform(
+  platform: ConnectorPlatform,
+  configs: {
+    feishu: FeishuConnectorInput | undefined
+    slack: SlackConnectorInput | undefined
+    discord: DiscordConnectorInput | undefined
+    teams: TeamsConnectorInput | undefined
+  },
+) {
+  return configs[platform]
+}
+
+function platformStatus(
+  config:
+    | FeishuConnectorInput
+    | SlackConnectorInput
+    | DiscordConnectorInput
+    | TeamsConnectorInput
+    | undefined,
+  complete: boolean,
+): ConnectorStatus {
+  if (!config?.app_id.trim()) return "notConfigured"
+  if (!complete) return "incomplete"
+  return config.enabled ? "enabled" : "configured"
+}
+
+function isPlatformComplete(
+  platform: ConnectorPlatform,
+  config:
+    | FeishuConnectorInput
+    | SlackConnectorInput
+    | DiscordConnectorInput
+    | TeamsConnectorInput
+    | undefined,
+): boolean {
+  if (!config?.app_id.trim()) return false
+  switch (platform) {
+    case "feishu": {
+      const c = config as FeishuConnectorInput
+      return Boolean(
+        c.app_secret_ref.trim() &&
+        (c.event_mode === "websocket" || c.verification_token_ref.trim()),
+      )
+    }
+    case "slack": {
+      const c = config as SlackConnectorInput
+      return Boolean(
+        c.bot_token_ref.trim() &&
+        (c.event_mode === "socket" ? c.app_token_ref.trim() : c.signing_secret_ref.trim()),
+      )
+    }
+    case "discord": {
+      const c = config as DiscordConnectorInput
+      return Boolean(c.bot_token_ref.trim() && c.public_key_ref.trim())
+    }
+    case "teams": {
+      const c = config as TeamsConnectorInput
+      return Boolean(c.app_password_ref.trim())
+    }
+  }
+}
+
+function statusClass(status: ConnectorStatus): string {
+  switch (status) {
+    case "enabled":
+      return "bg-success-subtle text-success-emphasis"
+    case "configured":
+      return "bg-info-subtle text-info-emphasis"
+    case "incomplete":
+      return "bg-warning-subtle text-warning-emphasis"
+    case "notConfigured":
+      return "bg-surface-subtle text-fg-faint"
+  }
 }

--- a/apps/web/src/components/admin/channel-connectors/discordFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/discordFields.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Loader2, RefreshCw } from "lucide-react"
 
@@ -78,28 +78,42 @@ export function DiscordConnectorFields({
   canEdit,
   onToast,
 }: DiscordConnectorFieldsProps) {
+  const currentConfig = current ?? EMPTY_CONFIG
+  return (
+    <DiscordConnectorFieldsInner
+      key={configKey(currentConfig)}
+      workspaceID={workspaceID}
+      current={currentConfig}
+      canEdit={canEdit}
+      onToast={onToast}
+    />
+  )
+}
+
+type DiscordConnectorFieldsInnerProps = Omit<DiscordConnectorFieldsProps, "current"> & {
+  current: DiscordConnectorInput
+}
+
+function DiscordConnectorFieldsInner({
+  workspaceID,
+  current,
+  canEdit,
+  onToast,
+}: DiscordConnectorFieldsInnerProps) {
   const { t } = useTranslation("admin")
   const mut = useUpdateWorkspaceDiscordConnector(workspaceID)
   const createSecretMut = useCreateSecret(workspaceID)
 
-  const [draft, setDraft] = useState<DiscordConnectorInput>(current ?? EMPTY_CONFIG)
+  const [draft, setDraft] = useState<DiscordConnectorInput>(current)
   const [secretInputs, setSecretInputs] = useState<SecretInputs>({ ...EMPTY_SECRET_INPUTS })
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
 
-  useEffect(() => {
-    setDraft(current ?? EMPTY_CONFIG)
-    setSecretInputs({ ...EMPTY_SECRET_INPUTS })
-    setErrorMsg(null)
-  }, [current])
-
-  const dirty = !configEqual(draft, current ?? EMPTY_CONFIG) || secretInputsDirty(secretInputs)
+  const dirty = !configEqual(draft, current) || secretInputsDirty(secretInputs)
   const saving = mut.isPending || createSecretMut.isPending
 
-  const missingRequired = draft.enabled && (
-    !draft.app_id.trim() ||
-    (!draft.bot_token_ref.trim() && !secretInputs.botToken.trim()) ||
-    (!draft.public_key_ref.trim() && !secretInputs.publicKey.trim())
-  )
+  const missingRequired = missingRequiredFor(draft, secretInputs)
+  const missingRequiredToEnable = missingRequiredFor({ ...draft, enabled: true }, secretInputs)
+  const missingDraftIdentity = !draft.app_id.trim()
 
   const selectedIntents = parseIntents(draft.intents)
 
@@ -115,10 +129,15 @@ export function DiscordConnectorFields({
     })
   }
 
-  const onSave = async () => {
+  const onSave = async (nextEnabled = draft.enabled) => {
+    const nextDraft = { ...draft, enabled: nextEnabled }
+    if (missingRequiredFor(nextDraft, secretInputs)) {
+      setErrorMsg(t("connections.connector.discord.errors.incomplete"))
+      return
+    }
     setErrorMsg(null)
     try {
-      const config = await buildConfigWithSecretRefs(draft, secretInputs, async (body) => {
+      const config = await buildConfigWithSecretRefs(nextDraft, secretInputs, async (body) => {
         const secret = await createSecretMut.mutateAsync({ body })
         return secret.id
       })
@@ -139,12 +158,14 @@ export function DiscordConnectorFields({
           return
         }
       }
-      setErrorMsg(err instanceof Error ? err.message : t("connections.connector.discord.errors.generic"))
+      setErrorMsg(
+        err instanceof Error ? err.message : t("connections.connector.discord.errors.generic"),
+      )
     }
   }
 
   const onReset = () => {
-    setDraft(current ?? EMPTY_CONFIG)
+    setDraft(current)
     setSecretInputs({ ...EMPTY_SECRET_INPUTS })
     setErrorMsg(null)
   }
@@ -156,10 +177,17 @@ export function DiscordConnectorFields({
       docHref={t("connections.connector.discord.docLink.href")}
       docLabel={t("connections.connector.discord.docLink.label")}
     >
-      <Field
-        label={t("connections.connector.discord.fields.enabled.label")}
-        hint={t("connections.connector.discord.fields.enabled.hint")}
-      >
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-line bg-surface-subtle px-3 py-2">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-fg">
+            {draft.enabled
+              ? t("connections.connector.status.enabled")
+              : t("connections.connector.status.disabled")}
+          </p>
+          <p className="mt-0.5 text-xs text-fg-subtle">
+            {t("connections.connector.discord.fields.enabled.hint")}
+          </p>
+        </div>
         <label className="inline-flex items-center gap-2 text-sm text-fg">
           <input
             type="checkbox"
@@ -170,80 +198,76 @@ export function DiscordConnectorFields({
           />
           {t("connections.connector.discord.fields.enabled.toggle")}
         </label>
+      </div>
+
+      <Field
+        label={t("connections.connector.discord.fields.appId.label")}
+        hint={t("connections.connector.discord.fields.appId.hint")}
+        required
+      >
+        <input
+          type="text"
+          value={draft.app_id}
+          placeholder="1234567890"
+          onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
+          disabled={!canEdit || saving}
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          data-testid="discord-app-id-input"
+        />
       </Field>
 
-      {draft.enabled && (
-        <>
-          <Field
-            label={t("connections.connector.discord.fields.appId.label")}
-            hint={t("connections.connector.discord.fields.appId.hint")}
-            required
-          >
-            <input
-              type="text"
-              value={draft.app_id}
-              placeholder="1234567890"
-              onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
-              disabled={!canEdit || saving}
-              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
-              data-testid="discord-app-id-input"
-            />
-          </Field>
+      <SecretInput
+        label={t("connections.connector.discord.fields.botToken.label")}
+        hint={t("connections.connector.discord.fields.botToken.hint")}
+        savedHint={t("connections.connector.discord.fields.botToken.savedHint")}
+        savedBadge={t("connections.connector.savedBadge")}
+        value={secretInputs.botToken}
+        onChange={(v) => setSecretInputs((prev) => ({ ...prev, botToken: v }))}
+        required={!draft.bot_token_ref.trim()}
+        hasSavedValue={Boolean(draft.bot_token_ref.trim())}
+        disabled={!canEdit || saving}
+        testId="discord-bot-token-input"
+      />
 
-          <SecretInput
-            label={t("connections.connector.discord.fields.botToken.label")}
-            hint={t("connections.connector.discord.fields.botToken.hint")}
-            savedHint={t("connections.connector.discord.fields.botToken.savedHint")}
-            savedBadge={t("connections.connector.savedBadge")}
-            value={secretInputs.botToken}
-            onChange={(v) => setSecretInputs((prev) => ({ ...prev, botToken: v }))}
-            required={!draft.bot_token_ref.trim()}
-            hasSavedValue={Boolean(draft.bot_token_ref.trim())}
-            disabled={!canEdit || saving}
-            testId="discord-bot-token-input"
-          />
+      <SecretInput
+        label={t("connections.connector.discord.fields.publicKey.label")}
+        hint={t("connections.connector.discord.fields.publicKey.hint")}
+        savedHint={t("connections.connector.discord.fields.publicKey.savedHint")}
+        savedBadge={t("connections.connector.savedBadge")}
+        value={secretInputs.publicKey}
+        onChange={(v) => setSecretInputs((prev) => ({ ...prev, publicKey: v }))}
+        required={!draft.public_key_ref.trim()}
+        hasSavedValue={Boolean(draft.public_key_ref.trim())}
+        disabled={!canEdit || saving}
+        testId="discord-public-key-input"
+      />
 
-          <SecretInput
-            label={t("connections.connector.discord.fields.publicKey.label")}
-            hint={t("connections.connector.discord.fields.publicKey.hint")}
-            savedHint={t("connections.connector.discord.fields.publicKey.savedHint")}
-            savedBadge={t("connections.connector.savedBadge")}
-            value={secretInputs.publicKey}
-            onChange={(v) => setSecretInputs((prev) => ({ ...prev, publicKey: v }))}
-            required={!draft.public_key_ref.trim()}
-            hasSavedValue={Boolean(draft.public_key_ref.trim())}
-            disabled={!canEdit || saving}
-            testId="discord-public-key-input"
-          />
-
-          <Field
-            label={t("connections.connector.discord.fields.intents.label")}
-            hint={t("connections.connector.discord.fields.intents.hint")}
-          >
-            <div className="flex flex-wrap gap-2">
-              {DISCORD_INTENT_OPTIONS.map((intent) => {
-                const active = selectedIntents.includes(intent)
-                return (
-                  <button
-                    key={intent}
-                    type="button"
-                    onClick={() => toggleIntent(intent)}
-                    disabled={!canEdit || saving}
-                    className={`min-h-8 rounded-md border px-2.5 py-1 font-mono text-xs transition ${
-                      active
-                        ? "border-line-strong bg-surface-emphasis text-white"
-                        : "border-line bg-surface text-fg-muted hover:bg-surface-subtle"
-                    } disabled:opacity-60`}
-                    aria-pressed={active}
-                  >
-                    {intent}
-                  </button>
-                )
-              })}
-            </div>
-          </Field>
-        </>
-      )}
+      <Field
+        label={t("connections.connector.discord.fields.intents.label")}
+        hint={t("connections.connector.discord.fields.intents.hint")}
+      >
+        <div className="flex flex-wrap gap-2">
+          {DISCORD_INTENT_OPTIONS.map((intent) => {
+            const active = selectedIntents.includes(intent)
+            return (
+              <button
+                key={intent}
+                type="button"
+                onClick={() => toggleIntent(intent)}
+                disabled={!canEdit || saving}
+                className={`min-h-8 rounded-md border px-2.5 py-1 font-mono text-xs transition ${
+                  active
+                    ? "border-line-strong bg-surface-emphasis text-white"
+                    : "border-line bg-surface text-fg-muted hover:bg-surface-subtle"
+                } disabled:opacity-60`}
+                aria-pressed={active}
+              >
+                {intent}
+              </button>
+            )
+          })}
+        </div>
+      </Field>
 
       {!canEdit && (
         <p className="mt-3 text-sm text-fg-faint">{t("connections.connector.adminOnly")}</p>
@@ -255,7 +279,7 @@ export function DiscordConnectorFields({
         </p>
       )}
 
-      <div className="mt-4 flex items-center justify-end gap-2">
+      <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
         {dirty && (
           <button
             type="button"
@@ -269,17 +293,52 @@ export function DiscordConnectorFields({
         )}
         <button
           type="button"
-          onClick={onSave}
-          disabled={!canEdit || saving || !dirty || Boolean(missingRequired)}
-          className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
+          onClick={() => void onSave()}
+          disabled={
+            !canEdit || saving || !dirty || missingDraftIdentity || Boolean(missingRequired)
+          }
+          className="inline-flex items-center gap-2 rounded-md border border-line px-3 py-1.5 text-sm font-medium text-fg-muted hover:bg-surface-subtle disabled:opacity-60"
           data-testid="discord-save-button"
         >
           {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-          {t("connections.connector.actions.save")}
+          {draft.enabled
+            ? t("connections.connector.actions.save")
+            : t("connections.connector.actions.saveDraft")}
         </button>
+        {!draft.enabled && (
+          <button
+            type="button"
+            onClick={() => void onSave(true)}
+            disabled={!canEdit || saving || Boolean(missingRequiredToEnable)}
+            className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
+            data-testid="discord-save-enable-button"
+          >
+            {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {t("connections.connector.actions.saveAndEnable")}
+          </button>
+        )}
       </div>
     </Card>
   )
+}
+
+function missingRequiredFor(draft: DiscordConnectorInput, secretInputs: SecretInputs): boolean {
+  return (
+    draft.enabled &&
+    (!draft.app_id.trim() ||
+      (!draft.bot_token_ref.trim() && !secretInputs.botToken.trim()) ||
+      (!draft.public_key_ref.trim() && !secretInputs.publicKey.trim()))
+  )
+}
+
+function configKey(config: DiscordConnectorInput): string {
+  return [
+    config.enabled ? "1" : "0",
+    config.app_id,
+    config.bot_token_ref,
+    config.public_key_ref,
+    config.intents,
+  ].join("\u0000")
 }
 
 function applyChange(
@@ -314,7 +373,6 @@ async function buildConfigWithSecretRefs(
   createSecret: (body: CreateSecretRequest) => Promise<string>,
 ): Promise<DiscordConnectorInput> {
   const next = trimConfig(draft)
-  if (!next.enabled) return next
 
   for (const field of Object.keys(DISCORD_SECRET_FIELDS) as DiscordSecretField[]) {
     const plaintext = inputs[field].trim()
@@ -336,7 +394,10 @@ function trimConfig(config: DiscordConnectorInput): DiscordConnectorInput {
   }
 }
 
-function createDiscordSecretBody(spec: DiscordSecretFieldSpec, plaintext: string): CreateSecretRequest {
+function createDiscordSecretBody(
+  spec: DiscordSecretFieldSpec,
+  plaintext: string,
+): CreateSecretRequest {
   return {
     name: spec.namePrefix + "-" + randomHex(6),
     kind: spec.kind,

--- a/apps/web/src/components/admin/channel-connectors/feishuFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/feishuFields.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Loader2, RefreshCw } from "lucide-react"
 
@@ -81,35 +81,54 @@ export function FeishuConnectorFields({
   canEdit,
   onToast,
 }: FeishuConnectorFieldsProps) {
+  const currentConfig = current ?? EMPTY_CONFIG
+  return (
+    <FeishuConnectorFieldsInner
+      key={configKey(currentConfig)}
+      workspaceID={workspaceID}
+      current={currentConfig}
+      canEdit={canEdit}
+      onToast={onToast}
+    />
+  )
+}
+
+type FeishuConnectorFieldsInnerProps = Omit<FeishuConnectorFieldsProps, "current"> & {
+  current: FeishuConnectorInput
+}
+
+function FeishuConnectorFieldsInner({
+  workspaceID,
+  current,
+  canEdit,
+  onToast,
+}: FeishuConnectorFieldsInnerProps) {
   const { t } = useTranslation("admin")
   const mut = useUpdateWorkspaceFeishuConnector(workspaceID)
   const createSecretMut = useCreateSecret(workspaceID)
 
-  const [draft, setDraft] = useState<FeishuConnectorInput>(current ?? EMPTY_CONFIG)
+  const [draft, setDraft] = useState<FeishuConnectorInput>(current)
   const [secretInputs, setSecretInputs] = useState<SecretInputs>({ ...EMPTY_SECRET_INPUTS })
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
 
-  useEffect(() => {
-    setDraft(current ?? EMPTY_CONFIG)
-    setSecretInputs({ ...EMPTY_SECRET_INPUTS })
-    setErrorMsg(null)
-  }, [current])
-
-  const dirty = !configEqual(draft, current ?? EMPTY_CONFIG) || secretInputsDirty(secretInputs)
+  const dirty = !configEqual(draft, current) || secretInputsDirty(secretInputs)
   const saving = mut.isPending || createSecretMut.isPending
 
   // bot_open_id is intentionally NOT required: when left blank the server
   // derives it from the app credentials (bot/v3/info) at save time.
-  const missingRequired = draft.enabled && (
-    !draft.app_id.trim() ||
-    (!draft.app_secret_ref.trim() && !secretInputs.appSecret.trim()) ||
-    (draft.event_mode === "webhook" && !draft.verification_token_ref.trim() && !secretInputs.verificationToken.trim())
-  )
+  const missingRequired = missingRequiredFor(draft, secretInputs)
+  const missingRequiredToEnable = missingRequiredFor({ ...draft, enabled: true }, secretInputs)
+  const missingDraftIdentity = !draft.app_id.trim()
 
-  const onSave = async () => {
+  const onSave = async (nextEnabled = draft.enabled) => {
+    const nextDraft = { ...draft, enabled: nextEnabled }
+    if (missingRequiredFor(nextDraft, secretInputs)) {
+      setErrorMsg(t("connections.connector.feishu.errors.incomplete"))
+      return
+    }
     setErrorMsg(null)
     try {
-      const config = await buildConfigWithSecretRefs(draft, secretInputs, async (body) => {
+      const config = await buildConfigWithSecretRefs(nextDraft, secretInputs, async (body) => {
         const secret = await createSecretMut.mutateAsync({ body })
         return secret.id
       })
@@ -134,12 +153,14 @@ export function FeishuConnectorFields({
           return
         }
       }
-      setErrorMsg(err instanceof Error ? err.message : t("connections.connector.feishu.errors.generic"))
+      setErrorMsg(
+        err instanceof Error ? err.message : t("connections.connector.feishu.errors.generic"),
+      )
     }
   }
 
   const onReset = () => {
-    setDraft(current ?? EMPTY_CONFIG)
+    setDraft(current)
     setSecretInputs({ ...EMPTY_SECRET_INPUTS })
     setErrorMsg(null)
   }
@@ -151,10 +172,17 @@ export function FeishuConnectorFields({
       docHref={t("connections.connector.feishu.docLink.href")}
       docLabel={t("connections.connector.feishu.docLink.label")}
     >
-      <Field
-        label={t("connections.connector.feishu.fields.enabled.label")}
-        hint={t("connections.connector.feishu.fields.enabled.hint")}
-      >
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-line bg-surface-subtle px-3 py-2">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-fg">
+            {draft.enabled
+              ? t("connections.connector.status.enabled")
+              : t("connections.connector.status.disabled")}
+          </p>
+          <p className="mt-0.5 text-xs text-fg-subtle">
+            {t("connections.connector.feishu.fields.enabled.hint")}
+          </p>
+        </div>
         <label className="inline-flex items-center gap-2 text-sm text-fg">
           <input
             type="checkbox"
@@ -165,108 +193,104 @@ export function FeishuConnectorFields({
           />
           {t("connections.connector.feishu.fields.enabled.toggle")}
         </label>
+      </div>
+
+      <Field
+        label={t("connections.connector.feishu.fields.appId.label")}
+        hint={t("connections.connector.feishu.fields.appId.hint")}
+        required
+      >
+        <input
+          type="text"
+          value={draft.app_id}
+          placeholder="cli_xxxxxxxxxxxxxxxx"
+          onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
+          disabled={!canEdit || saving}
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          data-testid="feishu-app-id-input"
+        />
       </Field>
 
-      {draft.enabled && (
-        <>
-          <Field
-            label={t("connections.connector.feishu.fields.appId.label")}
-            hint={t("connections.connector.feishu.fields.appId.hint")}
-            required
-          >
-            <input
-              type="text"
-              value={draft.app_id}
-              placeholder="cli_xxxxxxxxxxxxxxxx"
-              onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
-              disabled={!canEdit || saving}
-              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
-              data-testid="feishu-app-id-input"
-            />
-          </Field>
+      <SecretInput
+        label={t("connections.connector.feishu.fields.appSecret.label")}
+        hint={t("connections.connector.feishu.fields.appSecret.hint")}
+        savedHint={t("connections.connector.feishu.fields.appSecret.savedHint")}
+        savedBadge={t("connections.connector.savedBadge")}
+        value={secretInputs.appSecret}
+        onChange={(v) => setSecretInputs((prev) => ({ ...prev, appSecret: v }))}
+        required={!draft.app_secret_ref.trim()}
+        hasSavedValue={Boolean(draft.app_secret_ref.trim())}
+        disabled={!canEdit || saving}
+        testId="feishu-app-secret-input"
+      />
 
-          <SecretInput
-            label={t("connections.connector.feishu.fields.appSecret.label")}
-            hint={t("connections.connector.feishu.fields.appSecret.hint")}
-            savedHint={t("connections.connector.feishu.fields.appSecret.savedHint")}
-            savedBadge={t("connections.connector.savedBadge")}
-            value={secretInputs.appSecret}
-            onChange={(v) => setSecretInputs((prev) => ({ ...prev, appSecret: v }))}
-            required={!draft.app_secret_ref.trim()}
-            hasSavedValue={Boolean(draft.app_secret_ref.trim())}
-            disabled={!canEdit || saving}
-            testId="feishu-app-secret-input"
-          />
+      <SecretInput
+        label={t("connections.connector.feishu.fields.verificationToken.label")}
+        hint={t("connections.connector.feishu.fields.verificationToken.hint")}
+        savedHint={t("connections.connector.feishu.fields.verificationToken.savedHint")}
+        savedBadge={t("connections.connector.savedBadge")}
+        value={secretInputs.verificationToken}
+        onChange={(v) => setSecretInputs((prev) => ({ ...prev, verificationToken: v }))}
+        required={draft.event_mode === "webhook" && !draft.verification_token_ref.trim()}
+        hasSavedValue={Boolean(draft.verification_token_ref.trim())}
+        disabled={!canEdit || saving}
+        testId="feishu-verification-token-input"
+      />
 
-          <SecretInput
-            label={t("connections.connector.feishu.fields.verificationToken.label")}
-            hint={t("connections.connector.feishu.fields.verificationToken.hint")}
-            savedHint={t("connections.connector.feishu.fields.verificationToken.savedHint")}
-            savedBadge={t("connections.connector.savedBadge")}
-            value={secretInputs.verificationToken}
-            onChange={(v) => setSecretInputs((prev) => ({ ...prev, verificationToken: v }))}
-            required={draft.event_mode === "webhook" && !draft.verification_token_ref.trim()}
-            hasSavedValue={Boolean(draft.verification_token_ref.trim())}
-            disabled={!canEdit || saving}
-            testId="feishu-verification-token-input"
-          />
+      <SecretInput
+        label={t("connections.connector.feishu.fields.encryptKey.label")}
+        hint={t("connections.connector.feishu.fields.encryptKey.hint")}
+        savedHint={t("connections.connector.feishu.fields.encryptKey.savedHint")}
+        savedBadge={t("connections.connector.savedBadge")}
+        value={secretInputs.encryptKey}
+        onChange={(v) => setSecretInputs((prev) => ({ ...prev, encryptKey: v }))}
+        required={false}
+        hasSavedValue={Boolean(draft.encrypt_key_ref.trim())}
+        disabled={!canEdit || saving}
+        testId="feishu-encrypt-key-input"
+      />
 
-          <SecretInput
-            label={t("connections.connector.feishu.fields.encryptKey.label")}
-            hint={t("connections.connector.feishu.fields.encryptKey.hint")}
-            savedHint={t("connections.connector.feishu.fields.encryptKey.savedHint")}
-            savedBadge={t("connections.connector.savedBadge")}
-            value={secretInputs.encryptKey}
-            onChange={(v) => setSecretInputs((prev) => ({ ...prev, encryptKey: v }))}
-            required={false}
-            hasSavedValue={Boolean(draft.encrypt_key_ref.trim())}
-            disabled={!canEdit || saving}
-            testId="feishu-encrypt-key-input"
-          />
+      <Field
+        label={t("connections.connector.feishu.fields.botOpenId.label")}
+        hint={t("connections.connector.feishu.fields.botOpenId.hint")}
+      >
+        <input
+          type="text"
+          value={draft.bot_open_id}
+          placeholder={t("connections.connector.feishu.fields.botOpenId.placeholder")}
+          onChange={(e) => setDraft({ ...draft, bot_open_id: e.target.value })}
+          disabled={!canEdit || saving}
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          data-testid="feishu-bot-open-id-input"
+        />
+      </Field>
 
-          <Field
-            label={t("connections.connector.feishu.fields.botOpenId.label")}
-            hint={t("connections.connector.feishu.fields.botOpenId.hint")}
-          >
-            <input
-              type="text"
-              value={draft.bot_open_id}
-              placeholder={t("connections.connector.feishu.fields.botOpenId.placeholder")}
-              onChange={(e) => setDraft({ ...draft, bot_open_id: e.target.value })}
-              disabled={!canEdit || saving}
-              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
-              data-testid="feishu-bot-open-id-input"
-            />
-          </Field>
-
-          <Field
-            label={t("connections.connector.feishu.fields.eventMode.label")}
-            hint={t("connections.connector.feishu.fields.eventMode.hint")}
-          >
-            <div className="grid grid-cols-2 gap-2">
-              {(["websocket", "webhook"] as const).map((mode) => {
-                const active = draft.event_mode === mode
-                return (
-                  <button
-                    key={mode}
-                    type="button"
-                    onClick={() => setDraft({ ...draft, event_mode: mode })}
-                    disabled={!canEdit || saving}
-                    className={`min-h-9 rounded-md border px-3 py-1.5 text-sm font-medium transition ${
-                      active
-                        ? "border-line-strong bg-surface-emphasis text-white"
-                        : "border-line bg-surface text-fg-muted hover:bg-surface-subtle"
-                    } disabled:opacity-60`}
-                    aria-pressed={active}
-                  >
-                    {t(`connections.connector.feishu.fields.eventMode.options.${mode}`)}
-                  </button>
-                )
-              })}
-            </div>
-          </Field>
-        </>
-      )}
+      <Field
+        label={t("connections.connector.feishu.fields.eventMode.label")}
+        hint={t("connections.connector.feishu.fields.eventMode.hint")}
+      >
+        <div className="grid grid-cols-2 gap-2">
+          {(["websocket", "webhook"] as const).map((mode) => {
+            const active = draft.event_mode === mode
+            return (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setDraft({ ...draft, event_mode: mode })}
+                disabled={!canEdit || saving}
+                className={`min-h-9 rounded-md border px-3 py-1.5 text-sm font-medium transition ${
+                  active
+                    ? "border-line-strong bg-surface-emphasis text-white"
+                    : "border-line bg-surface text-fg-muted hover:bg-surface-subtle"
+                } disabled:opacity-60`}
+                aria-pressed={active}
+              >
+                {t(`connections.connector.feishu.fields.eventMode.options.${mode}`)}
+              </button>
+            )
+          })}
+        </div>
+      </Field>
 
       {!canEdit && (
         <p className="mt-3 text-sm text-fg-faint">{t("connections.connector.adminOnly")}</p>
@@ -278,7 +302,7 @@ export function FeishuConnectorFields({
         </p>
       )}
 
-      <div className="mt-4 flex items-center justify-end gap-2">
+      <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
         {dirty && (
           <button
             type="button"
@@ -292,17 +316,56 @@ export function FeishuConnectorFields({
         )}
         <button
           type="button"
-          onClick={onSave}
-          disabled={!canEdit || saving || !dirty || Boolean(missingRequired)}
-          className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
+          onClick={() => void onSave()}
+          disabled={
+            !canEdit || saving || !dirty || missingDraftIdentity || Boolean(missingRequired)
+          }
+          className="inline-flex items-center gap-2 rounded-md border border-line px-3 py-1.5 text-sm font-medium text-fg-muted hover:bg-surface-subtle disabled:opacity-60"
           data-testid="feishu-save-button"
         >
           {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-          {t("connections.connector.actions.save")}
+          {draft.enabled
+            ? t("connections.connector.actions.save")
+            : t("connections.connector.actions.saveDraft")}
         </button>
+        {!draft.enabled && (
+          <button
+            type="button"
+            onClick={() => void onSave(true)}
+            disabled={!canEdit || saving || Boolean(missingRequiredToEnable)}
+            className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
+            data-testid="feishu-save-enable-button"
+          >
+            {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {t("connections.connector.actions.saveAndEnable")}
+          </button>
+        )}
       </div>
     </Card>
   )
+}
+
+function missingRequiredFor(draft: FeishuConnectorInput, secretInputs: SecretInputs): boolean {
+  return (
+    draft.enabled &&
+    (!draft.app_id.trim() ||
+      (!draft.app_secret_ref.trim() && !secretInputs.appSecret.trim()) ||
+      (draft.event_mode === "webhook" &&
+        !draft.verification_token_ref.trim() &&
+        !secretInputs.verificationToken.trim()))
+  )
+}
+
+function configKey(config: FeishuConnectorInput): string {
+  return [
+    config.enabled ? "1" : "0",
+    config.app_id,
+    config.app_secret_ref,
+    config.verification_token_ref,
+    config.encrypt_key_ref,
+    config.bot_open_id,
+    config.event_mode,
+  ].join("\u0000")
 }
 
 function applyChange(
@@ -324,7 +387,9 @@ function applyChange(
 }
 
 function secretInputsDirty(inputs: SecretInputs): boolean {
-  return Boolean(inputs.appSecret.trim() || inputs.verificationToken.trim() || inputs.encryptKey.trim())
+  return Boolean(
+    inputs.appSecret.trim() || inputs.verificationToken.trim() || inputs.encryptKey.trim(),
+  )
 }
 
 async function buildConfigWithSecretRefs(
@@ -333,7 +398,6 @@ async function buildConfigWithSecretRefs(
   createSecret: (body: CreateSecretRequest) => Promise<string>,
 ): Promise<FeishuConnectorInput> {
   const next = trimConfig(draft)
-  if (!next.enabled) return next
 
   for (const field of Object.keys(FEISHU_SECRET_FIELDS) as FeishuSecretField[]) {
     const plaintext = inputs[field].trim()
@@ -357,7 +421,10 @@ function trimConfig(config: FeishuConnectorInput): FeishuConnectorInput {
   }
 }
 
-function createFeishuSecretBody(spec: FeishuSecretFieldSpec, plaintext: string): CreateSecretRequest {
+function createFeishuSecretBody(
+  spec: FeishuSecretFieldSpec,
+  plaintext: string,
+): CreateSecretRequest {
   return {
     name: spec.namePrefix + "-" + randomHex(6),
     kind: spec.kind,

--- a/apps/web/src/components/admin/channel-connectors/slackFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/slackFields.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Loader2, RefreshCw } from "lucide-react"
 
@@ -80,35 +80,52 @@ export function SlackConnectorFields({
   canEdit,
   onToast,
 }: SlackConnectorFieldsProps) {
+  const currentConfig = current ?? EMPTY_CONFIG
+  return (
+    <SlackConnectorFieldsInner
+      key={configKey(currentConfig)}
+      workspaceID={workspaceID}
+      current={currentConfig}
+      canEdit={canEdit}
+      onToast={onToast}
+    />
+  )
+}
+
+type SlackConnectorFieldsInnerProps = Omit<SlackConnectorFieldsProps, "current"> & {
+  current: SlackConnectorInput
+}
+
+function SlackConnectorFieldsInner({
+  workspaceID,
+  current,
+  canEdit,
+  onToast,
+}: SlackConnectorFieldsInnerProps) {
   const { t } = useTranslation("admin")
   const mut = useUpdateWorkspaceSlackConnector(workspaceID)
   const createSecretMut = useCreateSecret(workspaceID)
 
-  const [draft, setDraft] = useState<SlackConnectorInput>(current ?? EMPTY_CONFIG)
+  const [draft, setDraft] = useState<SlackConnectorInput>(current)
   const [secretInputs, setSecretInputs] = useState<SecretInputs>({ ...EMPTY_SECRET_INPUTS })
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
 
-  useEffect(() => {
-    setDraft(current ?? EMPTY_CONFIG)
-    setSecretInputs({ ...EMPTY_SECRET_INPUTS })
-    setErrorMsg(null)
-  }, [current])
-
-  const dirty = !configEqual(draft, current ?? EMPTY_CONFIG) || secretInputsDirty(secretInputs)
+  const dirty = !configEqual(draft, current) || secretInputsDirty(secretInputs)
   const saving = mut.isPending || createSecretMut.isPending
 
-  const missingRequired = draft.enabled && (
-    !draft.app_id.trim() ||
-    (!draft.bot_token_ref.trim() && !secretInputs.botToken.trim()) ||
-    (draft.event_mode === "socket"
-      ? (!draft.app_token_ref.trim() && !secretInputs.appToken.trim())
-      : (!draft.signing_secret_ref.trim() && !secretInputs.signingSecret.trim()))
-  )
+  const missingRequired = missingRequiredFor(draft, secretInputs)
+  const missingRequiredToEnable = missingRequiredFor({ ...draft, enabled: true }, secretInputs)
+  const missingDraftIdentity = !draft.app_id.trim()
 
-  const onSave = async () => {
+  const onSave = async (nextEnabled = draft.enabled) => {
+    const nextDraft = { ...draft, enabled: nextEnabled }
+    if (missingRequiredFor(nextDraft, secretInputs)) {
+      setErrorMsg(t("connections.connector.slack.errors.incomplete"))
+      return
+    }
     setErrorMsg(null)
     try {
-      const config = await buildConfigWithSecretRefs(draft, secretInputs, async (body) => {
+      const config = await buildConfigWithSecretRefs(nextDraft, secretInputs, async (body) => {
         const secret = await createSecretMut.mutateAsync({ body })
         return secret.id
       })
@@ -129,12 +146,14 @@ export function SlackConnectorFields({
           return
         }
       }
-      setErrorMsg(err instanceof Error ? err.message : t("connections.connector.slack.errors.generic"))
+      setErrorMsg(
+        err instanceof Error ? err.message : t("connections.connector.slack.errors.generic"),
+      )
     }
   }
 
   const onReset = () => {
-    setDraft(current ?? EMPTY_CONFIG)
+    setDraft(current)
     setSecretInputs({ ...EMPTY_SECRET_INPUTS })
     setErrorMsg(null)
   }
@@ -146,10 +165,17 @@ export function SlackConnectorFields({
       docHref={t("connections.connector.slack.docLink.href")}
       docLabel={t("connections.connector.slack.docLink.label")}
     >
-      <Field
-        label={t("connections.connector.slack.fields.enabled.label")}
-        hint={t("connections.connector.slack.fields.enabled.hint")}
-      >
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-line bg-surface-subtle px-3 py-2">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-fg">
+            {draft.enabled
+              ? t("connections.connector.status.enabled")
+              : t("connections.connector.status.disabled")}
+          </p>
+          <p className="mt-0.5 text-xs text-fg-subtle">
+            {t("connections.connector.slack.fields.enabled.hint")}
+          </p>
+        </div>
         <label className="inline-flex items-center gap-2 text-sm text-fg">
           <input
             type="checkbox"
@@ -160,95 +186,91 @@ export function SlackConnectorFields({
           />
           {t("connections.connector.slack.fields.enabled.toggle")}
         </label>
+      </div>
+
+      <Field
+        label={t("connections.connector.slack.fields.appId.label")}
+        hint={t("connections.connector.slack.fields.appId.hint")}
+        required
+      >
+        <input
+          type="text"
+          value={draft.app_id}
+          placeholder="A0000000000000"
+          onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
+          disabled={!canEdit || saving}
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          data-testid="slack-app-id-input"
+        />
       </Field>
 
-      {draft.enabled && (
-        <>
-          <Field
-            label={t("connections.connector.slack.fields.appId.label")}
-            hint={t("connections.connector.slack.fields.appId.hint")}
-            required
-          >
-            <input
-              type="text"
-              value={draft.app_id}
-              placeholder="A0000000000000"
-              onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
-              disabled={!canEdit || saving}
-              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
-              data-testid="slack-app-id-input"
-            />
-          </Field>
+      <SecretInput
+        label={t("connections.connector.slack.fields.botToken.label")}
+        hint={t("connections.connector.slack.fields.botToken.hint")}
+        savedHint={t("connections.connector.slack.fields.botToken.savedHint")}
+        savedBadge={t("connections.connector.savedBadge")}
+        value={secretInputs.botToken}
+        onChange={(v) => setSecretInputs((prev) => ({ ...prev, botToken: v }))}
+        required={!draft.bot_token_ref.trim()}
+        hasSavedValue={Boolean(draft.bot_token_ref.trim())}
+        disabled={!canEdit || saving}
+        testId="slack-bot-token-input"
+      />
 
-          <SecretInput
-            label={t("connections.connector.slack.fields.botToken.label")}
-            hint={t("connections.connector.slack.fields.botToken.hint")}
-            savedHint={t("connections.connector.slack.fields.botToken.savedHint")}
-            savedBadge={t("connections.connector.savedBadge")}
-            value={secretInputs.botToken}
-            onChange={(v) => setSecretInputs((prev) => ({ ...prev, botToken: v }))}
-            required={!draft.bot_token_ref.trim()}
-            hasSavedValue={Boolean(draft.bot_token_ref.trim())}
-            disabled={!canEdit || saving}
-            testId="slack-bot-token-input"
-          />
-
-          {draft.event_mode === "socket" ? (
-            <SecretInput
-              label={t("connections.connector.slack.fields.appToken.label")}
-              hint={t("connections.connector.slack.fields.appToken.hint")}
-              savedHint={t("connections.connector.slack.fields.appToken.savedHint")}
-              savedBadge={t("connections.connector.savedBadge")}
-              value={secretInputs.appToken}
-              onChange={(v) => setSecretInputs((prev) => ({ ...prev, appToken: v }))}
-              required={!draft.app_token_ref.trim()}
-              hasSavedValue={Boolean(draft.app_token_ref.trim())}
-              disabled={!canEdit || saving}
-              testId="slack-app-token-input"
-            />
-          ) : (
-            <SecretInput
-              label={t("connections.connector.slack.fields.signingSecret.label")}
-              hint={t("connections.connector.slack.fields.signingSecret.hint")}
-              savedHint={t("connections.connector.slack.fields.signingSecret.savedHint")}
-              savedBadge={t("connections.connector.savedBadge")}
-              value={secretInputs.signingSecret}
-              onChange={(v) => setSecretInputs((prev) => ({ ...prev, signingSecret: v }))}
-              required={!draft.signing_secret_ref.trim()}
-              hasSavedValue={Boolean(draft.signing_secret_ref.trim())}
-              disabled={!canEdit || saving}
-              testId="slack-signing-secret-input"
-            />
-          )}
-
-          <Field
-            label={t("connections.connector.slack.fields.eventMode.label")}
-            hint={t("connections.connector.slack.fields.eventMode.hint")}
-          >
-            <div className="grid grid-cols-2 gap-2">
-              {(["socket", "events"] as const).map((mode) => {
-                const active = draft.event_mode === mode
-                return (
-                  <button
-                    key={mode}
-                    type="button"
-                    onClick={() => setDraft({ ...draft, event_mode: mode })}
-                    disabled={!canEdit || saving}
-                    className={`min-h-9 rounded-md border px-3 py-1.5 text-sm font-medium transition ${
-                      active
-                        ? "border-line-strong bg-surface-emphasis text-white"
-                        : "border-line bg-surface text-fg-muted hover:bg-surface-subtle"
-                    } disabled:opacity-60`}
-                    aria-pressed={active}
-                  >
-                    {t(`connections.connector.slack.fields.eventMode.options.${mode}`)}
-                  </button>
-                )
-              })}
-            </div>
-          </Field>
-        </>
+      {draft.event_mode === "socket" ? (
+        <SecretInput
+          label={t("connections.connector.slack.fields.appToken.label")}
+          hint={t("connections.connector.slack.fields.appToken.hint")}
+          savedHint={t("connections.connector.slack.fields.appToken.savedHint")}
+          savedBadge={t("connections.connector.savedBadge")}
+          value={secretInputs.appToken}
+          onChange={(v) => setSecretInputs((prev) => ({ ...prev, appToken: v }))}
+          required={!draft.app_token_ref.trim()}
+          hasSavedValue={Boolean(draft.app_token_ref.trim())}
+          disabled={!canEdit || saving}
+          testId="slack-app-token-input"
+        />
+      ) : (
+        <SecretInput
+          label={t("connections.connector.slack.fields.signingSecret.label")}
+          hint={t("connections.connector.slack.fields.signingSecret.hint")}
+          savedHint={t("connections.connector.slack.fields.signingSecret.savedHint")}
+          savedBadge={t("connections.connector.savedBadge")}
+          value={secretInputs.signingSecret}
+          onChange={(v) => setSecretInputs((prev) => ({ ...prev, signingSecret: v }))}
+          required={!draft.signing_secret_ref.trim()}
+          hasSavedValue={Boolean(draft.signing_secret_ref.trim())}
+          disabled={!canEdit || saving}
+          testId="slack-signing-secret-input"
+        />
       )}
+
+      <Field
+        label={t("connections.connector.slack.fields.eventMode.label")}
+        hint={t("connections.connector.slack.fields.eventMode.hint")}
+      >
+        <div className="grid grid-cols-2 gap-2">
+          {(["socket", "events"] as const).map((mode) => {
+            const active = draft.event_mode === mode
+            return (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setDraft({ ...draft, event_mode: mode })}
+                disabled={!canEdit || saving}
+                className={`min-h-9 rounded-md border px-3 py-1.5 text-sm font-medium transition ${
+                  active
+                    ? "border-line-strong bg-surface-emphasis text-white"
+                    : "border-line bg-surface text-fg-muted hover:bg-surface-subtle"
+                } disabled:opacity-60`}
+                aria-pressed={active}
+              >
+                {t(`connections.connector.slack.fields.eventMode.options.${mode}`)}
+              </button>
+            )
+          })}
+        </div>
+      </Field>
 
       {!canEdit && (
         <p className="mt-3 text-sm text-fg-faint">{t("connections.connector.adminOnly")}</p>
@@ -260,7 +282,7 @@ export function SlackConnectorFields({
         </p>
       )}
 
-      <div className="mt-4 flex items-center justify-end gap-2">
+      <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
         {dirty && (
           <button
             type="button"
@@ -274,17 +296,55 @@ export function SlackConnectorFields({
         )}
         <button
           type="button"
-          onClick={onSave}
-          disabled={!canEdit || saving || !dirty || Boolean(missingRequired)}
-          className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
+          onClick={() => void onSave()}
+          disabled={
+            !canEdit || saving || !dirty || missingDraftIdentity || Boolean(missingRequired)
+          }
+          className="inline-flex items-center gap-2 rounded-md border border-line px-3 py-1.5 text-sm font-medium text-fg-muted hover:bg-surface-subtle disabled:opacity-60"
           data-testid="slack-save-button"
         >
           {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-          {t("connections.connector.actions.save")}
+          {draft.enabled
+            ? t("connections.connector.actions.save")
+            : t("connections.connector.actions.saveDraft")}
         </button>
+        {!draft.enabled && (
+          <button
+            type="button"
+            onClick={() => void onSave(true)}
+            disabled={!canEdit || saving || Boolean(missingRequiredToEnable)}
+            className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
+            data-testid="slack-save-enable-button"
+          >
+            {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {t("connections.connector.actions.saveAndEnable")}
+          </button>
+        )}
       </div>
     </Card>
   )
+}
+
+function missingRequiredFor(draft: SlackConnectorInput, secretInputs: SecretInputs): boolean {
+  return (
+    draft.enabled &&
+    (!draft.app_id.trim() ||
+      (!draft.bot_token_ref.trim() && !secretInputs.botToken.trim()) ||
+      (draft.event_mode === "socket"
+        ? !draft.app_token_ref.trim() && !secretInputs.appToken.trim()
+        : !draft.signing_secret_ref.trim() && !secretInputs.signingSecret.trim()))
+  )
+}
+
+function configKey(config: SlackConnectorInput): string {
+  return [
+    config.enabled ? "1" : "0",
+    config.app_id,
+    config.bot_token_ref,
+    config.app_token_ref,
+    config.signing_secret_ref,
+    config.event_mode,
+  ].join("\u0000")
 }
 
 function applyChange(
@@ -314,7 +374,6 @@ async function buildConfigWithSecretRefs(
   createSecret: (body: CreateSecretRequest) => Promise<string>,
 ): Promise<SlackConnectorInput> {
   const next = trimConfig(draft)
-  if (!next.enabled) return next
 
   for (const field of Object.keys(SLACK_SECRET_FIELDS) as SlackSecretField[]) {
     const plaintext = inputs[field].trim()

--- a/apps/web/src/components/admin/channel-connectors/teamsFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/teamsFields.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Loader2, RefreshCw } from "lucide-react"
 
@@ -60,32 +60,52 @@ export function TeamsConnectorFields({
   canEdit,
   onToast,
 }: TeamsConnectorFieldsProps) {
+  const currentConfig = current ?? EMPTY_CONFIG
+  return (
+    <TeamsConnectorFieldsInner
+      key={configKey(currentConfig)}
+      workspaceID={workspaceID}
+      current={currentConfig}
+      canEdit={canEdit}
+      onToast={onToast}
+    />
+  )
+}
+
+type TeamsConnectorFieldsInnerProps = Omit<TeamsConnectorFieldsProps, "current"> & {
+  current: TeamsConnectorInput
+}
+
+function TeamsConnectorFieldsInner({
+  workspaceID,
+  current,
+  canEdit,
+  onToast,
+}: TeamsConnectorFieldsInnerProps) {
   const { t } = useTranslation("admin")
   const mut = useUpdateWorkspaceTeamsConnector(workspaceID)
   const createSecretMut = useCreateSecret(workspaceID)
 
-  const [draft, setDraft] = useState<TeamsConnectorInput>(current ?? EMPTY_CONFIG)
+  const [draft, setDraft] = useState<TeamsConnectorInput>(current)
   const [secretInputs, setSecretInputs] = useState<SecretInputs>({ ...EMPTY_SECRET_INPUTS })
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
 
-  useEffect(() => {
-    setDraft(current ?? EMPTY_CONFIG)
-    setSecretInputs({ ...EMPTY_SECRET_INPUTS })
-    setErrorMsg(null)
-  }, [current])
-
-  const dirty = !configEqual(draft, current ?? EMPTY_CONFIG) || secretInputsDirty(secretInputs)
+  const dirty = !configEqual(draft, current) || secretInputsDirty(secretInputs)
   const saving = mut.isPending || createSecretMut.isPending
 
-  const missingRequired = draft.enabled && (
-    !draft.app_id.trim() ||
-    (!draft.app_password_ref.trim() && !secretInputs.appPassword.trim())
-  )
+  const missingRequired = missingRequiredFor(draft, secretInputs)
+  const missingRequiredToEnable = missingRequiredFor({ ...draft, enabled: true }, secretInputs)
+  const missingDraftIdentity = !draft.app_id.trim()
 
-  const onSave = async () => {
+  const onSave = async (nextEnabled = draft.enabled) => {
+    const nextDraft = { ...draft, enabled: nextEnabled }
+    if (missingRequiredFor(nextDraft, secretInputs)) {
+      setErrorMsg(t("connections.connector.teams.errors.incomplete"))
+      return
+    }
     setErrorMsg(null)
     try {
-      const config = await buildConfigWithSecretRefs(draft, secretInputs, async (body) => {
+      const config = await buildConfigWithSecretRefs(nextDraft, secretInputs, async (body) => {
         const secret = await createSecretMut.mutateAsync({ body })
         return secret.id
       })
@@ -106,12 +126,14 @@ export function TeamsConnectorFields({
           return
         }
       }
-      setErrorMsg(err instanceof Error ? err.message : t("connections.connector.teams.errors.generic"))
+      setErrorMsg(
+        err instanceof Error ? err.message : t("connections.connector.teams.errors.generic"),
+      )
     }
   }
 
   const onReset = () => {
-    setDraft(current ?? EMPTY_CONFIG)
+    setDraft(current)
     setSecretInputs({ ...EMPTY_SECRET_INPUTS })
     setErrorMsg(null)
   }
@@ -123,10 +145,17 @@ export function TeamsConnectorFields({
       docHref={t("connections.connector.teams.docLink.href")}
       docLabel={t("connections.connector.teams.docLink.label")}
     >
-      <Field
-        label={t("connections.connector.teams.fields.enabled.label")}
-        hint={t("connections.connector.teams.fields.enabled.hint")}
-      >
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-line bg-surface-subtle px-3 py-2">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-fg">
+            {draft.enabled
+              ? t("connections.connector.status.enabled")
+              : t("connections.connector.status.disabled")}
+          </p>
+          <p className="mt-0.5 text-xs text-fg-subtle">
+            {t("connections.connector.teams.fields.enabled.hint")}
+          </p>
+        </div>
         <label className="inline-flex items-center gap-2 text-sm text-fg">
           <input
             type="checkbox"
@@ -137,55 +166,51 @@ export function TeamsConnectorFields({
           />
           {t("connections.connector.teams.fields.enabled.toggle")}
         </label>
+      </div>
+
+      <Field
+        label={t("connections.connector.teams.fields.appId.label")}
+        hint={t("connections.connector.teams.fields.appId.hint")}
+        required
+      >
+        <input
+          type="text"
+          value={draft.app_id}
+          placeholder="00000000-0000-0000-0000-000000000000"
+          onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
+          disabled={!canEdit || saving}
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          data-testid="teams-app-id-input"
+        />
       </Field>
 
-      {draft.enabled && (
-        <>
-          <Field
-            label={t("connections.connector.teams.fields.appId.label")}
-            hint={t("connections.connector.teams.fields.appId.hint")}
-            required
-          >
-            <input
-              type="text"
-              value={draft.app_id}
-              placeholder="00000000-0000-0000-0000-000000000000"
-              onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
-              disabled={!canEdit || saving}
-              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
-              data-testid="teams-app-id-input"
-            />
-          </Field>
+      <SecretInput
+        label={t("connections.connector.teams.fields.appPassword.label")}
+        hint={t("connections.connector.teams.fields.appPassword.hint")}
+        savedHint={t("connections.connector.teams.fields.appPassword.savedHint")}
+        savedBadge={t("connections.connector.savedBadge")}
+        value={secretInputs.appPassword}
+        onChange={(v) => setSecretInputs((prev) => ({ ...prev, appPassword: v }))}
+        required={!draft.app_password_ref.trim()}
+        hasSavedValue={Boolean(draft.app_password_ref.trim())}
+        disabled={!canEdit || saving}
+        testId="teams-app-password-input"
+      />
 
-          <SecretInput
-            label={t("connections.connector.teams.fields.appPassword.label")}
-            hint={t("connections.connector.teams.fields.appPassword.hint")}
-            savedHint={t("connections.connector.teams.fields.appPassword.savedHint")}
-            savedBadge={t("connections.connector.savedBadge")}
-            value={secretInputs.appPassword}
-            onChange={(v) => setSecretInputs((prev) => ({ ...prev, appPassword: v }))}
-            required={!draft.app_password_ref.trim()}
-            hasSavedValue={Boolean(draft.app_password_ref.trim())}
-            disabled={!canEdit || saving}
-            testId="teams-app-password-input"
-          />
-
-          <Field
-            label={t("connections.connector.teams.fields.tenantId.label")}
-            hint={t("connections.connector.teams.fields.tenantId.hint")}
-          >
-            <input
-              type="text"
-              value={draft.tenant_id}
-              placeholder="common"
-              onChange={(e) => setDraft({ ...draft, tenant_id: e.target.value })}
-              disabled={!canEdit || saving}
-              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
-              data-testid="teams-tenant-id-input"
-            />
-          </Field>
-        </>
-      )}
+      <Field
+        label={t("connections.connector.teams.fields.tenantId.label")}
+        hint={t("connections.connector.teams.fields.tenantId.hint")}
+      >
+        <input
+          type="text"
+          value={draft.tenant_id}
+          placeholder="common"
+          onChange={(e) => setDraft({ ...draft, tenant_id: e.target.value })}
+          disabled={!canEdit || saving}
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          data-testid="teams-tenant-id-input"
+        />
+      </Field>
 
       {!canEdit && (
         <p className="mt-3 text-sm text-fg-faint">{t("connections.connector.adminOnly")}</p>
@@ -197,7 +222,7 @@ export function TeamsConnectorFields({
         </p>
       )}
 
-      <div className="mt-4 flex items-center justify-end gap-2">
+      <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
         {dirty && (
           <button
             type="button"
@@ -211,17 +236,49 @@ export function TeamsConnectorFields({
         )}
         <button
           type="button"
-          onClick={onSave}
-          disabled={!canEdit || saving || !dirty || Boolean(missingRequired)}
-          className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
+          onClick={() => void onSave()}
+          disabled={
+            !canEdit || saving || !dirty || missingDraftIdentity || Boolean(missingRequired)
+          }
+          className="inline-flex items-center gap-2 rounded-md border border-line px-3 py-1.5 text-sm font-medium text-fg-muted hover:bg-surface-subtle disabled:opacity-60"
           data-testid="teams-save-button"
         >
           {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-          {t("connections.connector.actions.save")}
+          {draft.enabled
+            ? t("connections.connector.actions.save")
+            : t("connections.connector.actions.saveDraft")}
         </button>
+        {!draft.enabled && (
+          <button
+            type="button"
+            onClick={() => void onSave(true)}
+            disabled={!canEdit || saving || Boolean(missingRequiredToEnable)}
+            className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
+            data-testid="teams-save-enable-button"
+          >
+            {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {t("connections.connector.actions.saveAndEnable")}
+          </button>
+        )}
       </div>
     </Card>
   )
+}
+
+function missingRequiredFor(draft: TeamsConnectorInput, secretInputs: SecretInputs): boolean {
+  return (
+    draft.enabled &&
+    (!draft.app_id.trim() || (!draft.app_password_ref.trim() && !secretInputs.appPassword.trim()))
+  )
+}
+
+function configKey(config: TeamsConnectorInput): string {
+  return [
+    config.enabled ? "1" : "0",
+    config.app_id,
+    config.app_password_ref,
+    config.tenant_id,
+  ].join("\u0000")
 }
 
 function applyChange(
@@ -248,7 +305,6 @@ async function buildConfigWithSecretRefs(
   createSecret: (body: CreateSecretRequest) => Promise<string>,
 ): Promise<TeamsConnectorInput> {
   const next = trimConfig(draft)
-  if (!next.enabled) return next
 
   for (const field of Object.keys(TEAMS_SECRET_FIELDS) as TeamsSecretField[]) {
     const plaintext = inputs[field].trim()

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -2627,7 +2627,24 @@
       "savedBadge": "Saved",
       "actions": {
         "save": "Save",
+        "saveDraft": "Save draft",
+        "saveAndEnable": "Save and enable",
         "reset": "Reset"
+      },
+      "status": {
+        "enabled": "Enabled",
+        "disabled": "Disabled"
+      },
+      "platformList": {
+        "title": "Messaging platforms",
+        "description": "Pick a platform, fill its credentials, then enable it when the config is complete.",
+        "noAppId": "No App ID",
+        "status": {
+          "enabled": "Enabled",
+          "configured": "Configured",
+          "incomplete": "Incomplete",
+          "notConfigured": "Not configured"
+        }
       },
       "platformSelect": {
         "label": "Platform",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -2627,7 +2627,24 @@
       "savedBadge": "已保存",
       "actions": {
         "save": "保存",
+        "saveDraft": "保存草稿",
+        "saveAndEnable": "保存并启用",
         "reset": "重置"
+      },
+      "status": {
+        "enabled": "已启用",
+        "disabled": "已停用"
+      },
+      "platformList": {
+        "title": "消息平台",
+        "description": "选择平台后直接填写凭据，配置完整后再启用。",
+        "noAppId": "未填写 App ID",
+        "status": {
+          "enabled": "已启用",
+          "configured": "已配置",
+          "incomplete": "未完整",
+          "notConfigured": "未配置"
+        }
       },
       "platformSelect": {
         "label": "平台",


### PR DESCRIPTION
## Summary
- replace the Connections platform dropdown with a status list for Feishu, Slack, Discord, and Teams
- keep connector fields visible before enabling so admins can fill credentials first
- split disabled connector actions into Save draft and Save and enable, preserving secret refs for drafts
- add English and Chinese UI copy for the new status/list actions

## Verification
- pnpm typecheck
- eslint on changed connector files
- prettier --check on changed files
- git diff --check
- docker build -t parsar:local .
- PARSAR_SERVER_IMAGE=parsar:local docker compose -f docker-compose.local.yml up -d --force-recreate
- http://127.0.0.1:18080/healthz -> {"status":"ok","name":"parsar"}

## Notes
- make check Go tests passed, but the migration smoke step failed locally when the temporary Postgres host port returned connection refused immediately after compose startup.