### PR TITLE
Deduplicate offset pagination

### DIFF
--- a/apps/web/src/components/ui/offset-pagination.tsx
+++ b/apps/web/src/components/ui/offset-pagination.tsx
@@ -1,0 +1,52 @@
+import { ChevronLeft, ChevronRight } from "lucide-react"
+
+import { cn } from "../../lib/utils"
+import { Button } from "./button"
+
+interface OffsetPaginationProps {
+  offset: number
+  limit: number
+  total: number
+  rangeLabel: (range: { from: number; to: number; total: number }) => string
+  previousLabel: string
+  nextLabel: string
+  onPrevious: () => void
+  onNext: () => void
+  className?: string
+}
+
+// Disable boundary buttons (vs. hiding) so layout stays stable.
+export function OffsetPagination({
+  offset,
+  limit,
+  total,
+  rangeLabel,
+  previousLabel,
+  nextLabel,
+  onPrevious,
+  onNext,
+  className,
+}: OffsetPaginationProps) {
+  if (total === 0) return null
+
+  const from = offset + 1
+  const to = Math.min(offset + limit, total)
+  const onFirstPage = offset === 0
+  const onLastPage = offset + limit >= total
+
+  return (
+    <div className={cn("flex items-center justify-between gap-3 px-1", className)}>
+      <span className="tabular-nums">{rangeLabel({ from, to, total })}</span>
+      <div className="flex items-center gap-2">
+        <Button size="sm" variant="outline" onClick={onPrevious} disabled={onFirstPage}>
+          <ChevronLeft className="h-3.5 w-3.5" />
+          {previousLabel}
+        </Button>
+        <Button size="sm" variant="outline" onClick={onNext} disabled={onLastPage}>
+          {nextLabel}
+          <ChevronRight className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -5,8 +5,6 @@ import {
   ArrowUpRight,
   Bot,
   CheckCircle2,
-  ChevronLeft,
-  ChevronRight,
   Clock,
   Code,
   Database,
@@ -29,6 +27,7 @@ import { Button } from "../../components/ui/button"
 import { EmptyState } from "../../components/ui/empty-state"
 import { ErrorState } from "../../components/ui/error-state"
 import { Input } from "../../components/ui/input"
+import { OffsetPagination } from "../../components/ui/offset-pagination"
 import { Skeleton } from "../../components/ui/skeleton"
 import {
   Tabs,
@@ -502,55 +501,22 @@ export function RunsPage() {
             </div>
           )}
 
-          <RunsPager
+          <OffsetPagination
             offset={offset}
             limit={RUNS_PAGE_SIZE}
             total={total}
-            onPrev={() => setOffset((cur) => Math.max(0, cur - RUNS_PAGE_SIZE))}
+            rangeLabel={({ from, to, total: rangeTotal }) =>
+              t("runs.table.pagination.range", { from, to, total: rangeTotal })
+            }
+            previousLabel={t("runs.table.pagination.prev")}
+            nextLabel={t("runs.table.pagination.next")}
+            onPrevious={() => setOffset((cur) => Math.max(0, cur - RUNS_PAGE_SIZE))}
             onNext={() => setOffset((cur) => cur + RUNS_PAGE_SIZE)}
+            className="text-sm text-fg-muted"
           />
         </div>
       )}
     </AdminLayout>
-  )
-}
-
-// Disable boundary buttons (vs. hiding) so layout stays stable.
-function RunsPager({
-  offset,
-  limit,
-  total,
-  onPrev,
-  onNext,
-}: {
-  offset: number
-  limit: number
-  total: number
-  onPrev: () => void
-  onNext: () => void
-}) {
-  const { t } = useTranslation("admin")
-  if (total === 0) return null
-  const from = offset + 1
-  const to = Math.min(offset + limit, total)
-  const onFirstPage = offset === 0
-  const onLastPage = offset + limit >= total
-  return (
-    <div className="flex items-center justify-between gap-3 px-1 text-sm text-fg-muted">
-      <span className="tabular-nums">
-        {t("runs.table.pagination.range", { from, to, total })}
-      </span>
-      <div className="flex items-center gap-2">
-        <Button size="sm" variant="outline" onClick={onPrev} disabled={onFirstPage}>
-          <ChevronLeft className="h-3.5 w-3.5" />
-          {t("runs.table.pagination.prev")}
-        </Button>
-        <Button size="sm" variant="outline" onClick={onNext} disabled={onLastPage}>
-          {t("runs.table.pagination.next")}
-          <ChevronRight className="h-3.5 w-3.5" />
-        </Button>
-      </div>
-    </div>
   )
 }
 

