### PR TITLE
Deduplicate store row mappers

### DIFF
--- a/server/internal/store/agentdaemon_device_owner.go
+++ b/server/internal/store/agentdaemon_device_owner.go
@@ -178,36 +178,20 @@ func (s *Store) ExpireAgentDaemonDeviceOwners(ctx context.Context, now time.Time
 }
 
 func agentDaemonOwnerFromClaimRow(r sqlc.ClaimAgentDaemonDeviceOwnerRow) AgentDaemonDeviceOwnerRead {
-	return AgentDaemonDeviceOwnerRead{
-		DeviceID:       r.DeviceID,
-		WorkspaceID:    r.WorkspaceID,
-		OwnerPodID:     r.OwnerPodID,
-		OwnerURL:       r.OwnerUrl,
-		Generation:     r.Generation,
-		Status:         r.Status,
-		ConnectedAt:    pgTime(r.ConnectedAt),
-		LastSeenAt:     pgTime(r.LastSeenAt),
-		LeaseExpiresAt: pgTime(r.LeaseExpiresAt),
-		UpdatedAt:      pgTime(r.UpdatedAt),
-	}
+	return agentDaemonOwnerFromRow(agentDaemonOwnerRow(r))
 }
 
 func agentDaemonOwnerFromGetRow(r sqlc.GetAgentDaemonDeviceOwnerRow) AgentDaemonDeviceOwnerRead {
-	return AgentDaemonDeviceOwnerRead{
-		DeviceID:       r.DeviceID,
-		WorkspaceID:    r.WorkspaceID,
-		OwnerPodID:     r.OwnerPodID,
-		OwnerURL:       r.OwnerUrl,
-		Generation:     r.Generation,
-		Status:         r.Status,
-		ConnectedAt:    pgTime(r.ConnectedAt),
-		LastSeenAt:     pgTime(r.LastSeenAt),
-		LeaseExpiresAt: pgTime(r.LeaseExpiresAt),
-		UpdatedAt:      pgTime(r.UpdatedAt),
-	}
+	return agentDaemonOwnerFromRow(agentDaemonOwnerRow(r))
 }
 
 func agentDaemonOwnerFromRenewRow(r sqlc.RenewAgentDaemonDeviceOwnerRow) AgentDaemonDeviceOwnerRead {
+	return agentDaemonOwnerFromRow(agentDaemonOwnerRow(r))
+}
+
+type agentDaemonOwnerRow sqlc.ClaimAgentDaemonDeviceOwnerRow
+
+func agentDaemonOwnerFromRow(r agentDaemonOwnerRow) AgentDaemonDeviceOwnerRead {
 	return AgentDaemonDeviceOwnerRead{
 		DeviceID:       r.DeviceID,
 		WorkspaceID:    r.WorkspaceID,

--- a/server/internal/store/capability_import.go
+++ b/server/internal/store/capability_import.go
@@ -681,36 +681,20 @@ func validateMCPSpecPreCommit(m canonical.MCPSpec) error {
 }
 
 func credentialKindFromListRow(row sqlc.ListCredentialKindsRow) CredentialKindRead {
-	return CredentialKindRead{
-		ID:          row.ID,
-		Code:        row.Code,
-		DisplayName: row.DisplayName,
-		Description: row.Description,
-		ValueSchema: decodeJSONMap(row.ValueSchema),
-		BuiltIn:     row.BuiltIn,
-		Source:      row.Source,
-		CreatedBy:   anyToString(row.CreatedBy),
-		CreatedAt:   pgTime(row.CreatedAt),
-		UpdatedAt:   pgTime(row.UpdatedAt),
-	}
+	return credentialKindFromRow(credentialKindRow(row))
 }
 
 func credentialKindFromGetRow(row sqlc.GetCredentialKindByCodeRow) CredentialKindRead {
-	return CredentialKindRead{
-		ID:          row.ID,
-		Code:        row.Code,
-		DisplayName: row.DisplayName,
-		Description: row.Description,
-		ValueSchema: decodeJSONMap(row.ValueSchema),
-		BuiltIn:     row.BuiltIn,
-		Source:      row.Source,
-		CreatedBy:   anyToString(row.CreatedBy),
-		CreatedAt:   pgTime(row.CreatedAt),
-		UpdatedAt:   pgTime(row.UpdatedAt),
-	}
+	return credentialKindFromRow(credentialKindRow(row))
 }
 
 func credentialKindFromCreateRow(row sqlc.CreateCredentialKindRow) CredentialKindRead {
+	return credentialKindFromRow(credentialKindRow(row))
+}
+
+type credentialKindRow sqlc.ListCredentialKindsRow
+
+func credentialKindFromRow(row credentialKindRow) CredentialKindRead {
 	return CredentialKindRead{
 		ID:          row.ID,
 		Code:        row.Code,


### PR DESCRIPTION
## Summary
- consolidate the three Agent Daemon owner row mappers behind one shared implementation
- consolidate the three credential kind row mappers behind one shared implementation
- retain named wrappers and explicit sqlc row type conversions so generated row drift remains a compile-time failure
- leave SQL, sqlc-generated files, and business behavior unchanged

## Validation
- `go test ./server/internal/store -run 'AgentDaemonDeviceOwner|CredentialKind|CapabilityImport' -count=3`\n- `go test ./server/internal/store ./server/internal/dev`\n- `go test ./server/internal/store -run TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation -count=3`\n- `git diff --check`\n- `make check` reaches the existing order-dependent `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation` failure; the same test passes independently three times