### PR TITLE
Drive workspace Feishu connectors from UI state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,9 @@ description and keep ownership on the side listed here.
 - Services exposed through a deployment platform may gain an ingress network,
   but they must remain explicitly attached to the Compose `default` network
   when they depend on internal service DNS names such as `postgres`.
+- DB-driven workspace connectors exposed in the admin UI must start and stop
+  from their persisted `enabled` and event-mode settings. Do not add a second
+  deployment environment flag after a connector is saved and marked enabled.
 - The local compose file must express the same default with
   `PARSAR_IMAGE_PULL_POLICY=always` for Parsar-owned images. Local image
   testing must opt out explicitly with `PARSAR_IMAGE_PULL_POLICY=never`.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,3 +92,7 @@ When a platform such as Dokploy adds its ingress network to `parsar-server`,
 keep the service attached to the Compose `default` network as well. Postgres
 and the local runtime are intentionally private and use that network for
 service discovery.
+
+The Feishu WebSocket inbound manager and outbound worker are driven by the
+workspace connector saved in the admin UI. No additional deployment flag is
+required after enabling the connector.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,8 +117,6 @@ services:
       #   openssl rand -hex 32
       PARSAR_MASTER_KEY: "${PARSAR_MASTER_KEY:-0000000000000000000000000000000000000000000000000000000000000000}"
       PARSAR_FEISHU_APP_REGISTRATION: "${PARSAR_FEISHU_APP_REGISTRATION:-}"
-      PARSAR_FEISHU_WEBSOCKET: "${PARSAR_FEISHU_WEBSOCKET:-}"
-      PARSAR_FEISHU_OUTBOUND: "${PARSAR_FEISHU_OUTBOUND:-}"
       # Workspace-dimension IM connector reconcilers (workspace_im_connectors
       # table → one Socket Mode / Gateway runner per workspace|app_id, hot-
       # reloading on token rotation). Opt-in gates read in main.go

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -1618,10 +1618,9 @@ func defaultFeishuSharedBotEnv(env func(string) string) feishuSharedBotEnv {
 }
 
 // buildFeishuWebSocketManager constructs the Feishu event-websocket inbound
-// manager from env. Returns nil when disabled.
+// manager for DB-driven workspace connectors and optional legacy env bots.
 //
 // Env contract:
-//   - PARSAR_FEISHU_WEBSOCKET                (default off; "true" enables)
 //   - PARSAR_FEISHU_WS_REFRESH_SECONDS       (optional; default 30, cap 600)
 //   - PARSAR_FEISHU_OPENAPI_BASE_URL         (optional; default SDK domain)
 //   - PARSAR_FEISHU_DEFAULT_BOT_APP_ID       (optional; falls back to PARSAR_FEISHU_APP_ID)
