### PR TITLE
refactor(web): polish shared interface styling

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#f7f7f7" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#252525" media="(prefers-color-scheme: dark)" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <!-- Fonts: Space Grotesk (display headings), Inter (Latin body/UI),
          Noto Sans SC (Chinese — Inter has no CJK glyphs, else it silently
@@ -19,10 +21,14 @@
     <script>
       ;(() => {
         const stored = localStorage.getItem("parsar.theme")
-        const preference = stored === "light" || stored === "dark" || stored === "system" ? stored : "system"
-        const resolved = preference === "system"
-          ? (matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
-          : preference
+        const preference =
+          stored === "light" || stored === "dark" || stored === "system" ? stored : "system"
+        const resolved =
+          preference === "system"
+            ? matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light"
+            : preference
         document.documentElement.dataset.theme = resolved
         document.documentElement.style.colorScheme = resolved
       })()

--- a/apps/web/src/components/layout/AdminLayout.tsx
+++ b/apps/web/src/components/layout/AdminLayout.tsx
@@ -3,10 +3,15 @@ import { useTranslation } from "react-i18next"
 import { cn } from "../../lib/utils"
 import { useAdminView, type AdminView } from "../../lib/admin-router"
 import {
-  MessageSquare, Play,
+  MessageSquare,
+  Play,
   CalendarClock,
-  Bot, Wrench, Database, Plug,
-  Users, Settings,
+  Bot,
+  Wrench,
+  Database,
+  Plug,
+  Users,
+  Settings,
   type LucideIcon,
 } from "lucide-react"
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher"
@@ -74,14 +79,21 @@ export function AdminLayout({
   const { navigate } = useAdminView()
 
   return (
-    <div className="flex h-screen flex-col overflow-hidden bg-surface-subtle/60 text-fg antialiased">
-      <header className="flex h-16 shrink-0 items-center gap-3 border-b border-line/70 bg-surface px-5">
-        <div className="flex items-center">
-          <img
-            src="/favicon.png"
-            alt="Parsar"
-            className="h-9 w-9"
-          />
+    <div className="flex h-screen flex-col overflow-hidden bg-surface-subtle text-fg antialiased">
+      <a
+        href="#main-content"
+        className="fixed left-4 top-3 z-50 -translate-y-20 rounded-lg bg-surface-emphasis px-3 py-2 text-sm font-medium text-fg-on-emphasis shadow-lg transition-transform focus:translate-y-0"
+      >
+        Skip to main content
+      </a>
+      <header className="flex h-16 shrink-0 items-center gap-4 border-b border-line/70 bg-surface/95 px-5 shadow-sm backdrop-blur">
+        <div className="flex items-center gap-2.5" translate="no">
+          <span className="grid h-9 w-9 place-items-center rounded-xl border border-line bg-surface shadow-sm">
+            <img src="/favicon.png" alt="" width="28" height="28" className="h-7 w-7" />
+          </span>
+          <span className="font-display text-lg font-semibold tracking-display text-fg">
+            Parsar
+          </span>
         </div>
 
         <WorkspaceSwitcher />
@@ -93,67 +105,68 @@ export function AdminLayout({
       </header>
 
       <div className="flex flex-1 overflow-hidden">
-        {!hideSidebar && <aside className="flex w-56 shrink-0 flex-col overflow-y-auto border-r border-line/70 bg-surface px-3 py-3">
-          {menuGroups.map((group, idx) => (
-            <nav
-              key={group.groupKey}
-              className={cn("flex flex-col", idx > 0 && "mt-4")}
-            >
-              <span className="mb-1 px-2 text-xs font-medium text-fg-faint">
-                {t(`nav.${group.groupKey}` as never)}
-              </span>
-              <ul className="flex flex-col gap-0.5">
-                {group.items.map((item) => {
-                  const Icon = item.icon
-                  const isActive = activeMenu === item.id
-                  return (
-                    <li key={item.id}>
-                      <button
-                        type="button"
-                        onClick={() => navigate(item.id)}
-                        className={cn(
-                          "group relative flex h-8 w-full items-center gap-2 rounded-md px-2 text-sm transition-colors",
-                          isActive
-                            ? "bg-surface-muted font-medium text-fg"
-                            : "font-normal text-fg-muted hover:bg-surface-muted/60 hover:text-fg"
-                        )}
-                      >
-                        <Icon
+        {!hideSidebar && (
+          <aside className="flex w-60 shrink-0 flex-col overflow-y-auto border-r border-line/70 bg-surface/80 px-3 py-4 backdrop-blur">
+            {menuGroups.map((group, idx) => (
+              <nav key={group.groupKey} className={cn("flex flex-col", idx > 0 && "mt-4")}>
+                <span className="mb-1.5 px-2 text-xs font-semibold uppercase tracking-wide text-fg-faint">
+                  {t(`nav.${group.groupKey}` as never)}
+                </span>
+                <ul className="flex flex-col gap-0.5">
+                  {group.items.map((item) => {
+                    const Icon = item.icon
+                    const isActive = activeMenu === item.id
+                    return (
+                      <li key={item.id}>
+                        <button
+                          type="button"
+                          onClick={() => navigate(item.id)}
                           className={cn(
-                            "h-4 w-4 shrink-0",
+                            "group relative flex h-9 w-full items-center gap-2.5 rounded-lg px-2.5 text-sm transition-[color,background-color,box-shadow] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info/30",
                             isActive
-                              ? "text-fg-muted"
-                              : "text-fg-faint group-hover:text-fg-muted"
+                              ? "bg-surface font-semibold text-fg shadow-sm ring-1 ring-line-muted"
+                              : "font-normal text-fg-muted hover:bg-surface-muted hover:text-fg",
                           )}
-                          strokeWidth={1.75}
-                        />
-                        <span className="truncate">
-                          {t(`nav.items.${item.itemKey}` as never)}
-                        </span>
-                        {item.badge !== undefined && (
-                          <span className="ml-auto inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-warning-subtle px-1.5 text-xs font-medium text-warning">
-                            {item.badge}
+                          aria-current={isActive ? "page" : undefined}
+                        >
+                          <Icon
+                            className={cn(
+                              "h-4 w-4 shrink-0",
+                              isActive
+                                ? "text-fg-muted"
+                                : "text-fg-faint group-hover:text-fg-muted",
+                            )}
+                            strokeWidth={1.75}
+                            aria-hidden="true"
+                          />
+                          <span className="truncate">
+                            {t(`nav.items.${item.itemKey}` as never)}
                           </span>
-                        )}
-                        {item.hint && (
-                          <span className="ml-auto text-xs uppercase tracking-wider text-fg-faint">
-                            {t(`nav.${item.hint}` as never)}
-                          </span>
-                        )}
-                      </button>
-                    </li>
-                  )
-                })}
-              </ul>
-            </nav>
-          ))}
-        </aside>}
+                          {item.badge !== undefined && (
+                            <span className="ml-auto inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full bg-warning-subtle px-1.5 text-xs font-medium text-warning">
+                              {item.badge}
+                            </span>
+                          )}
+                          {item.hint && (
+                            <span className="ml-auto text-xs uppercase tracking-wider text-fg-faint">
+                              {t(`nav.${item.hint}` as never)}
+                            </span>
+                          )}
+                        </button>
+                      </li>
+                    )
+                  })}
+                </ul>
+              </nav>
+            ))}
+          </aside>
+        )}
 
-        <main className="relative flex-1 overflow-y-auto">
+        <main id="main-content" className="relative flex-1 overflow-y-auto" tabIndex={-1}>
           {fullBleed ? (
             children
           ) : (
-            <div className={cn("relative mx-auto max-w-6xl px-10 py-10", contentClassName)}>
+            <div className={cn("relative mx-auto max-w-6xl px-10 py-9", contentClassName)}>
               {children}
             </div>
           )}

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -9,13 +9,15 @@ interface PageHeaderProps {
 
 export function PageHeader({ title, description, action, backLink }: PageHeaderProps) {
   return (
-    <div className="mb-8 flex flex-col gap-2">
+    <div className="mb-8 flex flex-col gap-2 border-b border-line-muted pb-6">
       {backLink && <div className="text-xs text-fg-subtle">{backLink}</div>}
       <div className="flex items-start justify-between gap-4">
-        <div className="space-y-1.5">
-          <h1 className="font-display text-3xl font-semibold leading-tight tracking-tight text-fg">{title}</h1>
+        <div className="min-w-0 max-w-3xl space-y-1.5">
+          <h1 className="font-display text-3xl font-semibold leading-tight tracking-display text-fg">
+            {title}
+          </h1>
           {description && (
-            <div className="max-w-2xl text-sm leading-relaxed text-fg-subtle">{description}</div>
+            <div className="max-w-2xl text-base leading-relaxed text-fg-subtle">{description}</div>
           )}
         </div>
         {action && <div className="flex shrink-0 items-center gap-2">{action}</div>}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -4,13 +4,16 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "../../lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/15 focus-visible:ring-offset-1 focus-visible:ring-offset-surface disabled:pointer-events-none disabled:opacity-50 active:translate-y-px",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-[color,background-color,border-color,box-shadow,transform,opacity] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info/35 focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:pointer-events-none disabled:opacity-50 active:translate-y-px motion-reduce:transition-none motion-reduce:active:translate-y-0",
   {
     variants: {
       variant: {
-        default: "bg-surface-emphasis text-white shadow-sm hover:bg-surface-inverse",
-        destructive: "bg-danger text-white shadow-sm hover:bg-danger-emphasis",
-        outline: "border border-line bg-surface text-fg shadow-sm hover:bg-surface-subtle hover:border-line-strong",
+        default:
+          "bg-surface-emphasis text-fg-on-emphasis shadow-sm hover:bg-surface-inverse hover:shadow-md",
+        destructive:
+          "bg-danger text-fg-on-emphasis shadow-sm hover:bg-danger-emphasis hover:shadow-md",
+        outline:
+          "border border-line bg-surface text-fg shadow-sm hover:border-line-strong hover:bg-surface-subtle hover:shadow-md",
         secondary: "bg-surface-muted text-fg hover:bg-surface-muted/70",
         ghost: "text-fg-muted hover:bg-surface-muted hover:text-fg",
         link: "text-fg underline-offset-4 hover:underline",
@@ -36,12 +39,11 @@ const buttonVariants = cva(
       size: "default",
       shape: "rounded",
     },
-  }
+  },
 )
 
 interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
   asChild?: boolean
 }
 
@@ -55,7 +57,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
       />
     )
-  }
+  },
 )
 Button.displayName = "Button"
 

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -9,8 +9,8 @@ export const Input = React.forwardRef<
     <input
       type={type}
       className={cn(
-        "flex h-9 w-full rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm transition-colors placeholder:text-fg-faint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong disabled:cursor-not-allowed disabled:opacity-50",
-        className
+        "flex h-9 w-full rounded-lg border border-line bg-surface px-3 py-1.5 text-sm shadow-sm transition-[border-color,box-shadow,background-color] placeholder:text-fg-faint hover:border-line-strong focus-visible:border-info focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info/20 disabled:cursor-not-allowed disabled:bg-surface-muted disabled:opacity-60",
+        className,
       )}
       ref={ref}
       {...props}

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,18 +1,13 @@
 import * as React from "react"
 import { cn } from "../../lib/utils"
 
-export const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
-))
+export const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto rounded-lg">
+      <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    </div>
+  ),
+)
 Table.displayName = "Table"
 
 export const TableHeader = React.forwardRef<
@@ -21,7 +16,7 @@ export const TableHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <thead
     ref={ref}
-    className={cn("border-b border-line bg-surface-subtle/40", className)}
+    className={cn("border-b border-line bg-surface-subtle/70", className)}
     {...props}
   />
 ))
