### PR TITLE
Enable default local sandbox runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,8 +62,11 @@ PARSAR_PG_PORT=15432
 PARSAR_HOST_IP=
 # Set to parsar:local after running: make docker-build PARSAR_IMAGE=parsar PARSAR_IMAGE_TAG=local
 PARSAR_SERVER_IMAGE=parsar:local
-# Run: stat -c '%g' /var/run/docker.sock  (Linux) or stat -f '%g' (macOS)
-DOCKER_GID=999
+# Shared token between parsar-server and the compose-resident local runtime.
+# install.sh generates this automatically for normal installs.
+PARSAR_SHARED_RUNTIME_TOKEN=
+# Internal WebSocket URL advertised to compose-resident daemon runtimes.
+PARSAR_AGENT_DAEMON_WS_URL=ws://parsar-server:8080/agent-daemon/ws
 
 # -----------------------------------------------------------------------------
 # Feishu Bot (optional — see docs/deploy/lan-deploy.md)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,10 +22,10 @@ user is the administrator.
 ## Requirements
 
 - Docker Engine with Docker Compose v2.
-- Linux host with access to `/var/run/docker.sock`. The local compose stack
-  enables Docker-managed agent sandboxes and mounts the Docker socket. The
-  sandbox image (`ghcr.io/minimax-ai-dev/parsar-sandbox:latest`) is pulled
-  automatically — build your own instead with:
+- No host Docker socket mount is required for the default install. The local
+  runtime is a compose service that runs the sandbox image
+  (`ghcr.io/minimax-ai-dev/parsar-sandbox:latest`) and connects back with
+  `parsar-daemon`. Build your own image instead with:
   ```bash
   docker build -f infra/sandbox/Dockerfile -t parsar-sandbox:local .
   PARSAR_SANDBOX_IMAGE=parsar-sandbox:local ./install.sh
@@ -39,8 +39,9 @@ The script:
   published copy to `~/.parsar/docker-compose.yml`
 - creates `~/.parsar/.env`
 - generates and persists `PARSAR_MASTER_KEY`
+- generates and persists `PARSAR_SHARED_RUNTIME_TOKEN`
 - generates and persists the Postgres password
-- starts Postgres, runs migrations, and starts `parsar-server`
+- starts Postgres, `parsar-server`, and the default local runtime service
 - leaves Feishu, Slack, and Discord integrations disabled unless explicitly
   enabled in `~/.parsar/.env`
 

--- a/apps/web/src/components/admin/DevicePicker.tsx
+++ b/apps/web/src/components/admin/DevicePicker.tsx
@@ -57,6 +57,12 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
   }, [compatibleDevices, localDevices, preserveSelected, value])
 
   useEffect(() => {
+    if (value || disabled || q.isLoading || q.isFetching || q.error) return
+    if (selectableDevices.length !== 1) return
+    onChange(selectableDevices[0].id)
+  }, [disabled, onChange, q.error, q.isFetching, q.isLoading, selectableDevices, value])
+
+  useEffect(() => {
     // Skip while fetching, not just isLoading: a sibling PairDaemonDialog
     // invalidates this list as the new daemon comes online, and during
     // that refetch the freshly-set value would get wiped before the new

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -52,7 +52,7 @@ function connectorForExecutionMode(mode: ExecutionMode): string {
 }
 
 function executionModeFromAgent(a?: Agent | null): ExecutionMode {
-  if (!a) return "sandbox"
+  if (!a) return "local_device"
   if (a.connector_type === "http") return "external"
   if (a.connector_type === "agent_daemon") {
     return String(agentConfig(a).daemon_mode ?? "local") === "sandbox" ? "sandbox" : "local_device"
@@ -261,7 +261,7 @@ export function CreateAgentDialog({
   const defaultAgentDescription = t("agents.form.defaults.description", { workspace: workspaceDisplayName })
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
-  const [executionMode, setExecutionMode] = useState<ExecutionMode>("sandbox")
+  const [executionMode, setExecutionMode] = useState<ExecutionMode>("local_device")
   const [agentEngine, setAgentEngine] = useState<AgentEngine>("claude_code")
   const [sandboxSize, setSandboxSize] = useState<SandboxSize>("standard")
   const [modelID, setModelID] = useState("")
@@ -507,7 +507,7 @@ export function CreateAgentDialog({
       const cloneSuffix = cloneSource?.name ? " (Copy)" : ""
       setName(params.get("agent_name") ?? (cloneSource ? `${cloneSource.name}${cloneSuffix}` : defaultAgentName))
       setDescription(params.get("agent_description") ?? cloneSource?.description ?? defaultAgentDescription)
-      setExecutionMode(cloneSource ? executionModeFromAgent(cloneSource) : "sandbox")
+      setExecutionMode(cloneSource ? executionModeFromAgent(cloneSource) : "local_device")
       setAgentEngine(cloneSource ? agentEngineFromAgent(cloneSource) : "claude_code")
       setSandboxSize(cloneSource ? sandboxSizeFromAgent(cloneSource) : "standard")
       setModelID(cloneSource ? modelIDFromAgent(cloneSource) : "")
@@ -1024,18 +1024,18 @@ export function CreateAgentDialog({
                   <Field label={t("agents.form.fields.executionMode")} required>
                     <div className={"grid gap-2 " + (mode === "create" ? "sm:grid-cols-3" : "sm:grid-cols-2")}>
                       <ChoiceCard
-                        icon={<Cloud className="h-4 w-4" />}
-                        title={t("agents.execution.sandbox.title")}
-                        description={t("agents.execution.sandbox.description")}
-                        selected={executionMode === "sandbox"}
-                        onSelect={() => setExecutionMode("sandbox")}
-                      />
-                      <ChoiceCard
                         icon={<Laptop className="h-4 w-4" />}
                         title={t("agents.execution.localDevice.title")}
                         description={t("agents.execution.localDevice.description")}
                         selected={executionMode === "local_device"}
                         onSelect={() => setExecutionMode("local_device")}
+                      />
+                      <ChoiceCard
+                        icon={<Cloud className="h-4 w-4" />}
+                        title={t("agents.execution.sandbox.title")}
+                        description={t("agents.execution.sandbox.description")}
+                        selected={executionMode === "sandbox"}
+                        onSelect={() => setExecutionMode("sandbox")}
                       />
                       {mode === "create" && (
                         <ChoiceCard

--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -129,7 +129,7 @@ export function RuntimePage() {
   const daemonRuntimesQuery = useWorkspaceRuntimes(workspaceID ?? "", "agent_daemon")
   const workspacesQ = useMyWorkspaces()
 
-  const [tab, setTab] = useState<RuntimeTab>("sandbox")
+  const [tab, setTab] = useState<RuntimeTab>("local_device")
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [sortKey, setSortKey] = useState<SortKey>("last_active")
   const [confirming, setConfirming] = useState(false)
@@ -866,18 +866,18 @@ function RuntimeTabs({ tab, onChange }: { tab: RuntimeTab; onChange: (next: Runt
     <div className="mb-4 border-b border-line" role="tablist" aria-label={t("runtime.page.title")}>
       <div className="flex flex-wrap items-end gap-1">
         <RuntimeTabButton
-          active={tab === "sandbox"}
-          onClick={() => onChange("sandbox")}
-          testId="runtime-tab-sandbox"
-        >
-          {t("runtime.providers.sandbox.title")}
-        </RuntimeTabButton>
-        <RuntimeTabButton
           active={tab === "local_device"}
           onClick={() => onChange("local_device")}
           testId="runtime-tab-local-device"
         >
           {t("runtime.providers.localDevice.title", { defaultValue: "Local Device" })}
+        </RuntimeTabButton>
+        <RuntimeTabButton
+          active={tab === "sandbox"}
+          onClick={() => onChange("sandbox")}
+          testId="runtime-tab-sandbox"
+        >
+          {t("runtime.providers.sandbox.title")}
         </RuntimeTabButton>
         <RuntimeTabButton
           active={tab === "external"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,14 @@
 # Parsar local edition (all-in-one) — Phase 1 deliverable.
 #
-# One command, single machine, zero secrets to generate:
+# One command, single machine:
 #
-#   docker compose up
+#   ./install.sh
 #
-# Brings up Postgres + parsar-server (which runs migrations on startup
-# before serving). Open http://127.0.0.1:18080 locally, or
+# The installer writes a .env with PARSAR_SHARED_RUNTIME_TOKEN, then brings
+# up Postgres + parsar-server + a compose-resident local runtime. Open
+# http://127.0.0.1:18080 locally, or
 # http://<server-ip>:18080 from another machine, and create the first owner
 # account in the web setup flow.
-#
 # Profile not fork: this is the SAME image as the self-host deployment
 # (deploy/compose/compose.selfhost.yml). Differences live only in this file
 # + the env values below. No separate "local" binary or image.
@@ -20,10 +20,11 @@
 #       make docker-build PARSAR_IMAGE=parsar PARSAR_IMAGE_TAG=local
 #       PARSAR_SERVER_IMAGE=parsar:local docker compose up
 #
-# Override knobs (all optional — defaults make `up` work with no .env):
+# Override knobs:
 #   PARSAR_PROJECT_NAME   compose project/network prefix (default: parsar)
 #   PARSAR_SERVER_IMAGE   server image ref (default: GHCR latest)
-#   PARSAR_SANDBOX_IMAGE  sandbox image ref (default: GHCR latest)
+#   PARSAR_SANDBOX_IMAGE  default local runtime image ref (default: GHCR latest)
+#   PARSAR_SHARED_RUNTIME_TOKEN shared token for parsar-runtime pairing
 #   PARSAR_LOCAL_PORT     host port for the web UI (default: 18080)
 #   PARSAR_PG_PORT        host port for Postgres (default: 15432)
 #   PARSAR_BIND_ADDR      host bind address (default: 0.0.0.0)
@@ -31,9 +32,7 @@
 #   PARSAR_DATA_DIR       host path for server data (default: named volume)
 
 # Explicit project name so the auto-created network is always parsar_default
-# regardless of the clone directory name. The sandbox provider hard-codes this
-# network below (AGENT_DAEMON_SANDBOX_DOCKER_NETWORK); mismatched names would
-# leave every acquired sandbox unable to reach parsar-server.
+# regardless of the clone directory name.
 name: ${PARSAR_PROJECT_NAME:-parsar}
 
 networks:
@@ -154,31 +153,12 @@ services:
       PARSAR_DISCORD_GATEWAY: "${PARSAR_DISCORD_GATEWAY:-}"
       PARSAR_DISCORD_APP_ID: "${PARSAR_DISCORD_APP_ID:-}"
       PARSAR_DISCORD_BOT_TOKEN: "${PARSAR_DISCORD_BOT_TOKEN:-}"
-      # Docker sandbox — Agent runs inside a sandboxed container with
-      # Claude Code + Codex + Pi + parsar-daemon. The server calls docker
-      # to start / exec / stop sandbox containers via the mounted
-      # /var/run/docker.sock below. Defaults to the GHCR-published image
-      # (infra/sandbox/Dockerfile, built + pushed by
-      # .github/workflows/sandbox-image-release.yml). Build your own
-      # instead with:
-      #   docker build -f infra/sandbox/Dockerfile -t parsar-sandbox:local .
-      #   PARSAR_SANDBOX_IMAGE=parsar-sandbox:local
-      # The network below is pinned to `parsar_default` — the top-level
-      # `name: parsar` + `networks:` block at the head of this file
-      # guarantees that alias regardless of the clone directory.
-      AGENT_DAEMON_SANDBOX_BACKEND: "docker"
-      AGENT_DAEMON_SANDBOX_DOCKER_IMAGE: "${PARSAR_SANDBOX_IMAGE:-ghcr.io/minimax-ai-dev/parsar-sandbox:latest}"
-      AGENT_DAEMON_SANDBOX_DOCKER_NETWORK: "${PARSAR_PROJECT_NAME:-parsar}_default"
-      AGENT_DAEMON_SANDBOX_SERVER_URL: "http://parsar-server:8080"
-    group_add:
-      - "${DOCKER_GID:-999}"
+      # Shared token used only by the compose-resident local runtime below.
+      # install.sh generates a random value into .env.
+      PARSAR_SHARED_RUNTIME_TOKEN: "${PARSAR_SHARED_RUNTIME_TOKEN:-}"
+      PARSAR_AGENT_DAEMON_WS_URL: "ws://parsar-server:8080/agent-daemon/ws"
     volumes:
       - ${PARSAR_DATA_DIR:-parsar-local-data}:/var/lib/parsar
-      # Docker sandbox — the server calls `docker` against the host
-      # daemon to acquire/release sandbox containers. The GID mapping
-      # above (DOCKER_GID) grants the parsar user rights on the socket.
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ${PARSAR_DOCKER_BIN:-/usr/bin/docker}:/usr/bin/docker:ro
     # The image's baked-in HEALTHCHECK probes /healthz with `wget --spider`
     # (an HTTP HEAD), but /healthz is GET-only and answers HEAD with 405 —
     # so the default probe reports the container "unhealthy" even though it
@@ -193,6 +173,24 @@ services:
       start_period: 15s
       retries: 3
 
+  parsar-runtime:
+    image: ${PARSAR_SANDBOX_IMAGE:-ghcr.io/minimax-ai-dev/parsar-sandbox:latest}
+    restart: unless-stopped
+    depends_on:
+      parsar-server:
+        condition: service_healthy
+    environment:
+      PARSAR_SERVER_URL: "http://parsar-server:8080"
+      PARSAR_SHARED_RUNTIME_TOKEN: "${PARSAR_SHARED_RUNTIME_TOKEN:-}"
+      PARSAR_RUNTIME_NAME: "local-sandbox"
+      PARSAR_RUNTIME_PROFILE: "default-runtime"
+    command: ["/opt/parsar/bin/runtime-entrypoint.sh"]
+    volumes:
+      - parsar-runtime-home:/root/.parsar
+      - parsar-runtime-workspace:/workspace
+
 volumes:
   parsar-local-pg:
   parsar-local-data:
+  parsar-runtime-home:
+  parsar-runtime-workspace:

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -3670,9 +3670,10 @@ paths:
     post:
       consumes:
       - application/json
-      description: Consumes a pairing token minted by POST /api/v1/workspaces/{workspaceID}/runtimes
-        and returns the runner credential used to authenticate subsequent heartbeats.
-        Open endpoint — the daemon has no credential yet.
+      description: Consumes a pairing token minted by POST /api/v1/workspaces/{workspaceID}/runtimes,
+        or the configured shared local-runtime token, and returns the runner credential
+        used to authenticate subsequent heartbeats. Open endpoint — the daemon has
+        no credential yet.
       operationId: pairRuntime
       parameters:
       - description: Pairing token exchange
@@ -3702,6 +3703,12 @@ paths:
             type: object
         "500":
           description: Credential mint or persist failed
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Shared local runtime cannot pair before workspace setup
           schema:
             additionalProperties:
               type: string

--- a/infra/sandbox/Dockerfile
+++ b/infra/sandbox/Dockerfile
@@ -134,7 +134,10 @@ RUN chmod +x /usr/local/bin/parsar-daemon /usr/local/bin/parsar \
 # inject snapshot/incremental` at runtime. settings.json pointing at
 # these scripts is written per-sandbox at seed time, not baked here.
 COPY infra/sandbox/hooks/claude /opt/parsar/hooks/claude
