### PR TITLE
Guard conversation sends on sandbox health

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -289,6 +289,13 @@
       "sending": "Sending…",
       "stopAria": "Stop generating"
     },
+    "sandboxGuard": {
+      "checking": "Checking this Agent's sandbox before sending…",
+      "missing": "This Agent does not have a healthy sandbox yet. Provision or rebuild its sandbox from the Agent detail page before sending a message.",
+      "notLive": "This Agent's sandbox is not ready ({{status}}). Rebuild it from the Agent detail page before sending a message.",
+      "error": "Could not check this Agent's sandbox health: {{error}}",
+      "errorFallback": "unknown error"
+    },
     "loadError": {
       "title": "Failed to load conversation",
       "description": "Backend returned an error.",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -289,6 +289,13 @@
       "sending": "发送中…",
       "stopAria": "停止生成"
     },
+    "sandboxGuard": {
+      "checking": "发送前正在检查此 Agent 的 sandbox…",
+      "missing": "此 Agent 还没有健康的 sandbox。请先在 Agent 详情页创建或重建 sandbox，再发送消息。",
+      "notLive": "此 Agent 的 sandbox 还没就绪（{{status}}）。请先在 Agent 详情页重建 sandbox，再发送消息。",
+      "error": "无法检查此 Agent 的 sandbox 健康状态：{{error}}",
+      "errorFallback": "未知错误"
+    },
     "loadError": {
       "title": "无法加载对话",
       "description": "后端返回错误。",

--- a/apps/web/src/lib/agent-runtime.ts
+++ b/apps/web/src/lib/agent-runtime.ts
@@ -1,0 +1,16 @@
+import type { Agent } from "./api-types"
+
+export function agentExecutionPlacement(agent: Agent | undefined | null): "local" | "sandbox" | "unknown" {
+  if (!agent) return "unknown"
+  if (agent.runtime === "local") return "local"
+  if (agent.runtime === "sandbox") return "sandbox"
+  const config = agent.config ?? {}
+  const mode = String(config.daemon_mode ?? "")
+  if (mode === "sandbox") return "sandbox"
+  if (mode === "local") return "local"
+  return "unknown"
+}
+
+export function agentNeedsSandbox(agent: Agent | undefined | null): boolean {
+  return agent?.connector_type === "agent_daemon" && agentExecutionPlacement(agent) === "sandbox"
+}

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -90,6 +90,7 @@ import {
 import { useMyCredentials } from "../../lib/api-credentials"
 import { useMyWorkspaces } from "../../lib/api-workspaces"
 import { useMarketplaceList } from "../../lib/api-marketplace"
+import { agentExecutionPlacement } from "../../lib/agent-runtime"
 import type { Agent, AgentCapability, AgentRunStatus, AgentRunSummary, Capability, CapabilityVersion, Model, UserCredential } from "../../lib/api-types"
 import { useWorkspaceId } from "../../lib/workspace"
 import { useRelativeTime } from "../../lib/relative-time"
@@ -128,7 +129,7 @@ function runtimeOf(a: Agent): "local" | "sandbox" {
   // trust it alone — for agent_daemon the placement lives in
   // pa.config.daemon_mode. "unknown" fallback maps to "sandbox" so the
   // detail label still renders for very old rows.
-  const placement = executionPlacement(a)
+  const placement = agentExecutionPlacement(a)
   return placement === "local" ? "local" : "sandbox"
 }
 
@@ -171,21 +172,6 @@ function runtimeLivenessTone(agent: Agent): LivenessTone | null {
   if (lv === "online" || lv === "live") return "online"
   if (lv === "pending_pairing" || lv === "pending") return "pending"
   return "offline"
-}
-
-/**
- * Intended execution placement. Prefers the per-agent `runtime` mirror,
- * falls back to `pa.config.daemon_mode` (the backend zeroes the mirror
- * for `agent_daemon` rows). "unknown" only for pre-mirror legacy rows.
- */
-function executionPlacement(agent: Agent): "local" | "sandbox" | "unknown" {
-  if (agent.runtime === "local") return "local"
-  if (agent.runtime === "sandbox") return "sandbox"
-  const pa = (agent.config as Record<string, unknown> | undefined) ?? {}
-  const mode = String(pa.daemon_mode ?? "")
-  if (mode === "sandbox") return "sandbox"
-  if (mode === "local") return "local"
-  return "unknown"
 }
 
 function StatusDot({ tone, title }: { tone: LivenessTone; title?: string }) {
@@ -246,7 +232,7 @@ function TruncatedName({
  */
 function RuntimeCell({ agent }: { agent: Agent }) {
   const { t } = useTranslation("admin")
-  const placement = executionPlacement(agent)
+  const placement = agentExecutionPlacement(agent)
 
   // Prefer the active sandbox's E2B id over runtime_name (which is the
   // synthetic "sandbox <pa-shortid>" — meaningless to the user).

--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -1,6 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
+import type { TFunction } from "i18next"
 import { AlertTriangle, Bot, Check, ChevronLeft, ChevronRight, ChevronDown, CircleDot, Clock, MessageSquarePlus, Pencil, Send, ShieldAlert, Square, Trash2, X, Loader2 } from "lucide-react"
 
 import { AdminLayout } from "../../components/layout/AdminLayout"
@@ -20,6 +21,7 @@ import { Skeleton } from "../../components/ui/skeleton"
 import { useAdminView } from "../../lib/admin-router"
 import { ApiError } from "../../lib/api-client"
 import { useAgents, useCancelRun, useCancelConversation } from "../../lib/api-agents"
+import { agentNeedsSandbox } from "../../lib/agent-runtime"
 import {
   createConversation,
   sendUserMessage,
@@ -32,6 +34,7 @@ import {
   useSendUserMessage,
   useUpdateConversationTitle,
 } from "../../lib/api-conversations"
+import { useSandboxBinding, type SandboxBinding } from "../../lib/api-sandbox"
 import type {
   ConversationListItem,
   ConversationTimelineRun,
@@ -51,6 +54,11 @@ const FOLD_KEY = "parsar:conv:sidebarFolded"
  *   just_completed: brief post-completion flash before clearing
  */
 type RunStatus = "generating" | "just_completed"
+
+interface SandboxSendGuard {
+  blocked: boolean
+  message: string
+}
 
 /* ============================================================== */
 /*  ConversationsPage — top-level: 3-col shell (admin | conv | main) */
@@ -87,6 +95,15 @@ export function ConversationsPage() {
     currentConv?.primary_agent_id ||
     (allAgents[0]?.id ?? "")
   const selectedAgent = allAgents.find((a) => a.id === selectedAgentId)
+  const needsSandbox = agentNeedsSandbox(selectedAgent)
+  const sandboxQ = useSandboxBinding(
+    needsSandbox ? wsId : null,
+    needsSandbox ? selectedAgentId : null,
+  )
+  const sandboxGuard = useMemo(
+    () => sandboxSendGuard(t, selectedAgent, sandboxQ.data, sandboxQ.isLoading, sandboxQ.error),
+    [t, selectedAgent, sandboxQ.data, sandboxQ.isLoading, sandboxQ.error],
+  )
 
   // Sidebar conversations: scoped to the selected agent.
   const convsQ = useConversations(wsId, selectedAgentId)
@@ -199,10 +216,35 @@ export function ConversationsPage() {
           onSendFromEmpty={handleSendFromEmpty}
           onRenameAfterFirstMessage={handleRenameConversation}
           focusComposer={focusTarget === "compose"}
+          sandboxGuard={sandboxGuard}
         />
       </div>
     </AdminLayout>
   )
+}
+
+function sandboxSendGuard(
+  t: TFunction<"admin">,
+  agent: Agent | undefined,
+  binding: SandboxBinding | null | undefined,
+  loading: boolean,
+  error: unknown,
+): SandboxSendGuard | undefined {
+  if (!agentNeedsSandbox(agent)) return undefined
+  if (loading) {
+    return { blocked: true, message: t("conversations.sandboxGuard.checking") }
+  }
+  if (error) {
+    const detail = error instanceof Error ? error.message : t("conversations.sandboxGuard.errorFallback")
+    return { blocked: true, message: t("conversations.sandboxGuard.error", { error: detail }) }
+  }
+  if (!binding) {
+    return { blocked: true, message: t("conversations.sandboxGuard.missing") }
+  }
+  if (binding.status_kind !== "live") {
+    return { blocked: true, message: t("conversations.sandboxGuard.notLive", { status: binding.status }) }
+  }
+  return { blocked: false, message: "" }
 }
 
 /* ============================================================== */
@@ -597,6 +639,7 @@ interface MainProps {
   onSendFromEmpty: (content: string) => Promise<void>
   onRenameAfterFirstMessage: (cid: string, title: string) => Promise<void>
   focusComposer?: boolean
+  sandboxGuard?: SandboxSendGuard
 }
 
 function ConversationMain(p: MainProps) {
@@ -645,6 +688,7 @@ function ConversationMain(p: MainProps) {
             pageDescription={p.onPageDescription}
             onSendFromEmpty={p.onSendFromEmpty}
             focusComposer={p.focusComposer}
+            sandboxGuard={p.sandboxGuard}
           />
         ) : p.messageCount === 0 ? (
           // 0 messages: keep the EmptyChat aurora so a new conv looks
@@ -655,9 +699,15 @@ function ConversationMain(p: MainProps) {
             conversationId={p.conversationId}
             onRenameAfterFirstMessage={p.onRenameAfterFirstMessage}
             focusComposer={p.focusComposer}
+            sandboxGuard={p.sandboxGuard}
           />
         ) : (
-          <ChatStream conversationId={p.conversationId} agent={p.agent} sidebarFolded={p.folded} />
+          <ChatStream
+            conversationId={p.conversationId}
+            agent={p.agent}
+            sidebarFolded={p.folded}
+            sandboxGuard={p.sandboxGuard}
+          />
         )}
       </div>
     </main>
@@ -675,6 +725,7 @@ function EmptyChat({
   onSendFromEmpty,
   onRenameAfterFirstMessage,
   focusComposer,
+  sandboxGuard,
 }: {
   agent: Agent | undefined
   pageDescription: string
@@ -684,6 +735,7 @@ function EmptyChat({
   onSendFromEmpty?: (content: string) => Promise<void>
   onRenameAfterFirstMessage?: (cid: string, title: string) => Promise<void>
   focusComposer?: boolean
+  sandboxGuard?: SandboxSendGuard
 }) {
   const { t } = useTranslation("admin")
   return (
@@ -712,7 +764,7 @@ function EmptyChat({
 
             <ComposerForm
               conversationId={conversationId ?? ""}
-              disabled={!agent}
+              disabled={!agent || sandboxGuard?.blocked}
               autoFocus={focusComposer}
               placeholder={
                 agent
@@ -721,6 +773,7 @@ function EmptyChat({
               }
               onSendDirect={!conversationId && agent ? onSendFromEmpty : undefined}
               onAfterSend={conversationId && onRenameAfterFirstMessage ? (title) => onRenameAfterFirstMessage(conversationId, title) : undefined}
+              blockReason={sandboxGuard?.blocked ? sandboxGuard.message : undefined}
             />
           </div>
         </div>
@@ -733,7 +786,17 @@ function EmptyChat({
 /*  Chat stream — user (right bubble) + agent (left plain text)     */
 /* ============================================================== */
 
-function ChatStream({ conversationId, agent, sidebarFolded }: { conversationId: string; agent: Agent | undefined; sidebarFolded?: boolean }) {
+function ChatStream({
+  conversationId,
+  agent,
+  sidebarFolded,
+  sandboxGuard,
+}: {
+  conversationId: string
+  agent: Agent | undefined
+  sidebarFolded?: boolean
+  sandboxGuard?: SandboxSendGuard
+}) {
   const { t } = useTranslation("admin")
   const fmtAgo = useRelativeTime()
   const { navigate } = useAdminView()
@@ -946,7 +1009,7 @@ function ChatStream({ conversationId, agent, sidebarFolded }: { conversationId: 
           <ComposerForm
             conversationId={conversationId}
             placeholder={t("conversations.composer.placeholder", { agent: agent?.name ?? "" })}
-            disabled={!agent}
+            disabled={!agent || sandboxGuard?.blocked}
             onRunStarted={setActiveRunId}
             onStartError={setChatToast}
             activeRunId={activeRunId}
@@ -966,6 +1029,7 @@ function ChatStream({ conversationId, agent, sidebarFolded }: { conversationId: 
                 : undefined
             }
             cancelling={cancelRunMut.isPending}
+            blockReason={sandboxGuard?.blocked ? sandboxGuard.message : undefined}
           />
         </div>
       </div>
@@ -1156,6 +1220,7 @@ function ComposerForm({
   activeRunId,
   onCancelActiveRun,
   cancelling,
+  blockReason,
 }: {
   conversationId: string
   placeholder: string
@@ -1194,6 +1259,7 @@ function ComposerForm({
   activeRunId?: string | null
   onCancelActiveRun?: () => void
   cancelling?: boolean
+  blockReason?: string
 }) {
   const { t } = useTranslation("admin")
   const [content, setContent] = useState("")
@@ -1266,6 +1332,12 @@ function ComposerForm({
 
   return (
     <form onSubmit={submit}>
+      {blockReason && (
+        <div className="mb-2 flex items-start gap-2 rounded-md border border-warning-border bg-warning-subtle px-3 py-2 text-sm text-warning-emphasis">
+          <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" strokeWidth={2} aria-hidden="true" />
+          <span className="break-words">{blockReason}</span>
+        </div>
+      )}
       <div
         className={cn(
           "flex min-h-[64px] items-center gap-3 rounded-lg border border-line bg-surface px-3 py-2 shadow-[0_1px_2px_rgba(15,23,42,0.04),_0_12px_34px_rgba(15,23,42,0.08)] transition-shadow",


### PR DESCRIPTION
## Summary
- add a shared agent runtime placement helper
- check sandbox binding health before enabling conversation sends for sandbox-backed agents
- show localized blocking copy in empty and active conversation composers

## Verification
- cd apps/web && pnpm typecheck
- make check

Note: make check skipped the Postgres migration smoke test because Docker is not available in this environment.