### PR TITLE
Deduplicate scheduled task row mappers

### DIFF
--- a/server/internal/store/scheduled_tasks.go
+++ b/server/internal/store/scheduled_tasks.go
@@ -139,7 +139,9 @@ func scheduledRunTitle(name, timezone string, now time.Time) string {
 	return fmt.Sprintf("%s · %s", name, now.In(loc).Format("01-02 15:04"))
 }
 
-func scheduledTaskFromCreateRow(r sqlc.CreateScheduledTaskRow) ScheduledTaskRead {
+type scheduledTaskRow sqlc.CreateScheduledTaskRow
+
+func scheduledTaskFromRow(r scheduledTaskRow) ScheduledTaskRead {
 	return ScheduledTaskRead{
 		ID:                  r.ID,
 		AgentID:             r.AgentID,
@@ -160,98 +162,26 @@ func scheduledTaskFromCreateRow(r sqlc.CreateScheduledTaskRow) ScheduledTaskRead
 		CreatedAt:           r.CreatedAt.Time,
 		UpdatedAt:           r.UpdatedAt.Time,
 	}
+}
+
+func scheduledTaskFromCreateRow(r sqlc.CreateScheduledTaskRow) ScheduledTaskRead {
+	return scheduledTaskFromRow(scheduledTaskRow(r))
 }
 
 func scheduledTaskFromGetRow(r sqlc.GetScheduledTaskRow) ScheduledTaskRead {
-	return ScheduledTaskRead{
-		ID:                  r.ID,
-		AgentID:             r.AgentID,
-		ConversationID:      r.ConversationID,
-		Name:                r.Name,
-		Prompt:              r.Prompt,
-		CronExpr:            r.CronExpr,
-		Timezone:            r.Timezone,
-		Enabled:             r.Enabled,
-		FeishuChatID:        r.FeishuChatID,
-		FeishuChatName:      r.FeishuChatName,
-		NextRunAt:           timePtr(r.NextRunAt),
-		LastRunAt:           timePtr(r.LastRunAt),
-		LastRunID:           r.LastRunID,
-		LastStatus:          r.LastStatus,
-		ConsecutiveFailures: r.ConsecutiveFailures,
-		CreatedBy:           r.CreatedBy,
-		CreatedAt:           r.CreatedAt.Time,
-		UpdatedAt:           r.UpdatedAt.Time,
-	}
+	return scheduledTaskFromRow(scheduledTaskRow(r))
 }
 
 func scheduledTaskFromListRow(r sqlc.ListScheduledTasksByAgentRow) ScheduledTaskRead {
-	return ScheduledTaskRead{
-		ID:                  r.ID,
-		AgentID:             r.AgentID,
-		ConversationID:      r.ConversationID,
-		Name:                r.Name,
-		Prompt:              r.Prompt,
-		CronExpr:            r.CronExpr,
-		Timezone:            r.Timezone,
-		Enabled:             r.Enabled,
-		FeishuChatID:        r.FeishuChatID,
-		FeishuChatName:      r.FeishuChatName,
-		NextRunAt:           timePtr(r.NextRunAt),
-		LastRunAt:           timePtr(r.LastRunAt),
-		LastRunID:           r.LastRunID,
-		LastStatus:          r.LastStatus,
-		ConsecutiveFailures: r.ConsecutiveFailures,
-		CreatedBy:           r.CreatedBy,
-		CreatedAt:           r.CreatedAt.Time,
-		UpdatedAt:           r.UpdatedAt.Time,
-	}
+	return scheduledTaskFromRow(scheduledTaskRow(r))
 }
 
 func scheduledTaskFromListByWorkspaceRow(r sqlc.ListScheduledTasksByWorkspacePageRow) ScheduledTaskRead {
-	return ScheduledTaskRead{
-		ID:                  r.ID,
-		AgentID:             r.AgentID,
-		ConversationID:      r.ConversationID,
-		Name:                r.Name,
-		Prompt:              r.Prompt,
-		CronExpr:            r.CronExpr,
-		Timezone:            r.Timezone,
-		Enabled:             r.Enabled,
-		FeishuChatID:        r.FeishuChatID,
-		FeishuChatName:      r.FeishuChatName,
-		NextRunAt:           timePtr(r.NextRunAt),
-		LastRunAt:           timePtr(r.LastRunAt),
-		LastRunID:           r.LastRunID,
-		LastStatus:          r.LastStatus,
-		ConsecutiveFailures: r.ConsecutiveFailures,
-		CreatedBy:           r.CreatedBy,
-		CreatedAt:           r.CreatedAt.Time,
-		UpdatedAt:           r.UpdatedAt.Time,
-	}
+	return scheduledTaskFromRow(scheduledTaskRow(r))
 }
 
 func scheduledTaskFromUpdateRow(r sqlc.UpdateScheduledTaskRow) ScheduledTaskRead {
-	return ScheduledTaskRead{
-		ID:                  r.ID,
-		AgentID:             r.AgentID,
-		ConversationID:      r.ConversationID,
-		Name:                r.Name,
-		Prompt:              r.Prompt,
-		CronExpr:            r.CronExpr,
-		Timezone:            r.Timezone,
-		Enabled:             r.Enabled,
-		FeishuChatID:        r.FeishuChatID,
-		FeishuChatName:      r.FeishuChatName,
-		NextRunAt:           timePtr(r.NextRunAt),
-		LastRunAt:           timePtr(r.LastRunAt),
-		LastRunID:           r.LastRunID,
-		LastStatus:          r.LastStatus,
-		ConsecutiveFailures: r.ConsecutiveFailures,
-		CreatedBy:           r.CreatedBy,
-		CreatedAt:           r.CreatedAt.Time,
-		UpdatedAt:           r.UpdatedAt.Time,
-	}
+	return scheduledTaskFromRow(scheduledTaskRow(r))
 }
 
 // CreateScheduledTask inserts the task row. No conversation is built up front:

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -7668,17 +7668,6 @@ func decodeJSONMap(value []byte) map[string]any {
 	return decoded
 }
 
-func decodeJSONStringSlice(value []byte) []string {
-	if len(value) == 0 {
-		return []string{}
-	}
-	var decoded []string
-	if err := json.Unmarshal(value, &decoded); err != nil || decoded == nil {
-		return []string{}
-	}
-	return normalizeStringSlice(decoded)
-}
-
 // DecodeMessageAttachments lifts the attachments slice out of a messages.metadata
 // jsonb payload. Lossy on purpose: malformed entries are skipped silently so a single
 // bad attachment cannot nuke a run with other content. Shape matches MessageAttachment.


### PR DESCRIPTION
## Summary
- consolidate five identical scheduled-task sqlc row mappers behind one canonical mapper
- preserve named wrappers for each generated row type so sqlc shape changes remain compile-time failures
- remove the unused `decodeJSONStringSlice` helper
- avoid reflection, SQL changes, and generated-file changes

## Validation
- `go test ./server/internal/store -run 'TestScheduledTask|TestFireScheduledTask' -count=1`\n- `go test ./server/internal/store -count=1`\n- `git diff --check`\n\n## Diff\n- 11 insertions, 92 deletions\n- net 81 lines removed