-RUN chmod -R a+rx /opt/parsar/hooks
+RUN mkdir -p /opt/parsar/bin
+COPY infra/sandbox/scripts/runtime-entrypoint.sh /opt/parsar/bin/runtime-entrypoint.sh
+RUN chmod -R a+rx /opt/parsar/hooks \
+ && chmod +x /opt/parsar/bin/runtime-entrypoint.sh
 
 # --- Sandbox environment ---
 ENV IS_SANDBOX=1

--- a/infra/sandbox/scripts/runtime-entrypoint.sh
+++ b/infra/sandbox/scripts/runtime-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -eu
+
+server_url="${PARSAR_SERVER_URL:-http://parsar-server:8080}"
+token="${PARSAR_SHARED_RUNTIME_TOKEN:-}"
+profile="${PARSAR_RUNTIME_PROFILE:-default-runtime}"
+name="${PARSAR_RUNTIME_NAME:-local-sandbox}"
+
+if [ -z "$token" ]; then
+  echo "parsar-runtime: PARSAR_SHARED_RUNTIME_TOKEN is required" >&2
+  exit 1
+fi
+
+mkdir -p "$HOME/.parsar" /workspace
+
+while :; do
+  if parsar-daemon connect \
+    --profile "$profile" \
+    --url "$server_url" \
+    --token "$token" \
+    --device-name "$name"; then
+    exit 0
+  fi
+  echo "parsar-runtime: connect failed; retrying in 2s" >&2
+  sleep 2
+done

