### PR TITLE
Fix arm64 sandbox image build: TARGETARCH default shadows BuildKit auto-injection

### DIFF
--- a/infra/sandbox/Dockerfile
+++ b/infra/sandbox/Dockerfile
@@ -78,7 +78,15 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GOFLAGS=-trimpath \
 # Stage 2: runtime — the actual sandbox image.
 ###############################################################################
 FROM ${BASE_IMAGE}
-ARG TARGETARCH=amd64
+# Bare, no default: BuildKit auto-populates this per target platform for
+# every multi-platform build graph node. A hardcoded default here (we
+# used to have =amd64, reasoning "e2b is amd64-only anyway") SHADOWS
+# that auto-injection instead of just being a fallback — it silently
+# forced every platform, including arm64 build graph nodes, to resolve
+# TARGETARCH=amd64, downloading x86_64 CLI binaries onto an aarch64
+# rootfs (fails at exec time: "No such file or directory", the classic
+# symptom of a missing ELF interpreter for the wrong architecture).
+ARG TARGETARCH
 
 # --- Base tools ---
 # curl/ca-certificates for downloads, jq for JSON, git for repo ops,


### PR DESCRIPTION
## Summary
`sandbox-image-release.yml`'s `local` (parsar-sandbox) matrix leg failed on its first run after #87 merged:
```
/tmp/install-agents.sh: line 72: /usr/local/bin/claude: No such file or directory
```

Root cause: `infra/sandbox/Dockerfile`'s runtime stage had `ARG TARGETARCH=amd64`. BuildKit auto-populates `TARGETARCH` per target platform for every node in a multi-platform build graph, but giving it a hardcoded default on a re-declared `ARG` shadows that auto-injection instead of acting as a mere fallback — every platform, including the `arm64` build graph node, silently resolved `TARGETARCH=amd64`. `install-agents.sh` then downloaded the x86_64 Claude Code binary and tried to run it on an aarch64 rootfs; the kernel can't find the ELF interpreter for a wrong-architecture binary, which surfaces as `ENOENT` rather than the more obvious "exec format error".

Fix: bare `ARG TARGETARCH` (no default), matching the `go-builder` stage's existing correct pattern — the `e2b` matrix leg (amd64-only) is unaffected either way since BuildKit's auto value for an amd64 build is already `amd64`.

## Test plan
- [x] Isolated repro without a full slow QEMU-emulated build: built two throwaway one-line Dockerfiles differing only in the `ARG TARGETARCH` declaration, each targeting `--platform linux/arm64`. `ARG TARGETARCH=amd64` printed `"amd64"` (reproduces the bug in isolation); bare `ARG TARGETARCH` printed `"arm64"` (confirms the fix)
- [ ] CI: `sandbox images` workflow should now succeed on both matrix legs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)