### PR TITLE
Simplify Compose installation and preserve internal networking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,9 +72,25 @@ description and keep ownership on the side listed here.
 
 ### Install and image freshness
 
+- The root `docker-compose.yml` must be directly runnable with
+  `docker compose up -d`. Do not require `install.sh` to pre-generate `.env`
+  values for mandatory services to boot. If a service needs a local-only
+  shared secret, the compose file must provide a clearly documented dev-only
+  default and allow production/Dokploy installs to override it with a stable
+  random value.
 - The one-command installer is both install and upgrade path. Default GHCR
   images must be pulled before `docker compose up` so `:latest` does not
   silently reuse a stale local image after `main` changes.
+- `install.sh` may still write stable random overrides such as
+  `PARSAR_MASTER_KEY` and `PARSAR_SHARED_RUNTIME_TOKEN` for safer local
+  installs, but raw Compose/Dokploy deployments must not depend on those
+  installer-only side effects.
+- Keep `install.sh` a thin Compose wrapper. Its CLI is limited to installation
+  location, web bind/port, image overrides, and validation. Uncommon deployment
+  settings belong in the Compose environment rather than new installer flags.
+- Services exposed through a deployment platform may gain an ingress network,
+  but they must remain explicitly attached to the Compose `default` network
+  when they depend on internal service DNS names such as `postgres`.
 - The local compose file must express the same default with
   `PARSAR_IMAGE_PULL_POLICY=always` for Parsar-owned images. Local image
   testing must opt out explicitly with `PARSAR_IMAGE_PULL_POLICY=never`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,9 +2,9 @@
 
 ## One-command install
 
-Parsar can be installed without cloning the repository. The installer writes
-all generated config, secrets, database files, and runtime state under
-`~/.parsar/`.
+Parsar can be installed without cloning the repository. The installer is a
+small wrapper around the root `docker-compose.yml`; it keeps generated config,
+secrets, database files, and runtime state under `~/.parsar/`.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/parsar/main/install.sh | bash
@@ -37,11 +37,10 @@ The script:
 
 - uses `docker-compose.yml` from the current checkout, or downloads the
   published copy to `~/.parsar/docker-compose.yml`
-- creates `~/.parsar/.env`
-- generates and persists `PARSAR_MASTER_KEY`
-- generates and persists `PARSAR_SHARED_RUNTIME_TOKEN`
-- generates and persists the Postgres password
+- creates `~/.parsar/.env` with persistent random secrets and data paths
+- pulls the Parsar images so upgrades do not reuse a stale `latest` image
 - starts Postgres, `parsar-server`, and the default local runtime service
+- waits for the server health check
 - leaves Feishu, Slack, and Discord integrations disabled unless explicitly
   enabled in `~/.parsar/.env`
 