--- a/install.sh
+++ b/install.sh
@@ -20,7 +20,7 @@ Options:
                          when present, otherwise download the published template.
   --image IMAGE          parsar-server image.
                          Default: ghcr.io/minimax-ai-dev/parsar-server:latest
-  --sandbox-image IMAGE  Docker sandbox image.
+  --sandbox-image IMAGE  Default local runtime sandbox image.
                          Default: ghcr.io/minimax-ai-dev/parsar-sandbox:latest
                          To use your own build instead:
                          docker build -f infra/sandbox/Dockerfile -t parsar-sandbox:local .
@@ -197,12 +197,6 @@ fi
 
 detect_docker
 
-docker_bin="$(command -v docker || true)"
-docker_gid="999"
-if [ -S /var/run/docker.sock ] && command -v stat >/dev/null 2>&1; then
-  docker_gid="$(stat -c '%g' /var/run/docker.sock 2>/dev/null || printf '999')"
-fi
-
 umask 077
 mkdir -p "$parsar_home" "$parsar_home/postgres" "$parsar_home/data"
 
@@ -224,10 +218,9 @@ set_env "PARSAR_PUBLIC_URL" "$public_url" "$env_file"
 set_env "PARSAR_COOKIE_SECURE" "false" "$env_file"
 ensure_env "PARSAR_PG_PASSWORD" "$(random_hex 24)" "$env_file"
 ensure_env "PARSAR_MASTER_KEY" "$(random_hex 32)" "$env_file"
