### PR TITLE
Fix agent daemon session process lifecycle

### DIFF
--- a/apps/parsar-daemon/internal/agent/claudecode/ask_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/ask_test.go
@@ -290,7 +290,7 @@ func TestBuildAskUserToolResultMultiSelect(t *testing.T) {
 		t.Fatalf("buildAskUserToolResult: %v", err)
 	}
 	v := decodeAskResult(t, body)
-	if !strings.Contains(v.Message.Content[0].Content[0].Text, `"answer":"Safety, Performance"`) {
+	if !strings.Contains(v.Message.Content[0].Content[0].Text, `"answer":"Safety、Performance"`) {
 		t.Errorf("multi-select join failed: %s", v.Message.Content[0].Content[0].Text)
 	}
 }

--- a/apps/parsar-daemon/internal/agent/claudecode/options.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/options.go
@@ -28,9 +28,6 @@ type BuildResult struct {
 }
 
 // BuildArgs translates an AgentOptions map into the `claude` CLI argv.
-// resumeSessionID, if non-empty, takes precedence over any
-// "resume_session_id" key in opts. Unknown keys are silently ignored so
-// the wire schema can add fields without bumping the daemon version.
 func BuildArgs(opts map[string]any, resumeSessionID string) (BuildResult, error) {
 	args := []string{
 		"--output-format", "stream-json",
@@ -169,19 +166,8 @@ func BuildArgs(opts map[string]any, resumeSessionID string) (BuildResult, error)
 		}
 	}
 
-	// resume: --resume <session-id>. Explicit param wins over the map key.
-	resume := resumeSessionID
-	if resume == "" {
-		if v, ok := opts["resume_session_id"]; ok {
-			s, ok := v.(string)
-			if !ok {
-				return result, fmt.Errorf("claudecode.BuildArgs: resume_session_id must be string, got %T", v)
-			}
-			resume = s
-		}
-	}
-	if resume != "" {
-		args = append(args, "--resume", resume)
+	if resumeSessionID != "" {
+		args = append(args, "--resume", resumeSessionID)
 	}
 
 	// env: passthrough KEY=value pairs.

--- a/apps/parsar-daemon/internal/agent/claudecode/options_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/options_test.go
@@ -82,7 +82,7 @@ func TestBuildArgsHonoursPrimaryFlags(t *testing.T) {
 	}
 }
 