@@ -31,11 +26,7 @@ export const TableBody = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
 ))
 TableBody.displayName = "TableBody"
 
@@ -46,8 +37,8 @@ export const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      "border-b border-line-muted transition-colors hover:bg-surface-subtle/60 data-[state=selected]:bg-surface-subtle",
-      className
+      "border-b border-line-muted transition-colors hover:bg-surface-subtle data-[state=selected]:bg-info-subtle/50",
+      className,
     )}
     {...props}
   />
@@ -61,8 +52,8 @@ export const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-9 px-3 text-left align-middle text-xs font-medium uppercase tracking-wide text-fg-subtle",
-      className
+      "h-10 px-3 text-left align-middle text-xs font-semibold uppercase tracking-wide text-fg-subtle",
+      className,
     )}
     {...props}
   />
@@ -73,10 +64,6 @@ export const TableCell = React.forwardRef<
   HTMLTableCellElement,
   React.TdHTMLAttributes<HTMLTableCellElement>
 >(({ className, ...props }, ref) => (
-  <td
-    ref={ref}
-    className={cn("px-3 py-2.5 align-middle text-fg-muted", className)}
-    {...props}
-  />
+  <td ref={ref} className={cn("px-3 py-3 align-middle text-fg-muted", className)} {...props} />
 ))
 TableCell.displayName = "TableCell"

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -11,8 +11,8 @@ export const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-9 items-center gap-1 border-b border-line",
-      className
+      "inline-flex h-10 items-center gap-1 rounded-lg bg-surface-muted/70 p-1",
+      className,
     )}
     {...props}
   />
