### PR TITLE
Improve setup password hint copy

### DIFF
--- a/apps/web/src/i18n/locales/en-US/common.json
+++ b/apps/web/src/i18n/locales/en-US/common.json
@@ -135,7 +135,7 @@
     "workspacePlaceholder": "Acme",
     "passwordLabel": "Password",
     "passwordPlaceholder": "At least 12 characters, mix words + numbers",
-    "passwordHint": "Use at least 60 bits of entropy — a passphrase of 4+ words works well.",
+    "passwordHint": "Choose a longer password. A memorable phrase with 4 or more words works well.",
     "submitButton": "Create owner account",
     "submitting": "Creating your account...",
     "closedTitle": "Setup already complete",

--- a/apps/web/src/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/i18n/locales/zh-CN/common.json
@@ -135,7 +135,7 @@
     "workspacePlaceholder": "Acme",
     "passwordLabel": "密码",
     "passwordPlaceholder": "至少 12 位,词组 + 数字混合",
-    "passwordHint": "推荐使用至少 60 bits 熵的密码 — 4 个以上单词组成的短语最省心。",
+    "passwordHint": "建议使用更长、好记的密码。4 个以上词组成的短语就很合适。",
     "submitButton": "创建管理员账号",
     "submitting": "正在创建...",
     "closedTitle": "已完成初始化",


### PR DESCRIPTION
## Summary
- Reword setup password hints to avoid exposing entropy terminology to users
- Keep English and Simplified Chinese locale copy aligned

## Verification
- git diff --check
- make check was started but interrupted before completion