### PR TITLE
Expose local compose web port on all interfaces

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,8 @@
 #   docker compose up
 #
 # Brings up Postgres + parsar-server (which runs migrations on startup
-# before serving). Open http://127.0.0.1:18080 and create the first owner
+# before serving). Open http://127.0.0.1:18080 locally, or
+# http://<server-ip>:18080 from another machine, and create the first owner
 # account in the web setup flow.
 #
 # Profile not fork: this is the SAME image as the self-host deployment
@@ -25,7 +26,7 @@
 #   PARSAR_SANDBOX_IMAGE  sandbox image ref (default: GHCR latest)
 #   PARSAR_LOCAL_PORT     host port for the web UI (default: 18080)
 #   PARSAR_PG_PORT        host port for Postgres (default: 15432)
-#   PARSAR_BIND_ADDR      host bind address (default: 127.0.0.1)
+#   PARSAR_BIND_ADDR      host bind address (default: 0.0.0.0)
 #   PARSAR_PG_DATA_DIR    host path for Postgres data (default: named volume)
 #   PARSAR_DATA_DIR       host path for server data (default: named volume)
 
@@ -80,7 +81,7 @@ services:
         parsar-migrate
         exec /usr/local/bin/parsar-server
     ports:
-      - "${PARSAR_BIND_ADDR:-127.0.0.1}:${PARSAR_LOCAL_PORT:-18080}:8080"
+      - "${PARSAR_BIND_ADDR:-0.0.0.0}:${PARSAR_LOCAL_PORT:-18080}:8080"
     environment:
       DATABASE_URL: postgres://parsar:${PARSAR_PG_PASSWORD:-parsar}@postgres:5432/parsar?sslmode=disable
       # Network proxy — only needed if your host requires a proxy for internet


### PR DESCRIPTION
## Summary
- bind the local compose web port to all interfaces by default
- update the quickstart comments to mention access via server IP
- keep Postgres bound to localhost

## Verification
- docker compose -f docker-compose.yml config --format yaml
- make check *(fails in existing store test: TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation reports LatestVersion 2.0.0, want frozen 1.0.0)*