### PR TITLE
Add global dark mode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,6 +220,10 @@ split relevant pieces out first rather than growing the file further.
 - `packages/ui` / `packages/core` are reserved for logic shared across
   more than one app. Until they are populated, shared web-only logic
   still belongs in `apps/web/src/lib/`, not duplicated per page.
+- Global theme state lives in `apps/web/src/lib/theme.tsx`; page components
+  must not read or write theme `localStorage` directly. Light/dark styling
+  must flow through semantic tokens in `apps/web/src/style.css`, not per-page
+  raw colors or duplicated `dark:` branches.
 
 ### Testing granularity
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -16,6 +16,17 @@
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter:wght@300..700&family=Noto+Sans+SC:wght@400;500;700&family=Geist+Mono:wght@400..600&display=swap"
     />
     <title>Parsar</title>
+    <script>
+      ;(() => {
+        const stored = localStorage.getItem("parsar.theme")
+        const preference = stored === "light" || stored === "dark" || stored === "system" ? stored : "system"
+        const resolved = preference === "system"
+          ? (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
+          : preference
+        document.documentElement.dataset.theme = resolved
+        document.documentElement.style.colorScheme = resolved
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,0 +1,90 @@
+import { useEffect } from "react"
+import { useTranslation } from "react-i18next"
+import { AdminRouter } from "./pages/admin/AdminRouter"
+import { LoginPage } from "./pages/LoginPage"
+import { OnboardingPage } from "./pages/OnboardingPage"
+import {
+  JoinWorkspaceLanding,
+  popPendingJoinIntent,
+} from "./pages/JoinWorkspaceLanding"
+import { InviteAcceptPage } from "./pages/InviteAcceptPage"
+import { AuthProvider, useAuth } from "./lib/auth-context"
+import { ThemeProvider } from "./lib/theme-provider"
+import { useMyWorkspaces } from "./lib/api-workspaces"
+
+function LoadingScreen({ message }: { message: string }) {
+  return (
+    <main className="grid min-h-screen place-items-center bg-surface text-base text-fg-subtle">
+      {message}
+    </main>
+  )
+}
+
+function AuthedRoot() {
+  const { t } = useTranslation("common")
+  const wsQuery = useMyWorkspaces()
+
+  if (wsQuery.isLoading) {
+    return <LoadingScreen message={t("login.loading")} />
+  }
+  if ((wsQuery.data?.workspaces.length ?? 0) === 0) {
+    return <OnboardingPage />
+  }
+  return <AdminRouter />
+}
+
+function Root() {
+  const { t } = useTranslation("common")
+  const { isLoading, isAuthenticated } = useAuth()
+  const joinWsId = parseJoinWorkspaceId()
+  const inviteToken = parseInviteToken()
+
+  useEffect(() => {
+    if (isLoading || !isAuthenticated) return
+    if (joinWsId !== null) return
+    const pending = popPendingJoinIntent()
+    if (pending) {
+      window.location.replace(pending)
+    }
+  }, [isLoading, isAuthenticated, joinWsId])
+
+  if (inviteToken !== null) {
+    return <InviteAcceptPage token={inviteToken} />
+  }
+  if (joinWsId !== null) {
+    return <JoinWorkspaceLanding workspaceId={joinWsId} />
+  }
+  if (isLoading) {
+    return <LoadingScreen message={t("login.loading")} />
+  }
+  if (!isAuthenticated) {
+    return <LoginPage />
+  }
+  return <AuthedRoot />
+}
+
+function parseJoinWorkspaceId(): string | null {
+  if (typeof window === "undefined") return null
+  if (window.location.pathname !== "/join-workspace") return null
+  const id = new URLSearchParams(window.location.search).get("id")
+  return id && id.length > 0 ? id : null
+}
+
+function parseInviteToken(): string | null {
+  if (typeof window === "undefined") return null
+  const prefix = "/invite/"
+  if (!window.location.pathname.startsWith(prefix)) return null
+  const token = window.location.pathname.slice(prefix.length)
+  return token.length > 0 ? token : null
+}
+
+export function App() {
+  return (
+    <ThemeProvider>
+      <AuthProvider>
+        <Root />
+      </AuthProvider>
+    </ThemeProvider>
+  )
+}
+

--- a/apps/web/src/components/layout/AdminLayout.tsx
+++ b/apps/web/src/components/layout/AdminLayout.tsx
@@ -10,6 +10,7 @@ import {
   type LucideIcon,
 } from "lucide-react"
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher"
+import { ThemeMenu } from "./ThemeMenu"
 import { UserMenu } from "./UserMenu"
 
 interface AdminLayoutProps {
@@ -86,6 +87,7 @@ export function AdminLayout({
         <WorkspaceSwitcher />
 
         <div className="ml-auto flex items-center gap-2">
+          <ThemeMenu />
           <UserMenu />
         </div>
       </header>

--- a/apps/web/src/components/layout/ThemeMenu.tsx
+++ b/apps/web/src/components/layout/ThemeMenu.tsx
@@ -1,0 +1,69 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
+import { Check, Monitor, Moon, Sun, type LucideIcon } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { cn } from "../../lib/utils"
+import { useTheme, type ThemePreference } from "../../lib/theme"
+
+interface ThemeOption {
+  value: ThemePreference
+  labelKey: "light" | "dark" | "system"
+  icon: LucideIcon
+}
+
+const options: ThemeOption[] = [
+  { value: "light", labelKey: "light", icon: Sun },
+  { value: "dark", labelKey: "dark", icon: Moon },
+  { value: "system", labelKey: "system", icon: Monitor },
+]
+
+export function ThemeMenu() {
+  const { t } = useTranslation("common")
+  const { preference, resolvedTheme, setPreference } = useTheme()
+  const TriggerIcon = resolvedTheme === "dark" ? Moon : Sun
+
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          aria-label={t("theme.trigger")}
+          title={t("theme.trigger")}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md text-fg-muted transition-colors hover:bg-surface-muted hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong data-[state=open]:bg-surface-muted"
+        >
+          <TriggerIcon className="h-4 w-4" strokeWidth={1.75} />
+        </button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          sideOffset={6}
+          className="z-50 min-w-[180px] overflow-hidden rounded-md border border-line bg-surface p-1 text-sm text-fg-muted shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+        >
+          <DropdownMenu.Label className="px-2 py-1.5 text-xs font-medium text-fg-subtle">
+            {t("theme.label")}
+          </DropdownMenu.Label>
+          {options.map((option) => {
+            const Icon = option.icon
+            const selected = preference === option.value
+            return (
+              <DropdownMenu.Item
+                key={option.value}
+                onSelect={() => setPreference(option.value)}
+                className={cn(
+                  "flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 outline-none text-fg-muted",
+                  "data-[highlighted]:bg-surface-muted data-[highlighted]:text-fg"
+                )}
+              >
+                <Icon className="h-3.5 w-3.5" strokeWidth={1.75} />
+                <span className="flex-1">{t(`theme.options.${option.labelKey}` as never)}</span>
+                {selected && <Check className="h-3.5 w-3.5 text-fg-muted" strokeWidth={2} />}
+              </DropdownMenu.Item>
+            )
+          })}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+

--- a/apps/web/src/components/layout/UserMenu.tsx
+++ b/apps/web/src/components/layout/UserMenu.tsx
@@ -24,7 +24,7 @@ export function UserMenu() {
       <DropdownMenu.Trigger asChild>
         <button
           type="button"
-          className="inline-flex items-center gap-1.5 rounded-full px-1 py-0.5 hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200 data-[state=open]:bg-surface-muted"
+          className="inline-flex items-center gap-1.5 rounded-full px-1 py-0.5 hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong data-[state=open]:bg-surface-muted"
         >
           <span className="grid h-8 w-8 place-items-center overflow-hidden rounded-full bg-surface-muted text-sm font-semibold text-fg-muted">
             {user.avatar_url ? (

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -11,7 +11,7 @@ import {
   Send,
   X,
 } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import type { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 import { cn } from "../../lib/utils"
@@ -53,8 +53,14 @@ export function WorkspaceSwitcher() {
   const discoverableQuery = useDiscoverableWorkspaces({ limit: 5 })
   const [discoverDialogOpen, setDiscoverDialogOpen] = useState(false)
 
-  const workspaces = workspacesQuery.data?.workspaces ?? []
-  const discoverable = discoverableQuery.data?.workspaces ?? []
+  const workspaces = useMemo(
+    () => workspacesQuery.data?.workspaces ?? [],
+    [workspacesQuery.data?.workspaces]
+  )
+  const discoverable = useMemo(
+    () => discoverableQuery.data?.workspaces ?? [],
+    [discoverableQuery.data?.workspaces]
+  )
   const discoverableTotal = discoverableQuery.data?.total ?? discoverable.length
   const currentWorkspace = workspaces.find((w) => w.id === wsId)
 
@@ -102,7 +108,7 @@ export function WorkspaceSwitcher() {
           <button
             type="button"
             aria-label={t("workspaceSwitcher.triggerAriaLabel")}
-            className="ml-2 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-fg-muted hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200 data-[state=open]:bg-surface-muted"
+            className="ml-2 inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-sm text-fg-muted hover:bg-surface-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong data-[state=open]:bg-surface-muted"
           >
             <span className="font-medium">{triggerLabel}</span>
             {!wsId && (

--- a/apps/web/src/i18n/locales/en-US/common.json
+++ b/apps/web/src/i18n/locales/en-US/common.json
@@ -6,6 +6,15 @@
     "zh-CN": "中文",
     "en-US": "English"
   },
+  "theme": {
+    "label": "Theme",
+    "trigger": "Change theme",
+    "options": {
+      "light": "Light",
+      "dark": "Dark",
+      "system": "System"
+    }
+  },
   "actions": {
     "refresh": "Refresh",
     "cancel": "Cancel",

--- a/apps/web/src/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/i18n/locales/zh-CN/common.json
@@ -6,6 +6,15 @@
     "zh-CN": "中文",
     "en-US": "English"
   },
+  "theme": {
+    "label": "主题",
+    "trigger": "切换主题",
+    "options": {
+      "light": "浅色",
+      "dark": "深色",
+      "system": "跟随系统"
+    }
+  },
   "actions": {
     "refresh": "刷新",
     "cancel": "取消",

--- a/apps/web/src/lib/theme-provider.tsx
+++ b/apps/web/src/lib/theme-provider.tsx
@@ -1,0 +1,64 @@
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+import {
+  ThemeContext,
+  defaultThemePreference,
+  themeStorageKey,
+  type ResolvedTheme,
+  type ThemeContextValue,
+  type ThemePreference,
+} from "./theme"
+
+function readStoredPreference(): ThemePreference {
+  if (typeof window === "undefined") return defaultThemePreference
+  const stored = window.localStorage.getItem(themeStorageKey)
+  return stored === "light" || stored === "dark" || stored === "system"
+    ? stored
+    : defaultThemePreference
+}
+
+function systemTheme(): ResolvedTheme {
+  if (typeof window === "undefined") return "light"
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+}
+
+function applyTheme(resolvedTheme: ResolvedTheme) {
+  if (typeof document === "undefined") return
+  document.documentElement.dataset.theme = resolvedTheme
+  document.documentElement.style.colorScheme = resolvedTheme
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [preference, setPreference] = useState<ThemePreference>(() => readStoredPreference())
+  const [systemPreference, setSystemPreference] = useState<ResolvedTheme>(() => systemTheme())
+  const resolvedTheme = preference === "system" ? systemPreference : preference
+
+  useEffect(() => {
+    applyTheme(resolvedTheme)
+    window.localStorage.setItem(themeStorageKey, preference)
+  }, [preference, resolvedTheme])
+
+  useEffect(() => {
+    if (preference !== "system") return
+    const media = window.matchMedia("(prefers-color-scheme: dark)")
+    const onChange = () => setSystemPreference(systemTheme())
+    media.addEventListener("change", onChange)
+    return () => media.removeEventListener("change", onChange)
+  }, [preference])
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      preference,
+      resolvedTheme,
+      setPreference,
+    }),
+    [preference, resolvedTheme]
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -1,0 +1,24 @@
+import { createContext, useContext } from "react"
+
+export type ThemePreference = "light" | "dark" | "system"
+export type ResolvedTheme = "light" | "dark"
+
+export interface ThemeContextValue {
+  preference: ThemePreference
+  resolvedTheme: ResolvedTheme
+  setPreference: (preference: ThemePreference) => void
+}
+
+export const themeStorageKey = "parsar.theme"
+export const defaultThemePreference: ThemePreference = "system"
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+export function useTheme() {
+  const value = useContext(ThemeContext)
+  if (!value) {
+    throw new Error("useTheme must be used inside ThemeProvider")
+  }
+  return value
+}
+

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,19 +1,9 @@
-import { StrictMode, useEffect } from 'react'
+import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { AdminRouter } from './pages/admin/AdminRouter'
-import { LoginPage } from './pages/LoginPage'
-import { OnboardingPage } from './pages/OnboardingPage'
-import {
-  JoinWorkspaceLanding,
-  popPendingJoinIntent,
-} from './pages/JoinWorkspaceLanding'
-import { InviteAcceptPage } from './pages/InviteAcceptPage'
+import { App } from './App'
 import { bootstrapWorkspace } from './lib/bootstrap'
-import { AuthProvider, useAuth } from './lib/auth-context'
-import { useMyWorkspaces } from './lib/api-workspaces'
 import { prefetchProviderCatalog } from './lib/model-presets'
-import { useTranslation } from 'react-i18next'
 import './style.css'
 import './i18n' // bootstrap i18next
 import './i18n/types' // type-augment t() keys
@@ -34,93 +24,10 @@ const queryClient = new QueryClient({
 void bootstrapWorkspace()
 prefetchProviderCatalog()
 
-function LoadingScreen({ message }: { message: string }) {
-  return (
-    <main className="grid min-h-screen place-items-center bg-surface text-base text-fg-subtle">
-      {message}
-    </main>
-  )
-}
-
-// AuthedRoot decides whether the post-login user lands on the admin shell
-// or onboarding. Split out so useMyWorkspaces only runs once we know there's
-// a session — the endpoint is 401 without one.
-function AuthedRoot() {
-  const { t } = useTranslation("common")
-  const wsQuery = useMyWorkspaces()
-
-  if (wsQuery.isLoading) {
-    return <LoadingScreen message={t("login.loading")} />
-  }
-  // The hook's API-unreachable fallback returns MOCK_WORKSPACES (non-empty),
-  // so this branch fires only when the server actually responded with zero
-  // memberships — the brand-new-user case post-OAuth-callback.
-  if ((wsQuery.data?.workspaces.length ?? 0) === 0) {
-    return <OnboardingPage />
-  }
-  return <AdminRouter />
-}
-
-function Root() {
-  const { t } = useTranslation("common")
-  const { isLoading, isAuthenticated } = useAuth()
-
-  // Feishu rejection card → /join-workspace?id=<wsID>&from=feishu deep link.
-  // Matched before the auth-aware admin shell so an unauthenticated user on
-  // this URL hits the landing page directly.
-  const joinWsId = parseJoinWorkspaceId()
-  const inviteToken = parseInviteToken()
-
-  // OAuth callback returns to "/" by design. If we stashed an intent before
-  // the OAuth bounce, re-issue it now. Guarded on isAuthenticated to avoid a
-  // redirect loop during the initial session-resolution window.
-  useEffect(() => {
-    if (isLoading || !isAuthenticated) return
-    if (joinWsId !== null) return // already on the landing page
-    const pending = popPendingJoinIntent()
-    if (pending) {
-      window.location.replace(pending)
-    }
-  }, [isLoading, isAuthenticated, joinWsId])
-
-  if (inviteToken !== null) {
-    return <InviteAcceptPage token={inviteToken} />
-  }
-  if (joinWsId !== null) {
-    return <JoinWorkspaceLanding workspaceId={joinWsId} />
-  }
-  if (isLoading) {
-    return <LoadingScreen message={t("login.loading")} />
-  }
-  if (!isAuthenticated) {
-    return <LoginPage />
-  }
-  return <AuthedRoot />
-}
-
-// Pure URL parse (no react-router dependency) so the landing page stays
-// self-contained.
-function parseJoinWorkspaceId(): string | null {
-  if (typeof window === "undefined") return null
-  if (window.location.pathname !== "/join-workspace") return null
-  const id = new URLSearchParams(window.location.search).get("id")
-  return id && id.length > 0 ? id : null
-}
-
-function parseInviteToken(): string | null {
-  if (typeof window === "undefined") return null
-  const prefix = "/invite/"
-  if (!window.location.pathname.startsWith(prefix)) return null
-  const token = window.location.pathname.slice(prefix.length)
-  return token.length > 0 ? token : null
-}
-
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <AuthProvider>
-        <Root />
-      </AuthProvider>
+      <App />
     </QueryClientProvider>
   </StrictMode>,
 )

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -76,7 +76,9 @@ function SignInView() {
       />
       <section className="relative w-full max-w-[460px] rounded-2xl border border-line/80 bg-surface p-9 shadow-[0_1px_2px_rgb(0_0_0/0.04),0_20px_48px_-16px_rgb(0_0_0/0.16)]">
         <div className="mb-8 flex flex-col items-center text-center">
-          <img src="/parsar-banner.png" alt="Parsar" className="h-auto w-[320px] max-w-full" />
+          <div className="rounded-xl bg-fg-on-emphasis px-5 py-3 shadow-sm ring-1 ring-line-muted">
+            <img src="/parsar-banner.png" alt="Parsar" className="h-auto w-[280px] max-w-full" />
+          </div>
           <p className="mt-4 text-base leading-relaxed text-fg-subtle">{t("login.subtitle")}</p>
         </div>
 

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -65,7 +65,9 @@ export function SetupPage() {
       />
       <section className="relative w-full max-w-[460px] rounded-2xl border border-line/80 bg-surface p-9 shadow-[0_1px_2px_rgb(0_0_0/0.04),0_20px_48px_-16px_rgb(0_0_0/0.16)]">
         <div className="mb-7 flex flex-col items-center text-center">
-          <img src="/parsar-banner.png" alt="Parsar" className="h-auto w-[280px] max-w-full" />
+          <div className="rounded-xl bg-fg-on-emphasis px-5 py-3 shadow-sm ring-1 ring-line-muted">
+            <img src="/parsar-banner.png" alt="Parsar" className="h-auto w-[260px] max-w-full" />
+          </div>
           <h1 className="mt-4 text-lg font-semibold text-fg">{t("setup.title")}</h1>
           <p className="mt-2 text-base leading-relaxed text-fg-subtle">{t("setup.subtitle")}</p>
         </div>

--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -693,7 +693,7 @@ function ConversationMain(p: MainProps) {
   const isUnreachable = err instanceof ApiError && err.envelope.unreachable
 
   return (
-    <main className="relative flex min-w-0 flex-1 flex-col bg-[#fbfcfd]">
+    <main className="relative flex min-w-0 flex-1 flex-col bg-surface-subtle">
       {p.folded && (
         <button
           type="button"
@@ -784,7 +784,7 @@ function EmptyChat({
 }) {
   const { t } = useTranslation("admin")
   return (
-    <div className="flex flex-1 flex-col bg-[radial-gradient(circle_at_58%_28%,rgba(226,232,240,0.72),transparent_34%),linear-gradient(180deg,#fbfcfd_0%,#ffffff_72%)] px-5 py-6 sm:px-8">
+    <div className="flex flex-1 flex-col bg-surface-subtle px-5 py-6 sm:px-8">
       <div className="mx-auto flex min-h-0 w-full max-w-4xl flex-1 flex-col">
         <div className="flex items-center justify-between gap-3 text-xs text-fg-subtle">
           <span className="inline-flex items-center gap-1.5 rounded-md border border-line bg-surface/80 px-2 py-1 font-medium shadow-sm">
@@ -959,7 +959,7 @@ function ChatStream({
         </div>
       </div>
 
-      <div className="flex flex-1 flex-col overflow-y-auto bg-[#fbfcfd]">
+      <div className="flex flex-1 flex-col overflow-y-auto bg-surface-subtle">
         <div className="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-5 px-5 py-6 sm:px-6 lg:px-10">
           {timelineQ.isLoading ? (
             <Skeleton className="h-24 w-3/4" />
@@ -1011,7 +1011,7 @@ function ChatStream({
                 }
               />
             ) : (
-              <div className="flex w-fit items-center gap-2 rounded-md bg-surface px-3 py-2 text-sm text-fg-subtle shadow-sm ring-1 ring-slate-200/70">
+              <div className="flex w-fit items-center gap-2 rounded-md bg-surface px-3 py-2 text-sm text-fg-subtle shadow-sm ring-1 ring-line/70">
                 <span className="flex items-center gap-1" aria-hidden="true">
                   <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-success [animation-delay:-300ms]" />
                   <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-success [animation-delay:-150ms]" />
@@ -1047,7 +1047,7 @@ function ChatStream({
         </div>
       </div>
 
-      <div className="bg-gradient-to-t from-white via-white to-white/70 px-5 pb-4 pt-2 sm:px-6 lg:px-10">
+      <div className="border-t border-line/60 bg-surface/95 px-5 pb-4 pt-2 sm:px-6 lg:px-10">
         <div className="mx-auto max-w-4xl">
           {chatToast && (
             <ChatErrorToast message={chatToast} onDismiss={() => setChatToast(null)} />

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -95,14 +95,81 @@
   --color-accent-fg:        var(--color-fg-on-emphasis);
 }
 
+:root,
+html[data-theme="light"] {
+  color-scheme: light;
+  --app-selection-bg: oklch(0.86 0.05 260);
+  --app-selection-fg: oklch(0.18 0.02 260);
+  --app-scrollbar-thumb: oklch(0.84 0 0);
+  --app-scrollbar-thumb-hover: oklch(0.7 0 0);
+  --app-chat-canvas: var(--color-surface);
+  --app-chat-user-bubble: oklch(0.965 0 0);
+  --app-chat-agent-text: oklch(0.22 0 0);
+  --app-chat-composer-shadow: rgb(0 0 0 / 10%);
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+
+  --color-fg:          oklch(0.92 0 0);
+  --color-fg-emphasis: oklch(0.98 0 0);
+  --color-fg-muted:    oklch(0.76 0 0);
+  --color-fg-subtle:   oklch(0.66 0 0);
+  --color-fg-faint:    oklch(0.52 0 0);
+  --color-fg-on-emphasis: oklch(0.985 0 0);
+
+  --color-surface:          oklch(0.18 0 0);
+  --color-surface-subtle:   oklch(0.145 0 0);
+  --color-surface-muted:    oklch(0.25 0 0);
+  --color-surface-emphasis: oklch(0.33 0 0);
+  --color-surface-inverse:  oklch(0.4 0 0);
+
+  --color-line:         oklch(0.31 0 0);
+  --color-line-muted:   oklch(0.24 0 0);
+  --color-line-strong:  oklch(0.42 0 0);
+
+  --color-danger:           oklch(0.72 0.105 27.27);
+  --color-danger-emphasis:  oklch(0.82 0.095 27.49);
+  --color-danger-subtle:    oklch(0.25 0.035 25);
+  --color-danger-border:    oklch(0.38 0.055 25);
+
+  --color-warning:          oklch(0.76 0.08 74);
+  --color-warning-emphasis: oklch(0.84 0.075 74);
+  --color-warning-subtle:   oklch(0.25 0.03 78);
+  --color-warning-border:   oklch(0.38 0.045 78);
+
+  --color-success:          oklch(0.72 0.08 158);
+  --color-success-emphasis: oklch(0.82 0.075 158);
+  --color-success-subtle:   oklch(0.24 0.035 158);
+  --color-success-border:   oklch(0.36 0.05 158);
+
+  --color-info:             oklch(0.75 0.065 252.5);
+  --color-info-emphasis:    oklch(0.84 0.055 254.55);
+  --color-info-subtle:      oklch(0.24 0.035 252.5);
+  --color-info-border:      oklch(0.36 0.05 252.5);
+
+  --color-accent:           var(--color-fg);
+  --color-accent-emphasis:  var(--color-fg-emphasis);
+  --color-accent-fg:        var(--color-fg-on-emphasis);
+
+  --app-selection-bg: oklch(0.35 0.055 260);
+  --app-selection-fg: var(--color-fg-emphasis);
+  --app-scrollbar-thumb: oklch(0.36 0 0);
+  --app-scrollbar-thumb-hover: oklch(0.48 0 0);
+  --app-chat-canvas: var(--color-surface-subtle);
+  --app-chat-user-bubble: var(--color-surface-muted);
+  --app-chat-agent-text: var(--color-fg-muted);
+  --app-chat-composer-shadow: rgb(0 0 0 / 35%);
+}
+
 @keyframes fade-out {
   0%, 70% { opacity: 1; }
   100% { opacity: 0; }
 }
 
 :root {
-  color: #121212;
-  background: #ffffff;
+  color: var(--color-fg);
+  background: var(--color-surface);
   /* Monochrome type system. Inter renders Latin body/UI; Noto Sans SC renders
      Chinese (Inter has no CJK glyphs); system fonts are the final fallback.
      Display headings use Space Grotesk (see --font-display). */
@@ -174,8 +241,8 @@ textarea {
 
 /* Brand-tinted text selection (default is a flat grey-blue). */
 ::selection {
-  background: #c7d6ff;
-  color: #0f172a;
+  background: var(--app-selection-bg);
+  color: var(--app-selection-fg);
 }
 
 /* Thin, unobtrusive scrollbars for the admin shell — the default OS bars are
@@ -183,7 +250,7 @@ textarea {
    ::-webkit-scrollbar. */
 * {
   scrollbar-width: thin;
-  scrollbar-color: #cbd5e1 transparent;
+  scrollbar-color: var(--app-scrollbar-thumb) transparent;
 }
 
 ::-webkit-scrollbar {
@@ -195,11 +262,11 @@ textarea {
   border: 3px solid transparent;
   border-radius: 999px;
   background-clip: padding-box;
-  background-color: #cbd5e1;
+  background-color: var(--app-scrollbar-thumb);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background-color: #94a3b8;
+  background-color: var(--app-scrollbar-thumb-hover);
 }
 
 ::-webkit-scrollbar-track {
@@ -210,7 +277,7 @@ textarea {
   display: flex;
   min-height: 100vh;
   justify-content: center;
-  background: #fff;
+  background: var(--app-chat-canvas);
 }
 
 .chat-stage {
@@ -220,7 +287,7 @@ textarea {
   min-height: 100vh;
   flex-direction: column;
   align-items: center;
-  background: #ffffff;
+  background: var(--app-chat-canvas);
   padding: 18px 28px 118px;
 }
 
@@ -296,9 +363,9 @@ p {
 }
 
 .secondary-button {
-  border: 1px solid #e5e7eb;
-  background: #ffffff;
-  color: #374151;
+  border: 1px solid var(--color-line);
+  background: var(--color-surface);
+  color: var(--color-fg-muted);
 }
 
 .primary-button:disabled,
@@ -324,14 +391,14 @@ p {
 .console-page {
   display: flex;
   min-height: 100vh;
-  background: #f7f7f8;
+  background: var(--color-surface-subtle);
   padding: 0;
 }
 
 .console-sidebar {
   width: 220px;
-  border-right: 1px solid #e5e7eb;
-  background: #fff;
+  border-right: 1px solid var(--color-line);
+  background: var(--color-surface);
   padding: 18px 12px;
 }
 
@@ -343,15 +410,15 @@ p {
 .console-sidebar a {
   display: block;
   border-radius: 10px;
-  color: #64748b;
+  color: var(--color-fg-muted);
   padding: 9px 10px;
   text-decoration: none;
 }
 
 .console-sidebar a.active,
 .console-sidebar a:hover {
-  background: #f1f5f9;
-  color: #111827;
+  background: var(--color-surface-muted);
+  color: var(--color-fg);
 }
 
 .console-workspace {
@@ -375,7 +442,7 @@ p {
 
 .console-subtitle {
   margin: 8px 0 0;
-  color: #64748b;
+  color: var(--color-fg-subtle);
 }
 
 .console-summary,
@@ -406,9 +473,9 @@ p {
 
 .console-summary article,
 .console-panel {
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--color-line);
   border-radius: 22px;
-  background: #fff;
+  background: var(--color-surface);
   box-shadow: 0 10px 28px rgb(15 23 42 / 5%);
 }
 
@@ -423,11 +490,11 @@ p {
 .console-row small,
 .console-row p,
 .console-note {
-  color: #64748b;
+  color: var(--color-fg-subtle);
 }
 
 .console-summary strong {
-  color: #111827;
+  color: var(--color-fg-emphasis);
   font-size: 34px;
   line-height: 1;
 }
@@ -449,9 +516,9 @@ p {
   display: grid;
   gap: 10px;
   margin-bottom: 16px;
-  border: 1px solid #eef2f7;
+  border: 1px solid var(--color-line-muted);
   border-radius: 16px;
-  background: #fbfdff;
+  background: var(--color-surface-subtle);
   padding: 14px;
 }
 
@@ -459,10 +526,10 @@ p {
 .config-form select,
 .config-form textarea {
   width: 100%;
-  border: 1px solid #dbe3ef;
+  border: 1px solid var(--color-line);
   border-radius: 12px;
-  background: #fff;
-  color: #111827;
+  background: var(--color-surface);
+  color: var(--color-fg);
   padding: 10px 12px;
 }
 
@@ -475,15 +542,15 @@ p {
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 10px 12px;
-  border: 1px solid #eef2f7;
+  border: 1px solid var(--color-line-muted);
   border-radius: 16px;
-  background: #fbfdff;
+  background: var(--color-surface-subtle);
   padding: 12px;
 }
 
 .console-row.selected {
-  border-color: #93c5fd;
-  background: #eff6ff;
+  border-color: var(--color-info-border);
+  background: var(--color-info-subtle);
 }
 
 .console-row p {
@@ -595,7 +662,7 @@ p {
 .detail-section {
   border: 0;
   border-radius: 0;
-  background: #ffffff;
+  background: var(--app-chat-canvas);
   box-shadow: none;
 }
 
@@ -629,25 +696,25 @@ p {
 .composer-hint,
 .agent-meta,
 .details-footnote {
-  color: #64748b;
+  color: var(--color-fg-subtle);
   font-size: 13px;
 }
 
 .section-heading select {
   max-width: 340px;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--color-line);
   border-radius: 12px;
-  background: #fff;
-  color: #172033;
+  background: var(--color-surface);
+  color: var(--color-fg);
   padding: 8px 10px;
 }
 
 .empty-state {
   margin: 0;
-  border: 1px dashed #cbd5e1;
+  border: 1px dashed var(--color-line-strong);
   border-radius: 16px;
-  background: #f8fafc;
-  color: #64748b;
+  background: var(--color-surface-subtle);
+  color: var(--color-fg-subtle);
   padding: 16px;
 }
 
@@ -664,7 +731,7 @@ p {
 }
 
 .empty-chat-state p {
-  color: #6b7280;
+  color: var(--color-fg-subtle);
 }
 
 .chat-flow {
@@ -686,7 +753,7 @@ p {
 .chat-user .chat-bubble {
   max-width: min(72%, 620px);
   border-radius: 22px;
-  background: #f4f4f4;
+  background: var(--app-chat-user-bubble);
   padding: 12px 16px;
 }
 
@@ -717,7 +784,7 @@ p {
 
 .chat-bubble p {
   margin-bottom: 12px;
-  color: #202124;
+  color: var(--app-chat-agent-text);
   line-height: 1.75;
   white-space: pre-wrap;
 }
@@ -732,7 +799,7 @@ p {
   gap: 8px;
   margin-top: 10px;
   margin-bottom: 8px;
-  color: #64748b;
+  color: var(--color-fg-subtle);
   font-size: 13px;
 }
 
@@ -745,10 +812,10 @@ p {
 .handoff-chip {
   display: inline-flex;
   gap: 8px;
-  border: 1px solid #ececf1;
+  border: 1px solid var(--color-line);
   border-radius: 999px;
-  background: #fff;
-  color: #374151;
+  background: var(--color-surface);
+  color: var(--color-fg-muted);
   cursor: pointer;
   padding: 7px 10px;
   text-align: left;
@@ -765,7 +832,7 @@ p {
 
 .handoff-chip small {
   display: none;
-  color: #64748b;
+  color: var(--color-fg-subtle);
 }
 
 .composer-panel {
@@ -794,10 +861,10 @@ p {
   display: flex;
   align-items: center;
   gap: 10px;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--color-line);
   border-radius: 999px;
-  background: #ffffff;
-  box-shadow: 0 8px 28px rgb(0 0 0 / 10%);
+  background: var(--color-surface);
+  box-shadow: 0 8px 28px var(--app-chat-composer-shadow);
   padding: 8px 10px;
 }
 
@@ -807,7 +874,7 @@ p {
   resize: vertical;
   border: 0;
   background: transparent;
-  color: #202124;
+  color: var(--color-fg);
   line-height: 1.6;
   padding: 8px 4px;
 }
@@ -846,54 +913,54 @@ p {
 }
 
 .send-status {
-  border: 1px solid #ececf1;
-  background: #ffffff;
-  color: #475569;
+  border: 1px solid var(--color-line);
+  background: var(--color-surface);
+  color: var(--color-fg-muted);
 }
 
 .send-status strong {
-  color: #1d4ed8;
+  color: var(--color-info-emphasis);
   white-space: nowrap;
 }
 
 .send-status-error,
 .error-box {
-  border: 1px solid #fecaca;
-  background: #fff1f2;
-  color: #991b1b;
+  border: 1px solid var(--color-danger-border);
+  background: var(--color-danger-subtle);
+  color: var(--color-danger-emphasis);
 }
 
 .form-warning {
   margin: 0;
-  color: #b91c1c;
+  color: var(--color-danger);
   font-size: 12px;
   font-weight: 700;
 }
 
 .send-status-error strong {
-  color: #991b1b;
+  color: var(--color-danger-emphasis);
 }
 
 .send-status-warning,
 .send-status-stale,
 .stale-box {
-  border: 1px solid #fed7aa;
-  background: #fff7ed;
-  color: #9a3412;
+  border: 1px solid var(--color-warning-border);
+  background: var(--color-warning-subtle);
+  color: var(--color-warning-emphasis);
 }
 
 .send-status-warning strong,
 .send-status-stale strong {
-  color: #9a3412;
+  color: var(--color-warning-emphasis);
 }
 
 .send-status-completed {
-  border-color: #bbf7d0;
-  background: #f0fdf4;
+  border-color: var(--color-success-border);
+  background: var(--color-success-subtle);
 }
 
 .send-status-completed strong {
-  color: #166534;
+  color: var(--color-success-emphasis);
 }
 
 .agent-list,
@@ -906,9 +973,9 @@ p {
 .agent-card {
   display: grid;
   gap: 10px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--color-line);
   border-radius: 18px;
-  background: #fbfdff;
+  background: var(--color-surface);
   padding: 16px;
 }
 
@@ -926,18 +993,18 @@ p {
 .agent-card-header p,
 .agent-meta,
 .muted {
-  color: #64748b;
+  color: var(--color-fg-subtle);
 }
 
 .agent-summary {
-  color: #334155;
+  color: var(--color-fg-muted);
   font-weight: 700;
 }
 
 .agent-output-preview {
   display: -webkit-box;
   overflow: hidden;
-  color: #475569;
+  color: var(--color-fg-subtle);
   font-size: 13px;
   line-height: 1.6;
   -webkit-box-orient: vertical;
@@ -948,8 +1015,8 @@ p {
   display: inline-flex;
   align-items: center;
   border-radius: 999px;
-  background: #e2e8f0;
-  color: #334155;
+  background: var(--color-surface-muted);
+  color: var(--color-fg-muted);
   font-size: 12px;
   font-weight: 900;
   padding: 4px 9px;
@@ -960,23 +1027,23 @@ p {
 .pill-completed,
 .pill-approved,
 .pill-delivered {
-  background: #dcfce7;
-  color: #166534;
+  background: var(--color-success-subtle);
+  color: var(--color-success-emphasis);
 }
 
 .pill-queued,
 .pill-running,
 .pill-pending {
-  background: #fef3c7;
-  color: #92400e;
+  background: var(--color-warning-subtle);
+  color: var(--color-warning-emphasis);
 }
 
 .pill-failed,
 .pill-denied,
 .pill-cancelled,
 .pill-disabled {
-  background: #fee2e2;
-  color: #991b1b;
+  background: var(--color-danger-subtle);
+  color: var(--color-danger-emphasis);
 }
 
 .details-panel {
@@ -987,13 +1054,13 @@ p {
 
 .details-panel summary {
   cursor: pointer;
-  color: #1d4ed8;
+  color: var(--color-info-emphasis);
   font-weight: 900;
   padding: 18px 22px;
 }
 
 .details-panel[open] summary {
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--color-line);
 }
 
 .details-grid {
@@ -1015,14 +1082,14 @@ dl {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--color-line);
   border-radius: 16px;
-  background: #f8fafc;
+  background: var(--color-surface-subtle);
   padding: 16px;
 }
 
 dt {
-  color: #718096;
+  color: var(--color-fg-subtle);
   font-size: 12px;
   font-weight: 800;
   letter-spacing: 0.04em;
@@ -1035,7 +1102,7 @@ dd {
 }
 
 .subsection {
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--color-line);
   padding-top: 14px;
 }
 
@@ -1049,8 +1116,8 @@ dd {
 .message-output {
   margin: 0;
   border-radius: 16px;
-  background: #f1f5f9;
-  color: #1e293b;
+  background: var(--color-surface-muted);
+  color: var(--color-fg-muted);
   line-height: 1.7;
   padding: 14px;
 }
@@ -1089,14 +1156,14 @@ dd {
   display: flex;
   flex-direction: column;
   gap: 4px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--color-line);
   border-radius: 14px;
   padding: 12px;
 }
 
 .compact-list small,
 .event-list span {
-  color: #64748b;
+  color: var(--color-fg-subtle);
 }
 
 .metric-grid {
@@ -1111,19 +1178,19 @@ dd {
   min-height: 116px;
   flex-direction: column;
   justify-content: space-between;
-  border: 1px solid #dbeafe;
+  border: 1px solid var(--color-info-border);
   border-radius: 18px;
-  background: linear-gradient(180deg, #f8fbff 0%, #eef6ff 100%);
+  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-info-subtle) 100%);
   padding: 16px;
 }
 
 .metric-card span,
 .metric-card small {
-  color: #64748b;
+  color: var(--color-fg-subtle);
 }
 
 .metric-card strong {
-  color: #172033;
+  color: var(--color-fg-emphasis);
   font-size: 30px;
   line-height: 1;
 }
@@ -1132,7 +1199,7 @@ dd {
   display: grid;
   gap: 8px;
   margin: 0;
-  color: #475569;
+  color: var(--color-fg-muted);
   padding-left: 22px;
 }
 


### PR DESCRIPTION
## Summary
- add global light/dark/system theme state with pre-paint HTML initialization and persisted preference
- add a top-bar theme menu in the admin shell
- move app routing out of main.tsx so the entrypoint only bootstraps providers/rendering
- add dark-mode semantic token overrides and migrate key global shell/conversation surfaces away from hard-coded light backgrounds
- update login/setup logo treatment for dark backgrounds
- document the frontend theme ownership rule in CONTRIBUTING.md

## Verification
- pnpm --dir apps/web exec eslint src/App.tsx src/lib/theme.ts src/lib/theme-provider.tsx src/components/layout/ThemeMenu.tsx src/main.tsx src/components/layout/AdminLayout.tsx src/components/layout/UserMenu.tsx src/components/layout/WorkspaceSwitcher.tsx src/pages/LoginPage.tsx src/pages/SetupPage.tsx src/pages/admin/ConversationsPage.tsx
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web build
- make check
- Playwright screenshots: light login, dark login, mobile dark login, mocked authenticated admin shell after theme switch

## Notes
- Full apps/web lint still has existing unrelated React compiler rule failures outside this change; changed files pass targeted eslint with no warnings.