### PR TITLE
Update MiniMax provider catalog ordering

### DIFF
--- a/apps/web/src/lib/model-presets.catalog.json
+++ b/apps/web/src/lib/model-presets.catalog.json
@@ -1,5 +1,88 @@
 [
   {
+    "key": "minimax-cn",
+    "name": "MiniMax CN",
+    "adapter": "@ai-sdk/anthropic",
+    "defaultBaseURL": "https://api.minimaxi.com/anthropic",
+    "docUrl": "https://platform.minimaxi.com/document/anthropic-compatible-api",
+    "customHeaders": false,
+    "authSchemeSelector": false,
+    "protocols": [
+      {
+        "id": "anthropic",
+        "adapter": "@ai-sdk/anthropic",
+        "baseURL": "https://api.minimaxi.com/anthropic"
+      },
+      {
+        "id": "openai",
+        "adapter": "@ai-sdk/openai-compatible",
+        "baseURL": "https://api.minimaxi.com/v1"
+      }
+    ],
+    "models": [
+      {
+        "id": "MiniMax-M3",
+        "name": "MiniMax-M3",
+        "context": null,
+        "costIn": null,
+        "costOut": null,
+        "tool": true,
+        "reasoning": true,
+        "vision": true
+      },
+      {
+        "id": "MiniMax-M2.7",
+        "name": "MiniMax-M2.7",
+        "context": null,
+        "costIn": null,
+        "costOut": null,
+        "tool": true,
+        "reasoning": true,
+        "vision": false
+      },
+      {
+        "id": "MiniMax-M2.7-highspeed",
+        "name": "MiniMax-M2.7-highspeed",
+        "context": null,
+        "costIn": null,
+        "costOut": null,
+        "tool": true,
+        "reasoning": true,
+        "vision": false
+      },
+      {
+        "id": "MiniMax-M2.5",
+        "name": "MiniMax-M2.5",
+        "context": null,
+        "costIn": null,
+        "costOut": null,
+        "tool": true,
+        "reasoning": true,
+        "vision": false
+      },
+      {
+        "id": "MiniMax-M2.1",
+        "name": "MiniMax-M2.1",
+        "context": null,
+        "costIn": null,
+        "costOut": null,
+        "tool": true,
+        "reasoning": true,
+        "vision": false
+      },
+      {
+        "id": "MiniMax-M2",
+        "name": "MiniMax-M2",
+        "context": null,
+        "costIn": null,
+        "costOut": null,
+        "tool": true,
+        "reasoning": true,
+        "vision": false
+      }
+    ]
+  },
+  {
     "key": "anthropic",
     "name": "Anthropic",
     "adapter": "@ai-sdk/anthropic",
@@ -340,91 +423,8 @@
     ]
   },
   {
-    "key": "minimax-cn",
-    "name": "MiniMax CN",
-    "adapter": "@ai-sdk/anthropic",
-    "defaultBaseURL": "https://api.minimaxi.com/anthropic",
-    "docUrl": "https://platform.minimaxi.com/document/anthropic-compatible-api",
-    "customHeaders": false,
-    "authSchemeSelector": false,
-    "protocols": [
-      {
-        "id": "anthropic",
-        "adapter": "@ai-sdk/anthropic",
-        "baseURL": "https://api.minimaxi.com/anthropic"
-      },
-      {
-        "id": "openai",
-        "adapter": "@ai-sdk/openai-compatible",
-        "baseURL": "https://api.minimaxi.com/v1"
-      }
-    ],
-    "models": [
-      {
-        "id": "MiniMax-M3",
-        "name": "MiniMax-M3",
-        "context": null,
-        "costIn": null,
-        "costOut": null,
-        "tool": true,
-        "reasoning": true,
-        "vision": true
-      },
-      {
-        "id": "MiniMax-M2.7",
-        "name": "MiniMax-M2.7",
-        "context": null,
-        "costIn": null,
-        "costOut": null,
-        "tool": true,
-        "reasoning": true,
-        "vision": false
-      },
-      {
-        "id": "MiniMax-M2.7-highspeed",
-        "name": "MiniMax-M2.7-highspeed",
-        "context": null,
-        "costIn": null,
-        "costOut": null,
-        "tool": true,
-        "reasoning": true,
-        "vision": false
-      },
-      {
-        "id": "MiniMax-M2.5",
-        "name": "MiniMax-M2.5",
-        "context": null,
-        "costIn": null,
-        "costOut": null,
-        "tool": true,
-        "reasoning": true,
-        "vision": false
-      },
-      {
-        "id": "MiniMax-M2.1",
-        "name": "MiniMax-M2.1",
-        "context": null,
-        "costIn": null,
-        "costOut": null,
-        "tool": true,
-        "reasoning": true,
-        "vision": false
-      },
-      {
-        "id": "MiniMax-M2",
-        "name": "MiniMax-M2",
-        "context": null,
-        "costIn": null,
-        "costOut": null,
-        "tool": true,
-        "reasoning": true,
-        "vision": false
-      }
-    ]
-  },
-  {
     "key": "minimax-en",
-    "name": "MiniMax EN",
+    "name": "MiniMax Global",
     "adapter": "@ai-sdk/anthropic",
     "defaultBaseURL": "https://api.minimax.io/anthropic",
     "docUrl": "https://platform.minimax.io/docs/api-reference/text-anthropic-api",


### PR DESCRIPTION
## Summary
- Move MiniMax CN to the top of the model provider catalog
- Rename MiniMax EN to MiniMax Global

## Testing
- node -e "const c=require('./apps/web/src/lib/model-presets.catalog.json'); console.log(c.slice(0,8).map((p,i)=>String(i+1).padStart(2,'0')+'. '+p.name+' ('+p.key+')').join('\n'))"
- make check

Note: make check reported Docker is not available and skipped the Postgres migration smoke test, then completed successfully.