### PR TITLE
chore: narrow CI triggers and clarify dev DB target

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,43 @@ name: check
 on:
   push:
     branches: [main]
+    paths:
+      - "server/**"
+      - "internal/**"
+      - "apps/web/**"
+      - "packages/cli/**"
+      - "packages/opencode-plugin/**"
+      - "packages/eslint-config/**"
+      - "scripts/**"
+      - "docker-compose.dev.yml"
+      - "go.mod"
+      - "go.sum"
+      - "go.work"
+      - "go.work.sum"
+      - "package.json"
+      - "pnpm-workspace.yaml"
+      - "pnpm-lock.yaml"
+      - "Makefile"
+      - ".github/workflows/check.yml"
   pull_request:
+    paths:
+      - "server/**"
+      - "internal/**"
+      - "apps/web/**"
+      - "packages/cli/**"
+      - "packages/opencode-plugin/**"
+      - "packages/eslint-config/**"
+      - "scripts/**"
+      - "docker-compose.dev.yml"
+      - "go.mod"
+      - "go.sum"
+      - "go.work"
+      - "go.work.sum"
+      - "package.json"
+      - "pnpm-workspace.yaml"
+      - "pnpm-lock.yaml"
+      - "Makefile"
+      - ".github/workflows/check.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -10,7 +10,23 @@ name: govulncheck
 on:
   push:
     branches: [main]
+    paths:
+      - "server/**"
+      - "internal/**"
+      - "go.mod"
+      - "go.sum"
+      - "go.work"
+      - "go.work.sum"
+      - ".github/workflows/govulncheck.yml"
   pull_request:
+    paths:
+      - "server/**"
+      - "internal/**"
+      - "go.mod"
+      - "go.sum"
+      - "go.work"
+      - "go.work.sum"
+      - ".github/workflows/govulncheck.yml"
   schedule:
     - cron: "17 8 * * 1"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,23 @@ name: lint
 on:
   push:
     branches: [main]
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "go.work"
+      - "go.work.sum"
+      - ".golangci.yml"
+      - ".github/workflows/lint.yml"
   pull_request:
+    paths:
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - "go.work"
+      - "go.work.sum"
+      - ".golangci.yml"
+      - ".github/workflows/lint.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -21,14 +21,14 @@ on:
     paths:
       - 'docs/openapi/**'
       - 'redocly.yaml'
-      - 'server/**'
+      - 'server/**/*.go'
       - '.github/workflows/openapi.yml'
       - 'Makefile'
   pull_request:
     paths:
       - 'docs/openapi/**'
       - 'redocly.yaml'
-      - 'server/**'
+      - 'server/**/*.go'
       - '.github/workflows/openapi.yml'
       - 'Makefile'
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL := /bin/bash
 PARSAR_IMAGE     ?= parsar
 PARSAR_IMAGE_TAG ?= dev
 
-.PHONY: setup dev check reset-dev clean-dev paths migrate-dev sqlc-generate server web cli devgateway http-runner-once http-runner-loop dev-all smoke e2e-http-agent e2e-feishu-gateway dev-server-up dev-server-down dev-server-log bootstrap docker-build docker-build-no-cache openapi
+.PHONY: setup dev dev-db check reset-dev clean-dev paths migrate-dev sqlc-generate server web cli devgateway http-runner-once http-runner-loop dev-all smoke e2e-http-agent e2e-feishu-gateway dev-server-up dev-server-down dev-server-log bootstrap docker-build docker-build-no-cache openapi
 
 setup:
 	./scripts/setup.sh
@@ -38,8 +38,11 @@ bootstrap:
 sqlc-generate:
 	cd server && go run github.com/sqlc-dev/sqlc/cmd/sqlc@v1.29.0 generate
 
-dev:
+dev-db:
 	./scripts/dev-stack.sh
+
+# Backward-compatible alias. Prefer `make dev-db` for the DB-only dev stack.
+dev: dev-db
 
 check:
 	./scripts/check.sh

--- a/scripts/dev-all.sh
+++ b/scripts/dev-all.sh
@@ -21,7 +21,7 @@ PY
 
 # Pick an ephemeral Postgres port BEFORE sourcing dev-env.sh so its
 # default (15432) only fills the blank — dev-all intentionally runs on a
-# free port to avoid colliding with a `make dev` stack.
+# free port to avoid colliding with a `make dev-db` stack.
 if [[ -z "${PARSAR_POSTGRES_PORT:-}" ]]; then
   PARSAR_POSTGRES_PORT="$(free_port)"
   export PARSAR_POSTGRES_PORT

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -8,7 +8,7 @@
 # it wins (the `${VAR:-default}` form below only fills in the blank).
 #
 # Consumers:
-#   scripts/dev-stack.sh      (make dev)
+#   scripts/dev-stack.sh      (make dev-db; make dev is a compatibility alias)
 #   scripts/dev-all.sh        (make dev-all)
 #   scripts/dev-server-up.sh  (make dev-server-up)
 #   docker-compose.dev.yml    (reads the exported PARSAR_PG_* values;


### PR DESCRIPTION
## Summary
- add `make dev-db` as the explicit DB-only dev stack target while keeping `make dev` as a compatibility alias
- narrow check/lint/govulncheck workflow triggers to relevant source and config paths
- reduce OpenAPI workflow triggers from all server files to Go source/spec inputs

## Verification
- `actionlint`
- `git diff --check`
- `make check` (Docker unavailable locally, migration smoke skipped by existing script behavior)