### PR TITLE
enforce typography discipline across admin UI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,58 @@ Three concrete rules:
 When a dialog uses a multi-column grid, give every column `min-w-0` —
 otherwise long children push the grid track wider instead of wrapping.
 
+## Typography contract
+
+The type scale has 7 defined steps. Arbitrary pixel sizes (`text-[Npx]`) are
+banned by ESLint and will fail `make check`.
+
+| Utility     | Size   | Usage                                    |
+|-------------|--------|------------------------------------------|
+| `text-xs`   | 12 px  | Badges, micro-meta, table footnotes      |
+| `text-sm`   | 13 px  | Default body in dense admin UI           |
+| `text-base` | 14 px  | Form labels, buttons, inputs             |
+| `text-lg`   | 16 px  | Card titles, dialog headings             |
+| `text-xl`   | 20 px  | Section headings, sub-page titles        |
+| `text-2xl`  | 22 px  | Secondary page headings, feature names   |
+| `text-3xl`  | 28 px  | Page titles (display, with font-display) |
+
+### Heading hierarchy
+
+- **h1** — Page title only. `font-display text-3xl font-semibold leading-tight
+  tracking-tight text-fg`. Rendered in Space Grotesk. One per page, always
+  inside `<PageHeader>`.
+- **h2** — Section heading. `text-xl font-semibold text-fg`. Groups related
+  cards or panels. Dialog titles use `text-lg font-semibold leading-none text-fg`.
+- **h3** — Card/subsection title. `text-base font-semibold text-fg`.
+- **h4** — Field group label. `text-sm font-medium text-fg`.
+
+Do not use `font-display` on anything other than h1.
+
+### Uppercase rule
+
+`uppercase` is allowed ONLY on:
+
+- Table column headers (`<th>`) — via the shared `TableHead` component.
+- Standalone definition-term labels (`<dt>`) that label a single key-value pair.
+- Single-word dividers (e.g. "OR" between auth methods).
+
+`uppercase` is BANNED on:
+
+- Any heading element (h1–h4).
+- Form field labels.
+- Section group labels.
+- Navigation items.
+
+If in doubt, do not uppercase. The monochrome palette + font-weight alone
+provides sufficient hierarchy without case transformation.
+
+### Raw palette ban
+
+Never use Tailwind's built-in color palette directly (e.g. `text-slate-500`,
+`bg-red-50`). All colors must go through semantic tokens defined in
+`src/style.css` `@theme` block (`text-fg`, `text-fg-muted`, `bg-surface`,
+`border-line`, `text-danger`, etc.). ESLint enforces this.
+
 ## Code comments
 
 Write no comments by default. Leave a single line in the source only when

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -43,14 +43,14 @@ export default tseslint.config(
           selector:
             "Literal[value=/(?:^|\\s)text-\\[\\d+px\\](?:\\s|$)/]",
           message:
-            "Arbitrary font sizes are banned. Use one of: text-xs, text-sm, text-base, text-lg, text-2xl.",
+            "Arbitrary font sizes are banned. Use one of: text-xs, text-sm, text-base, text-lg, text-xl, text-2xl, text-3xl.",
         },
         {
           // Same, inside template literals.
           selector:
             "TemplateElement[value.cooked=/(?:^|\\s)text-\\[\\d+px\\](?:\\s|$)/]",
           message:
-            "Arbitrary font sizes are banned. Use one of: text-xs, text-sm, text-base, text-lg, text-2xl.",
+            "Arbitrary font sizes are banned. Use one of: text-xs, text-sm, text-base, text-lg, text-xl, text-2xl, text-3xl.",
         },
         {
           // Raw palette: text-slate-500, bg-red-50, border-emerald-200, …

--- a/apps/web/src/components/admin/DevicePicker.tsx
+++ b/apps/web/src/components/admin/DevicePicker.tsx
@@ -133,7 +133,7 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
         disabled={disabled}
         onChange={(e) => onChange(e.target.value)}
         data-testid="agent-daemon-device-picker"
-        className="h-9 min-w-0 flex-1 rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:cursor-not-allowed disabled:bg-surface-subtle"
+        className="h-9 min-w-0 flex-1 rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:cursor-not-allowed disabled:bg-surface-subtle"
       >
         <option value="">
           {t("agents.form.devicePicker.placeholder", {

--- a/apps/web/src/components/admin/FeishuConnectorPanel.tsx
+++ b/apps/web/src/components/admin/FeishuConnectorPanel.tsx
@@ -26,9 +26,9 @@ function Card({
   children: React.ReactNode
 }) {
   return (
-    <section className={`rounded-lg border border-line bg-surface p-4 ${className ?? ""}`}>
-      <header className="mb-3">
-        <h3 className="text-sm font-semibold uppercase tracking-wider text-fg-subtle">{title}</h3>
+    <section className={`rounded-lg border border-line bg-surface px-5 py-4 ${className ?? ""}`}>
+      <header className="mb-4">
+        <h3 className="text-lg font-semibold text-fg">{title}</h3>
         {description && <p className="mt-1 text-sm text-fg-subtle">{description}</p>}
       </header>
       {children}
@@ -49,12 +49,12 @@ function Field({
 }) {
   return (
     <div className="mb-3 last:mb-0">
-      <label className="mb-1 block text-xs uppercase tracking-wider text-fg-faint">
+      <label className="mb-1 block text-xs font-medium text-fg-faint">
         {label}
         {required && <span className="ml-1 text-danger">*</span>}
       </label>
       {children}
-      {hint && <p className="mt-1 text-xs text-fg-subtle">{hint}</p>}
+      {hint && <p className="mt-0.5 text-xs leading-tight text-fg-subtle">{hint}</p>}
     </div>
   )
 }
@@ -447,7 +447,7 @@ export function FeishuConnectorPanel({
               placeholder="cli_xxxxxxxxxxxxxxxx"
               onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
               disabled={!canEdit || saving}
-              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:bg-surface-subtle"
               data-testid="feishu-app-id-input"
             />
           </Field>
@@ -498,7 +498,7 @@ export function FeishuConnectorPanel({
               placeholder="ou_xxxxxxxxxxxxxxxx"
               onChange={(e) => setDraft({ ...draft, bot_open_id: e.target.value })}
               disabled={!canEdit || saving}
-              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+              className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:bg-surface-subtle"
               data-testid="feishu-bot-open-id-input"
             />
           </Field>
@@ -515,7 +515,7 @@ export function FeishuConnectorPanel({
         </p>
       )}
 
-      <div className="mt-4 flex items-center justify-end gap-2">
+      <div className="mt-5 flex items-center justify-end gap-2 border-t border-line/40 pt-4">
         {dirty && (
           <button
             type="button"
@@ -599,7 +599,7 @@ function FeishuDiagnosticsStrip({
       <div className="mt-3 grid grid-cols-1 gap-2 min-[520px]:grid-cols-3 sm:grid-cols-6">
         {counts.map(([key, value]) => (
           <div key={key} className="min-w-0 rounded-md bg-surface px-2 py-2 ring-1 ring-slate-200">
-            <p className="truncate text-xs uppercase tracking-wider text-fg-faint">
+            <p className="truncate text-xs font-medium text-fg-faint">
               {t(`agents.feishuConnector.diagnostics.stats.${key}`)}
             </p>
             <p className="mt-0.5 truncate font-mono text-sm font-semibold tabular-nums text-fg-emphasis">
@@ -665,7 +665,7 @@ function FeishuDiagnosticsBadge({ status }: { status: FeishuDiagnosticsStatus })
 function FeishuDiagnosticTime({ label, value }: { label: string; value: string }) {
   return (
     <div className="min-w-0">
-      <p className="text-xs uppercase tracking-wider text-fg-faint">{label}</p>
+      <p className="text-xs font-medium text-fg-faint">{label}</p>
       <p className="mt-0.5 truncate text-sm text-fg-muted" title={value}>
         {value}
       </p>
@@ -718,7 +718,7 @@ function SecretInput({
         onChange={(e) => onChange(e.target.value)}
         disabled={disabled}
         autoComplete="new-password"
-        className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+        className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:bg-surface-subtle"
         data-testid={testId}
       />
     </Field>

--- a/apps/web/src/components/admin/SandboxPanel.tsx
+++ b/apps/web/src/components/admin/SandboxPanel.tsx
@@ -21,7 +21,7 @@ import { useNow } from "../../lib/use-now"
 function Card({ title, className, children }: { title: string; className?: string; children: React.ReactNode }) {
   return (
     <section className={`rounded-lg border border-line bg-surface p-4 ${className ?? ""}`}>
-      <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-fg-subtle">{title}</h3>
+      <h3 className="mb-3 text-base font-semibold text-fg">{title}</h3>
       {children}
     </section>
   )

--- a/apps/web/src/components/admin/channel-connectors/ChannelConnectorPanel.tsx
+++ b/apps/web/src/components/admin/channel-connectors/ChannelConnectorPanel.tsx
@@ -75,7 +75,7 @@ export function ChannelConnectorPanel({
     >
       <section className="min-w-0">
         <div className="mb-3">
-          <h2 className="text-sm font-semibold uppercase tracking-wider text-fg-subtle">
+          <h2 className="text-base font-semibold text-fg">
             {t("connections.connector.platformList.title")}
           </h2>
           <p className="mt-1 text-sm text-fg-faint">

--- a/apps/web/src/components/admin/channel-connectors/PlatformSelector.tsx
+++ b/apps/web/src/components/admin/channel-connectors/PlatformSelector.tsx
@@ -28,7 +28,7 @@ export function PlatformSelector({
     <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-line bg-surface px-3 py-2">
       <label
         htmlFor={testId ?? "channel-connector-platform"}
-        className="text-xs uppercase tracking-wider text-fg-subtle"
+        className="text-xs font-medium text-fg-subtle"
       >
         {t("connections.connector.platformSelect.label")}
       </label>
@@ -37,7 +37,7 @@ export function PlatformSelector({
         value={value}
         onChange={(e) => onChange(e.target.value as ConnectorPlatform)}
         disabled={disabled}
-        className="h-8 rounded-md border border-line bg-surface px-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:cursor-not-allowed disabled:bg-surface-subtle"
+        className="h-8 rounded-md border border-line bg-surface px-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:cursor-not-allowed disabled:bg-surface-subtle"
         data-testid={testId ?? "channel-connector-platform-select"}
       >
         {options.map((opt) => (

--- a/apps/web/src/components/admin/channel-connectors/discordFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/discordFields.tsx
@@ -211,7 +211,7 @@ function DiscordConnectorFieldsInner({
           placeholder="1234567890"
           onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
           disabled={!canEdit || saving}
-          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:bg-surface-subtle"
           data-testid="discord-app-id-input"
         />
       </Field>
@@ -279,7 +279,7 @@ function DiscordConnectorFieldsInner({
         </p>
       )}
 
-      <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+      <div className="mt-5 flex flex-wrap items-center justify-end gap-2 border-t border-line/40 pt-4">
         {dirty && (
           <button
             type="button"

--- a/apps/web/src/components/admin/channel-connectors/feishuFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/feishuFields.tsx
@@ -206,7 +206,7 @@ function FeishuConnectorFieldsInner({
           placeholder="cli_xxxxxxxxxxxxxxxx"
           onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
           disabled={!canEdit || saving}
-          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:bg-surface-subtle"
           data-testid="feishu-app-id-input"
         />
       </Field>
@@ -260,7 +260,7 @@ function FeishuConnectorFieldsInner({
           placeholder={t("connections.connector.feishu.fields.botOpenId.placeholder")}
           onChange={(e) => setDraft({ ...draft, bot_open_id: e.target.value })}
           disabled={!canEdit || saving}
-          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:bg-surface-subtle"
           data-testid="feishu-bot-open-id-input"
         />
       </Field>
@@ -302,7 +302,7 @@ function FeishuConnectorFieldsInner({
         </p>
       )}
 
-      <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+      <div className="mt-5 flex flex-wrap items-center justify-end gap-2 border-t border-line/40 pt-4">
         {dirty && (
           <button
             type="button"

--- a/apps/web/src/components/admin/channel-connectors/shared.tsx
+++ b/apps/web/src/components/admin/channel-connectors/shared.tsx
@@ -24,9 +24,9 @@ export function Card({
   children: ReactNode
 }) {
   return (
-    <section className={`rounded-lg border border-line bg-surface p-4 ${className ?? ""}`}>
-      <header className="mb-3">
-        <h3 className="text-sm font-semibold uppercase tracking-wider text-fg-subtle">{title}</h3>
+    <section className={`rounded-lg border border-line bg-surface px-5 py-4 ${className ?? ""}`}>
+      <header className="mb-4">
+        <h3 className="text-lg font-semibold text-fg">{title}</h3>
         {description && <p className="mt-1 text-sm text-fg-subtle">{description}</p>}
         {docHref && docLabel && (
           <a
@@ -60,7 +60,7 @@ export function Field({
 }) {
   return (
     <div className="mb-3 last:mb-0">
-      <label className="mb-1 flex items-center gap-2 text-xs uppercase tracking-wider text-fg-faint">
+      <label className="mb-1 flex items-center gap-2 text-xs font-medium text-fg-faint">
         <span>
           {label}
           {required && <span className="ml-1 text-danger">*</span>}
@@ -68,7 +68,7 @@ export function Field({
         {badge}
       </label>
       {children}
-      {hint && <p className="mt-1 text-xs text-fg-subtle">{hint}</p>}
+      {hint && <p className="mt-0.5 text-xs leading-tight text-fg-subtle">{hint}</p>}
     </div>
   )
 }
@@ -104,7 +104,7 @@ export function SecretInput({
       badge={
         hasSavedValue ? (
           <span
-            className="inline-flex items-center gap-1 rounded-full bg-success-subtle px-1.5 py-0.5 text-[10px] font-medium normal-case tracking-normal text-success-emphasis"
+            className="inline-flex items-center gap-1 rounded-full bg-success-subtle px-1.5 py-0.5 text-xs font-medium normal-case tracking-normal text-success-emphasis"
             data-testid={`${testId}-saved-badge`}
           >
             <CheckCircle2 className="h-3 w-3" />
@@ -120,7 +120,7 @@ export function SecretInput({
         disabled={disabled}
         autoComplete="new-password"
         placeholder={hasSavedValue ? "••••••••" : undefined}
-        className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+        className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:bg-surface-subtle"
         data-testid={testId}
       />
     </Field>

--- a/apps/web/src/components/admin/channel-connectors/slackFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/slackFields.tsx
@@ -199,7 +199,7 @@ function SlackConnectorFieldsInner({
           placeholder="A0000000000000"
           onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
           disabled={!canEdit || saving}
-          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:bg-surface-subtle"
           data-testid="slack-app-id-input"
         />
       </Field>
@@ -282,7 +282,7 @@ function SlackConnectorFieldsInner({
         </p>
       )}
 
-      <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+      <div className="mt-5 flex flex-wrap items-center justify-end gap-2 border-t border-line/40 pt-4">
         {dirty && (
           <button
             type="button"

--- a/apps/web/src/components/admin/channel-connectors/teamsFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/teamsFields.tsx
@@ -179,7 +179,7 @@ function TeamsConnectorFieldsInner({
           placeholder="00000000-0000-0000-0000-000000000000"
           onChange={(e) => setDraft({ ...draft, app_id: e.target.value })}
           disabled={!canEdit || saving}
-          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:bg-surface-subtle"
           data-testid="teams-app-id-input"
         />
       </Field>
@@ -207,7 +207,7 @@ function TeamsConnectorFieldsInner({
           placeholder="common"
           onChange={(e) => setDraft({ ...draft, tenant_id: e.target.value })}
           disabled={!canEdit || saving}
-          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle"
+          className="h-9 w-full rounded-md border border-line bg-surface px-3 font-mono text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:bg-surface-subtle"
           data-testid="teams-tenant-id-input"
         />
       </Field>
@@ -222,7 +222,7 @@ function TeamsConnectorFieldsInner({
         </p>
       )}
 
-      <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+      <div className="mt-5 flex flex-wrap items-center justify-end gap-2 border-t border-line/40 pt-4">
         {dirty && (
           <button
             type="button"

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -13,7 +13,7 @@ export function PageHeader({ title, description, action, backLink }: PageHeaderP
       {backLink && <div className="text-xs text-fg-subtle">{backLink}</div>}
       <div className="flex items-start justify-between gap-4">
         <div className="space-y-1.5">
-          <h1 className="font-display text-[30px] font-semibold leading-[1.1] tracking-tight text-fg">{title}</h1>
+          <h1 className="font-display text-3xl font-semibold leading-tight tracking-tight text-fg">{title}</h1>
           {description && (
             <div className="max-w-2xl text-sm leading-relaxed text-fg-subtle">{description}</div>
           )}

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -123,7 +123,7 @@ export function WorkspaceSwitcher() {
             sideOffset={6}
             className="z-50 min-w-[300px] overflow-hidden rounded-md border border-line bg-surface p-1 text-sm text-fg-muted shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
           >
-            <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium uppercase tracking-wider text-fg-subtle">
+            <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium text-fg-subtle">
               <Layers className="h-3 w-3" strokeWidth={1.75} />
               {t("workspaceSwitcher.workspaceLabel")}
             </DropdownMenu.Label>
@@ -159,7 +159,7 @@ export function WorkspaceSwitcher() {
                         {ws.slug}
                       </span>
                     </div>
-                    <span className="text-xs uppercase tracking-wider text-fg-faint">
+                    <span className="text-xs font-medium text-fg-faint">
                       {ws.role}
                     </span>
                     {isActive && (
@@ -195,7 +195,7 @@ export function WorkspaceSwitcher() {
             {discoverable.length > 0 && (
               <>
                 <DropdownMenu.Separator className="my-1 h-px bg-surface-muted" />
-                <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium uppercase tracking-wider text-fg-subtle">
+                <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium text-fg-subtle">
                   <Globe className="h-3 w-3" strokeWidth={1.75} />
                   {t("workspaceSwitcher.discoverLabel")}
                 </DropdownMenu.Label>

--- a/apps/web/src/components/runtime/ConnectivityResultPanel.tsx
+++ b/apps/web/src/components/runtime/ConnectivityResultPanel.tsx
@@ -61,7 +61,7 @@ export function ConnectivityResultPanel({
         <button
           type="button"
           onClick={() => setExpanded((prev) => !prev)}
-          className={`flex min-w-0 flex-1 items-center gap-1 text-left text-sm font-medium ${styles.title} focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300`}
+          className={`flex min-w-0 flex-1 items-center gap-1 text-left text-sm font-medium ${styles.title} focus:outline-none focus-visible:ring-2 focus-visible:ring-line-strong`}
           aria-expanded={expanded}
           data-testid="connectivity-result-toggle"
         >
@@ -75,7 +75,7 @@ export function ConnectivityResultPanel({
         <button
           type="button"
           onClick={onDismiss}
-          className={`flex items-center gap-1 rounded-md px-1.5 py-0.5 text-sm font-normal ${styles.dismiss} focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300`}
+          className={`flex items-center gap-1 rounded-md px-1.5 py-0.5 text-sm font-normal ${styles.dismiss} focus:outline-none focus-visible:ring-2 focus-visible:ring-line-strong`}
           data-testid="connectivity-result-dismiss"
         >
           <X className="h-3 w-3" />

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -24,7 +24,7 @@ export function EmptyState({ icon: Icon, title, description, action, className }
         </div>
       )}
       <div className="space-y-1.5">
-        <p className="text-[15px] font-medium text-fg">{title}</p>
+        <p className="text-base font-medium text-fg">{title}</p>
         {description && (
           <p className="text-sm text-fg-subtle max-w-sm">{description}</p>
         )}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ export const Input = React.forwardRef<
     <input
       type={type}
       className={cn(
-        "flex h-9 w-full rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm transition-colors placeholder:text-fg-faint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-9 w-full rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm transition-colors placeholder:text-fg-faint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       ref={ref}

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -41,7 +41,7 @@ export const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-4 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300",
+      "mt-4 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong",
       className
     )}
     {...props}

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -77,12 +77,12 @@ function SignInView() {
       <section className="relative w-full max-w-[460px] rounded-2xl border border-line/80 bg-surface p-9 shadow-[0_1px_2px_rgb(0_0_0/0.04),0_20px_48px_-16px_rgb(0_0_0/0.16)]">
         <div className="mb-8 flex flex-col items-center text-center">
           <img src="/parsar-banner.png" alt="Parsar" className="h-auto w-[320px] max-w-full" />
-          <p className="mt-4 text-[14px] leading-relaxed text-fg-subtle">{t("login.subtitle")}</p>
+          <p className="mt-4 text-base leading-relaxed text-fg-subtle">{t("login.subtitle")}</p>
         </div>
 
         <form className="flex flex-col gap-4" onSubmit={onSubmit} noValidate>
           <label className="flex flex-col gap-1.5">
-            <span className="text-[13px] font-medium text-fg-muted">{t("login.emailLabel")}</span>
+            <span className="text-sm font-medium text-fg-muted">{t("login.emailLabel")}</span>
             <input
               type="email"
               value={email}
@@ -90,11 +90,11 @@ function SignInView() {
               placeholder={t("login.emailPlaceholder")}
               autoComplete="email"
               required
-              className="h-10 rounded-md border border-line bg-surface px-3 text-[14px] text-fg placeholder:text-fg-faint focus:border-fg/40 focus:outline-none focus:ring-1 focus:ring-fg/20"
+              className="h-10 rounded-md border border-line bg-surface px-3 text-base text-fg placeholder:text-fg-faint focus:border-fg/40 focus:outline-none focus:ring-1 focus:ring-fg/20"
             />
           </label>
           <label className="flex flex-col gap-1.5">
-            <span className="text-[13px] font-medium text-fg-muted">{t("login.passwordLabel")}</span>
+            <span className="text-sm font-medium text-fg-muted">{t("login.passwordLabel")}</span>
             <input
               type="password"
               value={password}
@@ -102,14 +102,14 @@ function SignInView() {
               placeholder={t("login.passwordPlaceholder")}
               autoComplete="current-password"
               required
-              className="h-10 rounded-md border border-line bg-surface px-3 text-[14px] text-fg placeholder:text-fg-faint focus:border-fg/40 focus:outline-none focus:ring-1 focus:ring-fg/20"
+              className="h-10 rounded-md border border-line bg-surface px-3 text-base text-fg placeholder:text-fg-faint focus:border-fg/40 focus:outline-none focus:ring-1 focus:ring-fg/20"
             />
           </label>
 
           {errorMsg && (
             <div
               role="alert"
-              className="rounded-md border border-danger/40 bg-danger/8 px-3 py-2 text-[13px] text-danger"
+              className="rounded-md border border-danger/40 bg-danger/8 px-3 py-2 text-sm text-danger"
             >
               {errorMsg}
             </div>
@@ -118,13 +118,13 @@ function SignInView() {
           <button
             type="submit"
             disabled={invalid || submitting}
-            className="mt-1 flex h-11 w-full items-center justify-center rounded-full bg-surface-emphasis px-5 text-[15px] font-medium text-white shadow-sm transition-all hover:bg-surface-inverse hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/20 focus-visible:ring-offset-2 focus-visible:ring-offset-surface active:translate-y-px disabled:cursor-not-allowed disabled:opacity-60"
+            className="mt-1 flex h-11 w-full items-center justify-center rounded-full bg-surface-emphasis px-5 text-lg font-medium text-white shadow-sm transition-all hover:bg-surface-inverse hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/20 focus-visible:ring-offset-2 focus-visible:ring-offset-surface active:translate-y-px disabled:cursor-not-allowed disabled:opacity-60"
           >
             {submitting ? t("login.submitting") : t("login.submitButton")}
           </button>
         </form>
 
-        <div className="my-6 flex items-center gap-3 text-[12px] uppercase tracking-wide text-fg-faint">
+        <div className="my-6 flex items-center gap-3 text-xs uppercase tracking-wide text-fg-faint">
           <span className="h-px flex-1 bg-line" />
           <span>{t("login.orDivider")}</span>
           <span className="h-px flex-1 bg-line" />
@@ -132,12 +132,12 @@ function SignInView() {
 
         <a
           href={feishuLoginUrl()}
-          className="mx-auto flex h-11 w-full items-center justify-center rounded-full border border-line bg-surface px-5 text-[14px] font-medium text-fg transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/20 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+          className="mx-auto flex h-11 w-full items-center justify-center rounded-full border border-line bg-surface px-5 text-base font-medium text-fg transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/20 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
         >
           {t("login.feishuButton")}
         </a>
 
-        <p className="mt-6 text-center text-[13px] leading-5 text-fg-faint">
+        <p className="mt-6 text-center text-sm leading-5 text-fg-faint">
           {t("login.noAccountHint")}
         </p>
       </section>

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -67,7 +67,7 @@ export function SetupPage() {
         <div className="mb-7 flex flex-col items-center text-center">
           <img src="/parsar-banner.png" alt="Parsar" className="h-auto w-[280px] max-w-full" />
           <h1 className="mt-4 text-lg font-semibold text-fg">{t("setup.title")}</h1>
-          <p className="mt-2 text-[14px] leading-relaxed text-fg-subtle">{t("setup.subtitle")}</p>
+          <p className="mt-2 text-base leading-relaxed text-fg-subtle">{t("setup.subtitle")}</p>
         </div>
 
         <form className="flex flex-col gap-4" onSubmit={onSubmit} noValidate>
@@ -110,7 +110,7 @@ export function SetupPage() {
           {errorMsg && (
             <div
               role="alert"
-              className="rounded-md border border-danger/40 bg-danger/8 px-3 py-2 text-[13px] text-danger"
+              className="rounded-md border border-danger/40 bg-danger/8 px-3 py-2 text-sm text-danger"
             >
               {errorMsg}
             </div>
@@ -119,7 +119,7 @@ export function SetupPage() {
           <button
             type="submit"
             disabled={invalid || submitting}
-            className="mt-1 flex h-11 w-full items-center justify-center rounded-full bg-surface-emphasis px-5 text-[15px] font-medium text-white shadow-sm transition-all hover:bg-surface-inverse hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/20 focus-visible:ring-offset-2 focus-visible:ring-offset-surface active:translate-y-px disabled:cursor-not-allowed disabled:opacity-60"
+            className="mt-1 flex h-11 w-full items-center justify-center rounded-full bg-surface-emphasis px-5 text-lg font-medium text-white shadow-sm transition-all hover:bg-surface-inverse hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/20 focus-visible:ring-offset-2 focus-visible:ring-offset-surface active:translate-y-px disabled:cursor-not-allowed disabled:opacity-60"
           >
             {submitting ? t("setup.submitting") : t("setup.submitButton")}
           </button>
@@ -152,7 +152,7 @@ function Field({
 }: FieldProps) {
   return (
     <label className="flex flex-col gap-1.5">
-      <span className="text-[13px] font-medium text-fg-muted">
+      <span className="text-sm font-medium text-fg-muted">
         {label}
         {required && <span className="ml-0.5 text-danger">*</span>}
       </span>
@@ -163,9 +163,9 @@ function Field({
         placeholder={placeholder}
         autoComplete={autoComplete}
         required={required}
-        className="h-10 rounded-md border border-line bg-surface px-3 text-[14px] text-fg placeholder:text-fg-faint focus:border-fg/40 focus:outline-none focus:ring-1 focus:ring-fg/20"
+        className="h-10 rounded-md border border-line bg-surface px-3 text-base text-fg placeholder:text-fg-faint focus:border-fg/40 focus:outline-none focus:ring-1 focus:ring-fg/20"
       />
-      {hint && <span className="text-[12px] leading-4 text-fg-faint">{hint}</span>}
+      {hint && <span className="text-xs leading-4 text-fg-faint">{hint}</span>}
     </label>
   )
 }

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -1104,7 +1104,7 @@ function VersionSelect({ versions, value, onChange }: { versions: CapabilityVers
     <select
       value={value}
       onChange={(event) => onChange(event.target.value)}
-      className="h-8 w-full rounded-md border border-line bg-surface px-2 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-slate-300"
+      className="h-8 w-full rounded-md border border-line bg-surface px-2 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-line-strong"
     >
       {versions.map((version, index) => (
         <option key={version.id} value={version.id}>v{version.version}{index === 0 ? ` · ${t("agents.detail.capabilities.switchDialog.latest")}` : ""}</option>
@@ -1363,7 +1363,7 @@ function RemoveCapabilityDialog({
 function Card({ title, className, children }: { title: string; className?: string; children: React.ReactNode }) {
   return (
     <section className={`rounded-lg border border-line bg-surface p-4 ${className ?? ""}`}>
-      <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-fg-subtle">{title}</h3>
+      <h3 className="mb-3 text-base font-semibold text-fg">{title}</h3>
       {children}
     </section>
   )
@@ -1372,7 +1372,7 @@ function Card({ title, className, children }: { title: string; className?: strin
 function Stat({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-lg border border-line bg-surface p-4">
-      <div className="text-xs uppercase tracking-wider text-fg-faint">{label}</div>
+      <div className="text-xs font-medium text-fg-faint">{label}</div>
       <div className="mt-1 text-2xl font-semibold tabular-nums text-fg">{value}</div>
     </div>
   )
@@ -1619,7 +1619,7 @@ function MetricsCard({ metrics, loading }: { metrics?: AgentMetrics; loading: bo
 function MetricStat({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md border border-line bg-surface-subtle/40 px-3 py-2">
-      <div className="text-xs uppercase tracking-wider text-fg-faint">{label}</div>
+      <div className="text-xs font-medium text-fg-faint">{label}</div>
       <div className="mt-0.5 text-2xl font-semibold tabular-nums text-fg">{value}</div>
     </div>
   )
@@ -1869,7 +1869,7 @@ function ConfigCapabilitiesSection({
   return (
     <section className="rounded-lg border border-line bg-surface p-4">
       <div className="mb-3 flex items-center justify-between">
-        <h3 className="text-sm font-semibold uppercase tracking-wider text-fg-subtle">
+        <h3 className="text-base font-semibold text-fg">
           {t("agents.detail.config.capabilities.title")}
         </h3>
         {isAdmin && installable.length > 0 && (

--- a/apps/web/src/pages/admin/ConnectorsPage.tsx
+++ b/apps/web/src/pages/admin/ConnectorsPage.tsx
@@ -229,7 +229,7 @@ export function ConnectorDetailPage({ id }: { id: string }) {
       </div>
 
       <section className="mt-6 rounded-lg border border-line bg-surface p-4">
-        <h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-fg-subtle">
+        <h3 className="mb-3 text-base font-semibold text-fg">
           {t("connectors.detail.agents")}
         </h3>
         {connector.agent_count === 0 ? (
@@ -254,7 +254,7 @@ export function ConnectorDetailPage({ id }: { id: string }) {
 function Stat({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
   return (
     <div className="rounded-lg border border-line bg-surface p-4">
-      <div className="text-xs uppercase tracking-wider text-fg-faint">{label}</div>
+      <div className="text-xs font-medium text-fg-faint">{label}</div>
       <div className={`mt-1 text-2xl font-semibold tabular-nums text-fg ${mono ? "font-mono" : ""}`}>{value}</div>
     </div>
   )

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -991,7 +991,7 @@ export function CreateAgentDialog({
                         value={sandboxSize}
                         onChange={(e) => setSandboxSize(e.target.value === "xl" ? "xl" : "standard")}
                         disabled={pending}
-                        className="h-9 rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:cursor-not-allowed disabled:bg-surface-subtle"
+                        className="h-9 rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:cursor-not-allowed disabled:bg-surface-subtle"
                       >
                         <option value="standard">{t("agents.form.sandboxSize.standard")}</option>
                         <option value="xl">{t("agents.form.sandboxSize.xl")}</option>
@@ -1382,7 +1382,7 @@ export function CreateAgentDialog({
 
               {aggregatedRequiredKinds.length > 0 && (
                 <section className="space-y-3">
-                  <h3 className="text-sm font-semibold uppercase tracking-wider text-fg-subtle">{t("agents.form.sections.credentials")}</h3>
+                  <h3 className="text-base font-semibold text-fg">{t("agents.form.sections.credentials")}</h3>
                   <CredentialCheckPanel
                     requiredKinds={aggregatedRequiredKinds}
                     workspaceID={workspaceID}
@@ -1623,7 +1623,7 @@ function CapabilityVersionPicker({
       // suffix) reminds the user that breaking changes can land
       // without warning. We don't disable "latest" outright — opting
       // into it is a deliberate user choice we surface explicitly.
-      className="ml-1 h-7 shrink-0 rounded-md border border-line bg-surface px-2 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-slate-300"
+      className="ml-1 h-7 shrink-0 rounded-md border border-line bg-surface px-2 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-line-strong"
       title={fromMarketplace ? t("agents.form.versionPicker.marketplaceHint") : t("agents.form.versionPicker.localHint")}
     >
       <option value="__latest__">

--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -570,7 +570,7 @@ export function CreateModelDialog({
                 id="model-auth-scheme"
                 value={authScheme}
                 onChange={(e) => setAuthScheme(e.target.value as "api-key" | "bearer")}
-                className="flex h-9 w-full rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+                className="flex h-9 w-full rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong"
               >
                 <option value="api-key">x-api-key</option>
                 <option value="bearer">Authorization: Bearer</option>
@@ -639,7 +639,7 @@ export function CreateModelDialog({
                       setExistingSecretID(e.target.value)
                       if (e.target.value !== "") setApiKey("")
                     }}
-                    className="flex h-9 w-full rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+                    className="flex h-9 w-full rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong"
                   >
                     <option value="">
                       {t("models.createModel.credentialMode.inlineSecret.reuseNone")}
@@ -913,7 +913,7 @@ export function EditModelDialog({
                   id="edit-model-secret"
                   value={secretID}
                   onChange={(e) => setSecretID(e.target.value)}
-                  className="flex h-9 w-full rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+                  className="flex h-9 w-full rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong"
                   disabled={newAPIKey.trim() !== ""}
                 >
                   <option value="">

--- a/apps/web/src/pages/admin/ModelKeyCombobox.tsx
+++ b/apps/web/src/pages/admin/ModelKeyCombobox.tsx
@@ -59,7 +59,7 @@ export function ModelKeyCombobox({ value, onChange, models, placeholder, id }: P
           id={id}
           type="button"
           className={cn(
-            "flex h-9 w-full items-center justify-between rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300",
+            "flex h-9 w-full items-center justify-between rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong",
             !value && "text-fg-faint",
           )}
         >
@@ -152,12 +152,12 @@ function ModelRow({
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-medium text-fg">{model.name}</span>
           {model.reasoning && (
-            <span className="rounded bg-surface-muted px-1.5 py-0.5 text-[10px] text-fg-muted">
+            <span className="rounded bg-surface-muted px-1.5 py-0.5 text-xs text-fg-muted">
               reasoning
             </span>
           )}
           {model.vision && (
-            <span className="rounded bg-surface-muted px-1.5 py-0.5 text-[10px] text-fg-muted">
+            <span className="rounded bg-surface-muted px-1.5 py-0.5 text-xs text-fg-muted">
               vision
             </span>
           )}

--- a/apps/web/src/pages/admin/ProviderTypeCombobox.tsx
+++ b/apps/web/src/pages/admin/ProviderTypeCombobox.tsx
@@ -60,7 +60,7 @@ export function ProviderTypeCombobox({ value, onChange, options, id }: Props) {
           id={id}
           type="button"
           className={cn(
-            "flex h-9 w-full items-center justify-between rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300",
+            "flex h-9 w-full items-center justify-between rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong",
             !selected && "text-fg-faint",
           )}
         >

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -954,7 +954,7 @@ function Card({ title, actions, className, children }: { title: string; actions?
   return (
     <section className={`rounded-lg border border-line bg-surface p-4 ${className ?? ""}`}>
       <div className="mb-3 flex items-center justify-between gap-3">
-        <h3 className="text-sm font-semibold uppercase tracking-wider text-fg-subtle">{title}</h3>
+        <h3 className="text-base font-semibold text-fg">{title}</h3>
         {actions}
       </div>
       {children}

--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -554,7 +554,7 @@ function CloudInstancesPanel({
                     }}
                     role="link"
                     aria-label={t("runtime.list.table.rowLabel", { agent: b.agent_id ?? b.sandbox_id })}
-                    className="cursor-pointer hover:bg-surface-subtle/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+                    className="cursor-pointer hover:bg-surface-subtle/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong"
                     data-testid={`runtime-row-${b.binding_id}`}
                   >
                     <TableCell onClick={(e) => e.stopPropagation()}>
@@ -818,7 +818,7 @@ function RuntimeTabButton({
       onClick={onClick}
       data-testid={testId}
       className={
-        "mb-[-1px] inline-flex min-h-10 items-center gap-2 border-b-2 px-3 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-300 " +
+        "mb-[-1px] inline-flex min-h-10 items-center gap-2 border-b-2 px-3 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-line-strong " +
         (active
           ? "border-line-strong text-fg"
           : "border-transparent text-fg-subtle hover:text-fg-emphasis")

--- a/apps/web/src/pages/admin/ScheduledTasksPage.tsx
+++ b/apps/web/src/pages/admin/ScheduledTasksPage.tsx
@@ -237,8 +237,8 @@ export function ScheduledTasksPage() {
       <div className="space-y-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div className="min-w-0">
-            <h2 className="text-[15px] font-semibold text-slate-900">{t("scheduledTasks.title")}</h2>
-            <p className="mt-0.5 text-[12px] text-slate-500">{t("scheduledTasks.subtitle")}</p>
+            <h2 className="text-base font-semibold text-fg">{t("scheduledTasks.title")}</h2>
+            <p className="mt-0.5 text-xs text-fg-faint">{t("scheduledTasks.subtitle")}</p>
           </div>
           <Button size="sm" onClick={openCreate} disabled={noAgents} data-testid="scheduled-new">
             <Plus className="mr-1 h-4 w-4" />
@@ -247,29 +247,29 @@ export function ScheduledTasksPage() {
         </div>
 
         {noAgents && (
-          <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-800 break-all">
+          <div className="rounded-md border border-warning-border bg-warning-subtle px-3 py-2 text-xs text-warning break-all">
             {t("scheduledTasks.noAgents")}
           </div>
         )}
 
         {notice && (
-          <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-800 break-all">
+          <div className="rounded-md border border-success-border bg-success-subtle px-3 py-2 text-xs text-success break-all">
             {notice}
           </div>
         )}
 
         {tasksQ.isLoading ? (
-          <p className="text-[13px] text-slate-500">…</p>
+          <p className="text-sm text-fg-faint">…</p>
         ) : tasksQ.error ? (
-          <p className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700 break-all">
+          <p className="rounded-md border border-danger-border bg-danger-subtle px-3 py-2 text-xs text-danger break-all">
             {t("scheduledTasks.loadError")}
           </p>
         ) : tasks.length === 0 ? (
-          <p className="rounded-md bg-slate-50 px-3 py-6 text-center text-[13px] text-slate-500">
+          <p className="rounded-md bg-surface-muted px-3 py-6 text-center text-sm text-fg-faint">
             {t("scheduledTasks.empty")}
           </p>
         ) : (
-          <div className="overflow-hidden rounded-md border border-slate-200">
+          <div className="overflow-hidden rounded-md border border-line">
             {tasks.map((task, i) => (
               <div
                 key={task.id}
@@ -277,20 +277,20 @@ export function ScheduledTasksPage() {
                 data-task-name={task.name}
                 className={
                   "flex flex-wrap items-center gap-3 px-3 py-2.5 " +
-                  (i > 0 ? "border-t border-slate-100 " : "")
+                  (i > 0 ? "border-t border-line-muted" : "")
                 }
               >
                 <div className="min-w-0 flex-1">
-                  <div className="truncate text-[13px] font-medium text-slate-900">{task.name}</div>
-                  <div className="mt-0.5 text-[12px] text-slate-500 break-all">
+                  <div className="truncate text-xs font-medium text-fg">{task.name}</div>
+                  <div className="mt-0.5 text-xs text-fg-faint break-all">
                     {t("scheduledTasks.desc.withTz", {
                       desc: describeCron(task.cron_expr, t, weekdays),
                       tz: task.timezone,
                     })}
                   </div>
                 </div>
-                <div className="flex w-32 shrink-0 items-center gap-1.5 text-[12px] text-slate-600" title={agentName.get(task.agent_id) ?? task.agent_id}>
-                  <Bot className="h-3.5 w-3.5 shrink-0 text-slate-400" strokeWidth={1.75} />
+                <div className="flex w-32 shrink-0 items-center gap-1.5 text-xs text-fg-subtle" title={agentName.get(task.agent_id) ?? task.agent_id}>
+                  <Bot className="h-3.5 w-3.5 shrink-0 text-fg-faint" strokeWidth={1.75} />
                   <span className="truncate">{agentName.get(task.agent_id) ?? task.agent_id}</span>
                 </div>
                 <div className="shrink-0">
@@ -298,10 +298,10 @@ export function ScheduledTasksPage() {
                     {t(`scheduledTasks.status.${task.last_status || "none"}` as never)}
                   </Badge>
                 </div>
-                <div className="w-32 shrink-0 text-[12px] text-slate-600">
+                <div className="w-32 shrink-0 text-xs text-fg-subtle">
                   {task.next_run_at ? fmtWhen(task.next_run_at) : t("scheduledTasks.never")}
                 </div>
-                <label className="flex shrink-0 cursor-pointer items-center gap-1.5 text-[12px] text-slate-600">
+                <label className="flex shrink-0 cursor-pointer items-center gap-1.5 text-xs text-fg-subtle">
                   <input
                     type="checkbox"
                     className="h-3.5 w-3.5"
@@ -397,7 +397,7 @@ function SchedPager({
   const onFirstPage = offset === 0
   const onLastPage = offset + limit >= total
   return (
-    <div className="flex items-center justify-between gap-3 px-1 text-[12px] text-slate-600">
+    <div className="flex items-center justify-between gap-3 px-1 text-xs text-fg-subtle">
       <span className="tabular-nums">
         {t("scheduledTasks.pagination.range", { from, to, total })}
       </span>
@@ -482,12 +482,12 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
 
         <div className="grid gap-3">
           <div className="grid min-w-0 gap-1.5">
-            <label className="text-[12px] font-medium text-slate-700">{t("scheduledTasks.dialog.name")}</label>
+            <label className="text-xs font-medium text-fg-muted">{t("scheduledTasks.dialog.name")}</label>
             <Input value={name} onChange={(e) => setName(e.target.value)} placeholder={t("scheduledTasks.dialog.namePlaceholder")} data-testid="scheduled-name" />
           </div>
 
           <div className="grid min-w-0 gap-1.5">
-            <label className="text-[12px] font-medium text-slate-700">{t("scheduledTasks.dialog.agent")}</label>
+            <label className="text-xs font-medium text-fg-muted">{t("scheduledTasks.dialog.agent")}</label>
             {task ? (
               <Input value={agentName.get(task.agent_id) ?? task.agent_id} disabled readOnly />
             ) : (
@@ -495,7 +495,7 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
                 value={agentID}
                 onChange={(e) => setAgentID(e.target.value)}
                 data-testid="scheduled-agent"
-                className="h-9 rounded-md border border-slate-200 bg-white px-3 text-[13px] shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
+                className="h-9 rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong"
               >
                 {agents.length === 0 && <option value="">—</option>}
                 {agents.map((a) => (
@@ -506,24 +506,24 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
           </div>
 
           <div className="grid min-w-0 gap-1.5">
-            <label className="text-[12px] font-medium text-slate-700">{t("scheduledTasks.dialog.prompt")}</label>
+            <label className="text-xs font-medium text-fg-muted">{t("scheduledTasks.dialog.prompt")}</label>
             <textarea
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
               placeholder={t("scheduledTasks.dialog.promptPlaceholder")}
               rows={4}
               data-testid="scheduled-prompt"
-              className="w-full resize-y rounded-md border border-slate-200 bg-white px-3 py-2 text-[13px] shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 whitespace-pre-wrap break-all"
+              className="w-full resize-y rounded-md border border-line bg-surface px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong whitespace-pre-wrap break-all"
             />
           </div>
 
           <div className="grid min-w-0 gap-1.5">
-            <label className="text-[12px] font-medium text-slate-700">{t("scheduledTasks.dialog.frequency")}</label>
+            <label className="text-xs font-medium text-fg-muted">{t("scheduledTasks.dialog.frequency")}</label>
             <select
               value={freq}
               onChange={(e) => setFreq(e.target.value as FreqType)}
               data-testid="scheduled-freq"
-              className="h-9 rounded-md border border-slate-200 bg-white px-3 text-[13px] shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
+              className="h-9 rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong"
             >
               <option value="daily">{t("scheduledTasks.freq.daily")}</option>
               <option value="weekday">{t("scheduledTasks.freq.weekday")}</option>
@@ -536,18 +536,18 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
 
           {freq !== "custom" && freq !== "hourly" && (
             <div className="grid min-w-0 gap-1.5">
-              <label className="text-[12px] font-medium text-slate-700">{t("scheduledTasks.dialog.time")}</label>
+              <label className="text-xs font-medium text-fg-muted">{t("scheduledTasks.dialog.time")}</label>
               <Input type="time" value={timeStr} onChange={(e) => setTimeStr(e.target.value)} />
             </div>
           )}
 
           {freq === "weekly" && (
             <div className="grid min-w-0 gap-1.5">
-              <label className="text-[12px] font-medium text-slate-700">{t("scheduledTasks.dialog.dayOfWeek")}</label>
+              <label className="text-xs font-medium text-fg-muted">{t("scheduledTasks.dialog.dayOfWeek")}</label>
               <select
                 value={dow}
                 onChange={(e) => setDow(Number(e.target.value))}
-                className="h-9 rounded-md border border-slate-200 bg-white px-3 text-[13px] shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
+                className="h-9 rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong"
               >
                 {weekdays.map((d, idx) => (
                   <option key={idx} value={idx}>{d}</option>
@@ -558,11 +558,11 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
 
           {freq === "monthly" && (
             <div className="grid min-w-0 gap-1.5">
-              <label className="text-[12px] font-medium text-slate-700">{t("scheduledTasks.dialog.dayOfMonth")}</label>
+              <label className="text-xs font-medium text-fg-muted">{t("scheduledTasks.dialog.dayOfMonth")}</label>
               <select
                 value={dom}
                 onChange={(e) => setDom(Number(e.target.value))}
-                className="h-9 rounded-md border border-slate-200 bg-white px-3 text-[13px] shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
+                className="h-9 rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong"
               >
                 {Array.from({ length: 28 }, (_, i) => i + 1).map((d) => (
                   <option key={d} value={d}>{d}</option>
@@ -573,7 +573,7 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
 
           {freq === "hourly" && (
             <div className="grid min-w-0 gap-1.5">
-              <label className="text-[12px] font-medium text-slate-700">{t("scheduledTasks.dialog.minute")}</label>
+              <label className="text-xs font-medium text-fg-muted">{t("scheduledTasks.dialog.minute")}</label>
               <Input
                 type="number"
                 min={0}
@@ -586,7 +586,7 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
 
           {freq === "custom" && (
             <div className="grid min-w-0 gap-1.5">
-              <label className="text-[12px] font-medium text-slate-700">{t("scheduledTasks.dialog.cronLabel")}</label>
+              <label className="text-xs font-medium text-fg-muted">{t("scheduledTasks.dialog.cronLabel")}</label>
               <Input
                 value={custom}
                 onChange={(e) => setCustom(e.target.value)}
@@ -600,12 +600,12 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
           )}
 
           <div className="grid min-w-0 gap-1.5">
-            <label className="text-[12px] font-medium text-slate-700">{t("scheduledTasks.dialog.timezone")}</label>
+            <label className="text-xs font-medium text-fg-muted">{t("scheduledTasks.dialog.timezone")}</label>
             <select
               value={tz}
               onChange={(e) => setTz(e.target.value)}
               data-testid="scheduled-tz"
-              className="h-9 rounded-md border border-slate-200 bg-white px-3 text-[13px] shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
+              className="h-9 rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong"
             >
               {tzOptions.map((z) => (
                 <option key={z} value={z}>{z}</option>
@@ -613,20 +613,20 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
             </select>
           </div>
 
-          <p className="rounded-md bg-slate-50 px-3 py-2 text-[12px] text-slate-600 whitespace-pre-wrap break-all">
+          <p className="rounded-md bg-surface-muted px-3 py-2 text-xs text-fg-subtle whitespace-pre-wrap break-all">
             {t("scheduledTasks.dialog.preview")}: {preview}
           </p>
 
           <div className="grid min-w-0 gap-0.5 opacity-60">
-            <label className="flex items-center gap-2 text-[12px] text-slate-600">
+            <label className="flex items-center gap-2 text-xs text-fg-subtle">
               <input type="checkbox" disabled className="h-3.5 w-3.5" />
               {t("scheduledTasks.dialog.feishu")}
             </label>
-            <span className="pl-5 text-[11px] text-slate-400">{t("scheduledTasks.dialog.feishuDisabledHint")}</span>
+            <span className="pl-5 text-xs text-fg-faint">{t("scheduledTasks.dialog.feishuDisabledHint")}</span>
           </div>
 
           {errMsg && (
-            <p className="rounded-md bg-red-50 px-3 py-2 text-[12px] text-red-700 break-all">{errMsg}</p>
+            <p className="rounded-md bg-danger-subtle px-3 py-2 text-xs text-danger break-all">{errMsg}</p>
           )}
         </div>
 

--- a/apps/web/src/pages/admin/UsagePage.tsx
+++ b/apps/web/src/pages/admin/UsagePage.tsx
@@ -246,7 +246,7 @@ export function UsagePage() {
 function Stat({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
   return (
     <div className="rounded-lg border border-line bg-surface p-4">
-      <div className="text-xs uppercase tracking-wider text-fg-faint">{label}</div>
+      <div className="text-xs font-medium text-fg-faint">{label}</div>
       <div className={`mt-1 text-2xl font-semibold tabular-nums text-fg ${mono ? "font-mono" : ""}`}>{value}</div>
     </div>
   )

--- a/apps/web/src/pages/admin/capabilities/ImportMCPForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportMCPForm.tsx
@@ -156,7 +156,7 @@ export function ImportMCPForm({
                   `{\n  "mcpServers": {\n    "github": {\n      "command": "docker",\n      "args": ["run", "-i", "ghcr.io/github/github-mcp-server"],\n      "env": {\n        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_xxx"\n      }\n    }\n  }\n}`,
                 )
           }
-          className="w-full rounded-md border border-line bg-surface px-3 py-2 font-mono text-xs leading-relaxed shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
+          className="w-full rounded-md border border-line bg-surface px-3 py-2 font-mono text-xs leading-relaxed shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong"
           spellCheck={false}
           autoCorrect="off"
           autoCapitalize="off"

--- a/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
@@ -276,7 +276,7 @@ export function ImportSkillForm({
                   "capabilities.import.skill.placeholder",
                   `---\nname: code-reviewer\ndescription: Review a diff and call out risky changes\n---\n\nYou are a careful code reviewer. When the user pastes a diff, walk through:\n\n1. Correctness — does the change do what it claims?\n2. Risk — what could break in production?\n3. Style — does it match the surrounding conventions?\n\nKeep responses concise.`,
                 )}
-                className="w-full rounded-md border border-line bg-surface px-3 py-2 font-mono text-xs leading-relaxed shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300"
+                className="w-full rounded-md border border-line bg-surface px-3 py-2 font-mono text-xs leading-relaxed shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong"
                 spellCheck={false}
                 autoCorrect="off"
                 autoCapitalize="off"

--- a/apps/web/src/pages/admin/capabilities/ImportSystemPromptForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportSystemPromptForm.tsx
@@ -67,7 +67,7 @@ export function ImportSystemPromptForm({ value, onChange }: Props) {
 
       <Field label={t("capabilities.import.systemPrompt.promptLabel", "Prompt content")} required>
         <textarea
-          className="min-h-[260px] w-full rounded-md border border-line bg-surface p-3 font-mono text-sm leading-relaxed text-fg-emphasis focus:outline-none focus:ring-2 focus:ring-slate-300"
+          className="min-h-[260px] w-full rounded-md border border-line bg-surface p-3 font-mono text-sm leading-relaxed text-fg-emphasis focus:outline-none focus:ring-2 focus:ring-line-strong"
           value={value.prompt}
           onChange={(e) => set({ prompt: e.target.value })}
           placeholder={t(

--- a/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityDetail.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityDetail.tsx
@@ -112,7 +112,7 @@ export function MarketplaceCapabilityDetail({ id }: { id: string }) {
 }
 
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
-  return <section className="rounded-lg border border-line bg-surface p-4"><h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-fg-subtle">{title}</h3>{children}</section>
+  return <section className="rounded-lg border border-line bg-surface p-4"><h3 className="mb-3 text-base font-semibold text-fg">{title}</h3>{children}</section>
 }
 
 function Detail({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -1363,7 +1363,7 @@ function DetailField({ label, value, mono }: { label: string; value: React.React
 }
 
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
-  return <section className="rounded-lg border border-line bg-surface p-4"><h3 className="mb-3 text-sm font-semibold uppercase tracking-wider text-fg-subtle">{title}</h3>{children}</section>
+  return <section className="rounded-lg border border-line bg-surface p-4"><h3 className="mb-3 text-base font-semibold text-fg">{title}</h3>{children}</section>
 }
 
 function ErrorBanner({ message }: { message: string }) {

--- a/apps/web/src/pages/admin/credentials/CredentialDialogs.tsx
+++ b/apps/web/src/pages/admin/credentials/CredentialDialogs.tsx
@@ -117,7 +117,7 @@ export function CredentialDialog({
                 value={kind}
                 onChange={(event) => setKind(event.target.value)}
                 disabled={kindLocked}
-                className="h-9 w-full rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-300 disabled:bg-surface-subtle disabled:text-fg-subtle"
+                className="h-9 w-full rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:bg-surface-subtle disabled:text-fg-subtle"
               >
                 {/* A locked kind may not be in the live options list
                     (legacy data, admin-added kind, in-flight prefill);

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -8,22 +8,26 @@
   --animate-fade-out: fade-out 2s ease-out forwards;
 
   /* ------------------------------------------------------------
-   * Type scale — 5 ticks, deliberately spartan. Every value below
-   * maps to a Tailwind utility (`text-xs`, …, `text-2xl`).
-   * Arbitrary sizes (`text-[13px]`) are forbidden by lint.
+   * Type scale — 7 ticks. Every value maps to a Tailwind utility
+   * (`text-xs` … `text-3xl`). Arbitrary sizes (`text-[13px]`)
+   * are forbidden by ESLint and will fail `make check`.
    * ---------------------------------------------------------- */
-  --text-xs:   0.75rem;    /* 12px — meta, table footnotes, badges */
-  --text-sm:   0.8125rem;  /* 13px — default body in a dense admin UI */
-  --text-base: 0.875rem;   /* 14px — form labels, buttons */
-  --text-lg:   1rem;       /* 16px — card / section titles */
-  --text-2xl:  1.375rem;   /* 22px — page titles (used sparingly) */
+  --text-xs:   0.75rem;    /* 12px — badges, micro-meta, table footnotes */
+  --text-sm:   0.8125rem;  /* 13px — default body in dense admin UI */
+  --text-base: 0.875rem;   /* 14px — form labels, buttons, inputs */
+  --text-lg:   1rem;       /* 16px — card titles, dialog headings */
+  --text-xl:   1.25rem;    /* 20px — section headings */
+  --text-2xl:  1.375rem;   /* 22px — secondary page headings */
+  --text-3xl:  1.75rem;    /* 28px — page titles (display) */
 
   /* Line heights pinned per step so we don't fight `leading-*`. */
   --text-xs--line-height:   1rem;
   --text-sm--line-height:   1.125rem;
   --text-base--line-height: 1.25rem;
   --text-lg--line-height:   1.5rem;
+  --text-xl--line-height:   1.75rem;
   --text-2xl--line-height:  1.875rem;
+  --text-3xl--line-height:  2.25rem;
 
   /* ------------------------------------------------------------
    * Semantic colors. Every color used in TSX MUST go through one
@@ -152,18 +156,14 @@ samp,
   box-sizing: border-box;
 }
 
-/* Base rem raised from the browser default 16px to 17px. The UI leaned
-   heavily on text-sm(14)/text-xs(12) which read cramped; raising the root
-   scales every rem-based size up ~6% (text-sm→14.9, text-base→17) so body
-   text breathes without editing 100+ callsites. */
 html {
-  font-size: 17px;
+  font-size: 16px;
 }
 
 body {
   margin: 0;
   min-width: 960px;
-  line-height: 1.6;
+  line-height: 1.5;
 }
 
 button,

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -36,6 +36,12 @@ fi
 
 pnpm typecheck
 
+if (cd apps/web && npx eslint src/ 2>&1) | grep -q "no-restricted-syntax"; then
+  echo "Design-system lint violations (arbitrary font sizes or raw palette):" >&2
+  (cd apps/web && npx eslint src/ 2>&1) | grep "no-restricted-syntax" >&2
+  exit 1
+fi
+
 for polluted in .parsar logs state cache config; do
   if [[ -e "$polluted" ]]; then
     echo "CWD pollution detected: $polluted" >&2


### PR DESCRIPTION
## Summary

- Expand type scale from 5→7 ticks (add `text-xl` 20px, `text-3xl` 28px) to cover all real needs
- Revert root font-size from 17px hack to standard 16px — rem math is predictable again
- Fix all 109 ESLint design-system violations (54 arbitrary font sizes + 55 raw palette colors)
- Remove `uppercase` from all headings and form labels (keep only on `<th>`/`<dt>`)
- Establish canonical heading hierarchy (h1→h3→h3→h4) documented in CONTRIBUTING.md
- Improve card/field density: wider card padding, tighter hint-to-input gap, border-t action bars
- Replace `ring-slate-300` → `ring-line-strong` globally (19 files)
- Add design-system lint guard to `scripts/check.sh` so violations fail `make check`

## Test plan

- [ ] `cd apps/web && pnpm typecheck` passes
- [ ] `cd apps/web && npx eslint src/` reports 0 `no-restricted-syntax` violations
- [ ] `make check` passes (once Docker/Postgres available)
- [ ] Visual: http://127.0.0.1:18080/?admin=connections shows clear heading hierarchy (28px title → 16px card title → 12px labels) with proper field density

🤖 Generated with [Claude Code](https://claude.com/claude-code)