--- a/apps/web/src/pages/admin/ScheduledTasksPage.tsx
+++ b/apps/web/src/pages/admin/ScheduledTasksPage.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
-import { Bot, ChevronLeft, ChevronRight, Pencil, Play, Plus, Trash2 } from "lucide-react"
+import { Bot, Pencil, Play, Plus, Trash2 } from "lucide-react"
 
 import { AdminLayout } from "../../components/layout/AdminLayout"
 import { Badge } from "../../components/ui/badge"
 import { Button } from "../../components/ui/button"
 import { Input } from "../../components/ui/input"
+import { OffsetPagination } from "../../components/ui/offset-pagination"
 import {
   Dialog,
   DialogContent,
@@ -334,12 +335,18 @@ export function ScheduledTasksPage() {
           </div>
         )}
 
-        <SchedPager
+        <OffsetPagination
           offset={offset}
           limit={SCHED_PAGE_SIZE}
           total={total}
-          onPrev={() => setOffset((cur) => Math.max(0, cur - SCHED_PAGE_SIZE))}
+          rangeLabel={({ from, to, total: rangeTotal }) =>
+            t("scheduledTasks.pagination.range", { from, to, total: rangeTotal })
+          }
+          previousLabel={t("scheduledTasks.pagination.prev")}
+          nextLabel={t("scheduledTasks.pagination.next")}
+          onPrevious={() => setOffset((cur) => Math.max(0, cur - SCHED_PAGE_SIZE))}
           onNext={() => setOffset((cur) => cur + SCHED_PAGE_SIZE)}
+          className="text-xs text-fg-subtle"
         />
 
         {dialogOpen && (
@@ -373,45 +380,6 @@ export function ScheduledTasksPage() {
         )}
       </div>
     </AdminLayout>
-  )
-}
-
-// Disable boundary buttons (vs. hiding) so layout stays stable.
-function SchedPager({
-  offset,
-  limit,
-  total,
-  onPrev,
-  onNext,
-}: {
-  offset: number
-  limit: number
-  total: number
-  onPrev: () => void
-  onNext: () => void
-}) {
-  const { t } = useTranslation("admin")
-  if (total === 0) return null
-  const from = offset + 1
-  const to = Math.min(offset + limit, total)
-  const onFirstPage = offset === 0
-  const onLastPage = offset + limit >= total
-  return (
-    <div className="flex items-center justify-between gap-3 px-1 text-xs text-fg-subtle">
-      <span className="tabular-nums">
-        {t("scheduledTasks.pagination.range", { from, to, total })}
-      </span>
-      <div className="flex items-center gap-2">
-        <Button size="sm" variant="outline" onClick={onPrev} disabled={onFirstPage}>
-          <ChevronLeft className="h-3.5 w-3.5" />
-          {t("scheduledTasks.pagination.prev")}
-        </Button>
-        <Button size="sm" variant="outline" onClick={onNext} disabled={onLastPage}>
-          {t("scheduledTasks.pagination.next")}
-          <ChevronRight className="h-3.5 w-3.5" />
-        </Button>
-      </div>
-    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- extract the identical Runs and Scheduled Tasks offset pager into a shared UI component
- preserve each page's existing translation keys, text styles, range calculation, and disabled boundary buttons
- leave the Capabilities pagination implementation unchanged

## Validation
- `pnpm --filter @parsar/web typecheck`
- target ESLint passes with the two pages' pre-existing `react-hooks/set-state-in-effect` rule disabled; the new component passes normal ESLint
- `pnpm --filter @parsar/web build`
- `git diff --check`
- `make check` reaches the existing order-dependent `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation` failure; that test passes independently with `-count=3`