### PR TITLE
Improve sandbox startup progress visibility

### DIFF
--- a/apps/web/src/components/admin/SandboxPanel.tsx
+++ b/apps/web/src/components/admin/SandboxPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Box, CalendarClock, Loader2, RotateCcw, ShieldAlert } from "lucide-react"
 
@@ -15,10 +15,27 @@ import {
 import { EmptyState } from "../ui/empty-state"
 import { ErrorState } from "../ui/error-state"
 import { Skeleton } from "../ui/skeleton"
-import { useSandboxBinding, useRebuildSandbox, useAcquireSandbox, useRenewSandbox, type SandboxStatusKind } from "../../lib/api-sandbox"
+import {
+  useSandboxBinding,
+  useRebuildSandbox,
+  useAcquireSandbox,
+  useRenewSandbox,
+  type SandboxStatusKind,
+} from "../../lib/api-sandbox"
+import { useWorkspaceRuntimes } from "../../lib/api-runtimes"
+import { findSandboxRuntimeForAgent, isSandboxPairingExpired } from "../../lib/sandbox-runtime"
 import { useNow } from "../../lib/use-now"
+import { SandboxPreparingNotice, SandboxStartupTimedOutNotice } from "./SandboxProvisioningNotice"
 
-function Card({ title, className, children }: { title: string; className?: string; children: React.ReactNode }) {
+function Card({
+  title,
+  className,
+  children,
+}: {
+  title: string
+  className?: string
+  children: React.ReactNode
+}) {
   return (
     <section className={`rounded-lg border border-line bg-surface p-4 ${className ?? ""}`}>
       <h3 className="mb-3 text-base font-semibold text-fg">{title}</h3>
@@ -37,8 +54,18 @@ function Field({ label, value, mono }: { label: string; value: React.ReactNode; 
 }
 
 function SandboxStatusBadge({ kind, status }: { kind: SandboxStatusKind; status: string }) {
-  if (kind === "live") return <Badge variant="success" dot>{status}</Badge>
-  if (kind === "transient") return <Badge variant="warning" dot>{status}</Badge>
+  if (kind === "live")
+    return (
+      <Badge variant="success" dot>
+        {status}
+      </Badge>
+    )
+  if (kind === "transient")
+    return (
+      <Badge variant="warning" dot>
+        {status}
+      </Badge>
+    )
   return <Badge variant="neutral">{status}</Badge>
 }
 
@@ -95,19 +122,22 @@ function ExpiresValue({ iso }: { iso?: string }) {
   const { t } = useTranslation("admin")
   const now = useNow()
   if (!iso) {
-    return <span className="text-sm text-fg-subtle">{t("agents.detail.sandbox.fields.expiresAtUnknown")}</span>
+    return (
+      <span className="text-sm text-fg-subtle">
+        {t("agents.detail.sandbox.fields.expiresAtUnknown")}
+      </span>
+    )
   }
   const desc = describeRemaining(iso, now)
   const toneClass =
-    desc?.tone === "red" ? "text-danger"
-    : desc?.tone === "amber" ? "text-warning"
-    : "text-success"
+    desc?.tone === "red" ? "text-danger" : desc?.tone === "amber" ? "text-warning" : "text-success"
   const absolute = new Date(iso).toLocaleString()
-  const label = desc?.state === "expired"
-    ? t("agents.detail.sandbox.expires.expired")
-    : desc
-      ? t("agents.detail.sandbox.expires.remaining", { value: desc.value })
-      : null
+  const label =
+    desc?.state === "expired"
+      ? t("agents.detail.sandbox.expires.expired")
+      : desc
+        ? t("agents.detail.sandbox.expires.remaining", { value: desc.value })
+        : null
   return (
     <span title={iso} className="text-sm text-fg-emphasis">
       {absolute}
@@ -139,7 +169,12 @@ function ConfirmDialog({
 }: ConfirmDialogProps) {
   const { t } = useTranslation("common")
   return (
-    <Dialog open={open} onOpenChange={(next) => { if (!next && !loading) onCancel() }}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !loading) onCancel()
+      }}
+    >
       <DialogContent showCloseButton={false} className="max-w-md gap-0 p-0">
         <DialogHeader className="flex flex-row items-start gap-3 space-y-0 p-5 pr-5">
           <div
@@ -153,9 +188,7 @@ function ConfirmDialog({
           </div>
           <div className="space-y-1.5">
             <DialogTitle className="text-sm">{title}</DialogTitle>
-            <DialogDescription className="text-sm leading-relaxed">
-              {description}
-            </DialogDescription>
+            <DialogDescription className="text-sm leading-relaxed">{description}</DialogDescription>
           </div>
         </DialogHeader>
         <DialogFooter className="flex flex-row items-center justify-end gap-2 border-t border-line-muted bg-surface-subtle/60 px-4 py-3">
@@ -187,15 +220,48 @@ export function SandboxPanel({
 }) {
   const { t } = useTranslation("admin")
   const query = useSandboxBinding(workspaceID, agentID)
+  const runtimeQuery = useWorkspaceRuntimes(workspaceID ?? "", "agent_daemon")
   const rebuildMut = useRebuildSandbox(workspaceID, agentID)
   const acquireMut = useAcquireSandbox(workspaceID, agentID)
   const renewMut = useRenewSandbox(workspaceID, agentID)
+  const now = useNow()
+  const refetchSandbox = query.refetch
+  const refetchRuntimes = runtimeQuery.refetch
 
   const [confirmingRebuild, setConfirmingRebuild] = useState(false)
+  const [provisioningSince, setProvisioningSince] = useState<number | null>(null)
 
   function handleConfirm() {
+    setProvisioningSince(Date.now())
     rebuildMut.mutate(undefined, { onSettled: () => setConfirmingRebuild(false) })
   }
+
+  function triggerAcquire() {
+    setProvisioningSince(Date.now())
+    acquireMut.mutate()
+  }
+
+  const binding = query.data
+  const sandboxRuntime = findSandboxRuntimeForAgent(runtimeQuery.data ?? [], agentID)
+  const runtimeTimedOut = sandboxRuntime ? isSandboxPairingExpired(sandboxRuntime, now) : false
+  const manualProvisioningActive =
+    provisioningSince !== null &&
+    now - provisioningSince < 5 * 60_000 &&
+    (!binding || binding.status_kind !== "live")
+  const preparing =
+    acquireMut.isPending ||
+    rebuildMut.isPending ||
+    manualProvisioningActive ||
+    Boolean(sandboxRuntime?.liveness === "pending_pairing" && !runtimeTimedOut)
+
+  useEffect(() => {
+    if (!preparing) return
+    const tick = window.setInterval(() => {
+      void refetchSandbox()
+      void refetchRuntimes()
+    }, 2500)
+    return () => window.clearInterval(tick)
+  }, [preparing, refetchSandbox, refetchRuntimes])
 
   if (query.isLoading) {
     return (
@@ -215,31 +281,44 @@ export function SandboxPanel({
       />
     )
   }
-
-  const binding = query.data
-
   if (!binding) {
     return (
       <Card title={t("agents.detail.sandbox.title")}>
-        <EmptyState
-          icon={Box}
-          title={t("agents.detail.sandbox.empty.title")}
-        />
-        <div className="mt-3 flex justify-center">
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={acquireMut.isPending}
-            onClick={() => acquireMut.mutate()}
-          >
-            {acquireMut.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
-            {t("agents.detail.sandbox.actions.provision")}
-          </Button>
-        </div>
-        {acquireMut.isSuccess && (
-          <p className="mt-2 text-center text-sm text-fg-subtle">
-            {t("agents.detail.sandbox.provisioningHint")}
-          </p>
+        {preparing ? (
+          <SandboxPreparingNotice
+            runtime={sandboxRuntime}
+            startedAt={
+              sandboxRuntime?.created_at ??
+              (provisioningSince ? new Date(provisioningSince).toISOString() : undefined)
+            }
+          />
+        ) : sandboxRuntime && runtimeTimedOut ? (
+          <SandboxStartupTimedOutNotice
+            runtime={sandboxRuntime}
+            retrying={acquireMut.isPending}
+            onRetry={triggerAcquire}
+          />
+        ) : (
+          <>
+            <EmptyState icon={Box} title={t("agents.detail.sandbox.empty.title")} />
+            <div className="mt-3 flex justify-center">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={acquireMut.isPending}
+                onClick={triggerAcquire}
+              >
+                {acquireMut.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+                {t("agents.detail.sandbox.actions.provision")}
+              </Button>
+            </div>
+          </>
+        )}
+        {acquireMut.error && (
+          <ErrorState
+            title={t("agents.detail.sandbox.provisionError")}
+            description={(acquireMut.error as Error).message}
+          />
         )}
       </Card>
     )
@@ -255,7 +334,9 @@ export function SandboxPanel({
               size="sm"
               variant="outline"
               data-testid="sandbox-renew-button"
-              disabled={renewMut.isPending || rebuildMut.isPending || binding.status_kind !== "live"}
+              disabled={
+                renewMut.isPending || rebuildMut.isPending || binding.status_kind !== "live"
+              }
               onClick={() => renewMut.mutate()}
             >
               <CalendarClock className="mr-1 h-3.5 w-3.5" strokeWidth={2} />
@@ -267,7 +348,9 @@ export function SandboxPanel({
               size="sm"
               variant="outline"
               data-testid="sandbox-rebuild-button"
-              disabled={rebuildMut.isPending || renewMut.isPending || binding.status_kind !== "live"}
+              disabled={
+                rebuildMut.isPending || renewMut.isPending || binding.status_kind !== "live"
+              }
               onClick={() => setConfirmingRebuild(true)}
             >
               <RotateCcw className="mr-1 h-3.5 w-3.5" strokeWidth={2} />
@@ -278,21 +361,54 @@ export function SandboxPanel({
           </div>
         </div>
         <dl>
-          <Field label={t("agents.detail.sandbox.fields.sandboxId")} value={binding.sandbox_id} mono />
-          <Field label={t("agents.detail.sandbox.fields.templateId")} value={binding.template_id} mono />
-          <Field label={t("agents.detail.sandbox.fields.expiresAt")} value={<ExpiresValue iso={binding.expires_at} />} />
-          <Field label={t("agents.detail.sandbox.fields.lastActive")} value={<Timestamp iso={binding.last_active_at} />} />
-          <Field label={t("agents.detail.sandbox.fields.createdAt")} value={<Timestamp iso={binding.created_at} />} />
+          <Field
+            label={t("agents.detail.sandbox.fields.sandboxId")}
+            value={binding.sandbox_id}
+            mono
+          />
+          <Field
+            label={t("agents.detail.sandbox.fields.templateId")}
+            value={binding.template_id}
+            mono
+          />
+          <Field
+            label={t("agents.detail.sandbox.fields.expiresAt")}
+            value={<ExpiresValue iso={binding.expires_at} />}
+          />
+          <Field
+            label={t("agents.detail.sandbox.fields.lastActive")}
+            value={<Timestamp iso={binding.last_active_at} />}
+          />
+          <Field
+            label={t("agents.detail.sandbox.fields.createdAt")}
+            value={<Timestamp iso={binding.created_at} />}
+          />
           {binding.killed_at && (
-            <Field label={t("agents.detail.sandbox.fields.killedAt")} value={<Timestamp iso={binding.killed_at} />} />
+            <Field
+              label={t("agents.detail.sandbox.fields.killedAt")}
+              value={<Timestamp iso={binding.killed_at} />}
+            />
           )}
-          <Field label={t("agents.detail.sandbox.fields.bindingId")} value={binding.binding_id} mono />
-          <Field label={t("agents.detail.sandbox.fields.cacheKey")} value={binding.cache_key} mono />
+          <Field
+            label={t("agents.detail.sandbox.fields.bindingId")}
+            value={binding.binding_id}
+            mono
+          />
+          <Field
+            label={t("agents.detail.sandbox.fields.cacheKey")}
+            value={binding.cache_key}
+            mono
+          />
         </dl>
         {binding.status_kind !== "live" && (
           <p className="mt-3 rounded-md border border-line bg-surface-subtle px-3 py-2 text-sm text-fg-muted">
             {t("agents.detail.sandbox.notLiveHint")}
           </p>
+        )}
+        {preparing && (
+          <div className="mt-3">
+            <SandboxPreparingNotice runtime={sandboxRuntime} />
+          </div>
         )}
       </Card>
 
@@ -310,7 +426,9 @@ export function SandboxPanel({
       )}
       {renewMut.isSuccess && renewMut.data?.expires_at && (
         <div className="rounded-md border border-success-border bg-success-subtle px-3 py-2 text-sm text-success-emphasis">
-          {t("agents.detail.sandbox.renewedToast", { expiresAt: new Date(renewMut.data.expires_at).toLocaleString() })}
+          {t("agents.detail.sandbox.renewedToast", {
+            expiresAt: new Date(renewMut.data.expires_at).toLocaleString(),
+          })}
         </div>
       )}
 

--- a/apps/web/src/components/admin/SandboxProvisioningNotice.tsx
+++ b/apps/web/src/components/admin/SandboxProvisioningNotice.tsx
@@ -1,0 +1,138 @@
+import { useTranslation } from "react-i18next"
+import { Loader2 } from "lucide-react"
+
+import { Button } from "../ui/button"
+import type { Runtime } from "../../lib/api-runtimes"
+import { useNow } from "../../lib/use-now"
+
+type StepState = "active" | "pending"
+
+function Detail({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div>
+      <dt className="mb-0.5 text-xs uppercase tracking-wider text-fg-faint">{label}</dt>
+      <dd className={`text-sm text-fg-emphasis ${mono ? "font-mono break-all" : ""}`}>{value}</dd>
+    </div>
+  )
+}
+
+function elapsedSeconds(startedAt?: string): number {
+  if (!startedAt) return 0
+  const started = new Date(startedAt).getTime()
+  if (Number.isNaN(started)) return 0
+  return Math.max(0, Math.floor((Date.now() - started) / 1000))
+}
+
+function Step({ state, label, detail }: { state: StepState; label: string; detail?: string }) {
+  return (
+    <li className="grid grid-cols-[1rem_1fr] gap-2">
+      <span
+        className={
+          state === "active"
+            ? "mt-1 h-2 w-2 rounded-full bg-warning-emphasis"
+            : "mt-1 h-2 w-2 rounded-full border border-warning-border bg-surface"
+        }
+      />
+      <span>
+        <span className="block text-sm font-medium text-warning-emphasis">{label}</span>
+        {detail && (
+          <span className="block text-sm leading-relaxed text-warning-emphasis">{detail}</span>
+        )}
+      </span>
+    </li>
+  )
+}
+
+export function SandboxPreparingNotice({
+  runtime,
+  startedAt,
+}: {
+  runtime?: Runtime | null
+  startedAt?: string
+}) {
+  const { t } = useTranslation("admin")
+  useNow()
+  const elapsed = elapsedSeconds(startedAt)
+  const imagePullActive = elapsed >= 10
+  const slowImagePull = elapsed >= 30
+  return (
+    <div className="rounded-md border border-warning-border bg-warning-subtle px-3 py-2">
+      <div className="flex items-center gap-2 text-sm font-medium text-warning-emphasis">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        {t("agents.detail.sandbox.preparing.title")}
+      </div>
+      <p className="mt-1 text-sm leading-relaxed text-warning-emphasis">
+        {t("agents.detail.sandbox.preparing.body")}
+      </p>
+      <p className="mt-1 text-sm leading-relaxed text-warning-emphasis">
+        {t("agents.detail.sandbox.preparing.coldStartBody")}
+      </p>
+      <ol className="mt-3 space-y-2">
+        <Step
+          state={imagePullActive ? "pending" : "active"}
+          label={t("agents.detail.sandbox.preparing.steps.prepareImage")}
+          detail={t("agents.detail.sandbox.preparing.steps.prepareImageDetail")}
+        />
+        <Step
+          state={imagePullActive ? "active" : "pending"}
+          label={t("agents.detail.sandbox.preparing.steps.pullImage")}
+          detail={
+            slowImagePull
+              ? t("agents.detail.sandbox.preparing.steps.pullImageSlowDetail")
+              : t("agents.detail.sandbox.preparing.steps.pullImageDetail")
+          }
+        />
+        <Step
+          state="pending"
+          label={t("agents.detail.sandbox.preparing.steps.startContainer")}
+          detail={t("agents.detail.sandbox.preparing.steps.startContainerDetail")}
+        />
+        <Step
+          state="pending"
+          label={t("agents.detail.sandbox.preparing.steps.pairDaemon")}
+          detail={t("agents.detail.sandbox.preparing.steps.pairDaemonDetail")}
+        />
+      </ol>
+      <dl className="mt-2 space-y-1">
+        {runtime && (
+          <Detail label={t("agents.detail.sandbox.preparing.runtimeId")} value={runtime.id} mono />
+        )}
+        {startedAt && (
+          <Detail
+            label={t("agents.detail.sandbox.preparing.started")}
+            value={new Date(startedAt).toLocaleString()}
+          />
+        )}
+      </dl>
+    </div>
+  )
+}
+
+export function SandboxStartupTimedOutNotice({
+  runtime,
+  retrying,
+  onRetry,
+}: {
+  runtime: Runtime
+  retrying: boolean
+  onRetry: () => void
+}) {
+  const { t } = useTranslation("admin")
+  return (
+    <div className="rounded-md border border-danger-border bg-danger-subtle px-3 py-2">
+      <div className="text-sm font-medium text-danger-emphasis">
+        {t("agents.detail.sandbox.startupTimedOut.title")}
+      </div>
+      <p className="mt-1 text-sm leading-relaxed text-danger-emphasis">
+        {t("agents.detail.sandbox.startupTimedOut.body")}
+      </p>
+      <dl className="mt-2">
+        <Detail label={t("agents.detail.sandbox.preparing.runtimeId")} value={runtime.id} mono />
+      </dl>
+      <Button size="sm" variant="outline" className="mt-3" disabled={retrying} onClick={onRetry}>
+        {retrying && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+        {t("agents.detail.sandbox.actions.retryProvision")}
+      </Button>
+    </div>
+  )
+}

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1325,7 +1325,8 @@
           "rebuilding": "Rebuilding…",
           "renew": "Renew",
           "renewing": "Renewing…",
-          "provision": "Provision Sandbox"
+          "provision": "Provision Sandbox",
+          "retryProvision": "Retry provisioning"
         },
         "expires": {
           "remaining": "{{value}} remaining",
@@ -1333,7 +1334,30 @@
           "fresh": "Just renewed"
         },
         "renewedToast": "Renewed until {{expiresAt}}",
-        "provisioningHint": "Sandbox is being provisioned, typically takes 10-30 seconds…",
+        "provisionError": "Provisioning failed",
+        "provisioningHint": "Sandbox is being provisioned. A warm start usually takes 10-30 seconds; the first local Docker startup can take longer while the sandbox image is pulled.",
+        "preparing": {
+          "title": "Preparing sandbox",
+          "body": "Starting the sandbox and waiting for parsar-daemon to pair.",
+          "coldStartBody": "A warm start usually takes 10-30 seconds. The first local Docker startup can take longer while the sandbox image is pulled.",
+          "runtimeId": "Runtime id",
+          "started": "Started",
+          "steps": {
+            "prepareImage": "Prepare image",
+            "prepareImageDetail": "Checking the sandbox image and startup settings.",
+            "pullImage": "Pull sandbox image",
+            "pullImageDetail": "If this image is not cached locally, Docker may be downloading it now.",
+            "pullImageSlowDetail": "Still waiting. First pull can take several minutes on a slow network.",
+            "startContainer": "Start container",
+            "startContainerDetail": "Create the isolated sandbox container after the image is ready.",
+            "pairDaemon": "Pair daemon",
+            "pairDaemonDetail": "Wait for parsar-daemon inside the sandbox to connect back."
+          }
+        },
+        "startupTimedOut": {
+          "title": "Sandbox startup timed out",
+          "body": "The sandbox did not pair before the startup token expired. This often happens when the first local Docker startup is still pulling the sandbox image."
+        },
         "confirm": {
           "kill": {
             "title": "Kill this sandbox?",
@@ -2522,6 +2546,12 @@
       "daemonRuntimes": {
         "title": "Sandbox Daemons",
         "description": "parsar-daemon processes running inside Cloud Sandboxes. They belong to Cloud Sandbox, not Local Device.",
+        "status": {
+          "preparing": "Preparing",
+          "preparingDetail": "Starting the sandbox and waiting for parsar-daemon to pair. First local Docker startup may include pulling the sandbox image.",
+          "timedOut": "Startup timed out",
+          "timedOutDetail": "The sandbox did not pair before the startup token expired. Retry provisioning from the Agent detail."
+        },
         "errors": {
           "loadFailed": "Failed to load Sandbox Daemons"
         },
@@ -2875,14 +2905,41 @@
     "never": "—",
     "enabled": "Enabled",
     "disabled": "Disabled",
-    "col": { "name": "Name", "frequency": "Frequency", "status": "Status", "nextRun": "Next run", "actions": "Actions" },
+    "col": {
+      "name": "Name",
+      "frequency": "Frequency",
+      "status": "Status",
+      "nextRun": "Next run",
+      "actions": "Actions"
+    },
     "action": { "edit": "Edit", "runNow": "Run now", "delete": "Delete" },
     "runNowOk": "Triggered a run",
     "runNowErr": "Failed to trigger",
     "deleteConfirm": "Delete this scheduled task? Past runs are kept.",
-    "status": { "queued": "Queued", "running": "Running", "completed": "Succeeded", "failed": "Failed", "cancelled": "Cancelled", "interrupted": "Interrupted", "skipped_overlap": "Skipped (overlap)", "auto_disabled": "Auto-disabled", "none": "Not run yet" },
-    "pagination": { "prev": "Previous", "next": "Next", "range": "Showing {{from}}-{{to}} of {{total}}" },
-    "freq": { "hourly": "Hourly", "daily": "Daily", "weekly": "Weekly", "monthly": "Monthly", "weekday": "Weekdays", "custom": "Custom" },
+    "status": {
+      "queued": "Queued",
+      "running": "Running",
+      "completed": "Succeeded",
+      "failed": "Failed",
+      "cancelled": "Cancelled",
+      "interrupted": "Interrupted",
+      "skipped_overlap": "Skipped (overlap)",
+      "auto_disabled": "Auto-disabled",
+      "none": "Not run yet"
+    },
+    "pagination": {
+      "prev": "Previous",
+      "next": "Next",
+      "range": "Showing {{from}}-{{to}} of {{total}}"
+    },
+    "freq": {
+      "hourly": "Hourly",
+      "daily": "Daily",
+      "weekly": "Weekly",
+      "monthly": "Monthly",
+      "weekday": "Weekdays",
+      "custom": "Custom"
+    },
     "desc": {
       "hourly": "Hourly at minute {{minute}}",
       "daily": "Daily at {{time}}",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1325,7 +1325,8 @@
           "rebuilding": "Rebuilding…",
           "renew": "续期",
           "renewing": "续期中…",
-          "provision": "分配沙盒"
+          "provision": "分配沙盒",
+          "retryProvision": "重试分配"
         },
         "expires": {
           "remaining": "剩余 {{value}}",
@@ -1333,7 +1334,30 @@
           "fresh": "刚续期"
         },
         "renewedToast": "已续期到 {{expiresAt}}",
-        "provisioningHint": "沙盒正在准备中，通常需要 10-30 秒…",
+        "provisionError": "分配失败",
+        "provisioningHint": "沙盒正在准备中。热启动通常需要 10-30 秒；本地 Docker 首次启动可能需要先拉取沙盒镜像，因此会更久。",
+        "preparing": {
+          "title": "正在准备沙盒",
+          "body": "正在启动沙盒，并等待 parsar-daemon 完成配对。",
+          "coldStartBody": "热启动通常需要 10-30 秒。本地 Docker 首次启动可能需要先拉取沙盒镜像，因此会更久。",
+          "runtimeId": "Runtime id",
+          "started": "开始于",
+          "steps": {
+            "prepareImage": "准备镜像",
+            "prepareImageDetail": "检查沙盒镜像和启动参数。",
+            "pullImage": "拉取沙盒镜像",
+            "pullImageDetail": "如果本机还没有缓存该镜像，Docker 现在可能正在下载。",
+            "pullImageSlowDetail": "仍在等待。首次拉取在慢网络下可能需要几分钟。",
+            "startContainer": "启动容器",
+            "startContainerDetail": "镜像就绪后创建隔离的沙盒容器。",
+            "pairDaemon": "配对 daemon",
+            "pairDaemonDetail": "等待沙盒内的 parsar-daemon 反向连接。"
+          }
+        },
+        "startupTimedOut": {
+          "title": "沙盒启动超时",
+          "body": "沙盒没有在启动 token 过期前完成配对。常见原因是本地 Docker 首次启动仍在拉取沙盒镜像。"
+        },
         "confirm": {
           "kill": {
             "title": "确定 Kill 这个 sandbox 吗？",
@@ -2522,6 +2546,12 @@
       "daemonRuntimes": {
         "title": "沙盒内 Daemon",
         "description": "运行在云端沙盒里的 parsar-daemon 进程。它们属于云端沙盒，不是本地设备。",
+        "status": {
+          "preparing": "准备中",
+          "preparingDetail": "正在启动沙盒，并等待 parsar-daemon 完成配对。本地 Docker 首次启动可能需要先拉取沙盒镜像。",
+          "timedOut": "启动超时",
+          "timedOutDetail": "沙盒没有在启动 token 过期前完成配对。请到 Agent 详情页重试分配。"
+        },
         "errors": {
           "loadFailed": "无法加载沙盒内 Daemon"
         },
@@ -2875,14 +2905,41 @@
     "never": "—",
     "enabled": "已启用",
     "disabled": "已停用",
-    "col": { "name": "任务名", "frequency": "频率", "status": "状态", "nextRun": "下次运行", "actions": "操作" },
+    "col": {
+      "name": "任务名",
+      "frequency": "频率",
+      "status": "状态",
+      "nextRun": "下次运行",
+      "actions": "操作"
+    },
     "action": { "edit": "编辑", "runNow": "立即运行", "delete": "删除" },
     "runNowOk": "已触发一次运行",
     "runNowErr": "触发失败",
     "deleteConfirm": "确认删除该定时任务？历史运行记录会保留。",
-    "status": { "queued": "排队中", "running": "运行中", "completed": "成功", "failed": "失败", "cancelled": "已取消", "interrupted": "已中断", "skipped_overlap": "跳过(上次未完成)", "auto_disabled": "已自动停用", "none": "未运行" },
-    "pagination": { "prev": "上一页", "next": "下一页", "range": "第 {{from}}-{{to}} 条,共 {{total}} 条" },
-    "freq": { "hourly": "每小时", "daily": "每天", "weekly": "每周", "monthly": "每月", "weekday": "工作日", "custom": "自定义" },
+    "status": {
+      "queued": "排队中",
+      "running": "运行中",
+      "completed": "成功",
+      "failed": "失败",
+      "cancelled": "已取消",
+      "interrupted": "已中断",
+      "skipped_overlap": "跳过(上次未完成)",
+      "auto_disabled": "已自动停用",
+      "none": "未运行"
+    },
+    "pagination": {
+      "prev": "上一页",
+      "next": "下一页",
+      "range": "第 {{from}}-{{to}} 条,共 {{total}} 条"
+    },
+    "freq": {
+      "hourly": "每小时",
+      "daily": "每天",
+      "weekly": "每周",
+      "monthly": "每月",
+      "weekday": "工作日",
+      "custom": "自定义"
+    },
     "desc": {
       "hourly": "每小时第 {{minute}} 分",
       "daily": "每天 {{time}}",

--- a/apps/web/src/lib/sandbox-runtime.ts
+++ b/apps/web/src/lib/sandbox-runtime.ts
@@ -1,0 +1,20 @@
+import { isSandboxDaemonRuntime, type Runtime } from "./api-runtimes"
+
+export function sandboxRuntimeAgentID(runtime: Runtime): string {
+  const raw = runtime.config.agent_id
+  return typeof raw === "string" ? raw.trim() : ""
+}
+
+export function isSandboxPairingExpired(runtime: Runtime, nowMs = Date.now()): boolean {
+  if (runtime.liveness !== "pending_pairing" || !runtime.pairing_token_expires_at) return false
+  const expiresAt = new Date(runtime.pairing_token_expires_at).getTime()
+  return !Number.isNaN(expiresAt) && expiresAt <= nowMs
+}
+
+export function findSandboxRuntimeForAgent(runtimes: Runtime[], agentID: string): Runtime | null {
+  const matches = runtimes
+    .filter(isSandboxDaemonRuntime)
+    .filter((runtime) => sandboxRuntimeAgentID(runtime) === agentID)
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+  return matches[0] ?? null
+}

--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -1,11 +1,7 @@
 import React, { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import {
-  Cloud,
-  PlugZap,
-  Skull,
-  Zap,
-} from "lucide-react"
+import type { TFunction } from "i18next"
+import { Cloud, PlugZap, Skull, Zap } from "lucide-react"
 
 import { AdminLayout } from "../../components/layout/AdminLayout"
 import { PageHeader } from "../../components/layout/PageHeader"
@@ -46,6 +42,7 @@ import {
   useWorkspaceRuntimes,
   type Runtime,
 } from "../../lib/api-runtimes"
+import { isSandboxPairingExpired } from "../../lib/sandbox-runtime"
 import {
   killSandboxRequestRaw,
   useSandboxConnectivityTest,
@@ -64,8 +61,18 @@ type SortKey = "last_active" | "created_at" | "agent"
 type BadgeVariant = "success" | "warning" | "destructive" | "neutral" | "primary"
 
 function SandboxStatusBadge({ kind, status }: { kind: SandboxStatusKind; status: string }) {
-  if (kind === "live") return <Badge variant="success" dot>{status}</Badge>
-  if (kind === "transient") return <Badge variant="warning" dot>{status}</Badge>
+  if (kind === "live")
+    return (
+      <Badge variant="success" dot>
+        {status}
+      </Badge>
+    )
+  if (kind === "transient")
+    return (
+      <Badge variant="warning" dot>
+        {status}
+      </Badge>
+    )
   return <Badge variant="neutral">{status}</Badge>
 }
 
@@ -127,7 +134,9 @@ export function RuntimePage() {
   const [sortKey, setSortKey] = useState<SortKey>("last_active")
   const [confirming, setConfirming] = useState(false)
   const [bulkPending, setBulkPending] = useState(false)
-  const [bulkErrors, setBulkErrors] = useState<{ sandboxID: string; status: number | string; message: string }[]>([])
+  const [bulkErrors, setBulkErrors] = useState<
+    { sandboxID: string; status: number | string; message: string }[]
+  >([])
 
   useNow()
 
@@ -244,7 +253,10 @@ export function RuntimePage() {
       <ConfirmBulkKillDialog
         open={confirming}
         count={selected.size}
-        preview={activeBindings.filter((b) => selected.has(b.binding_id)).slice(0, 5).map((b) => b.sandbox_id)}
+        preview={activeBindings
+          .filter((b) => selected.has(b.binding_id))
+          .slice(0, 5)
+          .map((b) => b.sandbox_id)}
         loading={bulkPending}
         onCancel={() => setConfirming(false)}
         onConfirm={() => void performBulkKill()}
@@ -302,7 +314,8 @@ function CloudSandboxPanel({
 }) {
   const { t } = useTranslation("admin")
   const stateBody = cloudStateBody(t, cloudState, status)
-  const showCredentialControl = cloudState !== "loading" && cloudState !== "unknown" && status?.profile !== "managed"
+  const showCredentialControl =
+    cloudState !== "loading" && cloudState !== "unknown" && status?.profile !== "managed"
   const showInstances = !statusError && Boolean(workspaceID)
 
   return (
@@ -315,12 +328,12 @@ function CloudSandboxPanel({
             </div>
             <div className="min-w-0">
               <div className="flex flex-wrap items-center gap-2">
-                <h2 className="text-base font-semibold text-fg">{t("runtime.providers.sandbox.title")}</h2>
+                <h2 className="text-base font-semibold text-fg">
+                  {t("runtime.providers.sandbox.title")}
+                </h2>
                 <CloudStateBadge state={cloudState} />
               </div>
-              <p className="mt-1 max-w-3xl text-sm leading-relaxed text-fg-muted">
-                {stateBody}
-              </p>
+              <p className="mt-1 max-w-3xl text-sm leading-relaxed text-fg-muted">{stateBody}</p>
             </div>
           </div>
           <div className="flex shrink-0 flex-wrap items-center gap-2">
@@ -329,7 +342,6 @@ function CloudSandboxPanel({
             )}
           </div>
         </div>
-
       </div>
 
       <CloudDaemonRuntimesPanel
@@ -401,7 +413,10 @@ function CloudInstancesPanel({
   const { t } = useTranslation("admin")
   const checkLabelFor = useConnectivityCheckLabel()
   const [testingId, setTestingId] = useState<string | null>(null)
-  const [testResult, setTestResult] = useState<{ bindingId: string; result: ConnectivityResult } | null>(null)
+  const [testResult, setTestResult] = useState<{
+    bindingId: string
+    result: ConnectivityResult
+  } | null>(null)
   const connTest = useSandboxConnectivityTest()
 
   function handleTestConnection(b: SandboxBinding) {
@@ -495,7 +510,9 @@ function CloudInstancesPanel({
           <ul className="max-h-40 space-y-1 overflow-y-auto text-xs text-danger-emphasis">
             {bulkErrors.map((e) => (
               <li key={e.sandboxID} className="flex items-start gap-2 font-mono">
-                <span className="shrink-0 rounded bg-danger-subtle/70 px-1.5 py-0.5 text-xs text-danger-emphasis">{e.status}</span>
+                <span className="shrink-0 rounded bg-danger-subtle/70 px-1.5 py-0.5 text-xs text-danger-emphasis">
+                  {e.status}
+                </span>
                 <span className="shrink-0 text-danger-emphasis">{e.sandboxID}</span>
                 <span className="text-danger-emphasis">{e.message}</span>
               </li>
@@ -553,7 +570,9 @@ function CloudInstancesPanel({
                       }
                     }}
                     role="link"
-                    aria-label={t("runtime.list.table.rowLabel", { agent: b.agent_id ?? b.sandbox_id })}
+                    aria-label={t("runtime.list.table.rowLabel", {
+                      agent: b.agent_id ?? b.sandbox_id,
+                    })}
                     className="cursor-pointer hover:bg-surface-subtle/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong"
                     data-testid={`runtime-row-${b.binding_id}`}
                   >
@@ -567,12 +586,19 @@ function CloudInstancesPanel({
                         data-testid={`runtime-select-${b.binding_id}`}
                       />
                     </TableCell>
-                    <TableCell className="max-w-[180px] truncate font-mono text-sm text-fg-emphasis" title={b.sandbox_id}>
+                    <TableCell
+                      className="max-w-[180px] truncate font-mono text-sm text-fg-emphasis"
+                      title={b.sandbox_id}
+                    >
                       {b.sandbox_id}
                     </TableCell>
-                    <TableCell className="font-mono text-xs text-fg-subtle">{b.agent_id ?? "—"}</TableCell>
+                    <TableCell className="font-mono text-xs text-fg-subtle">
+                      {b.agent_id ?? "—"}
+                    </TableCell>
                     <TableCell className="text-sm text-fg-muted">{b.template_id}</TableCell>
-                    <TableCell><SandboxStatusBadge kind={b.status_kind} status={b.status} /></TableCell>
+                    <TableCell>
+                      <SandboxStatusBadge kind={b.status_kind} status={b.status} />
+                    </TableCell>
                     <TableCell>
                       <span title={b.last_active_at} className="text-sm text-fg-muted">
                         {relativeAgo(b.last_active_at)}
@@ -588,7 +614,11 @@ function CloudInstancesPanel({
                         variant="ghost"
                         size="sm"
                         className="h-7 gap-1 px-2 text-sm"
-                        disabled={!canTest || isTesting || (testingId !== null && testingId !== b.binding_id)}
+                        disabled={
+                          !canTest ||
+                          isTesting ||
+                          (testingId !== null && testingId !== b.binding_id)
+                        }
                         onClick={() => handleTestConnection(b)}
                         data-testid={`runtime-test-conn-${b.binding_id}`}
                       >
@@ -647,7 +677,9 @@ function CloudDaemonRuntimesPanel({
   if (error) {
     return (
       <ErrorState
-        title={t("runtime.cloud.daemonRuntimes.errors.loadFailed", { defaultValue: "Failed to load sandbox daemons" })}
+        title={t("runtime.cloud.daemonRuntimes.errors.loadFailed", {
+          defaultValue: "Failed to load sandbox daemons",
+        })}
         description={error instanceof Error ? error.message : String(error)}
         onRetry={onRefresh}
       />
@@ -666,7 +698,8 @@ function CloudDaemonRuntimesPanel({
           <p className="mt-0.5 max-w-3xl text-sm leading-relaxed text-fg-subtle">
             {t("runtime.cloud.daemonRuntimes.description", {
               count: runtimes.length,
-              defaultValue: "parsar-daemon processes running inside cloud sandboxes — these belong to the sandbox, not a physical device.",
+              defaultValue:
+                "parsar-daemon processes running inside cloud sandboxes — these belong to the sandbox, not a physical device.",
             })}
           </p>
         </div>
@@ -677,12 +710,28 @@ function CloudDaemonRuntimesPanel({
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>{t("runtime.cloud.daemonRuntimes.table.runtime", { defaultValue: "Runtime" })}</TableHead>
-            <TableHead>{t("runtime.cloud.daemonRuntimes.table.agent", { defaultValue: "Agent" })}</TableHead>
-            <TableHead>{t("runtime.cloud.daemonRuntimes.table.kind", { defaultValue: "Sandbox type" })}</TableHead>
-            <TableHead>{t("runtime.cloud.daemonRuntimes.table.agentEngines", { defaultValue: "Agent engines" })}</TableHead>
-            <TableHead>{t("runtime.cloud.daemonRuntimes.table.status", { defaultValue: "Status" })}</TableHead>
-            <TableHead>{t("runtime.cloud.daemonRuntimes.table.heartbeat", { defaultValue: "Last heartbeat" })}</TableHead>
+            <TableHead>
+              {t("runtime.cloud.daemonRuntimes.table.runtime", { defaultValue: "Runtime" })}
+            </TableHead>
+            <TableHead>
+              {t("runtime.cloud.daemonRuntimes.table.agent", { defaultValue: "Agent" })}
+            </TableHead>
+            <TableHead>
+              {t("runtime.cloud.daemonRuntimes.table.kind", { defaultValue: "Sandbox type" })}
+            </TableHead>
+            <TableHead>
+              {t("runtime.cloud.daemonRuntimes.table.agentEngines", {
+                defaultValue: "Agent engines",
+              })}
+            </TableHead>
+            <TableHead>
+              {t("runtime.cloud.daemonRuntimes.table.status", { defaultValue: "Status" })}
+            </TableHead>
+            <TableHead>
+              {t("runtime.cloud.daemonRuntimes.table.heartbeat", {
+                defaultValue: "Last heartbeat",
+              })}
+            </TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -704,9 +753,12 @@ function CloudDaemonRuntimesPanel({
                 {formatRuntimeAgentKinds(runtime)}
               </TableCell>
               <TableCell>
-                <RuntimeLivenessBadge runtime={runtime} />
+                <SandboxRuntimeStatus runtime={runtime} />
               </TableCell>
-              <TableCell className="text-sm text-fg-muted" title={runtime.last_heartbeat_at ?? undefined}>
+              <TableCell
+                className="text-sm text-fg-muted"
+                title={runtime.last_heartbeat_at ?? undefined}
+              >
                 {runtime.last_heartbeat_at ? relativeAgo(runtime.last_heartbeat_at) : "—"}
               </TableCell>
             </TableRow>
@@ -717,17 +769,63 @@ function CloudDaemonRuntimesPanel({
   )
 }
 
+function SandboxRuntimeStatus({ runtime }: { runtime: Runtime }) {
+  const { t } = useTranslation("admin")
+  const expired = isSandboxPairingExpired(runtime)
+  if (runtime.liveness === "pending_pairing") {
+    return (
+      <div className="space-y-1">
+        <Badge variant={expired ? "destructive" : "warning"}>
+          {expired
+            ? t("runtime.cloud.daemonRuntimes.status.timedOut", {
+                defaultValue: "Startup timed out",
+              })
+            : t("runtime.cloud.daemonRuntimes.status.preparing", { defaultValue: "Preparing" })}
+        </Badge>
+        <p className="max-w-sm text-xs leading-relaxed text-fg-subtle">
+          {expired
+            ? t("runtime.cloud.daemonRuntimes.status.timedOutDetail", {
+                defaultValue:
+                  "The sandbox did not pair before the startup token expired. Retry provisioning from the Agent detail.",
+              })
+            : t("runtime.cloud.daemonRuntimes.status.preparingDetail", {
+                defaultValue:
+                  "Starting the sandbox and waiting for parsar-daemon to pair. First local Docker startup may include pulling the sandbox image.",
+              })}
+        </p>
+      </div>
+    )
+  }
+  return <RuntimeLivenessBadge runtime={runtime} />
+}
+
 function RuntimeLivenessBadge({ runtime }: { runtime: Runtime }) {
   const { t } = useTranslation("admin")
   switch (runtime.liveness) {
     case "online":
-      return <Badge variant="success" dot>{t("runtime.agentDaemon.status.online", { defaultValue: "Online" })}</Badge>
+      return (
+        <Badge variant="success" dot>
+          {t("runtime.agentDaemon.status.online", { defaultValue: "Online" })}
+        </Badge>
+      )
     case "pending_pairing":
-      return <Badge variant="warning">{t("runtime.agentDaemon.status.pending_pairing", { defaultValue: "Pairing" })}</Badge>
+      return (
+        <Badge variant="warning">
+          {t("runtime.agentDaemon.status.pending_pairing", { defaultValue: "Pairing" })}
+        </Badge>
+      )
     case "error":
-      return <Badge variant="destructive">{t("runtime.agentDaemon.status.error", { defaultValue: "Error" })}</Badge>
+      return (
+        <Badge variant="destructive">
+          {t("runtime.agentDaemon.status.error", { defaultValue: "Error" })}
+        </Badge>
+      )
     default:
-      return <Badge variant="neutral">{t("runtime.agentDaemon.status.offline", { defaultValue: "Offline" })}</Badge>
+      return (
+        <Badge variant="neutral">
+          {t("runtime.agentDaemon.status.offline", { defaultValue: "Offline" })}
+        </Badge>
+      )
   }
 }
 
@@ -762,13 +860,7 @@ function shortID(id: string): string {
   return id.length > 12 ? id.slice(0, 12) : id
 }
 
-function RuntimeTabs({
-  tab,
-  onChange,
-}: {
-  tab: RuntimeTab
-  onChange: (next: RuntimeTab) => void
-}) {
+function RuntimeTabs({ tab, onChange }: { tab: RuntimeTab; onChange: (next: RuntimeTab) => void }) {
   const { t } = useTranslation("admin")
   return (
     <div className="mb-4 border-b border-line" role="tablist" aria-label={t("runtime.page.title")}>
@@ -838,9 +930,12 @@ function CloudStateBadge({ state }: { state: CloudState }) {
     error: "destructive",
     unknown: "warning",
   }
-  return <Badge variant={variantByState[state]} dot={state === "ready"}>{t(`runtime.cloud.state.${state}.label`)}</Badge>
+  return (
+    <Badge variant={variantByState[state]} dot={state === "ready"}>
+      {t(`runtime.cloud.state.${state}.label`)}
+    </Badge>
+  )
 }
-
 
 function ExternalAgentPanel() {
   const { t } = useTranslation("admin")
@@ -851,7 +946,9 @@ function ExternalAgentPanel() {
           <PlugZap className="h-4 w-4" strokeWidth={1.9} />
         </div>
         <div>
-          <h2 className="text-base font-semibold text-fg">{t("runtime.providers.external.title")}</h2>
+          <h2 className="text-base font-semibold text-fg">
+            {t("runtime.providers.external.title")}
+          </h2>
           <p className="mt-1 max-w-2xl text-sm leading-relaxed text-fg-muted">
             {t("runtime.external.body")}
           </p>
@@ -879,7 +976,12 @@ function ConfirmBulkKillDialog({
   const { t } = useTranslation("admin")
   const { t: tc } = useTranslation("common")
   return (
-    <Dialog open={open} onOpenChange={(next) => { if (!next && !loading) onCancel() }}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !loading) onCancel()
+      }}
+    >
       <DialogContent showCloseButton={false} className="max-w-md gap-0 p-0">
         <DialogHeader className="flex flex-row items-start gap-3 space-y-0 p-5 pr-5">
           <div className="shrink-0 rounded-full bg-danger-subtle p-2 text-danger-emphasis">
@@ -894,7 +996,11 @@ function ConfirmBulkKillDialog({
             </DialogDescription>
             {preview.length > 0 && (
               <ul className="mt-2 list-disc space-y-0.5 pl-5 text-sm text-fg-muted">
-                {preview.map((id) => <li key={id} className="font-mono">{id}</li>)}
+                {preview.map((id) => (
+                  <li key={id} className="font-mono">
+                    {id}
+                  </li>
+                ))}
                 {count > preview.length && (
                   <li className="list-none text-fg-faint">
                     {t("runtime.list.confirmBulkKill.andMore", { count: count - preview.length })}
@@ -942,7 +1048,7 @@ function resolveCloudState({
 }
 
 function cloudStateBody(
-  t: any,
+  t: TFunction<"admin">,
   state: CloudState,
   status: RuntimeStatus | undefined,
 ): string {


### PR DESCRIPTION
## Summary
- show sandbox provisioning as an explicit preparing state even before an active binding exists
- add an estimated startup timeline that calls out first-run Docker image pulls
- distinguish pending sandbox daemon startup from expired pairing timeouts in the Runtime page

## Tests
- pnpm --filter @parsar/web typecheck
- pnpm --filter @parsar/web exec eslint src/components/admin/SandboxPanel.tsx src/components/admin/SandboxProvisioningNotice.tsx src/pages/admin/RuntimePage.tsx src/lib/sandbox-runtime.ts
- pnpm --filter @parsar/web exec prettier --check src/components/admin/SandboxPanel.tsx src/components/admin/SandboxProvisioningNotice.tsx src/pages/admin/RuntimePage.tsx src/lib/sandbox-runtime.ts src/i18n/locales/en-US/admin.json src/i18n/locales/zh-CN/admin.json
- make check