-func TestBuildArgsResumeArgWinsOverMapKey(t *testing.T) {
+func TestBuildArgsResumeUsesExplicitSessionID(t *testing.T) {
 	res, err := claudecode.BuildArgs(map[string]any{
 		"resume_session_id": "from-map",
 	}, "from-arg")
@@ -98,11 +98,11 @@ func TestBuildArgsResumeArgWinsOverMapKey(t *testing.T) {
 	}
 }
 
-func TestBuildArgsResumeFromMapWhenArgEmpty(t *testing.T) {
+func TestBuildArgsIgnoresResumeSessionIDOption(t *testing.T) {
 	res, _ := claudecode.BuildArgs(map[string]any{"resume_session_id": "session_xyz"}, "")
 	defer res.Cleanup()
-	if !containsPair(res.Args, "--resume", "session_xyz") {
-		t.Errorf("--resume session_xyz not in %v", res.Args)
+	if slices.Contains(res.Args, "--resume") || slices.Contains(res.Args, "session_xyz") {
+		t.Errorf("resume_session_id option must be ignored, args=%v", res.Args)
 	}
 }
 
@@ -262,7 +262,6 @@ func TestBuildArgsRejectsWrongShapes(t *testing.T) {
 		{"plugin_dirs element not string", map[string]any{"plugin_dirs": []any{"/a", 7}}},
 		{"mcp_servers not object", map[string]any{"mcp_servers": "json string"}},
 		{"env value not string", map[string]any{"env": map[string]any{"K": 1}}},
-		{"resume_session_id not string", map[string]any{"resume_session_id": 5}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/parsar-daemon/internal/agent/claudecode/parser.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/parser.go
@@ -82,7 +82,7 @@ type translation struct {
 	// Terminal is true when this line was a `result` frame — the
 	// session should stop reading stdout after consuming it.
 	Terminal bool
-	// SessionID is the claude_session_id surfaced on a system init
+	// SessionID is the upstream Claude session id surfaced on a system init.
 	// line (and again on the result frame). session.go writes this
 	// into binding metadata for --resume.
 	SessionID string
@@ -438,12 +438,12 @@ func (t *translator) translateResult(line []byte, subtype string) (translation, 
 		envs = append(envs, errEnv)
 	}
 
-	// Fold session_id into Metadata so the server-side connector can
-	// RememberSession on this done event — without this, the next
-	// prompt starts a brand-new chat (no --resume), losing context.
 	var doneMeta map[string]any
 	if strings.TrimSpace(msg.SessionID) != "" {
-		doneMeta = map[string]any{"claude_session_id": msg.SessionID}
+		doneMeta = map[string]any{
+			proto.DoneMetaAgentSessionID:   msg.SessionID,
+			proto.DoneMetaAgentSessionType: "claude_session",
+		}
 	}
 	doneEnv, err := proto.NewEnvelope(proto.TypeDone, t.runID, proto.DonePayload{
 		Content:  msg.Result,

--- a/apps/parsar-daemon/internal/agent/claudecode/parser_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/parser_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/claudecode"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
 )
 
 // counterMinter emits perm_001, perm_002, ... for deterministic
@@ -328,13 +329,14 @@ func TestTranslateResultSuccessEmitsUsageThenDone(t *testing.T) {
 	if done.Content != "final answer text" {
 		t.Errorf("done.Content = %q", done.Content)
 	}
-	// claude_session_id MUST flow through DonePayload.Metadata so the
-	// connector can --resume on the next turn.
 	if done.Metadata == nil {
-		t.Fatalf("done.Metadata missing — claude_session_id never reaches the connector")
+		t.Fatalf("done.Metadata missing")
 	}
-	if got, _ := done.Metadata["claude_session_id"].(string); got != "sess_abc" {
-		t.Errorf("done.Metadata.claude_session_id = %q, want sess_abc", got)
+	if got, _ := done.Metadata[proto.DoneMetaAgentSessionID].(string); got != "sess_abc" {
+		t.Errorf("done.Metadata.agent_session_id = %q, want sess_abc", got)
+	}
+	if got, _ := done.Metadata[proto.DoneMetaAgentSessionType].(string); got != "claude_session" {
+		t.Errorf("done.Metadata.agent_session_type = %q", got)
 	}
 }
 

--- a/apps/parsar-daemon/internal/agent/claudecode/session.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/session.go
@@ -9,14 +9,13 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/clirunner"
 	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
 	obslog "github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
 )
@@ -69,7 +68,7 @@ type Session struct {
 	runID string
 	cfg   sessionConfig
 
-	cmd     *exec.Cmd
+	proc    *clirunner.Process
 	stdin   io.WriteCloser
 	stdinMu sync.Mutex
 
@@ -83,7 +82,6 @@ type Session struct {
 	// cancelCtx is a child of parent ctx so Session.Cancel can signal
 	// everyone without racing router shutdown.
 	cancelCtx context.Context
-	cancelFn  context.CancelFunc
 
 	cancelOnce sync.Once
 
@@ -92,17 +90,13 @@ type Session struct {
 	askTimersMu sync.Mutex
 	askTimers   map[string]*time.Timer
 
-	// latestSessionID is the most recent claude_session_id seen on a
+	// latestSessionID is the most recent upstream session id seen on a
 	// system-init / result frame. The cancel-path done envelope reads
 	// it back so the server can RememberSession even when claude was
 	// killed mid-prompt (without it, the next user message starts a
 	// brand-new chat with no --resume).
 	latestSessionIDMu sync.Mutex
 	latestSessionID   string
-
-	// waitDone closes after the stdout pump fully drains and Wait
-	// returns. Used by Cancel's SIGKILL escalation timer.
-	waitDone chan struct{}
 
 	buildCleanup func()
 }
@@ -135,7 +129,7 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		"run_id", req.RunID, "agent_kind", req.AgentKind,
 		"prompt_len", len(req.Prompt), "work_dir", req.WorkDir,
 		"has_agent_options", req.AgentOptions != nil,
-		"resume_session_id", req.ResumeSessionID,
+		"agent_session_id", req.AgentSessionID,
 		"claude_binary", cfg.claudeBinary)
 
 	// Install plugins BEFORE BuildArgs so the resolved local paths
@@ -211,7 +205,7 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 			"warn_count", len(installRes.Warnings))
 	}
 
-	buildRes, err := BuildArgs(pluginOpts, req.ResumeSessionID)
+	buildRes, err := BuildArgs(pluginOpts, req.AgentSessionID)
 	if err != nil {
 		cfg.logger.Error("claudecode: BuildArgs failed", "run_id", req.RunID, "err", err)
 		return nil, fmt.Errorf("claudecode: build args: %w", err)
@@ -219,65 +213,43 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 	cfg.logger.Info("claudecode: BuildArgs ok",
 		"run_id", req.RunID, "args", buildRes.Args, "env_count", len(buildRes.Env))
 
-	cancelCtx, cancelFn := context.WithCancel(parent)
-
 	args := append([]string{}, buildRes.Args...)
 	args = append(args, cfg.extraArgs...)
-
-	cmd := exec.CommandContext(cancelCtx, cfg.claudeBinary, args...)
-	cmd.Dir = sessionWorkDir
-	cmd.Env = append(os.Environ(), buildRes.Env...)
-
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		cancelFn()
-		buildRes.Cleanup()
-		return nil, fmt.Errorf("claudecode: stdin pipe: %w", err)
-	}
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		_ = stdin.Close()
-		cancelFn()
-		buildRes.Cleanup()
-		return nil, fmt.Errorf("claudecode: stdout pipe: %w", err)
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		_ = stdin.Close()
-		cancelFn()
-		buildRes.Cleanup()
-		return nil, fmt.Errorf("claudecode: stderr pipe: %w", err)
-	}
 
 	cfg.logger.Info("claudecode: starting subprocess",
 		"run_id", req.RunID, "binary", cfg.claudeBinary,
 		"args", args, "dir", sessionWorkDir)
-	if err := cmd.Start(); err != nil {
+	proc, err := clirunner.Start(clirunner.StartOptions{
+		Parent:      parent,
+		Binary:      cfg.claudeBinary,
+		Args:        args,
+		Dir:         sessionWorkDir,
+		Env:         append(os.Environ(), buildRes.Env...),
+		NeedStdin:   true,
+		KillTimeout: cfg.killTimeout,
+	})
+	if err != nil {
 		cfg.logger.Error("claudecode: cmd.Start failed",
 			"run_id", req.RunID, "binary", cfg.claudeBinary, "err", err)
-		_ = stdin.Close()
-		cancelFn()
 		buildRes.Cleanup()
 		return nil, fmt.Errorf("claudecode: start %q: %w", cfg.claudeBinary, err)
 	}
 	cfg.logger.Info("claudecode: subprocess started",
-		"run_id", req.RunID, "pid", cmd.Process.Pid)
+		"run_id", req.RunID, "pid", proc.Cmd.Process.Pid)
 
 	pending := newPendingTable()
 	askPending := newPendingAskTable()
 	s := &Session{
 		runID:        req.RunID,
 		cfg:          cfg,
-		cmd:          cmd,
-		stdin:        stdin,
+		proc:         proc,
+		stdin:        proc.Stdin,
 		pending:      pending,
 		askPending:   askPending,
 		translator:   newTranslator(req.RunID, pending, askPending, defaultPermIDMinter, defaultAskIDMinter),
 		out:          out,
-		cancelCtx:    cancelCtx,
-		cancelFn:     cancelFn,
+		cancelCtx:    proc.Context(),
 		askTimers:    make(map[string]*time.Timer),
-		waitDone:     make(chan struct{}),
 		buildCleanup: buildRes.Cleanup,
 	}
 
@@ -300,8 +272,8 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 	}
 
 	cfg.logger.Info("claudecode: launching stdout/stderr pumps", "run_id", req.RunID)
-	go s.pumpStderr(stderr)
-	go s.run(stdout)
+	go s.pumpStderr(proc.Stderr)
+	go s.run(proc.Stdout)
 
 	return s, nil
 }
@@ -321,23 +293,7 @@ func (s *Session) writeStdin(b []byte) (int, error) {
 func (s *Session) Cancel(_ context.Context) error {
 	s.cancelOnce.Do(func() {
 		s.stopAllAskTimers()
-		if s.cmd.Process == nil {
-			return
-		}
-		_ = s.cmd.Process.Signal(syscall.SIGTERM)
-
-		go func() {
-			select {
-			case <-s.waitDone:
-				return
-			case <-time.After(s.cfg.killTimeout):
-				_ = s.cmd.Process.Signal(syscall.SIGKILL)
-			}
-		}()
-
-		// Flip the context so blocked stdin writes / out sends see
-		// cancellation.
-		s.cancelFn()
+		s.proc.Cancel()
 	})
 	return nil
 }
@@ -503,7 +459,6 @@ func (s *Session) stopAskTimer(askID string) {
 // run is the stdout pump. Owns the out channel close.
 func (s *Session) run(stdout io.Reader) {
 	s.cfg.logger.Info("claudecode: run() stdout pump started", "run_id", s.runID)
-	defer close(s.waitDone)
 	defer s.buildCleanup()
 	defer s.closeOut()
 
@@ -562,12 +517,13 @@ func (s *Session) run(stdout io.Reader) {
 				}
 			case <-s.cancelCtx.Done():
 				s.cfg.logger.Info("claudecode: cancelled during out send", "run_id", s.runID)
-				_ = s.cmd.Wait() // reap
+				_ = s.proc.Wait()
 				return
 			}
 		}
 		if tx.Terminal {
 			terminal = true
+			s.finishAfterTerminal()
 			break
 		}
 	}
@@ -580,10 +536,10 @@ func (s *Session) run(stdout io.Reader) {
 	s.cfg.logger.Info("claudecode: stdout pump exiting",
 		"run_id", s.runID, "lines_read", lineCount, "terminal", terminal)
 
-	waitErr := s.cmd.Wait()
+	waitErr := s.proc.Wait()
 	s.cfg.logger.Info("claudecode: subprocess exited",
 		"run_id", s.runID, "wait_err", waitErr,
-		"exit_code", s.cmd.ProcessState.ExitCode())
+		"exit_code", s.proc.Cmd.ProcessState.ExitCode())
 
 	if !terminal {
 		s.synthesizeTerminal(waitErr)
@@ -623,10 +579,7 @@ func (s *Session) synthesizeTerminal(waitErr error) {
 	}
 }
 
-// doneMetaForCancel returns the metadata map attached to the cancel-
-// path Done envelope. Currently the only entry is claude_session_id,
-// which lets the server-side connector RememberSession on a cancelled
-// run so the next user message can --resume the same claude session.
+// doneMetaForCancel returns the metadata map attached to the cancel-path Done envelope.
 func (s *Session) doneMetaForCancel() map[string]any {
 	s.latestSessionIDMu.Lock()
 	id := s.latestSessionID
@@ -634,7 +587,10 @@ func (s *Session) doneMetaForCancel() map[string]any {
 	if id == "" {
 		return nil
 	}
-	return map[string]any{"claude_session_id": id}
+	return map[string]any{
+		proto.DoneMetaAgentSessionID:   id,
+		proto.DoneMetaAgentSessionType: "claude_session",
+	}
 }
 
 func (s *Session) trySend(env proto.Envelope) {
@@ -648,6 +604,18 @@ func (s *Session) trySend(env proto.Envelope) {
 
 func (s *Session) closeOut() {
 	s.closeOutOnce.Do(func() { close(s.out) })
+}
+
+func (s *Session) finishAfterTerminal() {
+	s.stdinMu.Lock()
+	if s.stdin != nil {
+		_ = s.stdin.Close()
+		s.stdin = nil
+	}
+	s.stdinMu.Unlock()
+	if s.proc != nil {
+		s.proc.Cancel()
+	}
 }
 
 // resolveSessionWorkDir returns the directory that BOTH plugin installs

--- a/apps/parsar-daemon/internal/agent/clirunner/process.go
+++ b/apps/parsar-daemon/internal/agent/clirunner/process.go
@@ -1,0 +1,145 @@
+package clirunner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+type StartOptions struct {
+	Parent      context.Context
+	Binary      string
+	Args        []string
+	Dir         string
+	Env         []string
+	NeedStdin   bool
+	KillTimeout time.Duration
+}
+
+type Process struct {
+	Cmd    *exec.Cmd
+	Stdin  io.WriteCloser
+	Stdout io.ReadCloser
+	Stderr io.ReadCloser
+
+	ctx       context.Context
+	cancel    context.CancelFunc
+	done      chan struct{}
+	killAfter time.Duration
+
+	cancelOnce sync.Once
+	waitOnce   sync.Once
+}
+
+func Start(opts StartOptions) (*Process, error) {
+	if opts.Parent == nil {
+		opts.Parent = context.Background()
+	}
+	if opts.Binary == "" {
+		return nil, fmt.Errorf("clirunner: binary required")
+	}
+	if opts.KillTimeout <= 0 {
+		opts.KillTimeout = 3 * time.Second
+	}
+
+	ctx, cancel := context.WithCancel(opts.Parent)
+	cmd := exec.CommandContext(ctx, opts.Binary, opts.Args...)
+	cmd.Dir = opts.Dir
+	if len(opts.Env) > 0 {
+		cmd.Env = append([]string{}, opts.Env...)
+	}
+
+	var stdin io.WriteCloser
+	var err error
+	if opts.NeedStdin {
+		stdin, err = cmd.StdinPipe()
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("clirunner: stdin pipe: %w", err)
+		}
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		closePipe(stdin)
+		cancel()
+		return nil, fmt.Errorf("clirunner: stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		closePipe(stdin)
+		cancel()
+		return nil, fmt.Errorf("clirunner: stderr pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		closePipe(stdin)
+		cancel()
+		return nil, fmt.Errorf("clirunner: start %q: %w", opts.Binary, err)
+	}
+
+	return &Process{
+		Cmd:       cmd,
+		Stdin:     stdin,
+		Stdout:    stdout,
+		Stderr:    stderr,
+		ctx:       ctx,
+		cancel:    cancel,
+		done:      make(chan struct{}),
+		killAfter: opts.KillTimeout,
+	}, nil
+}
+
+func (p *Process) Context() context.Context {
+	if p == nil || p.ctx == nil {
+		return context.Background()
+	}
+	return p.ctx
+}
+
+func (p *Process) Done() <-chan struct{} {
+	if p == nil {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	return p.done
+}
+
+func (p *Process) Cancel() {
+	if p == nil {
+		return
+	}
+	p.cancelOnce.Do(func() {
+		if p.Cmd != nil && p.Cmd.Process != nil {
+			_ = p.Cmd.Process.Signal(syscall.SIGTERM)
+			go func() {
+				select {
+				case <-p.done:
+				case <-time.After(p.killAfter):
+					_ = p.Cmd.Process.Signal(syscall.SIGKILL)
+				}
+			}()
+		}
+		if p.cancel != nil {
+			p.cancel()
+		}
+	})
+}
+
+func (p *Process) Wait() error {
+	if p == nil || p.Cmd == nil {
+		return nil
+	}
+	err := p.Cmd.Wait()
+	p.waitOnce.Do(func() { close(p.done) })
+	return err
+}
+
+func closePipe(p io.Closer) {
+	if p != nil {
+		_ = p.Close()
+	}
+}

--- a/apps/parsar-daemon/internal/agent/clirunner/process_test.go
+++ b/apps/parsar-daemon/internal/agent/clirunner/process_test.go
@@ -1,0 +1,78 @@
+package clirunner
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestStartWaitClosesDone(t *testing.T) {
+	proc, err := Start(StartOptions{
+		Parent: context.Background(),
+		Binary: helperBinary(),
+		Args:   []string{"-test.run=TestHelperProcess", "--", "exit"},
+		Env:    helperEnv(),
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := proc.Wait(); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	select {
+	case <-proc.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Done did not close")
+	}
+}
+
+func TestCancelCancelsContext(t *testing.T) {
+	proc, err := Start(StartOptions{
+		Parent:      context.Background(),
+		Binary:      helperBinary(),
+		Args:        []string{"-test.run=TestHelperProcess", "--", "sleep"},
+		Env:         helperEnv(),
+		KillTimeout: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	proc.Cancel()
+	select {
+	case <-proc.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("context was not cancelled")
+	}
+	_ = proc.Wait()
+}
+
+func helperBinary() string {
+	return os.Args[0]
+}
+
+func helperEnv() []string {
+	return append(os.Environ(), "GO_WANT_HELPER_PROCESS=1")
+}
+
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) < 2 {
+		os.Exit(2)
+	}
+	switch args[1] {
+	case "exit":
+		os.Exit(0)
+	case "sleep":
+		time.Sleep(10 * time.Second)
+		os.Exit(0)
+	default:
+		os.Exit(2)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/options.go
+++ b/apps/parsar-daemon/internal/agent/codex/options.go
@@ -2,6 +2,7 @@ package codex
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -55,9 +56,7 @@ type SessionPlan struct {
 	ApprovalPolicy AskForApproval
 	Sandbox        SandboxMode
 
-	// Cleanup is the deferred housekeeping the session must run after
-	// the child exits — usually removing the temporary CODEX_HOME tree.
-	// Always non-nil; defaults to a no-op.
+	// Cleanup is the deferred housekeeping the session must run after the child exits.
 	Cleanup func()
 }
 
@@ -104,7 +103,7 @@ type SessionPlan struct {
 // Approval / sandbox keys are not exposed to admin yet — the daemon
 // always runs silent + full-access. Wire them through once a UI to flip
 // them lands.
-func BuildSessionPlan(runID, workDir string, opts map[string]any) (SessionPlan, error) {
+func BuildSessionPlan(runID, agentStateKey, workDir string, opts map[string]any) (SessionPlan, error) {
 	cleanup := func() {}
 	plan := SessionPlan{
 		ApprovalPolicy: SilentGranularPolicy(),
@@ -129,14 +128,13 @@ func BuildSessionPlan(runID, workDir string, opts map[string]any) (SessionPlan, 
 		return plan, err
 	}
 
-	// Allocate a per-run CODEX_HOME so codex's config / auth / sessions
-	// tree never collides with the daemon's user home (or with another
-	// concurrent session). The dir is removed in plan.Cleanup.
-	codexHome, homeCleanup, err := allocCodexHome(runID)
+	codexHome, err := allocCodexHome(agentStateKey)
 	if err != nil {
 		return plan, err
 	}
-	cleanup = homeCleanup
+	if err := resetGeneratedConfig(codexHome); err != nil {
+		return plan, err
+	}
 	env = append(env, "CODEX_HOME="+codexHome)
 
 	// MCP servers come pre-rendered from server/internal/connector/agentdaemon
@@ -228,19 +226,38 @@ func resolveWorkDirCodex(input string) (string, error) {
 	return abs, nil
 }
 
-func allocCodexHome(runID string) (string, func(), error) {
-	if strings.TrimSpace(runID) == "" {
-		return "", func() {}, fmt.Errorf("codex: runID required for CODEX_HOME allocation")
+func allocCodexHome(agentStateKey string) (string, error) {
+	if strings.TrimSpace(agentStateKey) == "" {
+		return "", fmt.Errorf("codex: agentStateKey required for CODEX_HOME allocation")
 	}
 	root, err := paths.Root()
 	if err != nil {
-		return "", func() {}, err
+		return "", err
 	}
-	dir := filepath.Join(root, "parsar-daemon", "scratch", "codex-"+safeRunIDCodex(runID))
+	parts := strings.Split(agentStateKey, "/")
+	safeParts := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if safe := safePathPartCodex(part); safe != "" {
+			safeParts = append(safeParts, safe)
+		}
+	}
+	if len(safeParts) == 0 {
+		return "", fmt.Errorf("codex: invalid agentStateKey %q", agentStateKey)
+	}
+	dirParts := append([]string{root, "parsar-daemon", "agent-sessions"}, safeParts...)
+	dir := filepath.Join(dirParts...)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", func() {}, fmt.Errorf("codex: create CODEX_HOME %s: %w", dir, err)
+		return "", fmt.Errorf("codex: create CODEX_HOME %s: %w", dir, err)
 	}
-	return dir, func() { _ = os.RemoveAll(dir) }, nil
+	return dir, nil
+}
+
+func resetGeneratedConfig(codexHome string) error {
+	path := filepath.Join(codexHome, "config.toml")
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("codex: remove generated config %s: %w", path, err)
+	}
+	return nil
 }
 
 func buildSessionEnv(opts map[string]any) ([]string, error) {
@@ -427,7 +444,7 @@ func stringOpt(opts map[string]any, key string) string {
 	return strings.TrimSpace(s)
 }
 
-func safeRunIDCodex(runID string) string {
+func safePathPartCodex(runID string) string {
 	var b strings.Builder
 	for _, r := range runID {
 		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {

--- a/apps/parsar-daemon/internal/agent/codex/options_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/options_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBuildSessionPlan_DefaultsSilentAndFullAccess(t *testing.T) {
-	plan, err := BuildSessionPlan("run-1", "", nil)
+	plan, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", nil)
 	if err != nil {
 		t.Fatalf("BuildSessionPlan: %v", err)
 	}
@@ -25,7 +25,7 @@ func TestBuildSessionPlan_DefaultsSilentAndFullAccess(t *testing.T) {
 }
 
 func TestBuildSessionPlan_AllocsCodexHomeAndEnv(t *testing.T) {
-	plan, err := BuildSessionPlan("run-1", "", map[string]any{
+	plan, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", map[string]any{
 		"env": map[string]any{
 			"OPENAI_API_KEY": "sk-test",
 		},
@@ -58,8 +58,23 @@ func TestBuildSessionPlan_AllocsCodexHomeAndEnv(t *testing.T) {
 	}
 }
 
+func TestBuildSessionPlan_StableCodexHomeByStateKey(t *testing.T) {
+	stateKey := "conv-stable/agent-stable/codex"
+	planA, err := BuildSessionPlan("run-a", stateKey, "", nil)
+	if err != nil {
+		t.Fatalf("BuildSessionPlan A: %v", err)
+	}
+	planB, err := BuildSessionPlan("run-b", stateKey, "", nil)
+	if err != nil {
+		t.Fatalf("BuildSessionPlan B: %v", err)
+	}
+	if codexHomeFromEnv(planA.Env) == "" || codexHomeFromEnv(planA.Env) != codexHomeFromEnv(planB.Env) {
+		t.Fatalf("CODEX_HOME must be stable by state key: A=%q B=%q", codexHomeFromEnv(planA.Env), codexHomeFromEnv(planB.Env))
+	}
+}
+
 func TestBuildSessionPlan_RoutesReasoningSummary(t *testing.T) {
-	plan, err := BuildSessionPlan("run-1", "", map[string]any{
+	plan, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", map[string]any{
 		"reasoning_summary": "detailed",
 	})
 	if err != nil {
@@ -78,8 +93,17 @@ func TestBuildSessionPlan_RoutesReasoningSummary(t *testing.T) {
 	}
 }
 
+func codexHomeFromEnv(env []string) string {
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "CODEX_HOME=") {
+			return strings.TrimPrefix(kv, "CODEX_HOME=")
+		}
+	}
+	return ""
+}
+
 func TestBuildSessionPlan_OverrideSystemPromptReplacesAppend(t *testing.T) {
-	plan, err := BuildSessionPlan("run-1", "", map[string]any{
+	plan, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", map[string]any{
 		"system_prompt":          "user base",
 		"override_system_prompt": "you are pirate",
 	})
@@ -93,7 +117,7 @@ func TestBuildSessionPlan_OverrideSystemPromptReplacesAppend(t *testing.T) {
 }
 
 func TestBuildSessionPlan_EmptyOverrideKeepsSystemPrompt(t *testing.T) {
-	plan, err := BuildSessionPlan("run-1", "", map[string]any{
+	plan, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", map[string]any{
 		"system_prompt":          "user base",
 		"override_system_prompt": "",
 	})
@@ -107,7 +131,7 @@ func TestBuildSessionPlan_EmptyOverrideKeepsSystemPrompt(t *testing.T) {
 }
 
 func TestBuildSessionPlan_RejectsRelativeWorkDir(t *testing.T) {
-	_, err := BuildSessionPlan("run-1", "relative/dir", nil)
+	_, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "relative/dir", nil)
 	if err == nil {
 		t.Fatal("relative work_dir must error")
 	}
@@ -119,7 +143,7 @@ func TestBuildSessionPlan_RejectsRelativeWorkDir(t *testing.T) {
 // hard-fail the first turn instead of running.
 func TestBuildSessionPlan_CreatesMissingWorkDir(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "missing", "parents", "leaf")
-	plan, err := BuildSessionPlan("run-1", target, nil)
+	plan, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", target, nil)
 	if err != nil {
 		t.Fatalf("BuildSessionPlan: %v", err)
 	}
@@ -137,7 +161,7 @@ func TestBuildSessionPlan_CreatesMissingWorkDir(t *testing.T) {
 }
 
 func TestBuildSessionPlan_WritesMCPConfig(t *testing.T) {
-	plan, err := BuildSessionPlan("run-1", "", map[string]any{
+	plan, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", map[string]any{
 		"mcp_servers": map[string]any{
 			"docs": map[string]any{
 				"command": "docs-server",
@@ -177,7 +201,7 @@ func TestBuildSessionPlan_WritesMCPConfig(t *testing.T) {
 }
 
 func TestBuildSessionPlan_MissingMCPCommandErrors(t *testing.T) {
-	_, err := BuildSessionPlan("run-1", "", map[string]any{
+	_, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", map[string]any{
 		"mcp_servers": map[string]any{
 			"broken": map[string]any{
 				"args": []any{"--x"},

--- a/apps/parsar-daemon/internal/agent/codex/protocol.go
+++ b/apps/parsar-daemon/internal/agent/codex/protocol.go
@@ -10,9 +10,8 @@
 //
 //  2. Multi-turn context lives in a Codex "thread" identified by the
 //     thread_id returned in the first `thread/started` notification.
-//     The daemon stamps that id into DonePayload.Metadata["claude_session_id"]
-//     (the agent-neutral session-id key the binder layer already
-//     understands) so the connector's RememberSession path persists it.
+//     The daemon stamps that id into DonePayload.Metadata["agent_session_id"]
+//     so the connector's RememberSession path persists it.
 //     Subsequent turns spawn a fresh app-server and call `thread/resume`
 //     with that id to graft the prior turn's context back in.
 package codex
@@ -39,10 +38,10 @@ type JsonRpcRequest struct {
 // JsonRpcResponse is an outbound reply to a server-initiated request.
 // Either Result or Error must be non-nil.
 type JsonRpcResponse struct {
-	JsonRpc string         `json:"jsonrpc"`
-	ID      any            `json:"id"`
-	Result  any            `json:"result,omitempty"`
-	Error   *JsonRpcError  `json:"error,omitempty"`
+	JsonRpc string        `json:"jsonrpc"`
+	ID      any           `json:"id"`
+	Result  any           `json:"result,omitempty"`
+	Error   *JsonRpcError `json:"error,omitempty"`
 }
 
 // JsonRpcError carries a structured failure reply. Codes follow the
@@ -149,18 +148,18 @@ type SandboxPolicy struct {
 // ---------------------------------------------------------------------------
 
 type ThreadStartParams struct {
-	Cwd                   string         `json:"cwd"`
-	Model                 string         `json:"model,omitempty"`
-	ModelProvider         string         `json:"modelProvider,omitempty"`
-	ApprovalPolicy        AskForApproval `json:"approvalPolicy"`
+	Cwd            string         `json:"cwd"`
+	Model          string         `json:"model,omitempty"`
+	ModelProvider  string         `json:"modelProvider,omitempty"`
+	ApprovalPolicy AskForApproval `json:"approvalPolicy"`
 	// Sandbox is the v0.141+ field name; previously called sandboxPolicy
 	// and took a tagged-enum object. Wire format now is a kebab-case
 	// string: "read-only" / "workspace-write" / "danger-full-access".
 	// Sending the old object shape causes codex to silently default to
 	// read-only, which terminates the turn before the model can reply.
-	Sandbox               SandboxMode    `json:"sandbox,omitempty"`
-	DeveloperInstructions string         `json:"developerInstructions,omitempty"`
-	RuntimeWorkspaceRoots []string       `json:"runtimeWorkspaceRoots,omitempty"`
+	Sandbox               SandboxMode `json:"sandbox,omitempty"`
+	DeveloperInstructions string      `json:"developerInstructions,omitempty"`
+	RuntimeWorkspaceRoots []string    `json:"runtimeWorkspaceRoots,omitempty"`
 }
 
 type Thread struct {
@@ -223,11 +222,11 @@ type TurnInterruptParams struct {
 }
 
 type TurnUsage struct {
-	InputTokens         int `json:"inputTokens,omitempty"`
-	OutputTokens        int `json:"outputTokens,omitempty"`
-	CachedInputTokens   int `json:"cachedInputTokens,omitempty"`
+	InputTokens          int `json:"inputTokens,omitempty"`
+	OutputTokens         int `json:"outputTokens,omitempty"`
+	CachedInputTokens    int `json:"cachedInputTokens,omitempty"`
 	CacheReadInputTokens int `json:"cacheReadInputTokens,omitempty"`
-	TotalTokens         int `json:"totalTokens,omitempty"`
+	TotalTokens          int `json:"totalTokens,omitempty"`
 }
 
 type Turn struct {
@@ -267,10 +266,10 @@ type ThreadItem struct {
 	ID   string `json:"id,omitempty"`
 
 	// agentMessage / reasoning
-	Text         string   `json:"text,omitempty"`
-	Summary      []string `json:"summary,omitempty"`
-	Content      []string `json:"content,omitempty"`
-	SummaryText  string   `json:"summary_text,omitempty"`
+	Text        string   `json:"text,omitempty"`
+	Summary     []string `json:"summary,omitempty"`
+	Content     []string `json:"content,omitempty"`
+	SummaryText string   `json:"summary_text,omitempty"`
 
 	// commandExecution
 	Command  string `json:"command,omitempty"`

--- a/apps/parsar-daemon/internal/agent/codex/provider_config_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/provider_config_test.go
@@ -58,8 +58,8 @@ func TestWriteCodexProviderConfig_FullProvider(t *testing.T) {
 		BearerToken: "sk-test-fixture",
 		WireAPI:     "responses",
 		HTTPHeaders: map[string]string{
-			"X-Sub-Module":  "codex-internal",
-			"X-Request-ID":  "abc",
+			"X-Sub-Module": "codex-internal",
+			"X-Request-ID": "abc",
 		},
 		QueryParams: map[string]string{
 			"api-version": "2025-04-01-preview",
@@ -179,7 +179,7 @@ func TestNormaliseProviderConfig_Nil(t *testing.T) {
 }
 
 func TestBuildSessionPlan_PinsModelProviderWhenProviderSet(t *testing.T) {
-	plan, err := BuildSessionPlan("run-x", "", map[string]any{
+	plan, err := BuildSessionPlan("run-x", "conv-1/agent-1/codex", "", map[string]any{
 		"codex_provider": map[string]any{
 			"base_url":     "https://x/v1",
 			"bearer_token": "sk-x",
@@ -216,7 +216,7 @@ func TestBuildSessionPlan_PinsModelProviderWhenProviderSet(t *testing.T) {
 }
 
 func TestBuildSessionPlan_NoProviderLeavesBuiltinDefault(t *testing.T) {
-	plan, err := BuildSessionPlan("run-y", "", nil)
+	plan, err := BuildSessionPlan("run-y", "conv-1/agent-1/codex", "", nil)
 	if err != nil {
 		t.Fatalf("BuildSessionPlan: %v", err)
 	}

--- a/apps/parsar-daemon/internal/agent/codex/rpc.go
+++ b/apps/parsar-daemon/internal/agent/codex/rpc.go
@@ -70,9 +70,9 @@ type JSONRPCConfig struct {
 //   - response       (id + result|error)        → matched to a pending request
 //   - notification   (method + params, no id)   → routed to a per-method handler
 //   - server request (id + method + params)     → routed to a per-method handler,
-//                                                 reply is sent automatically
-//                                                 unless the handler returns
-//                                                 DeferReply.
+//     reply is sent automatically
+//     unless the handler returns
+//     DeferReply.
 //
 // stderr is line-pumped to the logger and never merged with stdout.
 type JSONRPCClient struct {
@@ -240,13 +240,24 @@ func (c *JSONRPCClient) Close() error {
 	var closeErr error
 	c.closeOnce.Do(func() {
 		c.mu.Lock()
+		cmd := c.cmd
+		stdin := c.stdin
 		c.alive = false
 		c.mu.Unlock()
-		if c.stdin != nil {
-			_ = c.stdin.Close()
+		if stdin != nil {
+			_ = stdin.Close()
 		}
-		if c.cmd != nil && c.cmd.Process != nil {
-			_ = c.cmd.Process.Kill()
+		if cmd != nil && cmd.Process != nil {
+			select {
+			case <-c.doneCh:
+			case <-time.After(250 * time.Millisecond):
+				_ = cmd.Process.Kill()
+				select {
+				case <-c.doneCh:
+				case <-time.After(rpcKillTimeout):
+					c.cfg.Logger.Warn("codex rpc child did not exit after kill", "tag", c.cfg.LogTag)
+				}
+			}
 		}
 		closeErr = c.drainPending(errors.New("codex rpc: client closed"))
 	})
@@ -387,7 +398,12 @@ func (c *JSONRPCClient) readStdoutLoop() {
 		c.dispatchFrame(line)
 	}
 	if err := sc.Err(); err != nil && !errors.Is(err, io.EOF) {
-		c.cfg.Logger.Warn("codex rpc stdout scan err", "tag", c.cfg.LogTag, "err", err)
+		c.mu.Lock()
+		alive := c.alive
+		c.mu.Unlock()
+		if alive {
+			c.cfg.Logger.Warn("codex rpc stdout scan err", "tag", c.cfg.LogTag, "err", err)
+		}
 	}
 }
 

--- a/apps/parsar-daemon/internal/agent/codex/rpc_process_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/rpc_process_test.go
@@ -1,0 +1,75 @@
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestJSONRPCClientCloseReapsChildProcess(t *testing.T) {
+	cfg := JSONRPCConfig{
+		Binary:         os.Args[0],
+		ExtraArgs:      []string{"-test.run=TestJSONRPCClientFakeCodexProcess", "--"},
+		Env:            append(os.Environ(), "CODEX_RPC_FAKE_PROCESS=1"),
+		LogTag:         "codex-rpc-process-test",
+		RequestTimeout: 2 * time.Second,
+	}
+	client := NewJSONRPCClient(cfg)
+
+	_, err := client.Start(context.Background(), InitializeParams{
+		ClientInfo: InitializeClientInfo{Name: "test", Version: "0"},
+	})
+	if err != nil {
+		t.Fatalf("start fake process: %v", err)
+	}
+	if client.cmd == nil || client.cmd.Process == nil {
+		t.Fatal("client did not spawn a child process")
+	}
+
+	if err := client.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	select {
+	case <-client.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("child process was not reaped")
+	}
+	if client.cmd.ProcessState == nil {
+		t.Fatalf("process state not exited after close: %#v", client.cmd.ProcessState)
+	}
+}
+
+func TestJSONRPCClientFakeCodexProcess(t *testing.T) {
+	if os.Getenv("CODEX_RPC_FAKE_PROCESS") != "1" {
+		return
+	}
+	line, err := bufio.NewReader(os.Stdin).ReadBytes('\n')
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read initialize: %v\n", err)
+		os.Exit(2)
+	}
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(line, &req); err != nil {
+		fmt.Fprintf(os.Stderr, "decode initialize: %v\n", err)
+		os.Exit(2)
+	}
+	resp := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      req.ID,
+		"result": map[string]any{
+			"userAgent": "fake-codex",
+			"codexHome": "/tmp/fake-codex-home",
+		},
+	}
+	body, _ := json.Marshal(resp)
+	fmt.Printf("%s\n", body)
+	for {
+		time.Sleep(time.Second)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -101,7 +101,7 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		cfg.killTimeout = rpcKillTimeout
 	}
 
-	plan, err := BuildSessionPlan(req.RunID, req.WorkDir, req.AgentOptions)
+	plan, err := BuildSessionPlan(req.RunID, req.AgentStateKey, req.WorkDir, req.AgentOptions)
 	if err != nil {
 		return nil, fmt.Errorf("codex: build session plan: %w", err)
 	}
@@ -192,14 +192,15 @@ func (s *Session) SubmitPromptForUserChoice(_ context.Context, _ string, _ proto
 
 func (s *Session) run(plan SessionPlan, req proto.PromptRequestPayload) {
 	defer close(s.waitDone)
+	defer func() { _ = s.rpc.Close() }()
 	defer s.cleanup()
 	defer s.closeOut()
 
 	// Resolve thread: resume if possible, else start fresh.
-	if strings.TrimSpace(req.ResumeSessionID) != "" {
-		if err := s.resumeThread(req.ResumeSessionID); err != nil {
+	if strings.TrimSpace(req.AgentSessionID) != "" {
+		if err := s.resumeThread(req.AgentSessionID); err != nil {
 			s.cfg.logger.Warn("codex: thread/resume failed; starting fresh",
-				"run_id", s.runID, "thread_id", req.ResumeSessionID, "err", err)
+				"run_id", s.runID, "thread_id", req.AgentSessionID, "err", err)
 			if err := s.startThread(plan); err != nil {
 				s.emitTerminal(fmt.Sprintf("codex: thread/start: %v", err), true)
 				return
@@ -232,10 +233,7 @@ func (s *Session) run(plan SessionPlan, req proto.PromptRequestPayload) {
 		return
 	}
 
-	// Block until the RPC child exits or cancellation arrives. The
-	// notification handlers will have called s.finalizeTurn by the
-	// time we reach here (turn/completed handler emits TypeDone +
-	// triggers Close).
+	// Block until terminal handlers close the RPC child or cancellation arrives.
 	select {
 	case <-s.rpc.Done():
 	case <-s.cancelCtx.Done():
@@ -483,9 +481,11 @@ func (s *Session) onTurnCompleted(raw json.RawMessage) {
 			body = appendOnNewline(body, errText)
 		}
 		s.emitTerminal(body, true)
+		s.finishAfterTerminal()
 		return
 	}
 	s.emitDone(finalText, usage)
+	s.finishAfterTerminal()
 }
 
 // turnErrorMessage extracts a human-readable error string from
@@ -541,6 +541,7 @@ func (s *Session) onTurnFailed(raw json.RawMessage) {
 		"turn_status", p.Turn.Status,
 		"last_err_text_present", s.peekLastErrText() != "")
 	s.emitTerminal("codex: turn failed", true)
+	s.finishAfterTerminal()
 }
 
 func (s *Session) onErrorNotif(raw json.RawMessage) {
@@ -582,11 +583,8 @@ func (s *Session) peekLastErrText() string {
 func (s *Session) emitDone(content string, usage *TurnUsage) {
 	doneMeta := map[string]any{}
 	if tid := s.currentThreadID(); tid != "" {
-		// Use the agent-neutral session-id key the binder already
-		// understands; codex thread_id and claude session_id share
-		// "upstream session id" semantics on the binding layer.
-		doneMeta["claude_session_id"] = tid
-		doneMeta["codex_thread_id"] = tid
+		doneMeta[proto.DoneMetaAgentSessionID] = tid
+		doneMeta[proto.DoneMetaAgentSessionType] = "codex_thread"
 	}
 	payload := proto.DonePayload{Content: content, Metadata: doneMeta}
 	if usage != nil {
@@ -643,8 +641,8 @@ func (s *Session) emitTerminal(message string, asError bool) {
 	}
 	doneMeta := map[string]any{}
 	if tid := s.currentThreadID(); tid != "" {
-		doneMeta["claude_session_id"] = tid
-		doneMeta["codex_thread_id"] = tid
+		doneMeta[proto.DoneMetaAgentSessionID] = tid
+		doneMeta[proto.DoneMetaAgentSessionType] = "codex_thread"
 	}
 	env, err := proto.NewEnvelope(proto.TypeDone, s.runID, proto.DonePayload{
 		Content:  message,
@@ -667,6 +665,15 @@ func (s *Session) trySend(env proto.Envelope) {
 
 func (s *Session) closeOut() {
 	s.closeOutOnce.Do(func() { close(s.out) })
+}
+
+func (s *Session) finishAfterTerminal() {
+	if s.cancelFn != nil {
+		s.cancelFn()
+	}
+	if s.rpc != nil {
+		_ = s.rpc.Close()
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/parsar-daemon/internal/agent/codex/session_log_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_log_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -169,6 +170,64 @@ func TestOnTurnFailed_LogsBufferedError(t *testing.T) {
 	}
 	if !strings.Contains(logs, `"last_err_text_present":true`) {
 		t.Fatalf("turn/failed log must note that an upstream error was buffered\n%s", logs)
+	}
+}
+
+func TestTerminalTurnClosesRPCAndCancelsSession(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(*Session)
+	}{
+		{
+			name: "completed",
+			run: func(s *Session) {
+				raw, _ := json.Marshal(TurnCompletedNotification{
+					Turn: Turn{ID: "turn-1", Status: "completed"},
+				})
+				s.onTurnCompleted(raw)
+			},
+		},
+		{
+			name: "failed",
+			run: func(s *Session) {
+				raw, _ := json.Marshal(TurnCompletedNotification{
+					Turn: Turn{ID: "turn-2", Status: "failed"},
+				})
+				s.onTurnFailed(raw)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rpc, _, cleanup := NewTestClient()
+			defer cleanup()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			out := make(chan proto.Envelope, 4)
+			s := &Session{
+				runID:     "run-terminal-" + tt.name,
+				cfg:       sessionConfig{logger: slog.New(slog.NewTextHandler(io.Discard, nil))},
+				out:       out,
+				rpc:       rpc.JSONRPCClient,
+				cancelCtx: ctx,
+				cancelFn:  cancel,
+			}
+			s.setThreadID("thread-" + tt.name)
+
+			tt.run(s)
+
+			if rpc.Alive() {
+				t.Fatal("terminal turn must close the codex RPC client")
+			}
+			select {
+			case <-ctx.Done():
+			default:
+				t.Fatal("terminal turn must cancel the session context")
+			}
+		})
 	}
 }
 

--- a/apps/parsar-daemon/internal/agent/pi/options.go
+++ b/apps/parsar-daemon/internal/agent/pi/options.go
@@ -17,10 +17,7 @@ type BuildResult struct {
 	Cleanup func()
 }
 
-// BuildArgs translates the daemon prompt_request into a `pi --mode json`
-// invocation. resumeSessionID, if non-empty, takes precedence over any
-// "resume_session_id" key in opts. pi has no working-directory flag, so
-// WorkDir is resolved here and the caller sets cmd.Dir.
+// BuildArgs translates the daemon prompt_request into a `pi --mode json` invocation.
 func BuildArgs(runID, prompt, workDir string, opts map[string]any, resumeSessionID string) (BuildResult, error) {
 	_ = runID
 	result := BuildResult{Cleanup: func() {}}
@@ -60,10 +57,15 @@ func BuildArgs(runID, prompt, workDir string, opts map[string]any, resumeSession
 		args = append(args, "--append-system-prompt", sys)
 	}
 
-	resume := strings.TrimSpace(resumeSessionID)
-	if resume == "" {
-		resume = stringOpt(opts, "resume_session_id")
+	if sessionDir := stringOpt(opts, "session_dir"); sessionDir != "" {
+		resolvedSessionDir, err := resolveSessionDirOption(sessionDir)
+		if err != nil {
+			return result, err
+		}
+		args = append(args, "--session-dir", resolvedSessionDir)
 	}
+
+	resume := strings.TrimSpace(resumeSessionID)
 	if resume != "" {
 		args = append(args, "--session", resume)
 	}
@@ -113,6 +115,30 @@ func resolveWorkDir(input string) (string, error) {
 	}
 	if err := os.MkdirAll(abs, 0o755); err != nil {
 		return "", fmt.Errorf("pi: mkdir work_dir %s: %w", abs, err)
+	}
+	return abs, nil
+}
+
+func resolveSessionDirOption(input string) (string, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" {
+		return "", nil
+	}
+	var abs string
+	switch {
+	case strings.HasPrefix(trimmed, "~/"):
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("pi: resolve home dir: %w", err)
+		}
+		abs = filepath.Join(home, strings.TrimPrefix(trimmed, "~/"))
+	case filepath.IsAbs(trimmed):
+		abs = trimmed
+	default:
+		return "", fmt.Errorf("pi: session_dir must be absolute or start with ~/, got %q", trimmed)
+	}
+	if err := os.MkdirAll(abs, 0o700); err != nil {
+		return "", fmt.Errorf("pi: mkdir session_dir %s: %w", abs, err)
 	}
 	return abs, nil
 }

--- a/apps/parsar-daemon/internal/agent/pi/options_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/options_test.go
@@ -107,20 +107,53 @@ func TestBuildArgsOverrideSystemPromptReplaces(t *testing.T) {
 	}
 }
 
-func TestBuildArgsResumeSessionExplicitWins(t *testing.T) {
+func TestBuildArgsResumeSessionUsesExplicitID(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "sessions")
 	res, err := pi.BuildArgs("run-1", "hello", "", map[string]any{
 		"resume_session_id": "from-opts",
+		"session_dir":       sessionDir,
 	}, "from-param")
 	if err != nil {
 		t.Fatalf("BuildArgs: %v", err)
 	}
 	defer res.Cleanup()
+	if !containsPair(res.Args, "--session-dir", sessionDir) {
+		t.Fatalf("args missing --session-dir: %v", res.Args)
+	}
 	if !containsPair(res.Args, "--session", "from-param") {
 		t.Fatalf("explicit resume id must win: %v", res.Args)
 	}
 }
 
-func TestBuildArgsResumeSessionFromOpts(t *testing.T) {
+func TestBuildArgsSessionDirCreatesAndAddsFlag(t *testing.T) {
+	sessionDir := filepath.Join(t.TempDir(), "missing", "sessions")
+	res, err := pi.BuildArgs("run-1", "hello", "", map[string]any{
+		"session_dir": sessionDir,
+	}, "")
+	if err != nil {
+		t.Fatalf("BuildArgs: %v", err)
+	}
+	defer res.Cleanup()
+	if !containsPair(res.Args, "--session-dir", sessionDir) {
+		t.Fatalf("args missing --session-dir: %v", res.Args)
+	}
+	info, err := os.Stat(sessionDir)
+	if err != nil {
+		t.Fatalf("stat session_dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("session_dir %q is not a directory", sessionDir)
+	}
+}
+
+func TestBuildArgsRejectsRelativeSessionDir(t *testing.T) {
+	_, err := pi.BuildArgs("run-1", "hello", "", map[string]any{"session_dir": "./sessions"}, "")
+	if err == nil || !strings.Contains(err.Error(), "session_dir") {
+		t.Fatalf("BuildArgs session_dir err = %v, want session_dir error", err)
+	}
+}
+
+func TestBuildArgsIgnoresResumeSessionIDOption(t *testing.T) {
 	res, err := pi.BuildArgs("run-1", "hello", "", map[string]any{
 		"resume_session_id": "sess-42",
 	}, "")
@@ -128,8 +161,8 @@ func TestBuildArgsResumeSessionFromOpts(t *testing.T) {
 		t.Fatalf("BuildArgs: %v", err)
 	}
 	defer res.Cleanup()
-	if !containsPair(res.Args, "--session", "sess-42") {
-		t.Fatalf("opts resume id missing: %v", res.Args)
+	if slices.Contains(res.Args, "--session") || slices.Contains(res.Args, "sess-42") {
+		t.Fatalf("resume_session_id option must be ignored: %v", res.Args)
 	}
 }
 

--- a/apps/parsar-daemon/internal/agent/pi/parser.go
+++ b/apps/parsar-daemon/internal/agent/pi/parser.go
@@ -24,6 +24,7 @@ type translator struct {
 	usage     proto.Usage
 	usageSet  bool
 	sessionID string
+	failed    bool
 }
 
 type translation struct {
@@ -203,6 +204,7 @@ func (t *translator) translateMessageEnd(line []byte) (translation, error) {
 	}
 
 	if msg.Message.StopReason == "error" {
+		t.failed = true
 		errMsg := msg.Message.ErrorMessage
 		if errMsg == "" {
 			errMsg = "pi: assistant message ended with error"
@@ -294,6 +296,7 @@ func (t *translator) terminalEnvelopes(waitErr error, stderr string, cancelled b
 		}
 	}
 
+	terminalFailed := t.failed || waitErr != nil || cancelled
 	if waitErr != nil || cancelled {
 		msg := "pi: subprocess exited without success"
 		if waitErr != nil {
@@ -311,12 +314,9 @@ func (t *translator) terminalEnvelopes(waitErr error, stderr string, cancelled b
 	}
 
 	metadata := map[string]any{"connector_path": "pi_print"}
-	if t.sessionID != "" {
-		metadata["pi_session_id"] = t.sessionID
-		// claude_session_id is the canonical key the server's resume
-		// write-back reads (binder MetaClaudeSessionID); mirror pi's id
-		// into it so --session resume works, exactly as codex does.
-		metadata["claude_session_id"] = t.sessionID
+	if t.sessionID != "" && !terminalFailed {
+		metadata[proto.DoneMetaAgentSessionID] = t.sessionID
+		metadata[proto.DoneMetaAgentSessionType] = "pi_session"
 	}
 	if env, err := proto.NewEnvelope(proto.TypeDone, t.runID, proto.DonePayload{
 		Content:    content,

--- a/apps/parsar-daemon/internal/agent/pi/parser_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/parser_test.go
@@ -165,6 +165,9 @@ func TestTranslateMessageEndAccumulatesUsageAcrossFrames(t *testing.T) {
 // that as TypeError despite the clean process exit.
 func TestTranslateMessageEndErrorStopReasonEmitsError(t *testing.T) {
 	tr := pi.NewTranslatorForTest("run-err")
+	if _, err := tr.Translate([]byte(`{"type":"session","id":"sess-bad","cwd":"/x","timestamp":"t"}`)); err != nil {
+		t.Fatalf("Translate header: %v", err)
+	}
 	line := `{"type":"message_end","message":{"role":"assistant","content":[],"provider":"anthropic","model":"m","usage":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"totalTokens":0,"cost":{"input":0,"output":0,"cacheRead":0,"cacheWrite":0,"total":0}},"stopReason":"error","errorMessage":"boom"}}`
 	tx, err := tr.Translate([]byte(line))
 	if err != nil {
@@ -181,6 +184,11 @@ func TestTranslateMessageEndErrorStopReasonEmitsError(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected TypeError mentioning boom, got %#v", tx.Envelopes)
+	}
+	envs := tr.TerminalEnvelopes(nil, "", false)
+	done := decodePayload[proto.DonePayload](t, envs[len(envs)-1])
+	if _, ok := done.Metadata[proto.DoneMetaAgentSessionID]; ok {
+		t.Fatalf("failed pi turn must not persist session metadata: %#v", done.Metadata)
 	}
 }
 
@@ -201,17 +209,19 @@ func TestTerminalAlwaysEmitsDoneWithSessionMetadata(t *testing.T) {
 	if done.Content != "hello" {
 		t.Fatalf("done content = %q, want hello", done.Content)
 	}
-	if done.Metadata["pi_session_id"] != "sess-abc" {
-		t.Fatalf("done metadata = %#v, want pi_session_id sess-abc", done.Metadata)
+	if done.Metadata[proto.DoneMetaAgentSessionID] != "sess-abc" {
+		t.Fatalf("done metadata = %#v, want agent_session_id sess-abc", done.Metadata)
 	}
-	// Resume hinges on the canonical claude_session_id (see parser.go).
-	if done.Metadata["claude_session_id"] != "sess-abc" {
-		t.Fatalf("done metadata = %#v, want claude_session_id sess-abc", done.Metadata)
+	if done.Metadata[proto.DoneMetaAgentSessionType] != "pi_session" {
+		t.Fatalf("done metadata = %#v, want pi_session", done.Metadata)
 	}
 }
 
 func TestTerminalErrorIncludesStderr(t *testing.T) {
 	tr := pi.NewTranslatorForTest("run-e")
+	if _, err := tr.Translate([]byte(`{"type":"session","id":"sess-failed","cwd":"/x","timestamp":"t"}`)); err != nil {
+		t.Fatalf("Translate header: %v", err)
+	}
 	envs := tr.TerminalEnvelopes(errors.New("exit status 2"), "bad auth", false)
 	if len(envs) < 2 || envs[0].Type != proto.TypeError || envs[len(envs)-1].Type != proto.TypeDone {
 		t.Fatalf("error terminal envs = %#v", envs)
@@ -219,6 +229,10 @@ func TestTerminalErrorIncludesStderr(t *testing.T) {
 	errPayload := decodePayload[proto.ErrorPayload](t, envs[0])
 	if !strings.Contains(errPayload.Error, "bad auth") {
 		t.Fatalf("error payload = %#v", errPayload)
+	}
+	done := decodePayload[proto.DonePayload](t, envs[len(envs)-1])
+	if _, ok := done.Metadata[proto.DoneMetaAgentSessionID]; ok {
+		t.Fatalf("failed pi process must not persist session metadata: %#v", done.Metadata)
 	}
 }
 

--- a/apps/parsar-daemon/internal/agent/pi/provider_config.go
+++ b/apps/parsar-daemon/internal/agent/pi/provider_config.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/paths"
 )
 
 // piManagedProviderSlug is the provider key the daemon always writes into
@@ -112,44 +114,91 @@ func normalisePiProvider(raw any) (piProviderConfig, bool, error) {
 }
 
 // resolveAgentDir returns the directory set as PI_CODING_AGENT_DIR for this
-// prompt — pi reads models.json (and writes sessions) there. Scoped per
-// conversation as a sibling of resolveSkillsRoot so consecutive turns reuse
-// the same sessions/ tree (resume) without two conversations racing. runID
-// scopes the one-shot fallback when there is no conversation.
-func resolveAgentDir(conversationID, runID string) (string, error) {
-	home, err := os.UserHomeDir()
+// prompt. AgentStateKey is preferred because it scopes by conversation, agent,
+// and engine; conversation/run fallbacks exist for older callers and tests.
+func resolveAgentDir(agentStateKey, conversationID, runID string) (string, error) {
+	root, err := paths.Root()
 	if err != nil {
-		return "", fmt.Errorf("pi: resolve home: %w", err)
+		return "", fmt.Errorf("pi: resolve state root: %w", err)
 	}
-	base := filepath.Join(home, ".parsar", "runtime", "pi")
+	base := filepath.Join(root, "runtime", "pi")
+	if key := strings.TrimSpace(agentStateKey); key != "" {
+		parts := safeStatePathParts(key)
+		if len(parts) == 0 {
+			return "", fmt.Errorf("pi: invalid agentStateKey %q", agentStateKey)
+		}
+		dirParts := append([]string{base, "state"}, parts...)
+		return filepath.Join(append(dirParts, "agent")...), nil
+	}
 	if id := strings.TrimSpace(conversationID); id != "" {
 		return filepath.Join(base, "conv-"+id, "agent"), nil
 	}
 	return filepath.Join(base, "run-"+strings.TrimSpace(runID), "agent"), nil
 }
 
-// applyPiManagedProvider materialises opts["pi_provider"] into a per-conversation
-// models.json and returns a clone of opts with PI_CODING_AGENT_DIR injected into
-// opts["env"] (so buildEnv forwards it). When no pi_provider is present it
-// returns opts unchanged. The caller's opts and env maps are never mutated.
-func applyPiManagedProvider(opts map[string]any, conversationID, runID string) (map[string]any, error) {
+func resolveSessionDir(agentDir string) (string, error) {
+	sessionDir := filepath.Join(agentDir, "sessions")
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		return "", fmt.Errorf("pi: mkdir session dir %s: %w", sessionDir, err)
+	}
+	return sessionDir, nil
+}
+
+// applyPiRuntimeState returns a clone of opts with a stable pi --session-dir.
+// When opts["pi_provider"] is present it also writes models.json and injects
+// PI_CODING_AGENT_DIR into opts["env"] so buildEnv forwards it.
+func applyPiRuntimeState(opts map[string]any, agentStateKey, conversationID, runID string) (map[string]any, error) {
+	agentDir, err := resolveAgentDir(agentStateKey, conversationID, runID)
+	if err != nil {
+		return opts, err
+	}
+	sessionDir, err := resolveSessionDir(agentDir)
+	if err != nil {
+		return opts, err
+	}
+
+	out := cloneAgentOptions(opts)
+	out["session_dir"] = sessionDir
+
 	cfg, ok, err := normalisePiProvider(opts["pi_provider"])
 	if err != nil {
 		return opts, err
 	}
 	if !ok {
-		return opts, nil
-	}
-	agentDir, err := resolveAgentDir(conversationID, runID)
-	if err != nil {
-		return opts, err
+		return out, nil
 	}
 	if err := writePiModelsJSON(agentDir, cfg); err != nil {
 		return opts, err
 	}
-	out := cloneAgentOptions(opts)
 	out["env"] = withAgentDirEnv(opts["env"], agentDir)
 	return out, nil
+}
+
+func safeStatePathParts(key string) []string {
+	rawParts := strings.Split(key, "/")
+	parts := make([]string, 0, len(rawParts))
+	for _, part := range rawParts {
+		if safe := safeStatePathPart(part); safe != "" {
+			parts = append(parts, safe)
+		}
+	}
+	return parts
+}
+
+func safeStatePathPart(part string) string {
+	var b strings.Builder
+	for _, r := range strings.TrimSpace(part) {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	out := b.String()
+	if out == "." || out == ".." {
+		return ""
+	}
+	return out
 }
 
 func withAgentDirEnv(existing any, agentDir string) map[string]any {

--- a/apps/parsar-daemon/internal/agent/pi/provider_config_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/provider_config_test.go
@@ -184,7 +184,7 @@ func TestNormalisePiProvider_WrongType(t *testing.T) {
 func TestResolveAgentDirConversationScoped(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
-	got, err := resolveAgentDir("conv-abc", "run-1")
+	got, err := resolveAgentDir("", "conv-abc", "run-1")
 	if err != nil {
 		t.Fatalf("resolveAgentDir: %v", err)
 	}
@@ -196,10 +196,36 @@ func TestResolveAgentDirConversationScoped(t *testing.T) {
 	}
 }
 
+func TestResolveAgentDirStateKeyScoped(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	got, err := resolveAgentDir("conv-abc/agent-xyz/pi", "ignored-conv", "run-1")
+	if err != nil {
+		t.Fatalf("resolveAgentDir: %v", err)
+	}
+	want := filepath.Join(tmp, ".parsar", "runtime", "pi", "state", "conv-abc", "agent-xyz", "pi", "agent")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveAgentDirSanitizesStateKey(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	got, err := resolveAgentDir("../conv abc/agent:xyz/pi", "ignored-conv", "run-1")
+	if err != nil {
+		t.Fatalf("resolveAgentDir: %v", err)
+	}
+	want := filepath.Join(tmp, ".parsar", "runtime", "pi", "state", "conv_abc", "agent_xyz", "pi", "agent")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
 func TestResolveAgentDirRunScopedFallback(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
-	got, err := resolveAgentDir("", "run-9")
+	got, err := resolveAgentDir("", "", "run-9")
 	if err != nil {
 		t.Fatalf("resolveAgentDir: %v", err)
 	}
@@ -209,7 +235,7 @@ func TestResolveAgentDirRunScopedFallback(t *testing.T) {
 	}
 }
 
-func TestApplyPiManagedProvider_WritesModelsAndSetsEnv(t *testing.T) {
+func TestApplyPiRuntimeState_WritesModelsSetsEnvAndSessionDir(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	callerEnv := map[string]any{"PARSAR_PI_API_KEY": "sk-proxy", "OTHER": "x"}
@@ -225,12 +251,13 @@ func TestApplyPiManagedProvider_WritesModelsAndSetsEnv(t *testing.T) {
 		},
 	}
 
-	out, err := applyPiManagedProvider(opts, "conv-xyz", "run-1")
+	out, err := applyPiRuntimeState(opts, "conv-xyz/agent-1/pi", "ignored-conv", "run-1")
 	if err != nil {
-		t.Fatalf("applyPiManagedProvider: %v", err)
+		t.Fatalf("applyPiRuntimeState: %v", err)
 	}
 
-	agentDir := filepath.Join(tmp, ".parsar", "runtime", "pi", "conv-conv-xyz", "agent")
+	agentDir := filepath.Join(tmp, ".parsar", "runtime", "pi", "state", "conv-xyz", "agent-1", "pi", "agent")
+	sessionDir := filepath.Join(agentDir, "sessions")
 	env, ok := out["env"].(map[string]any)
 	if !ok {
 		t.Fatalf("out[env] not a map: %T", out["env"])
@@ -240,6 +267,12 @@ func TestApplyPiManagedProvider_WritesModelsAndSetsEnv(t *testing.T) {
 	}
 	if env["PARSAR_PI_API_KEY"] != "sk-proxy" || env["OTHER"] != "x" {
 		t.Errorf("pre-existing env not preserved: %+v", env)
+	}
+	if out["session_dir"] != sessionDir {
+		t.Errorf("session_dir = %v, want %q", out["session_dir"], sessionDir)
+	}
+	if info, err := os.Stat(sessionDir); err != nil || !info.IsDir() {
+		t.Fatalf("session dir not created at %s: %v", sessionDir, err)
 	}
 
 	p := readModelsJSON(t, agentDir).Providers[piManagedProviderSlug]
@@ -251,21 +284,25 @@ func TestApplyPiManagedProvider_WritesModelsAndSetsEnv(t *testing.T) {
 	// and a shared reference would leak PI_CODING_AGENT_DIR back to the
 	// server-owned options map across turns.
 	if _, leaked := callerEnv["PI_CODING_AGENT_DIR"]; leaked {
-		t.Error("applyPiManagedProvider mutated the caller's env map")
+		t.Error("applyPiRuntimeState mutated the caller's env map")
 	}
 }
 
-func TestApplyPiManagedProvider_NoProviderNoop(t *testing.T) {
+func TestApplyPiRuntimeState_NoProviderStillPinsSessionDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
 	opts := map[string]any{"model": "anthropic/x"}
-	out, err := applyPiManagedProvider(opts, "conv-1", "run-1")
+	out, err := applyPiRuntimeState(opts, "conv-1/agent-1/pi", "ignored-conv", "run-1")
 	if err != nil {
-		t.Fatalf("applyPiManagedProvider: %v", err)
+		t.Fatalf("applyPiRuntimeState: %v", err)
 	}
 	if env, ok := out["env"].(map[string]any); ok {
 		if _, set := env["PI_CODING_AGENT_DIR"]; set {
 			t.Fatal("PI_CODING_AGENT_DIR must not be set when no pi_provider present")
 		}
 	}
+	want := filepath.Join(tmp, ".parsar", "runtime", "pi", "state", "conv-1", "agent-1", "pi", "agent", "sessions")
+	if out["session_dir"] != want {
+		t.Fatalf("session_dir = %v, want %q", out["session_dir"], want)
+	}
 }
-
-

--- a/apps/parsar-daemon/internal/agent/pi/session.go
+++ b/apps/parsar-daemon/internal/agent/pi/session.go
@@ -12,12 +12,11 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/exec"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/clirunner"
 	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
 	obslog "github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
 )
@@ -43,15 +42,13 @@ type Session struct {
 	runID string
 	cfg   sessionConfig
 
-	cmd *exec.Cmd
-	out chan<- proto.Envelope
+	proc *clirunner.Process
+	out  chan<- proto.Envelope
 
 	cancelCtx context.Context
-	cancelFn  context.CancelFunc
 
 	cancelOnce   sync.Once
 	closeOutOnce sync.Once
-	waitDone     chan struct{}
 	cleanup      func()
 
 	stderrMu sync.Mutex
@@ -99,45 +96,33 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		}
 	}
 
-	// Without this, pi never sees the proxy base_url + X-Sub-Module header and
-	// sends the managed key to api.anthropic.com → 401. Writes models.json and
-	// sets PI_CODING_AGENT_DIR in opts["env"] (buildEnv forwards it).
-	provOpts, provErr := applyPiManagedProvider(opts, req.ConversationID, req.RunID)
+	// Materialise pi's managed config and pin --session-dir to the stable
+	// conversation/agent/engine state key so --session can resolve reliably.
+	provOpts, provErr := applyPiRuntimeState(opts, req.AgentStateKey, req.ConversationID, req.RunID)
 	if provErr != nil {
 		return nil, fmt.Errorf("pi: apply managed provider: %w", provErr)
 	}
 	opts = provOpts
 
-	buildRes, err := BuildArgs(req.RunID, req.Prompt, req.WorkDir, opts, req.ResumeSessionID)
+	buildRes, err := BuildArgs(req.RunID, req.Prompt, req.WorkDir, opts, req.AgentSessionID)
 	if err != nil {
 		return nil, fmt.Errorf("pi: build args: %w", err)
 	}
-	cancelCtx, cancelFn := context.WithCancel(parent)
-
 	args := append([]string{}, buildRes.Args...)
 	args = append(args, cfg.extraArgs...)
-	cmd := exec.CommandContext(cancelCtx, cfg.piBinary, args...)
-	// pi has no working-directory flag, so the resolved WorkDir becomes
-	// the subprocess cwd.
+	dir := ""
 	if buildRes.WorkDir != "" {
-		cmd.Dir = buildRes.WorkDir
+		dir = buildRes.WorkDir
 	}
-	cmd.Env = append(os.Environ(), buildRes.Env...)
-
-	stdout, err := cmd.StdoutPipe()
+	proc, err := clirunner.Start(clirunner.StartOptions{
+		Parent:      parent,
+		Binary:      cfg.piBinary,
+		Args:        args,
+		Dir:         dir,
+		Env:         append(os.Environ(), buildRes.Env...),
+		KillTimeout: cfg.killTimeout,
+	})
 	if err != nil {
-		cancelFn()
-		buildRes.Cleanup()
-		return nil, fmt.Errorf("pi: stdout pipe: %w", err)
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		cancelFn()
-		buildRes.Cleanup()
-		return nil, fmt.Errorf("pi: stderr pipe: %w", err)
-	}
-	if err := cmd.Start(); err != nil {
-		cancelFn()
 		buildRes.Cleanup()
 		return nil, fmt.Errorf("pi: start %q: %w", cfg.piBinary, err)
 	}
@@ -145,33 +130,19 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 	s := &Session{
 		runID:     req.RunID,
 		cfg:       cfg,
-		cmd:       cmd,
+		proc:      proc,
 		out:       out,
-		cancelCtx: cancelCtx,
-		cancelFn:  cancelFn,
-		waitDone:  make(chan struct{}),
+		cancelCtx: proc.Context(),
 		cleanup:   buildRes.Cleanup,
 	}
-	go s.pumpStderr(stderr)
-	go s.run(stdout)
+	go s.pumpStderr(proc.Stderr)
+	go s.run(proc.Stdout)
 	return s, nil
 }
 
 func (s *Session) Cancel(context.Context) error {
 	s.cancelOnce.Do(func() {
-		if s.cmd.Process == nil {
-			return
-		}
-		_ = s.cmd.Process.Signal(syscall.SIGTERM)
-		go func() {
-			select {
-			case <-s.waitDone:
-				return
-			case <-time.After(s.cfg.killTimeout):
-				_ = s.cmd.Process.Signal(syscall.SIGKILL)
-			}
-		}()
-		s.cancelFn()
+		s.proc.Cancel()
 	})
 	return nil
 }
@@ -185,7 +156,6 @@ func (s *Session) SubmitPromptForUserChoice(context.Context, string, proto.Promp
 }
 
 func (s *Session) run(stdout io.Reader) {
-	defer close(s.waitDone)
 	defer s.cleanup()
 	defer s.closeOut()
 
@@ -202,7 +172,7 @@ func (s *Session) run(stdout io.Reader) {
 			select {
 			case s.out <- env:
 			case <-s.cancelCtx.Done():
-				_ = s.cmd.Wait()
+				_ = s.proc.Wait()
 				return
 			}
 		}
@@ -211,7 +181,7 @@ func (s *Session) run(stdout io.Reader) {
 		s.cfg.logger.Warn("pi: scan stdout", "run_id", s.runID, "err", err)
 	}
 
-	waitErr := s.cmd.Wait()
+	waitErr := s.proc.Wait()
 	for _, env := range tr.terminalEnvelopes(waitErr, s.stderrString(), s.cancelCtx.Err() != nil) {
 		s.trySend(env)
 	}

--- a/apps/parsar-daemon/internal/agent/pi/session_provider_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/session_provider_test.go
@@ -13,7 +13,7 @@ import (
 // TestNewSessionMaterialisesPiProviderModelsJSON proves agent_options["pi_provider"]
 // flows through newSession → models.json on disk at the per-conversation agent
 // dir. The env-forwarding of PI_CODING_AGENT_DIR is covered by the
-// applyPiManagedProvider + buildEnv unit tests.
+// applyPiRuntimeState + buildEnv unit tests.
 func TestNewSessionMaterialisesPiProviderModelsJSON(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -22,6 +22,7 @@ func TestNewSessionMaterialisesPiProviderModelsJSON(t *testing.T) {
 	req := proto.PromptRequestPayload{
 		RunID:          "run_prov",
 		ConversationID: "conv-prov",
+		AgentStateKey:  "conv-prov/agent-prov/pi",
 		Prompt:         "hello",
 		AgentOptions: map[string]any{
 			"model": "parsar/claude-opus-4-6-thinking-max",
@@ -60,12 +61,15 @@ func TestNewSessionMaterialisesPiProviderModelsJSON(t *testing.T) {
 		}
 	}
 
-	agentDir := filepath.Join(home, ".parsar", "runtime", "pi", "conv-conv-prov", "agent")
+	agentDir := filepath.Join(home, ".parsar", "runtime", "pi", "state", "conv-prov", "agent-prov", "pi", "agent")
 	p := readModelsJSON(t, agentDir).Providers[piManagedProviderSlug]
 	if p.BaseURL != "https://platform-api.example.com" {
 		t.Fatalf("models.json baseUrl wrong: %+v", p)
 	}
 	if p.APIKey != "$PARSAR_PI_API_KEY" {
 		t.Fatalf("models.json apiKey = %q, want $PARSAR_PI_API_KEY", p.APIKey)
+	}
+	if _, err := os.Stat(filepath.Join(agentDir, "sessions")); err != nil {
+		t.Fatalf("session dir not created: %v", err)
 	}
 }

--- a/apps/parsar-daemon/internal/agent/pi/session_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/session_test.go
@@ -179,8 +179,11 @@ func TestSessionJSONSuccessEmitsDeltaUsageAndDone(t *testing.T) {
 	if done.Usage.Provider != "anthropic" || done.Usage.InputTokens != 4 || done.Usage.OutputTokens != 2 {
 		t.Fatalf("done usage = %#v", done.Usage)
 	}
-	if done.Metadata["pi_session_id"] != "sess-xyz" {
-		t.Fatalf("done metadata = %#v, want pi_session_id sess-xyz", done.Metadata)
+	if done.Metadata[proto.DoneMetaAgentSessionID] != "sess-xyz" {
+		t.Fatalf("done metadata = %#v, want agent_session_id sess-xyz", done.Metadata)
+	}
+	if done.Metadata[proto.DoneMetaAgentSessionType] != "pi_session" {
+		t.Fatalf("done metadata = %#v, want pi_session", done.Metadata)
 	}
 }
 
@@ -213,6 +216,10 @@ func TestSessionModelErrorStopReasonStillEmitsErrorAndDone(t *testing.T) {
 	}
 	if !strings.Contains(errPayload.Error, "model boom") {
 		t.Fatalf("error payload = %#v, want model boom", errPayload)
+	}
+	done := decodePayload[proto.DonePayload](t, got[len(got)-1])
+	if _, ok := done.Metadata[proto.DoneMetaAgentSessionID]; ok {
+		t.Fatalf("model error must not persist session metadata: %#v", done.Metadata)
 	}
 }
 

--- a/apps/parsar-daemon/internal/dispatch/router.go
+++ b/apps/parsar-daemon/internal/dispatch/router.go
@@ -210,7 +210,8 @@ func (r *Router) handlePromptRequest(callerCtx context.Context, env proto.Envelo
 		"run_id", runID, "agent_kind", req.AgentKind,
 		"work_dir", req.WorkDir, "prompt_len", len(req.Prompt),
 		"has_agent_options", req.AgentOptions != nil,
-		"resume_session_id", req.ResumeSessionID)
+		"agent_session_id", req.AgentSessionID,
+		"agent_state_key", req.AgentStateKey)
 
 	factory, err := r.registry.Resolve(req.AgentKind)
 	if err != nil {

--- a/apps/parsar-daemon/internal/paths/paths.go
+++ b/apps/parsar-daemon/internal/paths/paths.go
@@ -97,9 +97,7 @@ func LogFile(profile string) (string, error) {
 	return filepath.Join(dir, "connect.log"), nil
 }
 
-// SessionsFile returns the absolute path to sessions.json. Used by
-// claudecode to persist conversation → claude_session_id for
-// --resume.
+// SessionsFile returns the absolute path to sessions.json.
 func SessionsFile(profile string) (string, error) {
 	dir, err := ProfileDir(profile)
 	if err != nil {

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -187,6 +187,11 @@ type DonePayload struct {
 	Metadata   map[string]any `json:"metadata,omitempty"`
 }
 
+const (
+	DoneMetaAgentSessionID   = "agent_session_id"
+	DoneMetaAgentSessionType = "agent_session_type"
+)
+
 // AgentKindCapabilities describes what a daemon-side agent_kind can
 // do inside one prompt session. Runtime-level capabilities such as
 // cancellation belong to the daemon connector itself; these bits are

--- a/internal/agentdaemon/proto/outbound.go
+++ b/internal/agentdaemon/proto/outbound.go
@@ -70,10 +70,11 @@ type PromptRequestPayload struct {
 	// inspects them.
 	AgentOptions map[string]any `json:"agent_options,omitempty"`
 
-	// ResumeSessionID, when set, tells the agent to continue an
-	// earlier session. Sourced from
-	// connector_session_bindings.metadata.claude_session_id.
-	ResumeSessionID string `json:"resume_session_id,omitempty"`
+	// AgentSessionID is the upstream engine session id to resume.
+	AgentSessionID string `json:"agent_session_id,omitempty"`
+
+	// AgentStateKey is the stable daemon-side state directory key.
+	AgentStateKey string `json:"agent_state_key,omitempty"`
 }
 
 // PromptAttachment is one piece of non-text user input the daemon-side

--- a/server/internal/agentdaemon/binding/binder.go
+++ b/server/internal/agentdaemon/binding/binder.go
@@ -1,11 +1,4 @@
-// Package binding owns the (conversation, agent) ↔ device mapping
-// for the agent_daemon connector, persisted via the generic
-// connector_session_bindings table:
-//
-//	connector_type      = "agent_daemon"
-//	binding_key         = agent id
-//	upstream_session_id = device id (runtimes row uuid)
-//	metadata.agent_kind / claude_session_id / work_dir
+// Package binding owns agent-daemon runtime bindings and engine sessions.
 package binding
 
 import (
@@ -13,68 +6,48 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
-	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
 )
 
-// ConnectorType is the connector_type value the binding rows carry.
-const ConnectorType = "agent_daemon"
-
-// JSON keys used inside connector_session_bindings.metadata.
 const (
-	MetaAgentKind        = "agent_kind"
-	MetaClaudeSessionID  = "claude_session_id"
-	MetaWorkDir          = "work_dir"
-	MetaCreatedByPicker  = "created_by_picker"
-	MetaCreatedBySandbox = "created_by_sandbox"
-	// MetaSessionUpdatedAt is the RFC3339 timestamp of the run whose
-	// done event most recently wrote claude_session_id. Used as the
-	// CAS guard in RememberSession so a stale done event cannot
-	// overwrite a fresher session id from a newer run.
-	MetaSessionUpdatedAt = "session_updated_at"
+	SessionTypeClaude = "claude_session"
+	SessionTypeCodex  = "codex_thread"
+	SessionTypePi     = "pi_session"
 )
 
 // Binding is the resolved view a caller cares about.
 type Binding struct {
-	ConversationID  string
-	AgentID         string
-	DeviceID        string
-	AgentKind       string
-	ClaudeSessionID string
-	WorkDir         string
+	ConversationID   string
+	AgentID          string
+	DeviceID         string
+	AgentKind        string
+	AgentSessionID   string
+	AgentSessionType string
+	AgentStateKey    string
+	WorkDir          string
+	Metadata         map[string]any
 }
 
-// ErrNotBound is returned by Resolve when a conversation has no
-// binding for the requested agent.
+// ErrNotBound is returned when a conversation has no runtime binding.
 var ErrNotBound = errors.New("agentdaemon: conversation has no device binding for agent")
 
-// Binder is the public interface the connector and gateway use.
+// Binder persists conversation/agent runtime placement and engine session ids.
 type Binder interface {
-	Resolve(ctx context.Context, conversationID, agentID string) (Binding, error)
+	Resolve(ctx context.Context, conversationID, agentID, agentKind string) (Binding, error)
 	Bind(ctx context.Context, b Binding) error
-	// RememberSession folds a Claude session id into an existing
-	// binding's metadata. runStartedAt acts as a CAS guard: the new
-	// session id is written only when the existing
-	// metadata.session_updated_at is older than runStartedAt (or
-	// absent). Pass time.Time{} to opt out of the guard.
-	RememberSession(ctx context.Context, conversationID, agentID, claudeSessionID string, runStartedAt time.Time) error
+	RememberSession(ctx context.Context, b Binding) error
 	InvalidateConversation(ctx context.Context, conversationID string) error
 	InvalidateDevice(ctx context.Context, deviceID string) error
 }
 
-// ----------------------------------------------------------------------
-// Postgres-backed implementation
-// ----------------------------------------------------------------------
-
-// PgBinder is the production wiring over connector_session_bindings.
-// A nil logger silently swallows internal-error logs: a DB outage
-// degrades to "no binding cached, pick fresh" which is correct, just
-// slower.
+// PgBinder is the production wiring over agent_runtime_bindings and agent_engine_sessions.
 type PgBinder struct {
 	pool   *pgxpool.Pool
 	logger func(format string, args ...any)
@@ -87,265 +60,181 @@ func NewPgBinder(pool *pgxpool.Pool, logger func(format string, args ...any)) *P
 	return &PgBinder{pool: pool, logger: logger}
 }
 
-// Resolve returns ErrNotBound when no row exists for (conversation,
-// agent); other DB errors surface as-is.
-func (b *PgBinder) Resolve(ctx context.Context, conversationID, agentID string) (Binding, error) {
+func (b *PgBinder) Resolve(ctx context.Context, conversationID, agentID, agentKind string) (Binding, error) {
 	if conversationID == "" || agentID == "" {
 		return Binding{}, ErrNotBound
 	}
-	q := sqlc.New(b.pool)
-	rows, err := q.ListConnectorSessionBindings(ctx, sqlc.ListConnectorSessionBindingsParams{
-		ConversationID: conversationID,
-		ConnectorType:  ConnectorType,
+	convUUID, err := uuidParam(conversationID)
+	if err != nil {
+		return Binding{}, fmt.Errorf("agentdaemon binding: conversation_id: %w", err)
+	}
+	agentUUID, err := uuidParam(agentID)
+	if err != nil {
+		return Binding{}, fmt.Errorf("agentdaemon binding: agent_id: %w", err)
+	}
+	row, err := sqlc.New(b.pool).GetAgentDaemonBinding(ctx, sqlc.GetAgentDaemonBindingParams{
+		ConversationID: convUUID,
+		AgentID:        agentUUID,
+		AgentKind:      normaliseAgentKind(agentKind),
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return Binding{}, ErrNotBound
 		}
-		return Binding{}, fmt.Errorf("agentdaemon binding: list: %w", err)
+		return Binding{}, fmt.Errorf("agentdaemon binding: get: %w", err)
 	}
-	for _, r := range rows {
-		if r.BindingKey != agentID {
-			continue
-		}
-		out := Binding{
-			ConversationID: conversationID,
-			AgentID:        agentID,
-			DeviceID:       r.UpstreamSessionID,
-		}
-		applyMetadata(&out, r.Metadata)
-		// Best-effort; errors swallowed.
-		if touchErr := q.TouchConnectorSessionBinding(ctx, sqlc.TouchConnectorSessionBindingParams{
-			ConversationID: conversationID,
-			ConnectorType:  ConnectorType,
-			BindingKey:     agentID,
-		}); touchErr != nil {
-			b.logger("agentdaemon binding: touch failed: %v", touchErr)
-		}
-		return out, nil
-	}
-	return Binding{}, ErrNotBound
+	return Binding{
+		ConversationID:   row.ConversationID,
+		AgentID:          row.AgentID,
+		DeviceID:         row.RuntimeID,
+		AgentKind:        normaliseAgentKind(agentKind),
+		AgentSessionID:   row.UpstreamSessionID,
+		AgentSessionType: row.UpstreamSessionType,
+		AgentStateKey:    row.StateDirKey,
+		WorkDir:          row.WorkDir,
+		Metadata:         decodeMetadata(row.Metadata),
+	}, nil
 }
 
-// ResolveDeviceByConversation returns the device id of any
-// agent_daemon binding under conversationID. Used by the feishuoutbound
-// card-writer to stamp device_id onto the inflight slot without having
-// to thread agent_id through — a conversation effectively has
-// a single agent_daemon device today, so picking the first binding is
-// safe. Returns ErrNotBound when no agent_daemon binding exists.
 func (b *PgBinder) ResolveDeviceByConversation(ctx context.Context, conversationID string) (string, error) {
 	if conversationID == "" {
 		return "", ErrNotBound
 	}
-	q := sqlc.New(b.pool)
-	rows, err := q.ListConnectorSessionBindings(ctx, sqlc.ListConnectorSessionBindingsParams{
-		ConversationID: conversationID,
-		ConnectorType:  ConnectorType,
-	})
+	convUUID, err := uuidParam(conversationID)
+	if err != nil {
+		return "", fmt.Errorf("agentdaemon binding: conversation_id: %w", err)
+	}
+	deviceID, err := sqlc.New(b.pool).ResolveAgentDaemonDeviceByConversation(ctx, convUUID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return "", ErrNotBound
 		}
-		return "", fmt.Errorf("agentdaemon binding: list: %w", err)
+		return "", fmt.Errorf("agentdaemon binding: resolve device: %w", err)
 	}
-	for _, r := range rows {
-		if r.UpstreamSessionID != "" {
-			return r.UpstreamSessionID, nil
-		}
-	}
-	return "", ErrNotBound
+	return deviceID, nil
 }
 
-// Bind upserts the (conversation, agent) → device mapping.
-// agent_kind defaults to "claude_code" when empty.
 func (b *PgBinder) Bind(ctx context.Context, in Binding) error {
 	if in.ConversationID == "" || in.AgentID == "" || in.DeviceID == "" {
 		return fmt.Errorf("agentdaemon binding: ConversationID, AgentID, DeviceID all required")
 	}
-	if in.AgentKind == "" {
-		in.AgentKind = "claude_code"
+	convUUID, err := uuidParam(in.ConversationID)
+	if err != nil {
+		return fmt.Errorf("agentdaemon binding: conversation_id: %w", err)
 	}
-	meta := map[string]any{MetaAgentKind: in.AgentKind}
-	if in.ClaudeSessionID != "" {
-		meta[MetaClaudeSessionID] = in.ClaudeSessionID
-		meta[MetaSessionUpdatedAt] = time.Now().UTC().Format(time.RFC3339Nano)
+	agentUUID, err := uuidParam(in.AgentID)
+	if err != nil {
+		return fmt.Errorf("agentdaemon binding: agent_id: %w", err)
 	}
-	if in.WorkDir != "" {
-		meta[MetaWorkDir] = in.WorkDir
+	deviceUUID, err := uuidParam(in.DeviceID)
+	if err != nil {
+		return fmt.Errorf("agentdaemon binding: runtime_id: %w", err)
 	}
-	rawMeta, err := json.Marshal(meta)
+	if err := sqlc.New(b.pool).UpsertAgentDaemonRuntimeBinding(ctx, sqlc.UpsertAgentDaemonRuntimeBindingParams{
+		ConversationID: convUUID,
+		AgentID:        agentUUID,
+		RuntimeID:      deviceUUID,
+		WorkDir:        in.WorkDir,
+	}); err != nil {
+		return fmt.Errorf("agentdaemon binding: upsert runtime: %w", err)
+	}
+	if strings.TrimSpace(in.AgentSessionID) != "" {
+		return b.RememberSession(ctx, in)
+	}
+	return nil
+}
+
+func (b *PgBinder) RememberSession(ctx context.Context, in Binding) error {
+	if strings.TrimSpace(in.AgentSessionID) == "" {
+		return nil
+	}
+	if in.ConversationID == "" || in.AgentID == "" {
+		return nil
+	}
+	convUUID, err := uuidParam(in.ConversationID)
+	if err != nil {
+		return fmt.Errorf("agentdaemon binding: conversation_id: %w", err)
+	}
+	agentUUID, err := uuidParam(in.AgentID)
+	if err != nil {
+		return fmt.Errorf("agentdaemon binding: agent_id: %w", err)
+	}
+	metadata, err := json.Marshal(nonNilMetadata(in.Metadata))
 	if err != nil {
 		return fmt.Errorf("agentdaemon binding: marshal metadata: %w", err)
 	}
-	if err := sqlc.New(b.pool).UpsertConnectorSessionBinding(ctx, sqlc.UpsertConnectorSessionBindingParams{
-		ConversationID:    in.ConversationID,
-		ConnectorType:     ConnectorType,
-		BindingKey:        in.AgentID,
-		UpstreamSessionID: in.DeviceID,
-		Metadata:          rawMeta,
+	if err := sqlc.New(b.pool).UpsertAgentDaemonEngineSession(ctx, sqlc.UpsertAgentDaemonEngineSessionParams{
+		ConversationID:      convUUID,
+		AgentID:             agentUUID,
+		AgentKind:           normaliseAgentKind(in.AgentKind),
+		UpstreamSessionID:   in.AgentSessionID,
+		UpstreamSessionType: normaliseSessionType(in.AgentSessionType),
+		StateDirKey:         defaultStateKey(in),
+		Metadata:            metadata,
 	}); err != nil {
-		return fmt.Errorf("agentdaemon binding: upsert: %w", err)
+		return fmt.Errorf("agentdaemon binding: upsert engine session: %w", err)
 	}
 	return nil
 }
 
-// RememberSession folds a Claude session id into an existing binding's
-// metadata. If no binding exists the call is a no-op.
-//
-// runStartedAt is the CAS guard: when non-zero, the new session id is
-// written only if the existing metadata.session_updated_at is older
-// than runStartedAt (or absent). Read-modify-write happens inside a
-// transaction with SELECT FOR UPDATE so two concurrent done events
-// for the same (conversation, agent) can't race.
-func (b *PgBinder) RememberSession(ctx context.Context, conversationID, agentID, claudeSessionID string, runStartedAt time.Time) error {
-	if claudeSessionID == "" {
-		return nil
-	}
-	if conversationID == "" || agentID == "" {
-		return nil
-	}
-	tx, err := b.pool.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("agentdaemon binding: begin tx: %w", err)
-	}
-	defer func() { _ = tx.Rollback(ctx) }()
-
-	var rawMeta []byte
-	var upstream string
-	err = tx.QueryRow(ctx, `
-select upstream_session_id, metadata
-from connector_session_bindings
-where conversation_id = $1
-  and connector_type = $2
-  and binding_key = $3
-for update`, conversationID, ConnectorType, agentID).Scan(&upstream, &rawMeta)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil
-		}
-		return fmt.Errorf("agentdaemon binding: select for update: %w", err)
-	}
-
-	var meta map[string]any
-	if len(rawMeta) > 0 {
-		if err := json.Unmarshal(rawMeta, &meta); err != nil {
-			return fmt.Errorf("agentdaemon binding: unmarshal metadata: %w", err)
-		}
-	}
-	if meta == nil {
-		meta = map[string]any{}
-	}
-
-	// Idempotent: same session id already stored.
-	if existing, _ := meta[MetaClaudeSessionID].(string); existing == claudeSessionID {
-		return nil
-	}
-
-	// Last-write-wins. The original CAS on runStartedAt vs stored
-	// MetaSessionUpdatedAt was meant to keep a stale done event from
-	// clobbering a newer run's session id, but in the supersede flow
-	// (run A asks → user cancels → run A's done arrives after run B
-	// has already started + finished) the "older" run actually holds
-	// the live transcript, including the ask history we want to
-	// --resume from. Same-(conversation, agent) runs are
-	// serialised by the sibling-blocked queue gate, so two writes
-	// never race for legitimate reasons; just keep the most recent.
-	_ = runStartedAt
-
-	meta[MetaClaudeSessionID] = claudeSessionID
-	meta[MetaSessionUpdatedAt] = time.Now().UTC().Format(time.RFC3339Nano)
-	newRaw, err := json.Marshal(meta)
-	if err != nil {
-		return fmt.Errorf("agentdaemon binding: marshal updated metadata: %w", err)
-	}
-	if _, err := tx.Exec(ctx, `
-update connector_session_bindings
-set metadata = $4,
-    last_active_at = now()
-where conversation_id = $1
-  and connector_type = $2
-  and binding_key = $3`, conversationID, ConnectorType, agentID, newRaw); err != nil {
-		return fmt.Errorf("agentdaemon binding: update metadata: %w", err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("agentdaemon binding: commit: %w", err)
-	}
-	return nil
-}
-
-// InvalidateConversation drops every binding for the conversation.
 func (b *PgBinder) InvalidateConversation(ctx context.Context, conversationID string) error {
 	if conversationID == "" {
 		return nil
 	}
-	if err := sqlc.New(b.pool).DeleteConnectorSessionBindingsByConversation(ctx, sqlc.DeleteConnectorSessionBindingsByConversationParams{
-		ConversationID: conversationID,
-		ConnectorType:  ConnectorType,
-	}); err != nil {
+	convUUID, err := uuidParam(conversationID)
+	if err != nil {
+		return fmt.Errorf("agentdaemon binding: conversation_id: %w", err)
+	}
+	if err := sqlc.New(b.pool).DeleteAgentDaemonBindingByConversation(ctx, convUUID); err != nil {
 		return fmt.Errorf("agentdaemon binding: invalidate conversation: %w", err)
 	}
 	return nil
 }
 
-// InvalidateDevice drops every binding that points at a given device.
-// Scoped to connector_type so we don't accidentally evict another
-// connector's bindings that happen to share an upstream id.
 func (b *PgBinder) InvalidateDevice(ctx context.Context, deviceID string) error {
 	if deviceID == "" {
 		return nil
 	}
-	if err := sqlc.New(b.pool).DeleteConnectorSessionBindingsByUpstreamSession(ctx, sqlc.DeleteConnectorSessionBindingsByUpstreamSessionParams{
-		ConnectorType:     ConnectorType,
-		UpstreamSessionID: deviceID,
-	}); err != nil {
+	deviceUUID, err := uuidParam(deviceID)
+	if err != nil {
+		return fmt.Errorf("agentdaemon binding: runtime_id: %w", err)
+	}
+	if err := sqlc.New(b.pool).DeleteAgentDaemonBindingByRuntime(ctx, deviceUUID); err != nil {
 		return fmt.Errorf("agentdaemon binding: invalidate device: %w", err)
 	}
 	return nil
 }
 
-func applyMetadata(out *Binding, raw []byte) {
-	if len(raw) == 0 {
-		return
-	}
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return
-	}
-	if v, ok := m[MetaAgentKind].(string); ok {
-		out.AgentKind = v
-	}
-	if v, ok := m[MetaClaudeSessionID].(string); ok {
-		out.ClaudeSessionID = v
-	}
-	if v, ok := m[MetaWorkDir].(string); ok {
-		out.WorkDir = v
-	}
-}
-
-// ----------------------------------------------------------------------
-// In-memory implementation (tests / when no DB is wired)
-// ----------------------------------------------------------------------
-
-// InMemoryBinder is the default zero-value binder used by tests and by
-// any router that runs without a database. It is concurrency-safe.
+// InMemoryBinder is the default zero-value binder used by tests and by routers without a database.
 type InMemoryBinder struct {
-	bindings map[string]Binding // key = conversation_id|agent_id
-	mu       sync.Mutex
+	runtimeBindings map[string]Binding
+	engineSessions  map[string]Binding
+	mu              sync.Mutex
 }
 
 func NewInMemoryBinder() *InMemoryBinder {
-	return &InMemoryBinder{bindings: map[string]Binding{}}
+	return &InMemoryBinder{
+		runtimeBindings: map[string]Binding{},
+		engineSessions:  map[string]Binding{},
+	}
 }
 
-func (b *InMemoryBinder) Resolve(_ context.Context, conversationID, agentID string) (Binding, error) {
+func (b *InMemoryBinder) Resolve(_ context.Context, conversationID, agentID, agentKind string) (Binding, error) {
 	if conversationID == "" || agentID == "" {
 		return Binding{}, ErrNotBound
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	out, ok := b.bindings[memKey(conversationID, agentID)]
+	out, ok := b.runtimeBindings[memKey(conversationID, agentID)]
 	if !ok {
 		return Binding{}, ErrNotBound
+	}
+	out.AgentKind = normaliseAgentKind(agentKind)
+	if sess, ok := b.engineSessions[sessionKey(conversationID, agentID, agentKind)]; ok {
+		out.AgentSessionID = sess.AgentSessionID
+		out.AgentSessionType = sess.AgentSessionType
+		out.AgentStateKey = sess.AgentStateKey
+		out.Metadata = sess.Metadata
 	}
 	return out, nil
 }
@@ -354,31 +243,41 @@ func (b *InMemoryBinder) Bind(_ context.Context, in Binding) error {
 	if in.ConversationID == "" || in.AgentID == "" || in.DeviceID == "" {
 		return fmt.Errorf("agentdaemon binding: ConversationID, AgentID, DeviceID all required")
 	}
-	if in.AgentKind == "" {
-		in.AgentKind = "claude_code"
-	}
+	in.AgentKind = normaliseAgentKind(in.AgentKind)
+	in.AgentStateKey = defaultStateKey(in)
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.bindings[memKey(in.ConversationID, in.AgentID)] = in
+	runtime := in
+	runtime.AgentSessionID = ""
+	runtime.AgentSessionType = ""
+	runtime.Metadata = nil
+	b.runtimeBindings[memKey(in.ConversationID, in.AgentID)] = runtime
+	if in.AgentSessionID != "" {
+		b.engineSessions[sessionKey(in.ConversationID, in.AgentID, in.AgentKind)] = in
+	}
 	return nil
 }
 
-func (b *InMemoryBinder) RememberSession(_ context.Context, conversationID, agentID, claudeSessionID string, runStartedAt time.Time) error {
-	if claudeSessionID == "" {
+func (b *InMemoryBinder) RememberSession(_ context.Context, in Binding) error {
+	if strings.TrimSpace(in.AgentSessionID) == "" {
 		return nil
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	key := memKey(conversationID, agentID)
-	cur, ok := b.bindings[key]
+	key := memKey(in.ConversationID, in.AgentID)
+	cur, ok := b.runtimeBindings[key]
 	if !ok {
 		return nil
 	}
-	// In-memory binder has no stored timestamp to CAS against; last
-	// write wins is the documented semantics for this stub.
-	_ = runStartedAt
-	cur.ClaudeSessionID = claudeSessionID
-	b.bindings[key] = cur
+	in.AgentKind = normaliseAgentKind(in.AgentKind)
+	in.AgentSessionType = normaliseSessionType(in.AgentSessionType)
+	in.AgentStateKey = defaultStateKey(in)
+	cur.AgentKind = in.AgentKind
+	cur.AgentSessionID = in.AgentSessionID
+	cur.AgentSessionType = in.AgentSessionType
+	cur.AgentStateKey = in.AgentStateKey
+	cur.Metadata = nonNilMetadata(in.Metadata)
+	b.engineSessions[sessionKey(in.ConversationID, in.AgentID, in.AgentKind)] = cur
 	return nil
 }
 
@@ -389,9 +288,14 @@ func (b *InMemoryBinder) InvalidateConversation(_ context.Context, conversationI
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	prefix := conversationID + "|"
-	for k := range b.bindings {
-		if hasPrefix(k, prefix) {
-			delete(b.bindings, k)
+	for k := range b.runtimeBindings {
+		if strings.HasPrefix(k, prefix) {
+			delete(b.runtimeBindings, k)
+		}
+	}
+	for k := range b.engineSessions {
+		if strings.HasPrefix(k, prefix) {
+			delete(b.engineSessions, k)
 		}
 	}
 	return nil
@@ -403,18 +307,72 @@ func (b *InMemoryBinder) InvalidateDevice(_ context.Context, deviceID string) er
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	for k, v := range b.bindings {
+	for k, v := range b.runtimeBindings {
 		if v.DeviceID == deviceID {
-			delete(b.bindings, k)
+			delete(b.runtimeBindings, k)
+			for sessKey := range b.engineSessions {
+				if strings.HasPrefix(sessKey, k+"|") {
+					delete(b.engineSessions, sessKey)
+				}
+			}
 		}
 	}
 	return nil
+}
+
+func uuidParam(v string) (pgtype.UUID, error) {
+	var out pgtype.UUID
+	if err := out.Scan(v); err != nil {
+		return pgtype.UUID{}, err
+	}
+	return out, nil
+}
+
+func decodeMetadata(raw []byte) map[string]any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil || out == nil {
+		return map[string]any{}
+	}
+	return out
+}
+
+func nonNilMetadata(in map[string]any) map[string]any {
+	if in == nil {
+		return map[string]any{}
+	}
+	return in
+}
+
+func normaliseAgentKind(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "claude_code"
+	}
+	return v
+}
+
+func normaliseSessionType(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return "agent_session"
+	}
+	return v
+}
+
+func defaultStateKey(in Binding) string {
+	if strings.TrimSpace(in.AgentStateKey) != "" {
+		return in.AgentStateKey
+	}
+	return in.ConversationID + "/" + in.AgentID + "/" + normaliseAgentKind(in.AgentKind)
 }
 
 func memKey(conversationID, agentID string) string {
 	return conversationID + "|" + agentID
 }
 
-func hasPrefix(s, prefix string) bool {
-	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+func sessionKey(conversationID, agentID, agentKind string) string {
+	return conversationID + "|" + agentID + "|" + normaliseAgentKind(agentKind)
 }

--- a/server/internal/agentdaemon/binding/binder_test.go
+++ b/server/internal/agentdaemon/binding/binder_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 )
 
 func TestInMemoryBinder_ResolveAndBind(t *testing.T) {
 	b := NewInMemoryBinder()
 	ctx := context.Background()
 
-	if _, err := b.Resolve(ctx, "conv-1", "pa-1"); !errors.Is(err, ErrNotBound) {
+	if _, err := b.Resolve(ctx, "conv-1", "pa-1", "claude_code"); !errors.Is(err, ErrNotBound) {
 		t.Fatalf("expected ErrNotBound on empty store, got %v", err)
 	}
 
@@ -25,7 +24,7 @@ func TestInMemoryBinder_ResolveAndBind(t *testing.T) {
 		t.Fatalf("Bind: %v", err)
 	}
 
-	got, err := b.Resolve(ctx, "conv-1", "pa-1")
+	got, err := b.Resolve(ctx, "conv-1", "pa-1", "claude_code")
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -59,22 +58,112 @@ func TestInMemoryBinder_RememberSession(t *testing.T) {
 
 	// RememberSession on a missing binding is a no-op so a stray
 	// session callback doesn't materialise a half-formed row.
-	if err := b.RememberSession(ctx, "conv-1", "pa-1", "claude-sess-xyz", time.Time{}); err != nil {
+	if err := b.RememberSession(ctx, Binding{
+		ConversationID:   "conv-1",
+		AgentID:          "pa-1",
+		AgentKind:        "claude_code",
+		AgentSessionID:   "claude-sess-xyz",
+		AgentSessionType: SessionTypeClaude,
+	}); err != nil {
 		t.Fatalf("RememberSession on missing binding: %v", err)
 	}
-	if _, err := b.Resolve(ctx, "conv-1", "pa-1"); !errors.Is(err, ErrNotBound) {
+	if _, err := b.Resolve(ctx, "conv-1", "pa-1", "claude_code"); !errors.Is(err, ErrNotBound) {
 		t.Fatalf("RememberSession should not create binding")
 	}
 
 	if err := b.Bind(ctx, Binding{ConversationID: "conv-1", AgentID: "pa-1", DeviceID: "dev-A"}); err != nil {
 		t.Fatalf("Bind: %v", err)
 	}
-	if err := b.RememberSession(ctx, "conv-1", "pa-1", "claude-sess-xyz", time.Time{}); err != nil {
+	if err := b.RememberSession(ctx, Binding{
+		ConversationID:   "conv-1",
+		AgentID:          "pa-1",
+		AgentKind:        "claude_code",
+		AgentSessionID:   "claude-sess-xyz",
+		AgentSessionType: SessionTypeClaude,
+	}); err != nil {
 		t.Fatalf("RememberSession: %v", err)
 	}
-	got, _ := b.Resolve(ctx, "conv-1", "pa-1")
-	if got.ClaudeSessionID != "claude-sess-xyz" {
-		t.Fatalf("ClaudeSessionID not persisted: %+v", got)
+	got, _ := b.Resolve(ctx, "conv-1", "pa-1", "claude_code")
+	if got.AgentSessionID != "claude-sess-xyz" || got.AgentSessionType != SessionTypeClaude {
+		t.Fatalf("agent session not persisted: %+v", got)
+	}
+	if got.AgentStateKey != "conv-1/pa-1/claude_code" {
+		t.Fatalf("AgentStateKey = %q", got.AgentStateKey)
+	}
+}
+
+func TestInMemoryBinder_RemembersEngineSessionsPerAgentKind(t *testing.T) {
+	b := NewInMemoryBinder()
+	ctx := context.Background()
+
+	if err := b.Bind(ctx, Binding{ConversationID: "conv-1", AgentID: "pa-1", DeviceID: "dev-A"}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	if err := b.RememberSession(ctx, Binding{
+		ConversationID:   "conv-1",
+		AgentID:          "pa-1",
+		AgentKind:        "claude_code",
+		AgentSessionID:   "claude-sess-1",
+		AgentSessionType: SessionTypeClaude,
+	}); err != nil {
+		t.Fatalf("RememberSession claude: %v", err)
+	}
+	if err := b.RememberSession(ctx, Binding{
+		ConversationID:   "conv-1",
+		AgentID:          "pa-1",
+		AgentKind:        "codex",
+		AgentSessionID:   "codex-thread-1",
+		AgentSessionType: SessionTypeCodex,
+	}); err != nil {
+		t.Fatalf("RememberSession codex: %v", err)
+	}
+
+	claude, err := b.Resolve(ctx, "conv-1", "pa-1", "claude_code")
+	if err != nil {
+		t.Fatalf("Resolve claude: %v", err)
+	}
+	codex, err := b.Resolve(ctx, "conv-1", "pa-1", "codex")
+	if err != nil {
+		t.Fatalf("Resolve codex: %v", err)
+	}
+	if claude.AgentSessionID != "claude-sess-1" || claude.AgentSessionType != SessionTypeClaude {
+		t.Fatalf("claude session = %+v", claude)
+	}
+	if codex.AgentSessionID != "codex-thread-1" || codex.AgentSessionType != SessionTypeCodex {
+		t.Fatalf("codex session = %+v", codex)
+	}
+	if claude.DeviceID != "dev-A" || codex.DeviceID != "dev-A" {
+		t.Fatalf("runtime binding should be shared, got claude=%q codex=%q", claude.DeviceID, codex.DeviceID)
+	}
+}
+
+func TestInMemoryBinder_BindWithSessionDoesNotLeakAcrossAgentKinds(t *testing.T) {
+	b := NewInMemoryBinder()
+	ctx := context.Background()
+
+	if err := b.Bind(ctx, Binding{
+		ConversationID:   "conv-1",
+		AgentID:          "pa-1",
+		DeviceID:         "dev-A",
+		AgentKind:        "codex",
+		AgentSessionID:   "codex-thread-1",
+		AgentSessionType: SessionTypeCodex,
+	}); err != nil {
+		t.Fatalf("Bind: %v", err)
+	}
+	codex, err := b.Resolve(ctx, "conv-1", "pa-1", "codex")
+	if err != nil {
+		t.Fatalf("Resolve codex: %v", err)
+	}
+	claude, err := b.Resolve(ctx, "conv-1", "pa-1", "claude_code")
+	if err != nil {
+		t.Fatalf("Resolve claude: %v", err)
+	}
+	if codex.AgentSessionID != "codex-thread-1" {
+		t.Fatalf("codex session missing: %+v", codex)
+	}
+	if claude.AgentSessionID != "" || claude.AgentSessionType != "" {
+		t.Fatalf("codex session leaked into claude resolve: %+v", claude)
 	}
 }
 
@@ -94,13 +183,13 @@ func TestInMemoryBinder_InvalidateConversation(t *testing.T) {
 	if err := b.InvalidateConversation(ctx, "conv-1"); err != nil {
 		t.Fatalf("InvalidateConversation: %v", err)
 	}
-	if _, err := b.Resolve(ctx, "conv-1", "pa-1"); !errors.Is(err, ErrNotBound) {
+	if _, err := b.Resolve(ctx, "conv-1", "pa-1", "claude_code"); !errors.Is(err, ErrNotBound) {
 		t.Errorf("conv-1/pa-1 should be evicted")
 	}
-	if _, err := b.Resolve(ctx, "conv-1", "pa-2"); !errors.Is(err, ErrNotBound) {
+	if _, err := b.Resolve(ctx, "conv-1", "pa-2", "claude_code"); !errors.Is(err, ErrNotBound) {
 		t.Errorf("conv-1/pa-2 should be evicted")
 	}
-	if _, err := b.Resolve(ctx, "conv-2", "pa-1"); err != nil {
+	if _, err := b.Resolve(ctx, "conv-2", "pa-1", "claude_code"); err != nil {
 		t.Errorf("conv-2 should survive: %v", err)
 	}
 }
@@ -116,11 +205,11 @@ func TestInMemoryBinder_InvalidateDevice(t *testing.T) {
 		t.Fatalf("InvalidateDevice: %v", err)
 	}
 	for _, conv := range []string{"conv-1", "conv-2"} {
-		if _, err := b.Resolve(ctx, conv, "pa-1"); !errors.Is(err, ErrNotBound) {
+		if _, err := b.Resolve(ctx, conv, "pa-1", "claude_code"); !errors.Is(err, ErrNotBound) {
 			t.Errorf("%s should be evicted after dev-A invalidation", conv)
 		}
 	}
-	if _, err := b.Resolve(ctx, "conv-3", "pa-1"); err != nil {
+	if _, err := b.Resolve(ctx, "conv-3", "pa-1", "claude_code"); err != nil {
 		t.Errorf("dev-B binding should survive: %v", err)
 	}
 }

--- a/server/internal/connector/agentdaemon/connector.go
+++ b/server/internal/connector/agentdaemon/connector.go
@@ -35,10 +35,7 @@ import (
 )
 
 // ConnectorType is the connector_type string this connector handles.
-// Re-exported from binding.ConnectorType so a single constant cannot
-// drift and callers that only import this package don't need a second
-// import for the registry MustRegister call.
-const ConnectorType = binding.ConnectorType
+const ConnectorType = "agent_daemon"
 
 // ErrUnsupportedAgentKind is returned when the resolved agent_kind is not
 // advertised as available by the selected daemon device.
@@ -358,7 +355,7 @@ func (c *Connector) streamPrompt(ctx context.Context, in connector.PromptInput, 
 		return errorChannel(in.RunID, err.Error()), nil
 	}
 
-	bind, err := c.binder.Resolve(ctx, in.ConversationID, in.AgentID)
+	bind, err := c.binder.Resolve(ctx, in.ConversationID, in.AgentID, agentKind)
 	if err != nil {
 		if errors.Is(err, binding.ErrNotBound) {
 			// Lazy-bind: pick up the runtime the user picked in the
@@ -400,6 +397,10 @@ func (c *Connector) streamPrompt(ctx context.Context, in connector.PromptInput, 
 			"run_id", in.RunID,
 			"conversation_id", in.ConversationID,
 			"device_id", bind.DeviceID)
+	}
+	bind.AgentKind = agentKind
+	if bind.AgentStateKey == "" {
+		bind.AgentStateKey = agentStateKey(in.ConversationID, in.AgentID, agentKind)
 	}
 
 	if ch, routed, routeErr := c.routeRemoteIfNeeded(ctx, bind, in, allowRemote); routed || routeErr != nil {
@@ -459,14 +460,15 @@ func (c *Connector) streamPrompt(ctx context.Context, in connector.PromptInput, 
 	}
 
 	req, err := proto.NewEnvelope(proto.TypePromptRequest, in.RunID, proto.PromptRequestPayload{
-		AgentKind:       agentKind,
-		ConversationID:  in.ConversationID,
-		RunID:           in.RunID,
-		Prompt:          in.TriggerMessageContent,
-		Attachments:     promptAttachmentsFromStore(in.TriggerAttachments),
-		WorkDir:         bind.WorkDir,
-		AgentOptions:    agentOptions,
-		ResumeSessionID: bind.ClaudeSessionID,
+		AgentKind:      agentKind,
+		ConversationID: in.ConversationID,
+		RunID:          in.RunID,
+		Prompt:         in.TriggerMessageContent,
+		Attachments:    promptAttachmentsFromStore(in.TriggerAttachments),
+		WorkDir:        bind.WorkDir,
+		AgentOptions:   agentOptions,
+		AgentSessionID: bind.AgentSessionID,
+		AgentStateKey:  bind.AgentStateKey,
 	})
 	if err != nil {
 		sess.Unsubscribe(in.RunID)
@@ -736,33 +738,27 @@ func (c *Connector) handleUpstream(
 			Usage:      usageFromProto(p.Usage),
 			Metadata:   p.Metadata,
 		}
-		// Best-effort: persist claude_session_id so the next turn can
-		// pass --resume. Errors logged but do not abort the run.
-		if claudeSess, ok := p.Metadata["claude_session_id"].(string); ok && claudeSess != "" {
-			c.rememberClaudeSession(ctx, in, claudeSess)
+		// Best-effort: persist the engine session id so the next turn can resume.
+		if agentSessionID, ok := p.Metadata[proto.DoneMetaAgentSessionID].(string); ok && agentSessionID != "" {
+			sessionType, _ := p.Metadata[proto.DoneMetaAgentSessionType].(string)
+			c.rememberAgentSession(ctx, in, agentSessionID, sessionType)
 		}
 		out <- connector.PromptEvent{Type: connector.EventDone, Final: final, Sequence: atomic.AddUint64(seq, 1)}
 	}
 }
 
-// rememberClaudeSession folds the daemon's done-event claude_session_id
-// back into the conversation binding. Stale done events (the run was
-// cancelled and a new one already started) are filtered by the binder's
-// own CAS guard on session_updated_at — both ours and the next run's
-// writebacks carry runStartedAt, the older one loses.
-func (c *Connector) rememberClaudeSession(ctx context.Context, in connector.PromptInput, claudeSess string) {
-	var runStartedAt time.Time
-	if c.runStatus != nil {
-		_, startedAt, statusErr := c.runStatus.GetAgentRunStatusAndStartedAt(ctx, in.RunID)
-		if statusErr != nil {
-			c.log.Warn("agent_daemon: read run status for session write-back",
-				"err", statusErr, "run_id", in.RunID)
-		} else {
-			runStartedAt = startedAt
-		}
-	}
-	if err := c.binder.RememberSession(ctx, in.ConversationID, in.AgentID, claudeSess, runStartedAt); err != nil {
-		c.log.Warn("agent_daemon: remember claude_session_id", "err", err, "run_id", in.RunID)
+func (c *Connector) rememberAgentSession(ctx context.Context, in connector.PromptInput, sessionID, sessionType string) {
+	agentKind := resolveAgentKind(in)
+	stateKey := agentStateKey(in.ConversationID, in.AgentID, agentKind)
+	if err := c.binder.RememberSession(ctx, binding.Binding{
+		ConversationID:   in.ConversationID,
+		AgentID:          in.AgentID,
+		AgentKind:        agentKind,
+		AgentSessionID:   sessionID,
+		AgentSessionType: sessionType,
+		AgentStateKey:    stateKey,
+	}); err != nil {
+		c.log.Warn("agent_daemon: remember agent session", "err", err, "run_id", in.RunID)
 	}
 }
 
@@ -1003,8 +999,13 @@ func configuredDeviceBinding(in connector.PromptInput) (binding.Binding, bool) {
 		AgentID:        in.AgentID,
 		DeviceID:       deviceID,
 		AgentKind:      resolveAgentKind(in),
+		AgentStateKey:  agentStateKey(in.ConversationID, in.AgentID, resolveAgentKind(in)),
 		WorkDir:        workDir,
 	}, true
+}
+
+func agentStateKey(conversationID, agentID, agentKind string) string {
+	return strings.TrimSpace(conversationID) + "/" + strings.TrimSpace(agentID) + "/" + strings.TrimSpace(agentKind)
 }
 
 // acquireSandboxBinding is the cold-start path: ErrNotBound and the

--- a/server/internal/connector/agentdaemon/connector_test.go
+++ b/server/internal/connector/agentdaemon/connector_test.go
@@ -660,7 +660,7 @@ func TestClose_InvalidatesBinder(t *testing.T) {
 	if err := c.Close(context.Background(), "conv-1"); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if _, err := binder.Resolve(context.Background(), "conv-1", "pa-1"); !errors.Is(err, binding.ErrNotBound) {
+	if _, err := binder.Resolve(context.Background(), "conv-1", "pa-1", "claude_code"); !errors.Is(err, binding.ErrNotBound) {
 		t.Fatalf("expected ErrNotBound after Close, got %v", err)
 	}
 }
@@ -868,7 +868,7 @@ func TestStreamPrompt_LocalModeConfiguredDeviceBindsConversation(t *testing.T) {
 		t.Fatalf("prompt_request mismatch: %+v", req)
 	}
 
-	b, err := binder.Resolve(context.Background(), "conv-1", "pa-1")
+	b, err := binder.Resolve(context.Background(), "conv-1", "pa-1", "claude_code")
 	if err != nil {
 		t.Fatalf("binder.Resolve after configured device: %v", err)
 	}
@@ -944,7 +944,7 @@ func TestStreamPrompt_LocalModeConfiguredDeviceBindsWithWorkdirKey(t *testing.T)
 		t.Fatalf("prompt_request work_dir mismatch: got %q, want %q (workdir alias should be honored)", req.WorkDir, "/repo/parsar")
 	}
 
-	b, err := binder.Resolve(context.Background(), "conv-1", "pa-1")
+	b, err := binder.Resolve(context.Background(), "conv-1", "pa-1", "claude_code")
 	if err != nil {
 		t.Fatalf("binder.Resolve after configured device: %v", err)
 	}
@@ -1005,7 +1005,7 @@ func TestStreamPrompt_SandboxModeIsNoLongerAutoAcquired(t *testing.T) {
 		t.Fatalf("expected sandbox-preparation hint, got %q", gotErr.Error)
 	}
 	// And nothing got bound.
-	if _, err := binder.Resolve(context.Background(), "conv-1", "pa-1"); err == nil {
+	if _, err := binder.Resolve(context.Background(), "conv-1", "pa-1", "claude_code"); err == nil {
 		t.Fatalf("expected no binding after refusing auto-acquire; one was persisted")
 	}
 }
@@ -1180,7 +1180,7 @@ loop:
 	// regresses, every subsequent turn would re-hit ErrNotBound and
 	// re-bind on the slow path, which mostly works but is wrong by
 	// design (see "lazy on first prompt" decision in the plan).
-	bind, err := binder.Resolve(context.Background(), "conv-1", "pa-1")
+	bind, err := binder.Resolve(context.Background(), "conv-1", "pa-1", "claude_code")
 	if err != nil {
 		t.Fatalf("expected binder.Resolve to succeed after lazy bind, got %v", err)
 	}
@@ -1233,7 +1233,7 @@ func TestStreamPrompt_NoDeviceConfigStillReportsPickDevice(t *testing.T) {
 	// And: nothing should have been written to the binder. If the new
 	// switch ever falls through to Bind with empty device_id, this
 	// would catch it before it corrupts a fresh row.
-	if _, err := binder.Resolve(context.Background(), "conv-1", "pa-1"); !errors.Is(err, binding.ErrNotBound) {
+	if _, err := binder.Resolve(context.Background(), "conv-1", "pa-1", "claude_code"); !errors.Is(err, binding.ErrNotBound) {
 		t.Fatalf("binder must remain unbound after 'pick a device' error, got %v", err)
 	}
 

--- a/server/internal/connector/agentdaemon/remote_http.go
+++ b/server/internal/connector/agentdaemon/remote_http.go
@@ -31,13 +31,13 @@ type remoteStreamPromptRequest struct {
 }
 
 type remoteSubmitPermissionRequest struct {
-	Generation int64                         `json:"generation"`
-	Decision   connector.PermissionDecision  `json:"decision"`
+	Generation int64                        `json:"generation"`
+	Decision   connector.PermissionDecision `json:"decision"`
 }
 
 type remoteSubmitPromptForUserChoiceRequest struct {
-	Generation int64                                  `json:"generation"`
-	Decision   connector.PromptForUserChoiceDecision  `json:"decision"`
+	Generation int64                                 `json:"generation"`
+	Decision   connector.PromptForUserChoiceDecision `json:"decision"`
 }
 
 // HTTPRemoteStreamer forwards StreamPrompt to the pod recorded in the
@@ -354,7 +354,7 @@ func (c *Connector) assertLocalOwner(ctx context.Context, in connector.PromptInp
 	if c.ownerResolver == nil {
 		return nil
 	}
-	bind, err := c.binder.Resolve(ctx, in.ConversationID, in.AgentID)
+	bind, err := c.binder.Resolve(ctx, in.ConversationID, in.AgentID, resolveAgentKind(in))
 	if err != nil {
 		return fmt.Errorf("stale_owner: resolve binding: %w", err)
 	}

--- a/server/internal/connector/agentdaemon/sandbox_provider_test.go
+++ b/server/internal/connector/agentdaemon/sandbox_provider_test.go
@@ -557,7 +557,7 @@ func TestE2BSandboxProvider_Release(t *testing.T) {
 	if e2bClient.killCalls != 1 {
 		t.Fatalf("Release should Kill; saw %d", e2bClient.killCalls)
 	}
-	if _, err := binder.Resolve(context.Background(), "conv-1", "pa-1"); !errors.Is(err, binding.ErrNotBound) {
+	if _, err := binder.Resolve(context.Background(), "conv-1", "pa-1", "claude_code"); !errors.Is(err, binding.ErrNotBound) {
 		t.Fatalf("Release should invalidate binder; resolve returned %v", err)
 	}
 	// Second release: no-op.

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -2905,10 +2905,8 @@ where conversation_id = @conversation_id::text
 -- Enumerate all bindings for one conversation and connector type.
 -- Backs connector diagnostic dumps without exposing one connector's
 -- upstream sessions to another connector. `metadata` is returned so
--- connectors that overload the column (e.g. agent_daemon stashes
--- agent_kind / claude_session_id / work_dir there) can reconstruct
--- the full binding in one query; callers that don't care just ignore
--- it (opencode/bindingstore.go is one such caller).
+-- connectors that overload the column can reconstruct the full binding
+-- in one query; callers that don't care just ignore it.
 select binding_key::text, upstream_session_id::text, metadata
 from connector_session_bindings
 where conversation_id = @conversation_id::text
@@ -2960,6 +2958,81 @@ where connector_type = @connector_type::text
 -- Test-only helper mirroring the in-memory size().
 select count(*)::bigint as total
 from connector_session_bindings;
+
+-- name: GetAgentDaemonBinding :one
+select
+  arb.conversation_id::text as conversation_id,
+  arb.agent_id::text as agent_id,
+  arb.runtime_id::text as runtime_id,
+  arb.work_dir::text as work_dir,
+  coalesce(aes.upstream_session_id, ''::text)::text as upstream_session_id,
+  coalesce(aes.upstream_session_type, ''::text)::text as upstream_session_type,
+  coalesce(aes.state_dir_key, ''::text)::text as state_dir_key,
+  coalesce(aes.metadata, '{}'::jsonb) as metadata
+from agent_runtime_bindings arb
+left join agent_engine_sessions aes
+  on aes.conversation_id = arb.conversation_id
+ and aes.agent_id = arb.agent_id
+ and aes.agent_kind = @agent_kind::text
+where arb.conversation_id = @conversation_id::uuid
+  and arb.agent_id = @agent_id::uuid;
+
+-- name: ResolveAgentDaemonDeviceByConversation :one
+select runtime_id::text
+from agent_runtime_bindings
+where conversation_id = @conversation_id::uuid
+order by updated_at desc
+limit 1;
+
+-- name: UpsertAgentDaemonRuntimeBinding :exec
+insert into agent_runtime_bindings(conversation_id, agent_id, runtime_id, work_dir, created_at, updated_at)
+values (@conversation_id::uuid, @agent_id::uuid, @runtime_id::uuid, @work_dir::text, now(), now())
+on conflict (conversation_id, agent_id) do update
+set runtime_id = excluded.runtime_id,
+    work_dir = excluded.work_dir,
+    updated_at = now();
+
+-- name: UpsertAgentDaemonEngineSession :exec
+insert into agent_engine_sessions(
+  conversation_id,
+  agent_id,
+  agent_kind,
+  upstream_session_id,
+  upstream_session_type,
+  state_dir_key,
+  metadata,
+  created_at,
+  updated_at
+)
+select
+  @conversation_id::uuid,
+  @agent_id::uuid,
+  @agent_kind::text,
+  @upstream_session_id::text,
+  @upstream_session_type::text,
+  @state_dir_key::text,
+  coalesce(@metadata::jsonb, '{}'::jsonb),
+  now(),
+  now()
+where exists (
+  select 1 from agent_runtime_bindings
+  where conversation_id = @conversation_id::uuid
+    and agent_id = @agent_id::uuid
+)
+on conflict (conversation_id, agent_id, agent_kind) do update
+set upstream_session_id = excluded.upstream_session_id,
+    upstream_session_type = excluded.upstream_session_type,
+    state_dir_key = excluded.state_dir_key,
+    metadata = excluded.metadata,
+    updated_at = now();
+
+-- name: DeleteAgentDaemonBindingByConversation :exec
+delete from agent_runtime_bindings
+where conversation_id = @conversation_id::uuid;
+
+-- name: DeleteAgentDaemonBindingByRuntime :exec
+delete from agent_runtime_bindings
+where runtime_id = @runtime_id::uuid;
 
 -- ============================================================
 

--- a/server/internal/db/sqlc/models.go
+++ b/server/internal/db/sqlc/models.go
@@ -96,6 +96,22 @@ type AgentDaemonDeviceOwner struct {
 	UpdatedAt      pgtype.Timestamptz `json:"updated_at"`
 }
 
+// Agent-daemon upstream engine session state
+type AgentEngineSession struct {
+	ConversationID pgtype.UUID `json:"conversation_id"`
+	AgentID        pgtype.UUID `json:"agent_id"`
+	AgentKind      string      `json:"agent_kind"`
+	// Agent-engine session identifier, e.g. Claude session id, Codex thread id, or Pi session id
+	UpstreamSessionID string `json:"upstream_session_id"`
+	// Agent-engine session id type, e.g. claude_session, codex_thread, pi_session
+	UpstreamSessionType string `json:"upstream_session_type"`
+	// Stable daemon-side state directory key for this conversation, agent, and engine
+	StateDirKey string             `json:"state_dir_key"`
+	Metadata    []byte             `json:"metadata"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
+}
+
 // Agent execution records
 type AgentRun struct {
 	// Run ID
@@ -190,6 +206,20 @@ type AgentRunEvent struct {
 	OccurredAt pgtype.Timestamptz `json:"occurred_at"`
 	// Persistence time
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
+}
+
+// Agent-daemon conversation to runtime-device bindings
+type AgentRuntimeBinding struct {
+	// Conversation using the runtime
+	ConversationID pgtype.UUID `json:"conversation_id"`
+	// Agent using the runtime
+	AgentID pgtype.UUID `json:"agent_id"`
+	// Runtime device assigned to this conversation and agent
+	RuntimeID pgtype.UUID `json:"runtime_id"`
+	// Stable working directory for this conversation and agent
+	WorkDir   string             `json:"work_dir"`
+	CreatedAt pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
 }
 
 // Compliance audit stream

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -2899,6 +2899,26 @@ func (q *Queries) DeleteAgentCapability(ctx context.Context, id pgtype.UUID) err
 	return err
 }
 
+const deleteAgentDaemonBindingByConversation = `-- name: DeleteAgentDaemonBindingByConversation :exec
+delete from agent_runtime_bindings
+where conversation_id = $1::uuid
+`
+
+func (q *Queries) DeleteAgentDaemonBindingByConversation(ctx context.Context, conversationID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteAgentDaemonBindingByConversation, conversationID)
+	return err
+}
+
+const deleteAgentDaemonBindingByRuntime = `-- name: DeleteAgentDaemonBindingByRuntime :exec
+delete from agent_runtime_bindings
+where runtime_id = $1::uuid
+`
+
+func (q *Queries) DeleteAgentDaemonBindingByRuntime(ctx context.Context, runtimeID pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deleteAgentDaemonBindingByRuntime, runtimeID)
+	return err
+}
+
 const deleteConnectorSessionBindingsByBindingKey = `-- name: DeleteConnectorSessionBindingsByBindingKey :exec
 delete from connector_session_bindings
 where connector_type = $1::text
@@ -3850,6 +3870,58 @@ func (q *Queries) GetAgentCapability(ctx context.Context, id pgtype.UUID) (GetAg
 		&i.PinningMode,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getAgentDaemonBinding = `-- name: GetAgentDaemonBinding :one
+select
+  arb.conversation_id::text as conversation_id,
+  arb.agent_id::text as agent_id,
+  arb.runtime_id::text as runtime_id,
+  arb.work_dir::text as work_dir,
+  coalesce(aes.upstream_session_id, ''::text)::text as upstream_session_id,
+  coalesce(aes.upstream_session_type, ''::text)::text as upstream_session_type,
+  coalesce(aes.state_dir_key, ''::text)::text as state_dir_key,
+  coalesce(aes.metadata, '{}'::jsonb) as metadata
+from agent_runtime_bindings arb
+left join agent_engine_sessions aes
+  on aes.conversation_id = arb.conversation_id
+ and aes.agent_id = arb.agent_id
+ and aes.agent_kind = $1::text
+where arb.conversation_id = $2::uuid
+  and arb.agent_id = $3::uuid
+`
+
+type GetAgentDaemonBindingParams struct {
+	AgentKind      string      `json:"agent_kind"`
+	ConversationID pgtype.UUID `json:"conversation_id"`
+	AgentID        pgtype.UUID `json:"agent_id"`
+}
+
+type GetAgentDaemonBindingRow struct {
+	ConversationID      string `json:"conversation_id"`
+	AgentID             string `json:"agent_id"`
+	RuntimeID           string `json:"runtime_id"`
+	WorkDir             string `json:"work_dir"`
+	UpstreamSessionID   string `json:"upstream_session_id"`
+	UpstreamSessionType string `json:"upstream_session_type"`
+	StateDirKey         string `json:"state_dir_key"`
+	Metadata            []byte `json:"metadata"`
+}
+
+func (q *Queries) GetAgentDaemonBinding(ctx context.Context, arg GetAgentDaemonBindingParams) (GetAgentDaemonBindingRow, error) {
+	row := q.db.QueryRow(ctx, getAgentDaemonBinding, arg.AgentKind, arg.ConversationID, arg.AgentID)
+	var i GetAgentDaemonBindingRow
+	err := row.Scan(
+		&i.ConversationID,
+		&i.AgentID,
+		&i.RuntimeID,
+		&i.WorkDir,
+		&i.UpstreamSessionID,
+		&i.UpstreamSessionType,
+		&i.StateDirKey,
+		&i.Metadata,
 	)
 	return i, err
 }
@@ -7271,10 +7343,8 @@ type ListConnectorSessionBindingsRow struct {
 // Enumerate all bindings for one conversation and connector type.
 // Backs connector diagnostic dumps without exposing one connector's
 // upstream sessions to another connector. `metadata` is returned so
-// connectors that overload the column (e.g. agent_daemon stashes
-// agent_kind / claude_session_id / work_dir there) can reconstruct
-// the full binding in one query; callers that don't care just ignore
-// it (opencode/bindingstore.go is one such caller).
+// connectors that overload the column can reconstruct the full binding
+// in one query; callers that don't care just ignore it.
 func (q *Queries) ListConnectorSessionBindings(ctx context.Context, arg ListConnectorSessionBindingsParams) ([]ListConnectorSessionBindingsRow, error) {
 	rows, err := q.db.Query(ctx, listConnectorSessionBindings, arg.ConversationID, arg.ConnectorType)
 	if err != nil {
@@ -9848,6 +9918,21 @@ func (q *Queries) ReserveSandboxBindingSlot(ctx context.Context, arg ReserveSand
 	return i, err
 }
 
+const resolveAgentDaemonDeviceByConversation = `-- name: ResolveAgentDaemonDeviceByConversation :one
+select runtime_id::text
+from agent_runtime_bindings
+where conversation_id = $1::uuid
+order by updated_at desc
+limit 1
+`
+
+func (q *Queries) ResolveAgentDaemonDeviceByConversation(ctx context.Context, conversationID pgtype.UUID) (string, error) {
+	row := q.db.QueryRow(ctx, resolveAgentDaemonDeviceByConversation, conversationID)
+	var runtime_id string
+	err := row.Scan(&runtime_id)
+	return runtime_id, err
+}
+
 const resolveAgentNameForConversation = `-- name: ResolveAgentNameForConversation :one
 select coalesce(a.name, '')::text as agent_name
 from conversations c
@@ -11616,6 +11701,90 @@ func (q *Queries) UpgradeAgentCapability(ctx context.Context, arg UpgradeAgentCa
 		&i.UpdatedAt,
 	)
 	return i, err
+}
+
+const upsertAgentDaemonEngineSession = `-- name: UpsertAgentDaemonEngineSession :exec
+insert into agent_engine_sessions(
+  conversation_id,
+  agent_id,
+  agent_kind,
+  upstream_session_id,
+  upstream_session_type,
+  state_dir_key,
+  metadata,
+  created_at,
+  updated_at
+)
+select
+  $1::uuid,
+  $2::uuid,
+  $3::text,
+  $4::text,
+  $5::text,
+  $6::text,
+  coalesce($7::jsonb, '{}'::jsonb),
+  now(),
+  now()
+where exists (
+  select 1 from agent_runtime_bindings
+  where conversation_id = $1::uuid
+    and agent_id = $2::uuid
+)
+on conflict (conversation_id, agent_id, agent_kind) do update
+set upstream_session_id = excluded.upstream_session_id,
+    upstream_session_type = excluded.upstream_session_type,
+    state_dir_key = excluded.state_dir_key,
+    metadata = excluded.metadata,
+    updated_at = now()
+`
+
+type UpsertAgentDaemonEngineSessionParams struct {
+	ConversationID      pgtype.UUID `json:"conversation_id"`
+	AgentID             pgtype.UUID `json:"agent_id"`
+	AgentKind           string      `json:"agent_kind"`
+	UpstreamSessionID   string      `json:"upstream_session_id"`
+	UpstreamSessionType string      `json:"upstream_session_type"`
+	StateDirKey         string      `json:"state_dir_key"`
+	Metadata            []byte      `json:"metadata"`
+}
+
+func (q *Queries) UpsertAgentDaemonEngineSession(ctx context.Context, arg UpsertAgentDaemonEngineSessionParams) error {
+	_, err := q.db.Exec(ctx, upsertAgentDaemonEngineSession,
+		arg.ConversationID,
+		arg.AgentID,
+		arg.AgentKind,
+		arg.UpstreamSessionID,
+		arg.UpstreamSessionType,
+		arg.StateDirKey,
+		arg.Metadata,
+	)
+	return err
+}
+
+const upsertAgentDaemonRuntimeBinding = `-- name: UpsertAgentDaemonRuntimeBinding :exec
+insert into agent_runtime_bindings(conversation_id, agent_id, runtime_id, work_dir, created_at, updated_at)
+values ($1::uuid, $2::uuid, $3::uuid, $4::text, now(), now())
+on conflict (conversation_id, agent_id) do update
+set runtime_id = excluded.runtime_id,
+    work_dir = excluded.work_dir,
+    updated_at = now()
+`
+
+type UpsertAgentDaemonRuntimeBindingParams struct {
+	ConversationID pgtype.UUID `json:"conversation_id"`
+	AgentID        pgtype.UUID `json:"agent_id"`
+	RuntimeID      pgtype.UUID `json:"runtime_id"`
+	WorkDir        string      `json:"work_dir"`
+}
+
+func (q *Queries) UpsertAgentDaemonRuntimeBinding(ctx context.Context, arg UpsertAgentDaemonRuntimeBindingParams) error {
+	_, err := q.db.Exec(ctx, upsertAgentDaemonRuntimeBinding,
+		arg.ConversationID,
+		arg.AgentID,
+		arg.RuntimeID,
+		arg.WorkDir,
+	)
+	return err
 }
 
 const upsertAuthIdentity = `-- name: UpsertAuthIdentity :exec

--- a/server/migrations/000008_agent_daemon_sessions.sql
+++ b/server/migrations/000008_agent_daemon_sessions.sql
@@ -1,0 +1,47 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS agent_runtime_bindings (
+  conversation_id uuid        NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  agent_id        uuid        NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  runtime_id      uuid        NOT NULL REFERENCES runtimes(id) ON DELETE CASCADE,
+  work_dir        text        NOT NULL DEFAULT '',
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (conversation_id, agent_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_runtime_bindings_runtime
+  ON agent_runtime_bindings(runtime_id);
+
+CREATE TABLE IF NOT EXISTS agent_engine_sessions (
+  conversation_id          uuid        NOT NULL,
+  agent_id                 uuid        NOT NULL,
+  agent_kind               text        NOT NULL,
+  upstream_session_id      text        NOT NULL,
+  upstream_session_type    text        NOT NULL,
+  state_dir_key            text        NOT NULL,
+  metadata                 jsonb       NOT NULL DEFAULT '{}'::jsonb,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (conversation_id, agent_id, agent_kind),
+  FOREIGN KEY (conversation_id, agent_id)
+    REFERENCES agent_runtime_bindings(conversation_id, agent_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_engine_sessions_agent
+  ON agent_engine_sessions(agent_id, agent_kind);
+
+COMMENT ON TABLE  agent_runtime_bindings IS 'Agent-daemon conversation to runtime-device bindings';
+COMMENT ON COLUMN agent_runtime_bindings.conversation_id IS 'Conversation using the runtime';
+COMMENT ON COLUMN agent_runtime_bindings.agent_id        IS 'Agent using the runtime';
+COMMENT ON COLUMN agent_runtime_bindings.runtime_id      IS 'Runtime device assigned to this conversation and agent';
+COMMENT ON COLUMN agent_runtime_bindings.work_dir        IS 'Stable working directory for this conversation and agent';
+
+COMMENT ON TABLE  agent_engine_sessions IS 'Agent-daemon upstream engine session state';
+COMMENT ON COLUMN agent_engine_sessions.upstream_session_id   IS 'Agent-engine session identifier, e.g. Claude session id, Codex thread id, or Pi session id';
+COMMENT ON COLUMN agent_engine_sessions.upstream_session_type IS 'Agent-engine session id type, e.g. claude_session, codex_thread, pi_session';
+COMMENT ON COLUMN agent_engine_sessions.state_dir_key         IS 'Stable daemon-side state directory key for this conversation, agent, and engine';
+
+-- +goose Down
+DROP TABLE IF EXISTS agent_engine_sessions;
+DROP TABLE IF EXISTS agent_runtime_bindings;


### PR DESCRIPTION
## Summary

- add a shared CLI process runner that reliably waits for agent child processes and escalates cancel from SIGTERM to SIGKILL
- persist upstream engine sessions for agent-daemon runs so follow-up turns resume Claude Code, Codex, and Pi instead of starting detached histories
- scope daemon-side state by conversation/agent/engine, including stable Codex `CODEX_HOME` and Pi `--session-dir`
- avoid persisting failed Pi sessions and add process/session regression tests

## Verification

- `go test -count=1 ./apps/parsar-daemon/internal/agent/claudecode ./apps/parsar-daemon/internal/agent/codex ./apps/parsar-daemon/internal/agent/pi ./apps/parsar-daemon/internal/agent/clirunner ./server/internal/agentdaemon/binding ./server/internal/connector/agentdaemon`
- `make check`
- rebuilt and restarted local Docker compose with clean volumes
- manually verified Claude Code, Codex, and Pi runs complete with no lingering `claude`, `codex`, or `pi` processes in the sandbox container
- manually verified Codex and Pi session rows are saved in `agent_engine_sessions` and resumed on subsequent turns