@@ -85,5 +84,11 @@ Edit `~/.parsar/.env` and rerun:
 curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/parsar/main/install.sh | bash
 ```
 
-The installer preserves generated secrets and refreshes non-secret settings
-such as ports, image names, and paths.
+The installer preserves generated secrets. It intentionally exposes only the
+common port, bind address, and image options; add uncommon Compose overrides
+directly to `.env` instead of adding more installer flags.
+
+When a platform such as Dokploy adds its ingress network to `parsar-server`,
+keep the service attached to the Compose `default` network as well. Postgres
+and the local runtime are intentionally private and use that network for
+service discovery.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,13 @@
-# Parsar local edition (all-in-one) — Phase 1 deliverable.
+# Parsar all-in-one deployment.
 #
 # One command, single machine:
 #
-#   ./install.sh
+#   docker compose up -d
 #
-# The installer writes a .env with PARSAR_SHARED_RUNTIME_TOKEN, then brings
-# up Postgres + parsar-server + a compose-resident local runtime. Open
-# http://127.0.0.1:18080 locally, or
-# http://<server-ip>:18080 from another machine, and create the first owner
-# account in the web setup flow.
-# Profile not fork: this is the SAME image as the self-host deployment
-# (deploy/compose/compose.selfhost.yml). Differences live only in this file
-# + the env values below. No separate "local" binary or image.
+# This file is the deployment contract. It does not require install.sh or an
+# .env file. Open http://127.0.0.1:18080 and create the first owner account.
+# install.sh is only a convenience wrapper that downloads this file, creates
+# persistent random secrets, starts the stack, and waits for health.
 #
 # Image source:
 #   - Default: GHCR prebuilt image (PARSAR_SERVER_IMAGE below).
@@ -20,40 +16,30 @@
 #       make docker-build PARSAR_IMAGE=parsar PARSAR_IMAGE_TAG=local
 #       PARSAR_IMAGE_PULL_POLICY=never PARSAR_SERVER_IMAGE=parsar:local docker compose up
 #
-# Override knobs:
-#   PARSAR_PROJECT_NAME   compose project/network prefix (default: parsar)
+# Common overrides:
 #   PARSAR_SERVER_IMAGE   server image ref (default: GHCR latest)
 #   PARSAR_SANDBOX_IMAGE  default local runtime image ref (default: GHCR latest)
 #   PARSAR_IMAGE_PULL_POLICY image freshness policy (default: always; set
 #                         never for local images)
-#   PARSAR_SHARED_RUNTIME_TOKEN shared token for parsar-runtime pairing
 #   PARSAR_LOCAL_PORT     host port for the web UI (default: 18080)
-#   PARSAR_PG_PORT        host port for Postgres (default: 15432)
-#   PARSAR_BIND_ADDR      host bind address (default: 0.0.0.0)
-#   PARSAR_PG_DATA_DIR    host path for Postgres data (default: named volume)
-#   PARSAR_DATA_DIR       host path for server data (default: named volume)
+#   PARSAR_BIND_ADDR      host bind address (default: 127.0.0.1)
+# Production deployments should also set PARSAR_PG_PASSWORD,
+# PARSAR_MASTER_KEY, and PARSAR_SHARED_RUNTIME_TOKEN to stable random values.
 
 # Explicit project name so the auto-created network is always parsar_default
 # regardless of the clone directory name.
-name: ${PARSAR_PROJECT_NAME:-parsar}
-
-networks:
-  default:
-    name: ${PARSAR_PROJECT_NAME:-parsar}_default
+name: parsar
 
 services:
   postgres:
     image: postgres:16-alpine
-    container_name: ${PARSAR_PROJECT_NAME:-parsar}-local-postgres
     restart: unless-stopped
     environment:
       POSTGRES_USER: parsar
       POSTGRES_PASSWORD: ${PARSAR_PG_PASSWORD:-parsar}
       POSTGRES_DB: parsar
-    ports:
-      - "127.0.0.1:${PARSAR_PG_PORT:-15432}:5432"
     volumes:
-      - ${PARSAR_PG_DATA_DIR:-parsar-local-pg}:/var/lib/postgresql/data
+      - ${PARSAR_PG_DATA_DIR:-postgres-data}:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U parsar -d parsar"]
       interval: 5s
@@ -64,11 +50,16 @@ services:
   parsar-server:
     image: ${PARSAR_SERVER_IMAGE:-ghcr.io/minimax-ai-dev/parsar-server:latest}
     pull_policy: ${PARSAR_IMAGE_PULL_POLICY:-always}
-    container_name: ${PARSAR_PROJECT_NAME:-parsar}-local-server
     restart: unless-stopped
     depends_on:
       postgres:
         condition: service_healthy
+    # Keep the application network explicit. Platforms such as Dokploy attach
+    # this service to an additional ingress network; the server must remain on
+    # the Compose default network so Docker DNS can resolve postgres and the
+    # compose-resident runtime can resolve parsar-server.
+    networks:
+      - default
     # Run migrations before serving, in the same container as the server.
     # goose migrations are idempotent (already-applied ones are skipped),
     # so re-running this on every `restart: unless-stopped` cycle is a
@@ -83,7 +74,7 @@ services:
         parsar-migrate
         exec /usr/local/bin/parsar-server
     ports:
-      - "${PARSAR_BIND_ADDR:-0.0.0.0}:${PARSAR_LOCAL_PORT:-18080}:8080"
+      - "${PARSAR_BIND_ADDR:-127.0.0.1}:${PARSAR_LOCAL_PORT:-18080}:8080"
     environment:
       DATABASE_URL: postgres://parsar:${PARSAR_PG_PASSWORD:-parsar}@postgres:5432/parsar?sslmode=disable
       # Network proxy — only needed if your host requires a proxy for internet
@@ -119,11 +110,12 @@ services:
       # Same service-name default the self-host compose uses (profile not
       # fork) — `parsar-server` is this service's network alias.
       PARSAR_AGENT_DAEMON_OWNER_URL: "http://parsar-server:8080"
-      # Optional connector credentials and workers. On the loopback default,
-      # the server seeds a stable dev-only PARSAR_MASTER_KEY so one-command
-      # local startup needs no secrets. Set a real 64-hex key when exposing
-      # this compose stack beyond loopback.
-      PARSAR_MASTER_KEY: "${PARSAR_MASTER_KEY:-}"
+      # Optional connector credentials and workers. The default key is fixed
+      # so docker-compose.yml can run standalone, but it is dev-only. Set a
+      # stable random 64-hex value when exposing this stack or preserving
+      # encrypted secrets across deployments:
+      #   openssl rand -hex 32
+      PARSAR_MASTER_KEY: "${PARSAR_MASTER_KEY:-0000000000000000000000000000000000000000000000000000000000000000}"
       PARSAR_FEISHU_APP_REGISTRATION: "${PARSAR_FEISHU_APP_REGISTRATION:-}"
       PARSAR_FEISHU_WEBSOCKET: "${PARSAR_FEISHU_WEBSOCKET:-}"
       PARSAR_FEISHU_OUTBOUND: "${PARSAR_FEISHU_OUTBOUND:-}"
@@ -157,11 +149,12 @@ services:
       PARSAR_DISCORD_APP_ID: "${PARSAR_DISCORD_APP_ID:-}"
       PARSAR_DISCORD_BOT_TOKEN: "${PARSAR_DISCORD_BOT_TOKEN:-}"
       # Shared token used only by the compose-resident local runtime below.
-      # install.sh generates a random value into .env.
-      PARSAR_SHARED_RUNTIME_TOKEN: "${PARSAR_SHARED_RUNTIME_TOKEN:-}"
+      # The fixed default keeps raw docker compose/Dokploy deployments from
+      # failing with an empty runtime token. Override it in real deployments.
+      PARSAR_SHARED_RUNTIME_TOKEN: "${PARSAR_SHARED_RUNTIME_TOKEN:-parsar-local-runtime-token-change-me}"
       PARSAR_AGENT_DAEMON_WS_URL: "ws://parsar-server:8080/agent-daemon/ws"
     volumes:
-      - ${PARSAR_DATA_DIR:-parsar-local-data}:/var/lib/parsar
+      - ${PARSAR_DATA_DIR:-server-data}:/var/lib/parsar
     # The image's baked-in HEALTHCHECK probes /healthz with `wget --spider`
     # (an HTTP HEAD), but /healthz is GET-only and answers HEAD with 405 —
     # so the default probe reports the container "unhealthy" even though it
@@ -185,7 +178,7 @@ services:
         condition: service_healthy
     environment:
       PARSAR_SERVER_URL: "http://parsar-server:8080"
-      PARSAR_SHARED_RUNTIME_TOKEN: "${PARSAR_SHARED_RUNTIME_TOKEN:-}"
+      PARSAR_SHARED_RUNTIME_TOKEN: "${PARSAR_SHARED_RUNTIME_TOKEN:-parsar-local-runtime-token-change-me}"
       PARSAR_RUNTIME_NAME: "local-sandbox"
       PARSAR_RUNTIME_PROFILE: "default-runtime"
     command: ["/opt/parsar/bin/runtime-entrypoint.sh"]
@@ -194,7 +187,7 @@ services:
       - parsar-runtime-workspace:/workspace
 
 volumes:
-  parsar-local-pg:
-  parsar-local-data:
+  postgres-data:
+  server-data:
   parsar-runtime-home:
   parsar-runtime-workspace:

--- a/install.sh
+++ b/install.sh
@@ -1,46 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEFAULT_COMPOSE_URL="https://raw.githubusercontent.com/MiniMax-AI-Dev/parsar/main/docker-compose.yml"
-DEFAULT_SERVER_IMAGE="ghcr.io/minimax-ai-dev/parsar-server:latest"
-DEFAULT_SANDBOX_IMAGE="ghcr.io/minimax-ai-dev/parsar-sandbox:latest"
+COMPOSE_URL="https://raw.githubusercontent.com/MiniMax-AI-Dev/parsar/main/docker-compose.yml"
 
 usage() {
-  cat <<'EOF'
-Parsar one-command installer.
+  cat <<'USAGE'
+Install or upgrade Parsar with Docker Compose.
 
 Usage:
   ./install.sh [options]
   curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/parsar/main/install.sh | bash
 
 Options:
-  --home PATH            Install state directory. Must be absolute or ~/...
-                         Default: ~/.parsar
-  --compose-file PATH    Compose file to use. Default: ./docker-compose.yml
-                         when present, otherwise download the published template.
-  --image IMAGE          parsar-server image.
-                         Default: ghcr.io/minimax-ai-dev/parsar-server:latest
-  --sandbox-image IMAGE  Default local runtime sandbox image.
-                         Default: ghcr.io/minimax-ai-dev/parsar-sandbox:latest
-                         To use your own build instead:
-                         docker build -f infra/sandbox/Dockerfile -t parsar-sandbox:local .
-                         --sandbox-image parsar-sandbox:local --pull-policy never
-  --pull-policy POLICY   Compose image pull policy: always, missing, or never.
-                         Default: always. Use never for local images.
-  --port PORT            Web UI host port. Default: 18080
-  --pg-port PORT         Postgres host port. Default: 15432
-  --bind ADDR            Web UI bind address. Default: 127.0.0.1
-  --public-url URL       Browser-facing URL. Default: http://127.0.0.1:<port>
-  --project-name NAME    Docker Compose project name. Default: parsar
-  --dry-run              Generate files and validate compose config only.
-  --help                 Show this help.
+  --home PATH          Install directory. Default: ~/.parsar
+  --port PORT          Web UI port. Default: 18080
+  --bind ADDRESS       Web UI bind address. Default: 127.0.0.1
+  --image IMAGE        Override the server image.
+  --sandbox-image IMAGE
+                       Override the sandbox image.
+  --compose-file PATH  Use an existing Compose file.
+  --dry-run            Prepare and validate without starting containers.
+  --help               Show this help.
 
-Environment variables with the same names are also honored:
-  PARSAR_HOME, PARSAR_COMPOSE_FILE, PARSAR_SERVER_IMAGE,
-  PARSAR_SANDBOX_IMAGE, PARSAR_IMAGE_PULL_POLICY,
-  PARSAR_LOCAL_PORT, PARSAR_PG_PORT, PARSAR_BIND_ADDR,
-  PARSAR_PUBLIC_URL, PARSAR_PROJECT_NAME.
-EOF
+Advanced Compose settings can be added directly to ~/.parsar/.env.
+USAGE
 }
 
 log() {
@@ -52,99 +35,68 @@ die() {
   exit 1
 }
 
-expand_home_path() {
+expand_path() {
   case "$1" in
     "~") printf '%s\n' "$HOME" ;;
     "~/"*) printf '%s/%s\n' "$HOME" "${1#~/}" ;;
     /*) printf '%s\n' "$1" ;;
-    *) die "path must be absolute or start with ~/; got: $1" ;;
+    *) die "path must be absolute or start with ~/: $1" ;;
   esac
 }
 
 random_hex() {
-  bytes="$1"
   if command -v openssl >/dev/null 2>&1; then
-    openssl rand -hex "$bytes"
-    return
+    openssl rand -hex "$1"
+  else
+    od -An -N"$1" -tx1 /dev/urandom | tr -d ' \n'
   fi
-  od -An -N"$bytes" -tx1 /dev/urandom | tr -d ' \n'
 }
 
 ensure_env() {
-  key="$1"
-  value="$2"
-  file="$3"
-  if grep -q "^${key}=" "$file" 2>/dev/null; then
-    return
-  fi
-  printf '%s=%s\n' "$key" "$value" >>"$file"
+  local key="$1" value="$2"
+  grep -q "^${key}=" "$env_file" 2>/dev/null || printf '%s=%s\n' "$key" "$value" >>"$env_file"
 }
 
 set_env() {
-  key="$1"
-  value="$2"
-  file="$3"
-  tmp="${file}.tmp.$$"
-  grep -v "^${key}=" "$file" 2>/dev/null >"$tmp" || true
-  printf '%s=%s\n' "$key" "$value" >>"$tmp"
-  mv "$tmp" "$file"
+  local key="$1" value="$2" temp_file="${env_file}.tmp.$$"
+  grep -v "^${key}=" "$env_file" 2>/dev/null >"$temp_file" || true
+  printf '%s=%s\n' "$key" "$value" >>"$temp_file"
+  mv "$temp_file" "$env_file"
 }
 
 detect_docker() {
   if docker compose version >/dev/null 2>&1 </dev/null && docker info >/dev/null 2>&1 </dev/null; then
     DOCKER=(docker)
-    return
-  fi
-  if command -v sudo >/dev/null 2>&1 &&
+  elif command -v sudo >/dev/null 2>&1 &&
     sudo -n docker compose version >/dev/null 2>&1 </dev/null &&
     sudo -n docker info >/dev/null 2>&1 </dev/null; then
     DOCKER=(sudo -n docker)
-    return
+  else
+    die "Docker Compose v2 is required and the current user cannot reach Docker"
   fi
-  die "Docker Compose v2 is required and the current user cannot reach the Docker daemon"
 }
 
-# Piped via `curl | bash`, our own stdin (fd 0) is the same pipe still
-# delivering the unparsed tail of this script. `docker`/`docker compose`
-# subcommands like `exec` forward stdin to the container by default, and
-# will happily drain that pipe out from under bash mid-parse (silently
-# truncating everything after the command that stole it — including the
-# closing banner). Redirect from /dev/null so no docker invocation can
-# ever compete with bash for bytes of its own source.
 docker_run() {
   "${DOCKER[@]}" "$@" </dev/null
 }
 
-compose_run() {
+compose() {
   docker_run compose -f "$compose_file" --env-file "$env_file" "$@"
 }
 
-fetch_compose() {
-  if [ -n "$compose_arg" ]; then
-    src="$(expand_home_path "$compose_arg")"
-    [ -f "$src" ] || die "compose file does not exist: $src"
-    compose_file="$src"
-    return
-  fi
-
-  if [ -f "./docker-compose.yml" ]; then
-    compose_file="$PWD/docker-compose.yml"
-    return
-  fi
-
-  compose_file="$parsar_home/docker-compose.yml"
+download_compose() {
   if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$DEFAULT_COMPOSE_URL" -o "$compose_file"
+    curl -fsSL "$COMPOSE_URL" -o "$compose_file"
   elif command -v wget >/dev/null 2>&1; then
-    wget -qO "$compose_file" "$DEFAULT_COMPOSE_URL"
+    wget -qO "$compose_file" "$COMPOSE_URL"
   else
-    die "curl or wget is required to download docker-compose.yml"
+    die "curl or wget is required"
   fi
 }
 
 wait_for_health() {
   for _ in $(seq 1 60); do
-    if compose_run exec -T parsar-server wget -qO- http://127.0.0.1:8080/healthz >/dev/null 2>&1; then
+    if compose exec -T parsar-server wget -qO- http://127.0.0.1:8080/healthz >/dev/null 2>&1; then
       return 0
     fi
     sleep 1
@@ -152,127 +104,86 @@ wait_for_health() {
   return 1
 }
 
-home_arg="${PARSAR_HOME:-$HOME/.parsar}"
-compose_arg="${PARSAR_COMPOSE_FILE:-}"
-server_image="${PARSAR_SERVER_IMAGE:-$DEFAULT_SERVER_IMAGE}"
-sandbox_image="${PARSAR_SANDBOX_IMAGE:-$DEFAULT_SANDBOX_IMAGE}"
-pull_policy="${PARSAR_IMAGE_PULL_POLICY:-always}"
-local_port="${PARSAR_LOCAL_PORT:-18080}"
-pg_port="${PARSAR_PG_PORT:-15432}"
-bind_addr="${PARSAR_BIND_ADDR:-127.0.0.1}"
-public_url="${PARSAR_PUBLIC_URL:-}"
-project_name="${PARSAR_PROJECT_NAME:-parsar}"
-dry_run="false"
+home="${PARSAR_HOME:-$HOME/.parsar}"
+port="${PARSAR_LOCAL_PORT:-18080}"
+bind="${PARSAR_BIND_ADDR:-127.0.0.1}"
+server_image="${PARSAR_SERVER_IMAGE:-}"
+sandbox_image="${PARSAR_SANDBOX_IMAGE:-}"
+compose_source="${PARSAR_COMPOSE_FILE:-}"
+dry_run=false
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --home) home_arg="${2:?missing value for --home}"; shift 2 ;;
-    --compose-file) compose_arg="${2:?missing value for --compose-file}"; shift 2 ;;
+    --home) home="${2:?missing value for --home}"; shift 2 ;;
+    --port) port="${2:?missing value for --port}"; shift 2 ;;
+    --bind) bind="${2:?missing value for --bind}"; shift 2 ;;
     --image) server_image="${2:?missing value for --image}"; shift 2 ;;
     --sandbox-image) sandbox_image="${2:?missing value for --sandbox-image}"; shift 2 ;;
-    --pull-policy) pull_policy="${2:?missing value for --pull-policy}"; shift 2 ;;
-    --port) local_port="${2:?missing value for --port}"; shift 2 ;;
-    --pg-port) pg_port="${2:?missing value for --pg-port}"; shift 2 ;;
-    --bind) bind_addr="${2:?missing value for --bind}"; shift 2 ;;
-    --public-url) public_url="${2:?missing value for --public-url}"; shift 2 ;;
-    --project-name) project_name="${2:?missing value for --project-name}"; shift 2 ;;
-    --dry-run) dry_run="true"; shift ;;
+    --compose-file) compose_source="${2:?missing value for --compose-file}"; shift 2 ;;
+    --dry-run) dry_run=true; shift ;;
     --help|-h) usage; exit 0 ;;
     *) die "unknown option: $1" ;;
   esac
 done
 
-case "$local_port" in (*[!0-9]*|"") die "--port must be numeric" ;; esac
-case "$pg_port" in (*[!0-9]*|"") die "--pg-port must be numeric" ;; esac
-case "$pull_policy" in
-  always|missing|never) ;;
-  *) die "--pull-policy must be one of: always, missing, never" ;;
-esac
-case "$project_name" in
-  ""|[!a-z0-9]*) die "--project-name must start with a lowercase letter or digit" ;;
-esac
-case "$project_name" in
-  *[!a-z0-9_-]*) die "--project-name may contain only lowercase letters, digits, underscores, and dashes" ;;
-esac
+case "$port" in (*[!0-9]*|"") die "--port must be numeric" ;; esac
 
-parsar_home="$(expand_home_path "$home_arg")"
-if [ -z "$public_url" ]; then
-  public_host="127.0.0.1"
-  if [ "$bind_addr" != "127.0.0.1" ] && [ "$bind_addr" != "localhost" ]; then
-    public_host="$bind_addr"
-  fi
-  public_url="http://${public_host}:${local_port}"
+home="$(expand_path "$home")"
+mkdir -p "$home/postgres" "$home/data"
+umask 077
+env_file="$home/.env"
+touch "$env_file"
+
+if [ -n "$compose_source" ]; then
+  compose_file="$(expand_path "$compose_source")"
+  [ -f "$compose_file" ] || die "compose file does not exist: $compose_file"
+elif [ -f "$PWD/docker-compose.yml" ]; then
+  compose_file="$PWD/docker-compose.yml"
+else
+  compose_file="$home/docker-compose.yml"
+  download_compose
 fi
+
+set_env PARSAR_LOCAL_PORT "$port"
+set_env PARSAR_BIND_ADDR "$bind"
+set_env PARSAR_PG_DATA_DIR "$home/postgres"
+set_env PARSAR_DATA_DIR "$home/data"
+[ -z "$server_image" ] || set_env PARSAR_SERVER_IMAGE "$server_image"
+[ -z "$sandbox_image" ] || set_env PARSAR_SANDBOX_IMAGE "$sandbox_image"
+ensure_env PARSAR_PG_PASSWORD "$(random_hex 24)"
+ensure_env PARSAR_MASTER_KEY "$(random_hex 32)"
+ensure_env PARSAR_SHARED_RUNTIME_TOKEN "$(random_hex 32)"
 
 detect_docker
-
-umask 077
-mkdir -p "$parsar_home" "$parsar_home/postgres" "$parsar_home/data"
-
-env_file="$parsar_home/.env"
-if [ ! -f "$env_file" ]; then
-  : >"$env_file"
-fi
-
-fetch_compose
-
-set_env "PARSAR_HOME" "$parsar_home" "$env_file"
-set_env "PARSAR_PROJECT_NAME" "$project_name" "$env_file"
-set_env "PARSAR_SERVER_IMAGE" "$server_image" "$env_file"
-set_env "PARSAR_SANDBOX_IMAGE" "$sandbox_image" "$env_file"
-set_env "PARSAR_IMAGE_PULL_POLICY" "$pull_policy" "$env_file"
-set_env "PARSAR_LOCAL_PORT" "$local_port" "$env_file"
-set_env "PARSAR_PG_PORT" "$pg_port" "$env_file"
-set_env "PARSAR_BIND_ADDR" "$bind_addr" "$env_file"
-set_env "PARSAR_PUBLIC_URL" "$public_url" "$env_file"
-set_env "PARSAR_COOKIE_SECURE" "false" "$env_file"
-ensure_env "PARSAR_PG_PASSWORD" "$(random_hex 24)" "$env_file"
-ensure_env "PARSAR_MASTER_KEY" "$(random_hex 32)" "$env_file"
-ensure_env "PARSAR_SHARED_RUNTIME_TOKEN" "$(random_hex 32)" "$env_file"
-set_env "PARSAR_PG_DATA_DIR" "$parsar_home/postgres" "$env_file"
-set_env "PARSAR_DATA_DIR" "$parsar_home/data" "$env_file"
-
 log "Using $compose_file"
-log "Wrote $env_file"
-compose_run config --quiet
+log "Using $env_file"
+compose config --quiet
 
-if [ "$dry_run" = "true" ]; then
-  log "Dry run complete; containers were not started"
+if [ "$dry_run" = true ]; then
+  log "Dry run complete"
   exit 0
 fi
 
-log "Starting Parsar with Docker Compose"
-if [ "$pull_policy" != "never" ]; then
-  log "Pulling Parsar images with policy: $pull_policy"
-  compose_run pull --ignore-pull-failures --policy "$pull_policy" parsar-server parsar-runtime || true
-else
-  log "Skipping image pull because PARSAR_IMAGE_PULL_POLICY=never"
-fi
-compose_run up -d --remove-orphans
+log "Pulling images"
+compose pull parsar-server parsar-runtime
+log "Starting Parsar"
+compose up -d --remove-orphans
 
-if wait_for_health; then
-  log "Parsar is healthy"
-else
-  compose_run ps >&2 || true
-  compose_run logs --tail 120 parsar-server >&2 || true
+if ! wait_for_health; then
+  compose ps >&2 || true
+  compose logs --tail 120 parsar-server >&2 || true
   die "parsar-server did not become healthy"
 fi
 
 cat <<EOF
 
-Parsar is running.
-
-Open:
-  ${public_url}
+Parsar is running at http://${bind}:${port}
 
 Create the first owner account in the web setup flow.
 
-Useful commands:
+Manage the stack:
   ${DOCKER[*]} compose -f "$compose_file" --env-file "$env_file" ps
-  ${DOCKER[*]} compose -f "$compose_file" --env-file "$env_file" logs -f parsar-server
+  ${DOCKER[*]} compose -f "$compose_file" --env-file "$env_file" logs -f
   ${DOCKER[*]} compose -f "$compose_file" --env-file "$env_file" down
-
-State and config:
-  $parsar_home
 
 EOF


### PR DESCRIPTION
## Summary
- make `docker-compose.yml` directly runnable without installer-generated configuration
- simplify `install.sh` into a thin installation wrapper
- preserve the Compose default network when Dokploy adds its ingress network
- update installation and architecture documentation

## Validation
- Compose configuration and installer dry-run pass
- raw Compose startup works without `.env`
- Dokploy deployment becomes healthy with both internal and ingress networks
- `git diff --check` passes
- `make check` only hits the existing order-dependent store test; it passes independently with `-count=3`