### PR TITLE
Deduplicate workspace admin request gate

### DIFF
--- a/server/internal/dev/auth_providers.go
+++ b/server/internal/dev/auth_providers.go
@@ -2,9 +2,6 @@ package dev
 
 import (
 	"net/http"
-	"strings"
-
-	"github.com/go-chi/chi/v5"
 )
 
 const (
@@ -109,13 +106,8 @@ func listAuthProviders(registry AuthProviderRegistry) http.HandlerFunc {
 //	@Router			/api/v1/workspaces/{workspaceID}/auth/providers [get]
 func listWorkspaceAuthProviders(runtimeStore RuntimeStore, registry AuthProviderRegistry) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
 			return
 		}
 		writeJSON(w, http.StatusOK, workspaceAuthProvidersResponse{

--- a/server/internal/dev/routes_helpers.go
+++ b/server/internal/dev/routes_helpers.go
@@ -167,6 +167,19 @@ func requireWorkspaceOwnerOrAdmin(r *http.Request, runtimeStore RuntimeStore, wo
 	return auth.RequireWorkspaceRole(requestContextForRBAC(r), runtimeStore, workspaceID, "owner", "admin")
 }
 
+func requireWorkspaceOwnerOrAdminRequest(w http.ResponseWriter, r *http.Request, runtimeStore RuntimeStore) (string, bool) {
+	workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
+	if !isUUID(workspaceID) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
+		return "", false
+	}
+	if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
+		writeRBACError(w, err)
+		return "", false
+	}
+	return workspaceID, true
+}
+
 // requireWorkspaceMember gates read endpoints scoped to a workspace.
 // Returns ErrNotMember when the caller is not an active member of the
 // workspace.
@@ -218,13 +231,7 @@ func gateWorkspaceOwnerOrAdmin(runtimeStore RuntimeStore, next http.HandlerFunc)
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed read APIs are disabled"})
 			return
 		}
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		if _, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore); !ok {
 			return
 		}
 		next(w, r)

--- a/server/internal/dev/routes_models.go
+++ b/server/internal/dev/routes_models.go
@@ -92,13 +92,7 @@ func createModel(runtimeStore RuntimeStore) http.HandlerFunc {
 		}
 		// Model catalog is org-global; URL workspaceID is only used
 		// for RBAC. The created model is NOT scoped to it.
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		if _, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore); !ok {
 			return
 		}
 		var req createModelBody
@@ -150,13 +144,8 @@ func disableModel(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed model registry is disabled"})
 			return
 		}
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
 			return
 		}
 		modelID := strings.TrimSpace(chi.URLParam(r, "modelID"))
@@ -199,13 +188,7 @@ func updateModel(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed model registry is disabled"})
 			return
 		}
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		if _, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore); !ok {
 			return
 		}
 		modelID := strings.TrimSpace(chi.URLParam(r, "modelID"))
@@ -316,13 +299,8 @@ func testModelConnectivity(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed model registry is disabled"})
 			return
 		}
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
 			return
 		}
 		modelID := strings.TrimSpace(chi.URLParam(r, "modelID"))

--- a/server/internal/dev/routes_secrets.go
+++ b/server/internal/dev/routes_secrets.go
@@ -41,13 +41,8 @@ func createSecret(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed secret vault is disabled"})
 			return
 		}
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
 			return
 		}
 		var req createSecretBody
@@ -148,13 +143,8 @@ func disableSecret(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed secret vault is disabled"})
 			return
 		}
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
 			return
 		}
 		secretID := strings.TrimSpace(chi.URLParam(r, "secretID"))

--- a/server/internal/dev/routes_workspace_members.go
+++ b/server/internal/dev/routes_workspace_members.go
@@ -88,13 +88,8 @@ func addWorkspaceMember(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed read APIs are disabled"})
 			return
 		}
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
 			return
 		}
 		var req addWorkspaceMemberRequest
@@ -151,13 +146,8 @@ type createInvitationResponse struct {
 
 func createInvitation(runtimeStore RuntimeStore, cfg *routerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
 			return
 		}
 		var req createInvitationRequest
@@ -223,13 +213,8 @@ func createInvitation(runtimeStore RuntimeStore, cfg *routerConfig) http.Handler
 
 func listInvitations(runtimeStore RuntimeStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
 			return
 		}
 
@@ -627,13 +612,8 @@ func listJoinRequests(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed read APIs are disabled"})
 			return
 		}
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
 			return
 		}
 		rows, err := runtimeStore.ListPendingJoinRequests(r.Context(), workspaceID)

--- a/server/internal/dev/routes_workspaces.go
+++ b/server/internal/dev/routes_workspaces.go
@@ -653,13 +653,8 @@ func updateWorkspace(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed read APIs are disabled"})
 			return
 		}
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
 			return
 		}
 		actorID, ok := devActorID(w, r)
@@ -704,13 +699,8 @@ func archiveWorkspace(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed read APIs are disabled"})
 			return
 		}
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceOwnerOrAdmin(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
 			return
 		}
 		actorID, ok := devActorID(w, r)


### PR DESCRIPTION
## Summary
- extract the repeated workspace UUID and owner/admin request gate
- replace 14 identical handler blocks while preserving each handler's existing nil-store response
- keep the existing RBAC error mapper and response text unchanged

## Validation
- `go test ./server/internal/dev -count=3`
- `git diff --check`

Net reduction: 63 lines.