@@ -26,8 +26,8 @@ export const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "relative -mb-px inline-flex h-9 items-center justify-center px-3 text-sm font-medium text-fg-subtle transition-colors hover:text-fg disabled:pointer-events-none disabled:opacity-50 data-[state=active]:text-fg data-[state=active]:after:absolute data-[state=active]:after:inset-x-0 data-[state=active]:after:bottom-0 data-[state=active]:after:h-px data-[state=active]:after:bg-surface-emphasis",
-      className
+      "inline-flex h-8 items-center justify-center rounded-md px-3 text-sm font-medium text-fg-subtle transition-[color,background-color,box-shadow] hover:bg-surface/60 hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info/30 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-surface data-[state=active]:text-fg data-[state=active]:shadow-sm",
+      className,
     )}
     {...props}
   />
@@ -42,7 +42,7 @@ export const TabsContent = React.forwardRef<
     ref={ref}
     className={cn(
       "mt-4 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong",
-      className
+      className,
     )}
     {...props}
   />

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,6 +1,9 @@
 import { useState, type FormEvent } from "react"
 import { useTranslation } from "react-i18next"
+import { ArrowRight, LoaderCircle } from "lucide-react"
 
+import { Button } from "../components/ui/button"
+import { Input } from "../components/ui/input"
 import { ApiError } from "../lib/api-client"
 import { useAuthProviders, useLoginWithPassword } from "../lib/api-auth"
 import { useBootstrapStatus } from "../lib/api-bootstrap"
