### PR TITLE
refactor: share fenced text splitter

### DIFF
--- a/server/internal/gateway/channel/discord/embed_test.go
+++ b/server/internal/gateway/channel/discord/embed_test.go
@@ -287,8 +287,9 @@ func TestRenderCredentialForm_FieldsAndButton(t *testing.T) {
 func TestCustomID_CapsAt100(t *testing.T) {
 	long := strings.Repeat("a", 200)
 	id := customID("permission_allow", long)
-	if runeLen(id) > discordCustomIDLimit {
-		t.Errorf("custom_id len = %d, want ≤ %d", runeLen(id), discordCustomIDLimit)
+	idLen := len([]rune(id))
+	if idLen > discordCustomIDLimit {
+		t.Errorf("custom_id len = %d, want ≤ %d", idLen, discordCustomIDLimit)
 	}
 	// No-value form returns the bare action.
 	if got := customID("permission_allow", ""); got != "permission_allow" {

--- a/server/internal/gateway/channel/discord/textcodec.go
+++ b/server/internal/gateway/channel/discord/textcodec.go
@@ -55,7 +55,7 @@ func (c *Channel) Format(text string) string {
 // closed with a fence and the next reopened with one, so neither half renders
 // as broken code.
 func (c *Channel) Truncate(text string) []string {
-	return splitPreservingFences(text, discordMaxMessageLen)
+	return channel.SplitPreservingFences(text, discordMaxMessageLen)
 }
 
 // ExtractMedia pulls Markdown image references (![alt](url)) out of the text,
@@ -82,66 +82,4 @@ func (c *Channel) ExtractMedia(text string) ([]channel.Media, string) {
 // isFence reports whether a line opens or closes a Markdown code fence.
 func isFence(line string) bool {
 	return strings.HasPrefix(strings.TrimSpace(line), "```")
-}
-
-// runeLen counts runes (Discord limits are character/rune based, not bytes).
-func runeLen(s string) int { return len([]rune(s)) }
-
-// splitPreservingFences splits text into ≤limit-rune chunks on line boundaries,
-// keeping fenced code blocks valid across a split. Mirrors the Slack adapter's
-// helper of the same name (the algorithm is platform-neutral).
-func splitPreservingFences(text string, limit int) []string {
-	if runeLen(text) <= limit {
-		return []string{text}
-	}
-	srcLines := strings.Split(text, "\n")
-
-	var (
-		out      []string
-		chunk    []string
-		chunkLen int
-		inFence  bool
-		fenceTok = "```"
-	)
-
-	flush := func() {
-		if len(chunk) == 0 {
-			return
-		}
-		body := chunk
-		if inFence {
-			body = append(append([]string(nil), chunk...), fenceTok)
-		}
-		out = append(out, strings.Join(body, "\n"))
-		chunk = nil
-		chunkLen = 0
-		if inFence {
-			chunk = append(chunk, fenceTok)
-			chunkLen = runeLen(fenceTok) + 1
-		}
-	}
-
-	for _, line := range srcLines {
-		add := runeLen(line) + 1 // +1 for the joining newline
-		if chunkLen+add > limit && len(chunk) > 0 {
-			flush()
-		}
-		chunk = append(chunk, line)
-		chunkLen += add
-		if isFence(line) {
-			if !inFence {
-				inFence = true
-				if tok := strings.TrimSpace(line); tok != "" {
-					fenceTok = tok
-				}
-			} else {
-				inFence = false
-				fenceTok = "```"
-			}
-		}
-	}
-	if len(chunk) > 0 {
-		out = append(out, strings.Join(chunk, "\n"))
-	}
-	return out
 }

--- a/server/internal/gateway/channel/discord/textcodec_test.go
+++ b/server/internal/gateway/channel/discord/textcodec_test.go
@@ -3,6 +3,8 @@ package discord
 import (
 	"strings"
 	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel"
 )
 
 // TestFormat_PassThroughMarkdown asserts Discord's near-pass-through Format:
@@ -70,7 +72,7 @@ func TestTruncate_ShortTextSingleChunk(t *testing.T) {
 // as broken code.
 func TestSplitPreservingFences(t *testing.T) {
 	text := "intro line\n```go\nL1\nL2\nL3\nL4\nL5\n```\noutro"
-	chunks := splitPreservingFences(text, 20)
+	chunks := channel.SplitPreservingFences(text, 20)
 	if len(chunks) < 2 {
 		t.Fatalf("expected multiple chunks, got %d", len(chunks))
 	}

--- a/server/internal/gateway/channel/slack/textcodec.go
+++ b/server/internal/gateway/channel/slack/textcodec.go
@@ -64,7 +64,7 @@ func formatInline(line string) string {
 // is closed with a fence and the next chunk reopened with one, so neither
 // half renders as broken code.
 func (c *Channel) Truncate(text string) []string {
-	return splitPreservingFences(text, slackMaxMessageLen)
+	return channel.SplitPreservingFences(text, slackMaxMessageLen)
 }
 
 // ExtractMedia pulls Markdown image references (![alt](url)) out of the text,
@@ -102,65 +102,4 @@ func escapeMrkdwn(s string) string {
 	s = strings.ReplaceAll(s, "<", "&lt;")
 	s = strings.ReplaceAll(s, ">", "&gt;")
 	return s
-}
-
-// runeLen counts runes (Slack limits are character/rune based, not bytes).
-func runeLen(s string) int { return len([]rune(s)) }
-
-// splitPreservingFences splits text into ≤limit-rune chunks on line
-// boundaries, keeping fenced code blocks valid across a split.
-func splitPreservingFences(text string, limit int) []string {
-	if runeLen(text) <= limit {
-		return []string{text}
-	}
-	srcLines := strings.Split(text, "\n")
-
-	var (
-		out      []string
-		chunk    []string
-		chunkLen int
-		inFence  bool
-		fenceTok = "```"
-	)
-
-	flush := func() {
-		if len(chunk) == 0 {
-			return
-		}
-		body := chunk
-		if inFence {
-			body = append(append([]string(nil), chunk...), fenceTok)
-		}
-		out = append(out, strings.Join(body, "\n"))
-		chunk = nil
-		chunkLen = 0
-		if inFence {
-			chunk = append(chunk, fenceTok)
-			chunkLen = runeLen(fenceTok) + 1
-		}
-	}
-
-	for _, line := range srcLines {
-		add := runeLen(line) + 1 // +1 for the joining newline
-		if chunkLen+add > limit && len(chunk) > 0 {
-			flush()
-		}
-		chunk = append(chunk, line)
-		chunkLen += add
-		if isFence(line) {
-			if !inFence {
-				inFence = true
-				if tok := strings.TrimSpace(line); tok != "" {
-					fenceTok = tok
-				}
-			} else {
-				inFence = false
-				fenceTok = "```"
-			}
-		}
-	}
-	if len(chunk) > 0 {
-		out = append(out, strings.Join(chunk, "\n"))
-	}
-	return out
 }

--- a/server/internal/gateway/channel/slack/textcodec_test.go
+++ b/server/internal/gateway/channel/slack/textcodec_test.go
@@ -3,6 +3,8 @@ package slack
 import (
 	"strings"
 	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel"
 )
 
 func TestFormat_MarkdownToMrkdwn(t *testing.T) {
@@ -66,7 +68,7 @@ func TestTruncate_ShortTextSingleChunk(t *testing.T) {
 // as broken code.
 func TestSplitPreservingFences(t *testing.T) {
 	text := "intro line\n```go\nL1\nL2\nL3\nL4\nL5\n```\noutro"
-	chunks := splitPreservingFences(text, 20)
+	chunks := channel.SplitPreservingFences(text, 20)
 	if len(chunks) < 2 {
 		t.Fatalf("expected multiple chunks, got %d", len(chunks))
 	}

--- a/server/internal/gateway/channel/teams/textcodec.go
+++ b/server/internal/gateway/channel/teams/textcodec.go
@@ -51,7 +51,7 @@ func (c *Channel) Format(text string) string {
 // Truncate splits text into chunks within Teams' per-message budget, preserving
 // fenced code blocks so neither half of a split renders as broken code.
 func (c *Channel) Truncate(text string) []string {
-	return splitPreservingFences(text, teamsMaxMessageLen)
+	return channel.SplitPreservingFences(text, teamsMaxMessageLen)
 }
 
 // ExtractMedia pulls Markdown image references (![alt](url)) out of the text,
@@ -78,66 +78,4 @@ func (c *Channel) ExtractMedia(text string) ([]channel.Media, string) {
 // isFence reports whether a line opens or closes a Markdown code fence.
 func isFence(line string) bool {
 	return strings.HasPrefix(strings.TrimSpace(line), "```")
-}
-
-// runeLen counts runes (Teams limits are character/rune based, not bytes).
-func runeLen(s string) int { return len([]rune(s)) }
-
-// splitPreservingFences splits text into ≤limit-rune chunks on line boundaries,
-// keeping fenced code blocks valid across a split (a chunk that ends mid-fence
-// is closed, and the next chunk reopened, with a fence token).
-func splitPreservingFences(text string, limit int) []string {
-	if runeLen(text) <= limit {
-		return []string{text}
-	}
-	srcLines := strings.Split(text, "\n")
-
-	var (
-		out      []string
-		chunk    []string
-		chunkLen int
-		inFence  bool
-		fenceTok = "```"
-	)
-
-	flush := func() {
-		if len(chunk) == 0 {
-			return
-		}
-		body := chunk
-		if inFence {
-			body = append(append([]string(nil), chunk...), fenceTok)
-		}
-		out = append(out, strings.Join(body, "\n"))
-		chunk = nil
-		chunkLen = 0
-		if inFence {
-			chunk = append(chunk, fenceTok)
-			chunkLen = runeLen(fenceTok) + 1
-		}
-	}
-
-	for _, line := range srcLines {
-		add := runeLen(line) + 1 // +1 for the joining newline
-		if chunkLen+add > limit && len(chunk) > 0 {
-			flush()
-		}
-		chunk = append(chunk, line)
-		chunkLen += add
-		if isFence(line) {
-			if !inFence {
-				inFence = true
-				if tok := strings.TrimSpace(line); tok != "" {
-					fenceTok = tok
-				}
-			} else {
-				inFence = false
-				fenceTok = "```"
-			}
-		}
-	}
-	if len(chunk) > 0 {
-		out = append(out, strings.Join(chunk, "\n"))
-	}
-	return out
 }

--- a/server/internal/gateway/channel/textcodec.go
+++ b/server/internal/gateway/channel/textcodec.go
@@ -1,5 +1,7 @@
 package channel
 
+import "strings"
+
 // TextCodec is an optional sub-interface for platform-aware text formatting
 // and length-bounded splitting. Each platform has a different markup dialect
 // and character cap, so the driver delegates formatting to the adapter.
@@ -20,4 +22,68 @@ type Media struct {
 	Kind string // "image" | "file" | "video"
 	URL  string
 	Key  string
+}
+
+// SplitPreservingFences splits text into ≤limit-rune chunks on line boundaries,
+// keeping fenced code blocks valid across a split (a chunk that ends mid-fence
+// is closed, and the next chunk reopened, with a fence token).
+func SplitPreservingFences(text string, limit int) []string {
+	runeLen := func(s string) int { return len([]rune(s)) }
+	isFence := func(line string) bool {
+		return strings.HasPrefix(strings.TrimSpace(line), "```")
+	}
+
+	if runeLen(text) <= limit {
+		return []string{text}
+	}
+	srcLines := strings.Split(text, "\n")
+
+	var (
+		out      []string
+		chunk    []string
+		chunkLen int
+		inFence  bool
+		fenceTok = "```"
+	)
+
+	flush := func() {
+		if len(chunk) == 0 {
+			return
+		}
+		body := chunk
+		if inFence {
+			body = append(append([]string(nil), chunk...), fenceTok)
+		}
+		out = append(out, strings.Join(body, "\n"))
+		chunk = nil
+		chunkLen = 0
+		if inFence {
+			chunk = append(chunk, fenceTok)
+			chunkLen = runeLen(fenceTok) + 1
+		}
+	}
+
+	for _, line := range srcLines {
+		add := runeLen(line) + 1 // +1 for the joining newline
+		if chunkLen+add > limit && len(chunk) > 0 {
+			flush()
+		}
+		chunk = append(chunk, line)
+		chunkLen += add
+		if isFence(line) {
+			if !inFence {
+				inFence = true
+				if tok := strings.TrimSpace(line); tok != "" {
+					fenceTok = tok
+				}
+			} else {
+				inFence = false
+				fenceTok = "```"
+			}
+		}
+	}
+	if len(chunk) > 0 {
+		out = append(out, strings.Join(chunk, "\n"))
+	}
+	return out
 }


### PR DESCRIPTION
## Summary
- move the identical Discord, Slack, and Teams fenced-text splitter into the shared channel package
- keep each adapter's message limit and formatting behavior unchanged
- update direct splitter tests to call the shared implementation

## Validation
- `go test ./server/internal/gateway/channel/discord`
- `go test ./server/internal/gateway/channel/slack`
- `go test ./server/internal/gateway/channel/teams`
- `go test ./server/internal/gateway/...`
- `git diff --check`

Net: 78 insertions, 192 deletions (114 lines removed).

Per request, full `make check` was not run.