+ensure_env "PARSAR_SHARED_RUNTIME_TOKEN" "$(random_hex 32)" "$env_file"
 set_env "PARSAR_PG_DATA_DIR" "$parsar_home/postgres" "$env_file"
 set_env "PARSAR_DATA_DIR" "$parsar_home/data" "$env_file"
-set_env "PARSAR_DOCKER_BIN" "${docker_bin:-/usr/bin/docker}" "$env_file"
-set_env "DOCKER_GID" "$docker_gid" "$env_file"
 
 log "Using $compose_file"
 log "Wrote $env_file"

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -704,7 +704,10 @@ func main() {
 	// inside the package. Wired AFTER dev.RegisterRoutesWithStore so
 	// chi's NotFound fallback still fires last.
 	if pool != nil && dbStore != nil {
-		runtimeDeps := runtimeapi.Deps{Store: dbStore}
+		runtimeDeps := runtimeapi.Deps{
+			Store:              dbStore,
+			SharedRuntimeToken: strings.TrimSpace(envLookup("PARSAR_SHARED_RUNTIME_TOKEN")),
+		}
 		sessionStore := auth.NewPostgresSessionStore(sqlc.New(pool))
 		authMw := auth.NewMiddleware(sessionStore).WithDevAuth(cfg.Auth.DevAuth)
 		r.Group(func(r chi.Router) {

--- a/server/cmd/server/sandbox_docker.go
+++ b/server/cmd/server/sandbox_docker.go
@@ -49,6 +49,9 @@ func resolveAgentDaemonPublicWSURL(env func(string) string, cfg config.Config) s
 	if env == nil {
 		env = os.Getenv
 	}
+	if wsURL := strings.TrimSpace(env("PARSAR_AGENT_DAEMON_WS_URL")); wsURL != "" {
+		return agentDaemonWSURLFromBase(wsURL)
+	}
 	if serverURL := strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_SERVER_URL")); serverURL != "" {
 		return agentDaemonWSURLFromBase(serverURL)
 	}
@@ -76,7 +79,9 @@ func agentDaemonWSURLFromBase(base string) string {
 	default:
 		parsed.Scheme = "ws"
 	}
-	parsed.Path = strings.TrimRight(parsed.Path, "/") + path
+	if strings.TrimRight(parsed.Path, "/") != path {
+		parsed.Path = strings.TrimRight(parsed.Path, "/") + path
+	}
 	return parsed.String()
 }
 

--- a/server/cmd/server/sandbox_docker_test.go
+++ b/server/cmd/server/sandbox_docker_test.go
@@ -155,6 +155,19 @@ func TestResolveAgentDaemonPublicWSURLUsesSandboxServerURL(t *testing.T) {
 	}
 }
 
+func TestResolveAgentDaemonPublicWSURLPrefersExplicitDaemonWSURL(t *testing.T) {
+	var cfg config.Config
+	cfg.Server.PublicURL = "http://127.0.0.1:18090"
+	env := dockerBackendEnv(map[string]string{
+		"PARSAR_AGENT_DAEMON_WS_URL": "ws://parsar-server:8080/agent-daemon/ws",
+	})
+
+	got := resolveAgentDaemonPublicWSURL(env, cfg)
+	if want := "ws://parsar-server:8080/agent-daemon/ws"; got != want {
+		t.Fatalf("resolveAgentDaemonPublicWSURL = %q, want %q", got, want)
+	}
+}
+
 func TestResolveAgentDaemonPublicWSURLLeavesNonLoopbackUntouched(t *testing.T) {
 	// A real public host is reachable from inside the container as-is; only the
 	// scheme swap from buildAgentDaemonWSURL applies.

--- a/server/internal/api/runtime/runtime.go
+++ b/server/internal/api/runtime/runtime.go
@@ -25,9 +25,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
 )
 
 // Deps bundles what the runtime package needs from cmd/server. Now is
@@ -36,6 +36,9 @@ import (
 type Deps struct {
 	Store *store.Store
 	Now   func() time.Time
+	// SharedRuntimeToken lets the compose-resident local sandbox pair with a
+	// pre-shared token instead of an admin-minted one-shot pairing token.
+	SharedRuntimeToken string
 }
 
 // RegisterAdminRoutes mounts the workspace-admin tree. Caller MUST wrap
@@ -664,7 +667,7 @@ type pairResponse struct {
 // the daemon has no credential yet.
 //
 //	@Summary		Complete runtime pairing
-//	@Description	Consumes a pairing token minted by POST /api/v1/workspaces/{workspaceID}/runtimes and returns the runner credential used to authenticate subsequent heartbeats. Open endpoint — the daemon has no credential yet.
+//	@Description	Consumes a pairing token minted by POST /api/v1/workspaces/{workspaceID}/runtimes, or the configured shared local-runtime token, and returns the runner credential used to authenticate subsequent heartbeats. Open endpoint — the daemon has no credential yet.
 //	@Tags			runtimes
 //	@ID				pairRuntime
 //	@Accept			json
@@ -673,12 +676,17 @@ type pairResponse struct {
 //	@Success		200		{object}	pairResponse		"Runtime promoted and runner credential minted"
 //	@Failure		400		{object}	map[string]string	"Bad request"
 //	@Failure		401		{object}	map[string]string	"Pairing token invalid or expired"
+//	@Failure		503		{object}	map[string]string	"Shared local runtime cannot pair before workspace setup"
 //	@Failure		500		{object}	map[string]string	"Credential mint or persist failed"
 //	@Router			/api/v1/runtimes/pair [post]
 func (h *handler) pairRuntime(w http.ResponseWriter, r *http.Request) {
 	var body pairRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "bad_json", err.Error())
+		return
+	}
+	if h.isSharedRuntimeToken(body.PairingToken) {
+		h.pairSharedRuntime(w, r, body)
 		return
 	}
 	// Consume the token first; only mint the long-lived credential once
@@ -713,6 +721,52 @@ func (h *handler) pairRuntime(w http.ResponseWriter, r *http.Request) {
 	if err := h.deps.Store.SetRuntimeRunnerCredentialHash(r.Context(), rt.ID, hash); err != nil {
 		writeError(w, http.StatusInternalServerError, "credential_persist_failed", err.Error())
 		return
+	}
+	rt.Config["runner_credential_hash"] = hash
+	writeJSON(w, http.StatusOK, pairResponse{
+		Runtime:          newRuntimeDTO(rt),
+		RunnerCredential: credential,
+	})
+}
+
+func (h *handler) isSharedRuntimeToken(presented string) bool {
+	configured := strings.TrimSpace(h.deps.SharedRuntimeToken)
+	presented = strings.TrimSpace(presented)
+	if configured == "" {
+		return false
+	}
+	if len(presented) != len(configured) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(presented), []byte(configured)) == 1
+}
+
+func (h *handler) pairSharedRuntime(w http.ResponseWriter, r *http.Request, body pairRequest) {
+	rt, err := h.deps.Store.PairSharedRuntime(r.Context(), store.PairSharedRuntimeInput{
+		Hostname:        body.Hostname,
+		Version:         body.Version,
+		RunnerPublicKey: body.RunnerPublicKey,
+	})
+	if err != nil {
+		if errors.Is(err, store.ErrNoWorkspaceForSharedRuntime) {
+			writeError(w, http.StatusServiceUnavailable, "workspace_not_ready",
+				"no workspace exists yet; complete the web setup flow first")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "pair_failed", err.Error())
+		return
+	}
+	credential, hash, err := store.MintRuntimeCredential()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "mint_failed", err.Error())
+		return
+	}
+	if err := h.deps.Store.SetRuntimeRunnerCredentialHash(r.Context(), rt.ID, hash); err != nil {
+		writeError(w, http.StatusInternalServerError, "credential_persist_failed", err.Error())
+		return
+	}
+	if rt.Config == nil {
+		rt.Config = map[string]any{}
 	}
 	rt.Config["runner_credential_hash"] = hash
 	writeJSON(w, http.StatusOK, pairResponse{

--- a/server/internal/api/runtime/runtime_test.go
+++ b/server/internal/api/runtime/runtime_test.go
@@ -102,6 +102,67 @@ func TestRuntimeHTTPSurfaceDaemonPairingRoundTrip(t *testing.T) {
 		http.StatusOK)
 }
 
+func TestSharedRuntimeStaticTokenPair(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	s := store.New(db)
+
+	const sharedToken = "test-shared-runtime-token"
+	r := chi.NewRouter()
+	runtimeapi.RegisterRunnerRoutes(r, runtimeapi.Deps{Store: s, SharedRuntimeToken: sharedToken})
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+
+	pairBody := map[string]any{
+		"pairing_token":     sharedToken,
+		"hostname":          "parsar-runtime",
+		"version":           "0.1.0",
+		"runner_public_key": "fakepubkey==",
+	}
+	postJSON(t, srv.URL+"/api/v1/runtimes/pair", pairBody, http.StatusServiceUnavailable)
+
+	ids := store.DefaultDevFixtureIDs()
+	if _, err := s.InsertDevFixture(ctx, ids); err != nil {
+		t.Fatalf("seed dev fixture: %v", err)
+	}
+
+	pairOut := postJSON(t, srv.URL+"/api/v1/runtimes/pair", pairBody, http.StatusOK)
+	credential := pairOut["runner_credential"].(string)
+	if !strings.HasPrefix(credential, "rtc_") {
+		t.Fatalf("runner credential prefix wrong: %q", credential)
+	}
+	rt := pairOut["runtime"].(map[string]any)
+	if rt["name"] != store.SharedRuntimeName {
+		t.Fatalf("runtime name = %v, want %q", rt["name"], store.SharedRuntimeName)
+	}
+	if rt["workspace_id"] != ids.WorkspaceID {
+		t.Fatalf("workspace_id = %v, want %v", rt["workspace_id"], ids.WorkspaceID)
+	}
+	rtID := rt["id"].(string)
+
+	repairOut := postJSON(t, srv.URL+"/api/v1/runtimes/pair", pairBody, http.StatusOK)
+	rt2 := repairOut["runtime"].(map[string]any)
+	if rt2["id"] != rtID {
+		t.Fatalf("re-pair changed runtime id: %v -> %v", rtID, rt2["id"])
+	}
+	if repairOut["runner_credential"] == credential {
+		t.Fatal("re-pair returned the same runner credential")
+	}
+
+	hb := postJSONBearer(t, srv.URL+"/api/v1/runtimes/"+rtID+"/heartbeat",
+		repairOut["runner_credential"].(string), nil, http.StatusOK)
+	if hb["liveness"] != "online" {
+		t.Fatalf("heartbeat liveness = %v, want online", hb["liveness"])
+	}
+
+	postJSON(t, srv.URL+"/api/v1/runtimes/pair", map[string]any{
+		"pairing_token":     "test-shared-runtime-tokeX",
+		"hostname":          "parsar-runtime",
+		"version":           "0.1.0",
+		"runner_public_key": "fakepubkey==",
+	}, http.StatusUnauthorized)
+}
+
 func TestRuntimeListFiltersSelectableLocalDaemon(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()

--- a/server/internal/db/queries/runtimes.sql
+++ b/server/internal/db/queries/runtimes.sql
@@ -6,6 +6,13 @@
 -- (uuid cast to text on the way out, jsonb cast for write-side params,
 -- @now/@id parameter naming).
 
+-- name: GetOldestActiveWorkspaceID :one
+select id::text as id
+from workspaces
+where deleted_at is null
+order by created_at asc, id asc
+limit 1;
+
 -- name: CreateRuntimePairing :one
 -- Admin UI calls this to register a new Agent Daemon runtime in
 -- pending_pairing state. The pairing token is generated server-side,
@@ -123,6 +130,46 @@ returning
   id::text       as id,
   liveness,
   last_heartbeat_at;
+
+-- name: UpsertSharedRuntime :one
+insert into runtimes(
+  id, workspace_id, type, name, liveness, provider,
+  owner_user_id, version, hostname,
+  last_heartbeat_at,
+  pairing_token_hash, pairing_token_expires_at,
+  config, created_at, updated_at, deleted_at
+)
+values (
+  @id::uuid, @workspace_id::uuid, @type, @name, 'offline', @provider,
+  null, @version, @hostname,
+  null,
+  null, null,
+  @config::jsonb, @now, @now, null
+)
+on conflict (workspace_id, name) where deleted_at is null
+do update set
+  version                  = excluded.version,
+  hostname                 = excluded.hostname,
+  config                   = coalesce(runtimes.config, '{}'::jsonb) || excluded.config,
+  liveness                 = case when runtimes.liveness = 'online' then 'online' else 'offline' end,
+  pairing_token_hash       = null,
+  pairing_token_expires_at = null,
+  updated_at               = @now
+returning
+  id::text                       as id,
+  workspace_id::text             as workspace_id,
+  type,
+  name,
+  liveness,
+  provider,
+  owner_user_id,
+  version,
+  hostname,
+  last_heartbeat_at,
+  pairing_token_expires_at,
+  config,
+  created_at,
+  updated_at;
 
 -- name: GetRuntime :one
 -- Single runtime fetch (admin detail page + runner self-query).

--- a/server/internal/db/sqlc/runtimes.sql.go
+++ b/server/internal/db/sqlc/runtimes.sql.go
@@ -100,7 +100,6 @@ func (q *Queries) ConsumePairingToken(ctx context.Context, arg ConsumePairingTok
 }
 
 const createRuntimePairing = `-- name: CreateRuntimePairing :one
-
 insert into runtimes(
   id, workspace_id, type, name, liveness, provider,
   owner_user_id, version, hostname,
@@ -162,13 +161,6 @@ type CreateRuntimePairingRow struct {
 	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 }
 
-// runtimes.sql — runtime lifecycle and Agent Daemon pairing queries.
-//
-// Scope: SQL backing the runtimes table: admin lifecycle, daemon
-// pairing, runtime credential heartbeat, and agent_daemon heartbeat
-// capability persistence. Conventions follow the existing store.sql
-// (uuid cast to text on the way out, jsonb cast for write-side params,
-// @now/@id parameter naming).
 // Admin UI calls this to register a new Agent Daemon runtime in
 // pending_pairing state. The pairing token is generated server-side,
 // hashed (sha256 hex) and stored here; the plaintext is returned to
@@ -206,6 +198,29 @@ func (q *Queries) CreateRuntimePairing(ctx context.Context, arg CreateRuntimePai
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const getOldestActiveWorkspaceID = `-- name: GetOldestActiveWorkspaceID :one
+
+select id::text as id
+from workspaces
+where deleted_at is null
+order by created_at asc, id asc
+limit 1
+`
+
+// runtimes.sql — runtime lifecycle and Agent Daemon pairing queries.
+//
+// Scope: SQL backing the runtimes table: admin lifecycle, daemon
+// pairing, runtime credential heartbeat, and agent_daemon heartbeat
+// capability persistence. Conventions follow the existing store.sql
+// (uuid cast to text on the way out, jsonb cast for write-side params,
+// @now/@id parameter naming).
+func (q *Queries) GetOldestActiveWorkspaceID(ctx context.Context) (string, error) {
+	row := q.db.QueryRow(ctx, getOldestActiveWorkspaceID)
+	var id string
+	err := row.Scan(&id)
+	return id, err
 }
 
 const getRuntime = `-- name: GetRuntime :one
@@ -710,5 +725,107 @@ func (q *Queries) TouchRuntimeHeartbeat(ctx context.Context, arg TouchRuntimeHea
 	row := q.db.QueryRow(ctx, touchRuntimeHeartbeat, arg.Now, arg.ID)
 	var i TouchRuntimeHeartbeatRow
 	err := row.Scan(&i.ID, &i.Liveness, &i.LastHeartbeatAt)
+	return i, err
+}
+
+const upsertSharedRuntime = `-- name: UpsertSharedRuntime :one
+insert into runtimes(
+  id, workspace_id, type, name, liveness, provider,
+  owner_user_id, version, hostname,
+  last_heartbeat_at,
+  pairing_token_hash, pairing_token_expires_at,
+  config, created_at, updated_at, deleted_at
+)
+values (
+  $1::uuid, $2::uuid, $3, $4, 'offline', $5,
+  null, $6, $7,
+  null,
+  null, null,
+  $8::jsonb, $9, $9, null
+)
+on conflict (workspace_id, name) where deleted_at is null
+do update set
+  version                  = excluded.version,
+  hostname                 = excluded.hostname,
+  config                   = coalesce(runtimes.config, '{}'::jsonb) || excluded.config,
+  liveness                 = case when runtimes.liveness = 'online' then 'online' else 'offline' end,
+  pairing_token_hash       = null,
+  pairing_token_expires_at = null,
+  updated_at               = $9
+returning
+  id::text                       as id,
+  workspace_id::text             as workspace_id,
+  type,
+  name,
+  liveness,
+  provider,
+  owner_user_id,
+  version,
+  hostname,
+  last_heartbeat_at,
+  pairing_token_expires_at,
+  config,
+  created_at,
+  updated_at
+`
+
+type UpsertSharedRuntimeParams struct {
+	ID          pgtype.UUID        `json:"id"`
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
+	Type        string             `json:"type"`
+	Name        string             `json:"name"`
+	Provider    string             `json:"provider"`
+	Version     string             `json:"version"`
+	Hostname    string             `json:"hostname"`
+	Config      []byte             `json:"config"`
+	Now         pgtype.Timestamptz `json:"now"`
+}
+
+type UpsertSharedRuntimeRow struct {
+	ID                    string             `json:"id"`
+	WorkspaceID           string             `json:"workspace_id"`
+	Type                  string             `json:"type"`
+	Name                  string             `json:"name"`
+	Liveness              string             `json:"liveness"`
+	Provider              string             `json:"provider"`
+	OwnerUserID           pgtype.UUID        `json:"owner_user_id"`
+	Version               string             `json:"version"`
+	Hostname              string             `json:"hostname"`
+	LastHeartbeatAt       pgtype.Timestamptz `json:"last_heartbeat_at"`
+	PairingTokenExpiresAt pgtype.Timestamptz `json:"pairing_token_expires_at"`
+	Config                []byte             `json:"config"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
+}
+
+func (q *Queries) UpsertSharedRuntime(ctx context.Context, arg UpsertSharedRuntimeParams) (UpsertSharedRuntimeRow, error) {
+	row := q.db.QueryRow(ctx, upsertSharedRuntime,
+		arg.ID,
+		arg.WorkspaceID,
+		arg.Type,
+		arg.Name,
+		arg.Provider,
+		arg.Version,
+		arg.Hostname,
+		arg.Config,
+		arg.Now,
+	)
+	var i UpsertSharedRuntimeRow
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.Type,
+		&i.Name,
+		&i.Liveness,
+		&i.Provider,
+		&i.OwnerUserID,
+		&i.Version,
+		&i.Hostname,
+		&i.LastHeartbeatAt,
+		&i.PairingTokenExpiresAt,
+		&i.Config,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
 	return i, err
 }

--- a/server/internal/store/runtimes_shared.go
+++ b/server/internal/store/runtimes_shared.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	sqlc "github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
+	"github.com/jackc/pgx/v5"
+)
+
+const SharedRuntimeName = "local-sandbox"
+
+const sharedRuntimeConfigKey = "shared_runtime"
+
+var ErrNoWorkspaceForSharedRuntime = errors.New("runtime: no workspace exists yet for shared-runtime pairing")
+
+type PairSharedRuntimeInput struct {
+	Hostname        string
+	Version         string
+	RunnerPublicKey string
+}
+
+func (s *Store) PairSharedRuntime(ctx context.Context, input PairSharedRuntimeInput) (RuntimeRead, error) {
+	pubkey := strings.TrimSpace(input.RunnerPublicKey)
+	if pubkey == "" {
+		return RuntimeRead{}, errors.New("runtime: runner_public_key required")
+	}
+	workspaceID, err := sqlc.New(s.db).GetOldestActiveWorkspaceID(ctx)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return RuntimeRead{}, ErrNoWorkspaceForSharedRuntime
+		}
+		return RuntimeRead{}, err
+	}
+	workspaceUUID, err := uuid(workspaceID)
+	if err != nil {
+		return RuntimeRead{}, fmt.Errorf("runtime: workspace_id: %w", err)
+	}
+	cfg := map[string]any{
+		sharedRuntimeConfigKey: true,
+		"runner_public_key":    pubkey,
+		"runtime_pool":         "local_default",
+	}
+	cfgJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return RuntimeRead{}, fmt.Errorf("runtime: marshal config: %w", err)
+	}
+	now := time.Now().UTC()
+	row, err := sqlc.New(s.db).UpsertSharedRuntime(ctx, sqlc.UpsertSharedRuntimeParams{
+		ID:          mustUUID(newID()),
+		WorkspaceID: workspaceUUID,
+		Type:        RuntimeTypeAgentDaemon,
+		Name:        SharedRuntimeName,
+		Provider:    RuntimeProviderAgentDaemon,
+		Version:     strings.TrimSpace(input.Version),
+		Hostname:    strings.TrimSpace(input.Hostname),
+		Config:      cfgJSON,
+		Now:         timestamptz(now),
+	})
+	if err != nil {
+		return RuntimeRead{}, err
+	}
+	runtime := runtimeReadFromUpsertSharedRow(row)
+	payload := runtimeAuditPayload(runtime)
+	payload["liveness"] = runtime.Liveness
+	s.emitRuntimeLifecycleAudit(now, auditRuntimePaired, runtime, payload)
+	return runtime, nil
+}
+
+func IsSharedRuntime(rt RuntimeRead) bool {
+	v, ok := rt.Config[sharedRuntimeConfigKey].(bool)
+	return ok && v
+}
+
+func runtimeReadFromUpsertSharedRow(r sqlc.UpsertSharedRuntimeRow) RuntimeRead {
+	return RuntimeRead{
+		ID:                    r.ID,
+		WorkspaceID:           r.WorkspaceID,
+		Type:                  r.Type,
+		Name:                  r.Name,
+		Liveness:              r.Liveness,
+		Provider:              r.Provider,
+		OwnerUserID:           nullableUUIDString(r.OwnerUserID),
+		Version:               r.Version,
+		Hostname:              r.Hostname,
+		LastHeartbeatAt:       nullableTime(r.LastHeartbeatAt),
+		PairingTokenExpiresAt: nullableTime(r.PairingTokenExpiresAt),
+		Config:                unmarshalJSONOrEmpty(r.Config),
+		CreatedAt:             r.CreatedAt.Time,
+		UpdatedAt:             r.UpdatedAt.Time,
+	}
+}


### PR DESCRIPTION
## Summary
- start a compose-resident default local sandbox runtime instead of requiring Docker socket access in parsar-server
- add shared local runtime pairing token support for the bundled runtime
- make Local Device the default runtime selection in the web UI

## Verification
- make openapi
- make check