@@ -69,15 +72,21 @@ function SignInView() {
   }
 
   return (
-    <main className="relative grid min-h-screen place-items-center overflow-hidden bg-surface px-6 text-fg">
+    <main className="relative grid min-h-screen place-items-center overflow-hidden bg-surface-subtle px-6 py-12 text-fg">
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 [background-image:radial-gradient(circle,var(--color-line-strong)_1px,transparent_1px)] [background-size:26px_26px] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_42%,black,transparent)] opacity-50"
+        className="pointer-events-none absolute inset-0 [background-image:radial-gradient(circle,var(--color-line-strong)_1px,transparent_1px)] [background-size:28px_28px] [mask-image:radial-gradient(ellipse_65%_58%_at_50%_45%,black,transparent)] opacity-35"
       />
-      <section className="relative w-full max-w-[460px] rounded-2xl border border-line/80 bg-surface p-9 shadow-[0_1px_2px_rgb(0_0_0/0.04),0_20px_48px_-16px_rgb(0_0_0/0.16)]">
+      <section className="app-panel relative w-full max-w-[460px] p-9">
         <div className="mb-8 flex flex-col items-center text-center">
-          <div className="rounded-xl bg-fg-on-emphasis px-5 py-3 shadow-sm ring-1 ring-line-muted">
-            <img src="/parsar-banner.png" alt="Parsar" className="h-auto w-[280px] max-w-full" />
+          <div className="rounded-2xl bg-fg-on-emphasis px-5 py-3 shadow-sm ring-1 ring-line-muted">
+            <img
+              src="/parsar-banner.png"
+              alt="Parsar"
+              width="560"
+              height="96"
+              className="h-auto w-[280px] max-w-full"
+            />
           </div>
           <p className="mt-4 text-base leading-relaxed text-fg-subtle">{t("login.subtitle")}</p>
         </div>
@@ -85,26 +94,29 @@ function SignInView() {
         <form className="flex flex-col gap-4" onSubmit={onSubmit} noValidate>
           <label className="flex flex-col gap-1.5">
             <span className="text-sm font-medium text-fg-muted">{t("login.emailLabel")}</span>
-            <input
+            <Input
               type="email"
+              name="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder={t("login.emailPlaceholder")}
               autoComplete="email"
+              spellCheck={false}
               required
-              className="h-10 rounded-md border border-line bg-surface px-3 text-base text-fg placeholder:text-fg-faint focus:border-fg/40 focus:outline-none focus:ring-1 focus:ring-fg/20"
+              className="h-11 text-base"
             />
           </label>
           <label className="flex flex-col gap-1.5">
             <span className="text-sm font-medium text-fg-muted">{t("login.passwordLabel")}</span>
-            <input
+            <Input
               type="password"
+              name="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder={t("login.passwordPlaceholder")}
               autoComplete="current-password"
               required
-              className="h-10 rounded-md border border-line bg-surface px-3 text-base text-fg placeholder:text-fg-faint focus:border-fg/40 focus:outline-none focus:ring-1 focus:ring-fg/20"
+              className="h-11 text-base"
             />
           </label>
 
@@ -117,13 +129,22 @@ function SignInView() {
             </div>
           )}
 