@@ -1629,12 +1628,9 @@ func defaultFeishuSharedBotEnv(env func(string) string) feishuSharedBotEnv {
 //   - PARSAR_FEISHU_DEFAULT_BOT_OPEN_ID      (optional; self-message dedup)
 //   - PARSAR_MASTER_KEY                      (REQUIRED when enabled)
 func buildFeishuWebSocketManager(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string) (*inbound.Manager, error) {
-	if !truthy(env("PARSAR_FEISHU_WEBSOCKET")) {
-		return nil, nil
-	}
 	masterKey := strings.TrimSpace(env("PARSAR_MASTER_KEY"))
 	if masterKey == "" {
-		return nil, errors.New("PARSAR_FEISHU_WEBSOCKET=true requires PARSAR_MASTER_KEY (same value the secret vault was sealed with)")
+		return nil, nil
 	}
 	secretsSvc, err := secrets.New(masterKey)
 	if err != nil {
@@ -2264,11 +2260,10 @@ func (r inboundPromptForUserChoiceRouter) SubmitPromptForUserChoice(ctx context.
 	return lastErr
 }
 
-// buildFeishuOutboundWorker constructs the Feishu outbound poll worker
-// from env. Returns nil (silent skip) when the feature flag is off.
+// buildFeishuOutboundWorker constructs the outbound worker for DB-driven
+// workspace connectors and optional legacy env bots.
 //
 // Env contract:
-//   - PARSAR_FEISHU_OUTBOUND                (default off; "true" enables)
 //   - PARSAR_FEISHU_OUTBOUND_POLL_SECONDS   (optional; default 10, cap 600)
 //   - PARSAR_FEISHU_OUTBOUND_BATCH_LIMIT    (optional; default 32, cap 256)
 //   - PARSAR_FEISHU_OPENAPI_BASE_URL        (optional; default Feishu prod)
@@ -2277,12 +2272,9 @@ func (r inboundPromptForUserChoiceRouter) SubmitPromptForUserChoice(ctx context.
 //   - PARSAR_MASTER_KEY                     (REQUIRED when enabled — same
 //     key used by the secret vault encryptor)
 func buildFeishuOutboundWorker(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, deviceResolver inflight.DeviceResolver, publicURL string) (*inflight.Worker, error) {
-	if !truthy(env("PARSAR_FEISHU_OUTBOUND")) {
-		return nil, nil
-	}
 	masterKey := strings.TrimSpace(env("PARSAR_MASTER_KEY"))
 	if masterKey == "" {
-		return nil, errors.New("PARSAR_FEISHU_OUTBOUND=true requires PARSAR_MASTER_KEY (same value the secret vault was sealed with)")
+		return nil, nil
 	}
 	secretsSvc, err := secrets.New(masterKey)
 	if err != nil {

--- a/server/cmd/server/main_test.go
+++ b/server/cmd/server/main_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/feishu"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/config"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 )
 
 func TestDecideFeishuStartup(t *testing.T) {
@@ -227,6 +228,48 @@ func TestDefaultFeishuSharedBotEnv(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWorkspaceFeishuWorkersFollowStoredConnectorConfiguration(t *testing.T) {
+	dbStore := store.New(nil)
+
+	t.Run("missing master key skips workers", func(t *testing.T) {
+		env := envMap(nil)
+		manager, err := buildFeishuWebSocketManager(env, dbStore, nil, "")
+		if err != nil {
+			t.Fatalf("buildFeishuWebSocketManager() error = %v", err)
+		}
+		if manager != nil {
+			t.Fatal("buildFeishuWebSocketManager() returned manager without master key")
+		}
+		worker, err := buildFeishuOutboundWorker(env, dbStore, nil, nil, "")
+		if err != nil {
+			t.Fatalf("buildFeishuOutboundWorker() error = %v", err)
+		}
+		if worker != nil {
+			t.Fatal("buildFeishuOutboundWorker() returned worker without master key")
+		}
+	})
+
+	t.Run("master key starts workers without feature flags", func(t *testing.T) {
+		env := envMap(map[string]string{
+			"PARSAR_MASTER_KEY": "0000000000000000000000000000000000000000000000000000000000000000",
+		})
+		manager, err := buildFeishuWebSocketManager(env, dbStore, nil, "")
+		if err != nil {
+			t.Fatalf("buildFeishuWebSocketManager() error = %v", err)
+		}
+		if manager == nil {
+			t.Fatal("buildFeishuWebSocketManager() returned nil with master key")
+		}
+		worker, err := buildFeishuOutboundWorker(env, dbStore, nil, nil, "")
+		if err != nil {
+			t.Fatalf("buildFeishuOutboundWorker() error = %v", err)
+		}
+		if worker == nil {
+			t.Fatal("buildFeishuOutboundWorker() returned nil with master key")
+		}
+	})
 }
 
 func TestResolveRuntimeProfile(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove the hidden `PARSAR_FEISHU_WEBSOCKET` and `PARSAR_FEISHU_OUTBOUND` gates from DB-driven workspace connectors
- start Feishu inbound and outbound workers whenever encrypted secret storage is available
- let the connector `enabled` and `event_mode` values saved by the UI control actual WebSocket connections
- preserve legacy environment-provided Feishu bot credentials
- document the UI ownership boundary and add regression coverage

## Validation
- `docker compose -f docker-compose.yml config --quiet`
- `go test ./server/cmd/server ./server/internal/gateway/inbound ./server/internal/gateway/inflight`
- `go test ./server/internal/store -run TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation -count=3`
- `git diff origin/main...HEAD --check`