### PR TITLE
Clarify architecture contribution rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,22 @@
 This file is the agent-friendly shortcut. The canonical contributor
 guide — including the hard rules, worktree workflow, architecture
 baseline, web UI rules, and the required `make check` — lives in
-[`CONTRIBUTING.md`](./CONTRIBUTING.md). Read it before any
-implementation, refactor, or schema / API change.
+[`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+## Architecture documentation
+
+For any substantial implementation, refactor, runtime/process change,
+schema/API change, or cross-package behavior change:
+
+- Read [`CONTRIBUTING.md`](./CONTRIBUTING.md) before touching code.
+- Update [`CONTRIBUTING.md`](./CONTRIBUTING.md) in the same branch when the
+  change creates, removes, or clarifies an architecture rule, ownership
+  boundary, workflow, required check, or generated artifact contract.
+- Do not let code establish a new convention that is absent from the
+  contributor guide.
+- Keep this file as a short agent-facing index. Put canonical long-form rules
+  in [`CONTRIBUTING.md`](./CONTRIBUTING.md), and delete duplicated prose here
+  instead of maintaining two copies.
 
 ## Language
 
@@ -28,89 +42,12 @@ Headlines:
   `apps/web/src/pages/admin/AgentsPage.tsx` are known oversized files —
   do not add more weight to them; split out the piece you're touching.
 
-## HTTP contract (swaggo generation)
+## Generated contracts
 
-`docs/openapi/openapi.yaml` is a **build artifact**, not a hand-edited
-file. It is regenerated from swaggo annotations on Go handlers by
-`make openapi`. The CI drift check (`.github/workflows/openapi.yml`)
-runs the same command in a clean checkout and fails the PR if the
-committed file diverges from the annotations.
+Full rules: [`CONTRIBUTING.md#required-checks`](./CONTRIBUTING.md#required-checks).
+Headlines:
 
-### When you add or change an endpoint
-
-1. Write / modify the handler.
-2. Add or update the swaggo annotation block **directly above the
-   `func` line**, with no blank line between:
-
-   ```go
-   // createAgent creates a new agent in a workspace. Owner/admin only.
-   //
-   //	@Summary		Create an agent in a workspace
-   //	@Description	Longer prose the operator sees under the summary.
-   //	@Tags			agents
-   //	@ID				createDevAgent
-   //	@Accept			json
-   //	@Produce		json
-   //	@Param			workspaceID	path	string				true	"Workspace UUID"
-   //	@Param			body		body	createAgentBody		true	"Agent create payload"
-   //	@Success		201 {object} map[string]interface{} "Created agent"
-   //	@Failure		400 {object} map[string]string "workspace_id must be a valid uuid"
-   //	@Failure		403 {object} map[string]string "Caller is not workspace owner/admin"
-   //	@Router			/api/v1/workspaces/{workspaceID}/agents [post]
-   func createAgent(runtimeStore RuntimeStore, ...) http.HandlerFunc {
-   ```
-
-3. Run `make openapi`. The recipe auto-installs
-   `github.com/swaggo/swag/cmd/swag@v1.16.4` on first use, regenerates
-   `docs/openapi/openapi.yaml`, and prints the new path count.
-4. Commit the handler edit **and** the regenerated YAML in the same
-   commit.
-5. `make check` must still pass.
-
-### Rules the CI enforces (so save yourself a rebase)
-
-- **Tab-separated fields** in the annotation. `//` + Tab + directive +
-  Tab-Tab + value. Look at
-  `server/internal/api/health.go:livenessHandler` or
-  `server/internal/dev/routes.go:createAgent` for the canonical format.
-- **`@Router` method lowercase**: `[get] [post] [patch] [delete] [put]`.
-- **`@Router` path is the full path**, including `/api/v1/…` or `/dev/…`
-  — swag does not know about the outer `r.Route("/api/v1", …)` group.
-- **`@Tags` is a single kebab-case tag** from the existing set (agents,
-  workspaces, conversations, agent-runs, scheduled-tasks, models,
-  secrets, capabilities, auth, me, connections, bootstrap, health,
-  runtimes, gateway, dev, feishu, workspace-members, uploads,
-  sandboxes, memories, meta, internal, agent-daemon). Introducing a new
-  tag is fine — just be deliberate.
-- **`@ID` is a globally-unique lowerCamelCase string**. Dev-mode
-  handlers prefix with `dev` (`createDevAgent`, `listDevWorkspaceModels`).
-- **Every path/query/header parameter is declared**. Missing parameters
-  cause swag to emit incomplete specs, which the drift check will
-  eventually surface but is faster to catch locally.
-- **Handlers must be named functions.** swaggo cannot attach annotations
-  to `r.Post("/x", func(w, r) { … })` — the anonymous closure has no
-  identifier. Extract to a factory like
-  `func fooHandler(deps) http.HandlerFunc { return func(w, r) { … } }`
-  and annotate the factory.
-- **Do not hand-edit `docs/openapi/openapi.yaml`.** The next
-  `make openapi` will overwrite your edits and the CI drift check will
-  reject the PR anyway.
-
-### When you deliberately want to skip a handler
-
-Internal helpers, middleware factories, and per-conversation dispatch
-closures that are not user-visible routes should have **no** `@Router`
-annotation. They are invisible to swag and will not appear in the
-spec. Do not add a placeholder `@Router` just to silence a hunch — that
-publishes a phantom endpoint.
-
-### Browsing the spec
-
-Once the server is running (`make dev-server-up`):
-
-- `GET /api/v1/openapi.yaml` — raw spec, use for
-  `openapi-typescript` / `oapi-codegen` / `curl` piping.
-- `GET /docs` — Swagger UI viewer, groups endpoints by tag.
-
-The Go server re-reads the YAML on every request, so a local
-`make openapi` regeneration is visible without restarting the server.
+- Handler/API changes require swaggo annotations, `make openapi`, and the
+  regenerated `docs/openapi/openapi.yaml`.
+- DB query changes require `make sqlc-generate` and regenerated sqlc files.
+- Always run `make check` before reporting completion.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,15 @@ read it before opening a PR.
   `~/`. Reject relative paths outright — do not resolve them against the CWD.
 - Before any install / setup step, ask yourself: does this write to the
   user's current directory? If yes, fix it before shipping.
+- Before any substantial implementation, refactor, runtime/process change,
+  schema/API change, or cross-package behavior change, read this guide. If
+  the change creates, removes, or clarifies an architecture rule, ownership
+  boundary, workflow, required check, or generated artifact contract, update
+  this guide in the same branch.
+- Keep contributor docs concise and single-sourced. `AGENTS.md` is only the
+  agent-facing shortcut; canonical rules live here. When two documents repeat
+  the same long-form rule, delete the duplicate and link to the canonical
+  section.
 
 ## Worktree workflow
 
@@ -54,6 +63,97 @@ Direct development on `main` is not allowed. Every session honours this rule.
 - Agent Daemon runs are dispatched to the `parsar-daemon` runtime bound to
   the agent (`project_agents.runtime_id`); the daemon's internal adapter
   picks which CLI actually executes.
+
+## Architecture boundaries
+
+The repo has several concepts that sound similar but must stay separate.
+When adding or changing code, name the boundary explicitly in the PR
+description and keep ownership on the side listed here.
+
+### Runtime and execution concepts
+
+- `connector_type` chooses the protocol Parsar uses to run an agent
+  (`agent_daemon`, `http_agent`, ...). It does not say where the process
+  runs.
+- `runtime_id` chooses the concrete paired runtime/device/sandbox that will
+  receive a run. It is a routing handle, not agent configuration.
+- `agent_kind` chooses the daemon-side engine (`claude_code`, `codex`,
+  `pi`, `opencode`). It is interpreted only by `parsar-daemon`.
+- Placement labels such as local device, cloud sandbox, and external agent
+  are UI/product concepts. Do not branch business logic on display copy.
+  Derive placement from typed runtime/provider/config fields in one shared
+  helper per layer.
+
+### Server versus daemon ownership
+
+- The server owns auth, workspaces, agent records, runtime bindings, run
+  records, audit/usage persistence, and upstream engine session ids.
+- `parsar-daemon` owns CLI discovery, process spawning, CLI-specific env,
+  cwd selection inside its host/container, permission prompts, and translating
+  CLI streams into Parsar daemon protocol frames.
+- `internal/agentdaemon/proto` is the only shared wire contract between the
+  server and daemon. The daemon must not import `server/internal/...`, and the
+  server must not import daemon-internal adapter packages.
+- Any state needed to recover a conversation after a server restart, daemon
+  reconnect, or child-process exit must be stored durably by the server.
+  In-memory maps may cache waiters or sockets only; they must not be the
+  source of truth for conversation/session continuity.
+- Work directory validation is a cross-boundary security rule: user input is
+  accepted only as an absolute path or `~/...`; daemon-side fallbacks must stay
+  under `~/.parsar/`.
+
+### Agent CLI adapter contract
+
+- Every daemon-side agent adapter must use a shared process runner for CLI
+  subprocesses. New adapters must not hand-roll separate `Start`, stdin,
+  cancellation, timeout, and `Wait` loops.
+- Every subprocess must be waited/reaped. Cancellation must close stdin when
+  appropriate, send a graceful signal first, and escalate to kill after a
+  bounded timeout.
+- A Parsar conversation is not a long-lived OS process. Each prompt turn may
+  start a CLI process, but the adapter must either resume the upstream engine
+  session on the next turn or explicitly document why that engine cannot
+  resume.
+- When an engine supports resume, persist the upstream session id through
+  `agent_engine_sessions` and pass `AgentSessionID` plus `AgentStateKey` over
+  the daemon protocol. Do not keep resume ids only in adapter memory, files
+  without a server record, or frontend state.
+- Adapter-specific state directories must be derived from `AgentStateKey`
+  under `~/.parsar/`; never use the repo checkout, container image working
+  directory, or the process CWD as hidden state.
+
+### Sandbox and local runtime lifecycle
+
+- The default local install path provides one ready-to-use sandbox runtime.
+  Do not require the Parsar server container to create sibling Docker
+  containers through `/var/run/docker.sock` for normal first-run operation.
+- Local Docker lifecycle, cloud sandbox lifecycle, and user-paired devices are
+  different providers behind the same daemon protocol. Keep provider-specific
+  create/renew/kill logic in `server/internal/sandbox/...` or a narrowly named
+  runtime provider; do not spread Docker/E2B calls through handlers,
+  connectors, or frontend components.
+- Dynamic local sandbox scaling is not a product guarantee. If it is added,
+  it must be owned by an explicit local supervisor/runtime provider with a
+  reviewed Docker socket boundary, not by ad hoc server-side `docker run`
+  calls.
+- Eager acquisition must be best-effort. Failure to prewarm a sandbox should
+  surface as runtime health/provisioning state, not crash unrelated startup
+  paths.
+
+### API, DB, and generated surfaces
+
+- New persistent state starts with a migration and sqlc query. Avoid direct
+  SQL embedded in route handlers or connector code unless the package already
+  owns that persistence boundary and tests cover it.
+- JSON config blobs are allowed only at integration boundaries where providers
+  are genuinely schemaless. Once two call sites read the same key, introduce a
+  typed parser/normalizer and make all callers use it.
+- Frontend API shape mirrors must live in `apps/web/src/lib/` next to the API
+  client/hook that owns them. Page components should receive typed values, not
+  parse runtime/provider/config JSON themselves.
+- Generated files (`docs/openapi/openapi.yaml`, `server/internal/db/sqlc/*`)
+  are committed artifacts, but never the source of truth. Change annotations
+  or SQL first, then regenerate.
 
 ## Code quality & architecture
 

--- a/server/internal/agentdaemon/gateway/owner_test.go
+++ b/server/internal/agentdaemon/gateway/owner_test.go
@@ -13,6 +13,7 @@ type fakeOwnerStore struct {
 	renewOK      bool
 	renewCalls   int
 	releaseCalls int
+	releaseCh    chan struct{}
 	lastRenewGen int64
 }
 
@@ -28,6 +29,13 @@ func (f *fakeOwnerStore) RenewAgentDaemonDeviceOwner(_ context.Context, in store
 
 func (f *fakeOwnerStore) ReleaseAgentDaemonDeviceOwner(context.Context, store.ReleaseAgentDaemonDeviceOwnerInput) (bool, error) {
 	f.releaseCalls++
+	if f.releaseCh != nil {
+		select {
+		case <-f.releaseCh:
+		default:
+			close(f.releaseCh)
+		}
+	}
 	return true, nil
 }
 
@@ -38,7 +46,7 @@ func (f *fakeOwnerStore) GetAgentDaemonDeviceOwner(context.Context, string) (sto
 func TestSessionOwnerLeaseLostClosesStaleConnection(t *testing.T) {
 	reg := NewRegistry()
 	conn := newFakeConn()
-	owners := &fakeOwnerStore{renewOK: false}
+	owners := &fakeOwnerStore{renewOK: false, releaseCh: make(chan struct{})}
 	lease := &ownerLease{store: owners, deviceID: "dev-1", ownerPodID: "pod-a", generation: 7, ttl: time.Minute}
 	sess := NewSessionWithOwner(conn, "dev-1", "wks-1", proto.Version, reg, nil, lease)
 	reg.Register(sess)
@@ -56,7 +64,12 @@ func TestSessionOwnerLeaseLostClosesStaleConnection(t *testing.T) {
 	if owners.renewCalls == 0 || owners.lastRenewGen != 7 {
 		t.Fatalf("renew not called with generation 7: calls=%d gen=%d", owners.renewCalls, owners.lastRenewGen)
 	}
-	if owners.releaseCalls == 0 {
+	select {
+	case <-owners.releaseCh:
+	case <-time.After(2 * time.Second):
 		t.Fatal("release not called on close")
+	}
+	if owners.releaseCalls == 0 {
+		t.Fatal("release count not incremented")
 	}
 }


### PR DESCRIPTION
## Summary
- add architecture boundary rules to CONTRIBUTING.md for runtimes, daemon ownership, CLI adapter lifecycle, sandbox lifecycle, and generated surfaces
- make AGENTS.md a concise agent-facing shortcut and link long-form rules back to CONTRIBUTING.md
- document that substantial changes must keep CONTRIBUTING.md updated and avoid duplicated contributor docs
- fix a gateway owner lease test race by waiting for release cleanup explicitly

## Verification
- make check