-          <button
+          <Button
             type="submit"
             disabled={invalid || submitting}
-            className="mt-1 flex h-11 w-full items-center justify-center rounded-full bg-surface-emphasis px-5 text-lg font-medium text-white shadow-sm transition-all hover:bg-surface-inverse hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/20 focus-visible:ring-offset-2 focus-visible:ring-offset-surface active:translate-y-px disabled:cursor-not-allowed disabled:opacity-60"
+            size="lg"
+            shape="pill"
+            className="mt-1 h-11 w-full text-base"
           >
+            {submitting ? (
+              <LoaderCircle
+                className="h-4 w-4 animate-spin motion-reduce:animate-none"
+                aria-hidden="true"
+              />
+            ) : null}
             {submitting ? t("login.submitting") : t("login.submitButton")}
-          </button>
+            {!submitting ? <ArrowRight className="h-4 w-4" aria-hidden="true" /> : null}
+          </Button>
         </form>
 
         {ssoProviders.length > 0 && (
@@ -139,7 +160,7 @@ function SignInView() {
                 <a
                   key={provider.id}
                   href={provider.login_url}
-                  className="flex h-11 w-full items-center justify-center rounded-full border border-line bg-surface px-5 text-base font-medium text-fg transition-colors hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fg/20 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+                  className="flex h-11 w-full items-center justify-center rounded-full border border-line bg-surface px-5 text-base font-medium text-fg shadow-sm transition-[color,background-color,border-color,box-shadow] hover:border-line-strong hover:bg-surface-subtle hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info/30 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
                 >
                   {t("login.ssoButton", { provider: provider.label })}
                 </a>

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -231,12 +231,59 @@ body {
   margin: 0;
   min-width: 960px;
   line-height: 1.5;
+  overflow-x: hidden;
+  background:
+    radial-gradient(circle at 50% -20%, color-mix(in oklab, var(--color-info-subtle) 54%, transparent), transparent 38rem),
+    var(--color-surface-subtle);
+}
+
+button,
+a,
+input,
+select,
+textarea {
+  -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
 }
 
 button,
 select,
 textarea {
   font: inherit;
+}
+
+button,
+a {
+  text-underline-offset: 0.2em;
+}
+
+:where(h1, h2, h3, h4, h5, h6) {
+  scroll-margin-top: 5rem;
+  text-wrap: balance;
+}
+
+:where(p, li, dd) {
+  text-wrap: pretty;
+}
+
+.app-panel {
+  border: 1px solid color-mix(in oklab, var(--color-line) 82%, transparent);
+  border-radius: 0.875rem;
+  background: color-mix(in oklab, var(--color-surface) 94%, transparent);
+  box-shadow:
+    0 1px 2px rgb(0 0 0 / 4%),
+    0 12px 32px -24px rgb(0 0 0 / 28%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 
 /* Brand-tinted text selection (default is a flat grey-blue). */


### PR DESCRIPTION
## Summary

- refine the admin shell with stronger visual hierarchy, navigation states, branding, and keyboard skip navigation
- polish shared buttons, inputs, tables, tabs, page headers, and global interaction styles without changing behavior
- update the sign-in experience to reuse shared controls and improve loading, focus, image sizing, and form semantics
- add theme-color metadata, reduced-motion support, touch feedback, balanced headings, and reusable panel styling

## Validation

- `pnpm --filter @parsar/web typecheck`
- `pnpm --filter @parsar/web build`
- targeted ESLint on changed TypeScript files (0 errors; 2 existing Fast Refresh warnings)
- `git diff --check`

## Known baseline failure

`make check` was run before the rebase. It reached an unrelated backend store test failure:

- `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation`
- `server/internal/store/capabilities_pinning_mode_test.go:308`

The failing assertion concerns capability version freezing after deprecation and is unrelated to these frontend-only changes.
