### PR TITLE
Deduplicate tolerant JSONB slot decoding

### DIFF
--- a/server/internal/store/jsonb_decode.go
+++ b/server/internal/store/jsonb_decode.go
@@ -1,0 +1,20 @@
+package store
+
+import "encoding/json"
+
+func decodeJSONBValue[T any](raw any) T {
+	var value T
+	switch raw := raw.(type) {
+	case nil:
+		return value
+	case []byte:
+		_ = json.Unmarshal(raw, &value)
+	case string:
+		_ = json.Unmarshal([]byte(raw), &value)
+	default:
+		if data, err := json.Marshal(raw); err == nil {
+			_ = json.Unmarshal(data, &value)
+		}
+	}
+	return value
+}

--- a/server/internal/store/jsonb_decode_test.go
+++ b/server/internal/store/jsonb_decode_test.go
@@ -1,0 +1,39 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDecodeJSONBValue(t *testing.T) {
+	type decodedValue struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+
+	tests := []struct {
+		name string
+		raw  any
+		want decodedValue
+	}{
+		{name: "nil", raw: nil},
+		{name: "bytes", raw: []byte(`{"name":"bytes","count":1}`), want: decodedValue{Name: "bytes", Count: 1}},
+		{name: "string", raw: `{"name":"string","count":2}`, want: decodedValue{Name: "string", Count: 2}},
+		{name: "map", raw: map[string]any{"name": "map", "count": 3}, want: decodedValue{Name: "map", Count: 3}},
+		{name: "malformed JSON", raw: []byte(`{"name":`)},
+		{name: "marshal failure", raw: make(chan int)},
+		{
+			name: "partial decode",
+			raw:  []byte(`{"name":"preserved","count":"invalid"}`),
+			want: decodedValue{Name: "preserved"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := decodeJSONBValue[decodedValue](test.raw); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("decodeJSONBValue() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/server/internal/store/pending_credential_form.go
+++ b/server/internal/store/pending_credential_form.go
@@ -313,23 +313,6 @@ func (s *Store) CountStalePendingCredentialFormSlots(ctx context.Context, cutoff
 	return n, nil
 }
 
-// decodePendingCredentialFormSlot mirrors decodeWorkingSlot /
-// decodePermissionSlot in store_inflight.go: tolerant of nil / []byte
-// / string / map[string]any (pgx may decode jsonb to any of these
-// shapes depending on driver internals).
 func decodePendingCredentialFormSlot(raw any) PendingCredentialFormSlot {
-	var slot PendingCredentialFormSlot
-	switch v := raw.(type) {
-	case nil:
-		return slot
-	case []byte:
-		_ = json.Unmarshal(v, &slot)
-	case string:
-		_ = json.Unmarshal([]byte(v), &slot)
-	default:
-		if data, err := json.Marshal(v); err == nil {
-			_ = json.Unmarshal(data, &slot)
-		}
-	}
-	return slot
+	return decodeJSONBValue[PendingCredentialFormSlot](raw)
 }

--- a/server/internal/store/store_inflight.go
+++ b/server/internal/store/store_inflight.go
@@ -782,59 +782,16 @@ func (s *Store) StampQueueCardSent(ctx context.Context, runID string, now time.T
 
 // ----- private helpers -----
 
-// decodeWorkingSlot turns jsonb opaque returned from sqlc into a typed
-// slot. Tolerant of missing/empty input.
 func decodeWorkingSlot(raw any) WorkingInflightSlot {
-	var slot WorkingInflightSlot
-	switch v := raw.(type) {
-	case nil:
-		return slot
-	case []byte:
-		_ = json.Unmarshal(v, &slot)
-	case string:
-		_ = json.Unmarshal([]byte(v), &slot)
-	default:
-		// jsonb sometimes lands as map[string]any when the driver
-		// decodes ahead of us; re-marshal to use json struct tags.
-		if data, err := json.Marshal(v); err == nil {
-			_ = json.Unmarshal(data, &slot)
-		}
-	}
-	return slot
+	return decodeJSONBValue[WorkingInflightSlot](raw)
 }
 
 func decodePermissionSlot(raw any) PermissionInflightSlot {
-	var slot PermissionInflightSlot
-	switch v := raw.(type) {
-	case nil:
-		return slot
-	case []byte:
-		_ = json.Unmarshal(v, &slot)
-	case string:
-		_ = json.Unmarshal([]byte(v), &slot)
-	default:
-		if data, err := json.Marshal(v); err == nil {
-			_ = json.Unmarshal(data, &slot)
-		}
-	}
-	return slot
+	return decodeJSONBValue[PermissionInflightSlot](raw)
 }
 
 func decodePromptForUserChoiceSlot(raw any) PromptForUserChoiceInflightSlot {
-	var slot PromptForUserChoiceInflightSlot
-	switch v := raw.(type) {
-	case nil:
-		return slot
-	case []byte:
-		_ = json.Unmarshal(v, &slot)
-	case string:
-		_ = json.Unmarshal([]byte(v), &slot)
-	default:
-		if data, err := json.Marshal(v); err == nil {
-			_ = json.Unmarshal(data, &slot)
-		}
-	}
-	return slot
+	return decodeJSONBValue[PromptForUserChoiceInflightSlot](raw)
 }
 
 // Keep the pgtype import live.


### PR DESCRIPTION
## Summary

- centralize tolerant JSONB decoding for inflight and pending credential slots
- preserve nil, byte, string, pre-decoded value, ignored-error, and partial-decode semantics
- add table-driven contract coverage for all supported and malformed input shapes

## Validation

- `go test ./server/internal/store -run 'TestDecodeJSONBValue|Inflight|PendingCredentialForm' -count=3`
- `go test ./server/internal/store`
- `go test ./server/internal/store -run '^TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation$' -count=3`
- `git diff --check`
- `make check` *(only the known order-dependent `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation` failed; it passes independently three times as shown above)*
