### PR TITLE
chore: speed up CI checks

### DIFF
--- a/.github/workflows/parsar-server-release.yml
+++ b/.github/workflows/parsar-server-release.yml
@@ -77,10 +77,21 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up QEMU
+        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      - name: Choose build platforms
+        id: platforms
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            echo "value=linux/amd64" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=linux/amd64,linux/arm64" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Compute lowercase GHCR image name
         id: image
@@ -112,7 +123,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ steps.platforms.outputs.value }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,8 @@ COPY packages/ui/package.json packages/ui/
 COPY packages/views/package.json packages/views/
 
 # Install only the deps the web app actually needs.
-RUN pnpm install --filter @parsar/web... --frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --store-dir /pnpm/store --filter @parsar/web... --frozen-lockfile
 
 # Source for the web app (and any workspace packages it imports).
 COPY apps/web ./apps/web
@@ -84,7 +85,8 @@ COPY go.mod go.sum go.work ./
 # go.work.sum may not exist on freshly-cloned checkouts; the trailing
 # glob makes the COPY tolerate that.
 COPY go.work.sum* ./
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY internal ./internal
 COPY server ./server
@@ -92,7 +94,9 @@ COPY server ./server
 # Build all three binaries in one RUN so the layer represents one
 # logical "compile" operation. -s -w strips debug info / symbol table;
 # combined they shave ~25% off binary size with no runtime cost.
-RUN cd server \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd server \
  && mkdir -p /out \
  && CGO_ENABLED=0 GOOS="$TARGETOS" GOARCH="$TARGETARCH" GOFLAGS=-trimpath go build -ldflags="-s -w" \
       -o /out/parsar-server    ./cmd/server \
@@ -111,7 +115,9 @@ COPY apps/parsar-daemon ./apps/parsar-daemon
 # minting server hand the host-appropriate binary to the one-line connect
 # command with no GitHub release (PARSAR_DAEMON_CONNECT_URL path). CGO
 # stays off so each cross-target links statically.
-RUN mkdir -p /out/daemon \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    mkdir -p /out/daemon \
  && for target in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64; do \
       os="${target%/*}"; arch="${target#*/}"; \
       CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" GOFLAGS=-trimpath \

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -28,40 +28,19 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/dev-env.sh"
 docker compose -f docker-compose.dev.yml down -v --remove-orphans >/dev/null 2>&1 || true
 docker compose -f docker-compose.dev.yml up -d postgres >/dev/null
 
-# Wait for Postgres to actually accept connections. pg_isready can return
-# 0 (accepting) only after the entrypoint finishes initdb and the
-# postmaster binds 5432 — on cold cache CI that takes 5–15s. We poll
-# up to 60s and treat any non-zero exit as "not yet". The previous
-# loop double-checked outside the loop, which raced the initdb window
-# (#12 follow-up: CI hit "Postgres did not become ready" 1.5s after
-# Started because the very first probe transient-failed and a second
-# probe was issued before postmaster was up).
-pg_ready=0
-for _ in $(seq 1 60); do
-  if docker compose -f docker-compose.dev.yml exec -T postgres pg_isready -U "$PARSAR_PG_USER" -d "$PARSAR_PG_DB" >/dev/null 2>&1; then
-    pg_ready=1
-    break
-  fi
-  sleep 1
-done
-
-if [[ "$pg_ready" -ne 1 ]]; then
-  echo "Postgres did not become ready within 60s" >&2
-  docker compose -f docker-compose.dev.yml logs --tail=80 postgres >&2 || true
-  exit 1
-fi
-
 PARSAR_CHECK_DATABASE_URL="${DATABASE_URL:-$(parsar_dev_database_url)}"
 export PARSAR_CHECK_DATABASE_URL
 export PARSAR_TEST_DATABASE_URL="$PARSAR_CHECK_DATABASE_URL"
 
-# `pg_isready` can flip green slightly before the server will accept a
-# first real client session on cold CI boots, so verify an actual SQL
-# round-trip before invoking migrations.
+# Wait for the same host-published endpoint that Go tests will use.
+# The Postgres image briefly starts an internal bootstrap server during
+# initdb, so a TCP SQL round-trip is the only readiness signal that
+# proves the final server and mapped port are usable.
 pg_connect_ready=0
-for _ in $(seq 1 30); do
+for _ in $(seq 1 60); do
   if docker compose -f docker-compose.dev.yml exec -T postgres \
-    psql -U "$PARSAR_PG_USER" -d "$PARSAR_PG_DB" -c 'select 1' >/dev/null 2>&1; then
+    env PGPASSWORD="$PARSAR_PG_PASSWORD" \
+    psql -h 127.0.0.1 -p 5432 -U "$PARSAR_PG_USER" -d "$PARSAR_PG_DB" -c 'select 1' >/dev/null 2>&1; then
     pg_connect_ready=1
     break
   fi
@@ -69,7 +48,7 @@ for _ in $(seq 1 30); do
 done
 
 if [[ "$pg_connect_ready" -ne 1 ]]; then
-  echo "Postgres accepted readiness probes but not SQL connections within 30s" >&2
+  echo "Postgres did not accept SQL connections within 60s" >&2
   docker compose -f docker-compose.dev.yml logs --tail=80 postgres >&2 || true
   exit 1
 fi

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -21,13 +21,6 @@ set -euo pipefail
 
 go test $(cd server && go list ./... | grep -Ev 'internal/(store|seed)$')
 
-# store + seed share the same Postgres test database; keep them serial
-# with -p 1. Cross-package serialisation inside store is already done
-# via pg_advisory_lock(8675309) in openTestDB, so limiting the outer
-# `go test` runner is only about not letting seed and store trample
-# each other's TRUNCATE.
-go test -p 1 ./server/internal/store ./server/internal/seed
-
 ./scripts/check-migrations.sh
 
 if [[ ! -d node_modules ]]; then


### PR DESCRIPTION
## Summary
- remove the redundant no-DB store/seed test pass from `make check` while keeping the Postgres-backed smoke test
- make the Postgres migration smoke readiness probe use one real SQL round-trip
- build only linux/amd64 for parsar-server image PR checks while keeping multi-arch builds for main/tag/manual runs
- add BuildKit cache mounts for pnpm and Go compilation inside the Dockerfile

## Verification
- `make check` passed locally; Docker was unavailable, so the existing script skipped the Postgres migration smoke test
- `bash -n scripts/check.sh scripts/check-migrations.sh`
- `actionlint` on `.github/workflows/parsar-server-release.yml`
- `git diff --check`

## CI timing context
Recent runs showed `check` around 4m19s and `parsar-server image` around 5m08s, with Docker image build and `make check` as the dominant costs.