### PR TITLE
Simplify self-hosted Compose README

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -1,87 +1,23 @@
 # `deploy/compose/` — self-hosted deployment templates
 
-This directory contains a **starting-point** Docker Compose layout for
-running Parsar in a self-hosted environment (on-prem single host,
-private staging, single-tenant production). It is **not** the dev
-compose stack (`docker-compose.dev.yml` at the repo root) and **not** a
-turnkey production deployment — it is the smallest concrete file pair
-that proves the open-source binary can come up with config + secrets
-injected from outside the repo.
+This directory contains the Docker Compose template and example environment
+file for self-hosted Parsar deployments. For setup, secrets, migrations,
+bootstrap, health checks, and production operations, follow the canonical
+[`deploy runbook`](../../docs/deploy/deploy-runbook.md).
 
 ## Files
 
 | File | Purpose |
 |---|---|
-| `compose.selfhost.yml` | Two-service compose (`postgres` + `parsar-server`) with image / volumes / health checks. |
-| `.env.example` | Every env var the compose file references, plus the env vars Parsar reads at runtime. All values are placeholders. |
+| [`compose.selfhost.yml`](./compose.selfhost.yml) | Self-hosted Postgres and Parsar server services. |
+| [`.env.example`](./.env.example) | Placeholder values for the Compose and server environment. Do not store real secrets here. |
 
-## Three operator paths
+## Validate
 
-Pick the one that matches your environment, then read the matching
-section in `docs/deploy/deploy-runbook.md`:
-
-1. **Single host, bundled Postgres** — use `compose.selfhost.yml` as-is.
-   Bind-mount a config file in if you want; otherwise rely on env-only
-   injection.
-2. **Single host, external Postgres** — comment out the `postgres`
-   service block in `compose.selfhost.yml`, override `DATABASE_URL` in
-   `.env`, keep everything else.
-3. **Kubernetes** — copy the env block from `compose.selfhost.yml`
-   into your Deployment manifest, copy the health-check block into
-   your `livenessProbe` / `readinessProbe` (per
-   `docs/deploy/health-and-smoke.md`), and store secrets in a K8s
-   `Secret` instead of `.env`.
-
-## Where do real values come from?
-
-**Never from this directory.** This whole folder is committed to the
-open-source repo; any real secret here is a leak.
-
-| Value class | Where it lives |
-|---|---|
-| Real image tag (your own registry path) | Set via `PARSAR_SERVER_IMAGE` in `.env` (or a CI variable) |
-| Postgres password | Your secret manager → `.env` (uncommitted) |
-| `PARSAR_MASTER_KEY` / `PARSAR_BOOTSTRAP_TOKEN` | Generated with `openssl rand -hex 32`, stored in secret manager, injected into `.env` (uncommitted) or container env |
-| Feishu `app_id` / `app_secret` / `verification_token` | Feishu open platform → secret manager → `.env` |
-| E2B API key | E2B dashboard → secret manager → `.env` |
-
-## Image build contract
-
-The `parsar-server` image referenced by `PARSAR_SERVER_IMAGE` ships its
-binaries on `$PATH` at `/usr/local/bin`, so they are invoked by **bare
-name** (NOT `./parsar-...` — the image's `WORKDIR` is `/var/lib/parsar`,
-which does not contain them):
-
-- `parsar-server` — the long-running HTTP server (the image `CMD`
-  defaults to `/usr/local/bin/parsar-server`).
-- `parsar-migrate` — the goose-driven migration runner used by the
-  runbook's `docker compose ... exec parsar-server parsar-migrate` step.
-- `parsar-bootstrap` — optional headless first-owner provisioning CLI
-  for automated deployments that do not use the web setup flow.
-
-The Dockerfile that builds this image lives at the repo root
-(`Dockerfile`); `make docker-build` produces an image satisfying this
-contract. Operators building their own image must install the same
-binaries on `$PATH` for the runbook to work as written.
-
-> The dev path (`make server` / `make migrate-dev`) does NOT need this
-> image — it shells out via `go run ./cmd/server` / `go run ./cmd/migrate`.
-
-## Verifying the compose file
-
-After filling `.env`, run:
+Copy `.env.example` to an untracked `.env`, fill its required placeholders,
+then verify the resolved Compose configuration without starting containers:
 
 ```bash
-docker compose -f deploy/compose/compose.selfhost.yml --env-file deploy/compose/.env config
+docker compose -f deploy/compose/compose.selfhost.yml \
+  --env-file deploy/compose/.env config
 ```
-
-This expands every `${VAR}` and prints the merged config without
-starting any container. CI can use the same command to keep the file
-syntactically honest after future edits.
-
-## Related docs
-
-- `docs/deploy/deploy-runbook.md` — end-to-end runbook (Postgres → config → migration → bootstrap → smoke).
-- `docs/deploy/config.example.yaml` — annotated YAML template covering every config knob.
-- `docs/deploy/feishu-prod.md` — Feishu app + event-subscription wiring.
-- `docs/deploy/health-and-smoke.md` — `/healthz`, `/readyz`, and the `scripts/smoke.sh` checker.


### PR DESCRIPTION
## Summary
- reduce `deploy/compose/README.md` to the directory purpose and file responsibilities
- keep the shortest Compose validation command
- point setup, secrets, migrations, bootstrap, health checks, and operations to the canonical deploy runbook
- leave the Compose template and example environment unchanged

## Validation
- branch starts exactly from `origin/main` at `cb88aab` (includes PRs #109-#112)
- all relative links in `deploy/compose/README.md` resolve
- `git diff --check` passes
- only `deploy/compose/README.md` changes
- focused flaky store test passes independently with `-count=3`
- `make check` reaches the existing order-dependent `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation` failure