### PR TITLE
test: share Slack and Discord credential resolver contract

### DIFF
--- a/server/internal/gateway/channel/discord/credentials_test.go
+++ b/server/internal/gateway/channel/discord/credentials_test.go
@@ -6,11 +6,9 @@ import (
 	"testing"
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel/testutil"
 )
 
-// fakeSecretLookup stands in for the store: it returns a canned secret for one
-// guild and a not-found error for everything else, recording the guild it was
-// asked about so the test can assert the resolver forwarded the right key.
 type fakeSecretLookup struct {
 	byGuild map[string]DiscordBotSecret
 	asked   string
@@ -18,136 +16,32 @@ type fakeSecretLookup struct {
 
 func (f *fakeSecretLookup) ResolveDiscordBotSecretByGuild(_ context.Context, guildID string) (DiscordBotSecret, error) {
 	f.asked = guildID
-	if s, ok := f.byGuild[guildID]; ok {
-		return s, nil
+	if secret, ok := f.byGuild[guildID]; ok {
+		return secret, nil
 	}
 	return DiscordBotSecret{}, errors.New("no discord_bot secret for guild " + guildID)
 }
 
-// fakeDecrypter maps an opaque envelope back to a cleartext payload by string
-// key, so the resolver's payload→token extraction is exercised without real
-// AES-GCM. A decryptErr forces the decrypt-failure branch.
-type fakeDecrypter struct {
-	payloads   map[string]map[string]any
-	decryptErr error
+func TestDBCredentialResolverContract(t *testing.T) {
+	testutil.RunCredentialResolverContract(t, testutil.CredentialResolverContract{
+		Platform:      "discord",
+		Tenant:        "G_ACME",
+		UnknownTenant: "G_UNKNOWN",
+		NoAppTenant:   "G_NOAPP",
+		BadTenant:     "G_BAD",
+		EmptyTenant:   "G_EMPTY",
+		ResolvedToken: "bot-acme-123",
+		FallbackToken: "bot-env-default",
+		NewResolver: func(secrets map[string]testutil.CredentialSecret, decrypter *testutil.FakeDecrypter, fallback channel.CredentialResolver) (channel.CredentialResolver, func() string) {
+			lookup := &fakeSecretLookup{byGuild: make(map[string]DiscordBotSecret, len(secrets))}
+			for guildID, secret := range secrets {
+				lookup.byGuild[guildID] = DiscordBotSecret(secret)
+			}
+			return NewDBCredentialResolver(lookup, decrypter, fallback), func() string { return lookup.asked }
+		},
+		NewFallback:  NewStaticCredentialResolver,
+		MissingToken: errNoBotToken,
+	})
 }
 
-func (f *fakeDecrypter) Decrypt(envelope []byte) (map[string]any, error) {
-	if f.decryptErr != nil {
-		return nil, f.decryptErr
-	}
-	if p, ok := f.payloads[string(envelope)]; ok {
-		return p, nil
-	}
-	return map[string]any{}, nil
-}
-
-func TestDBCredentialResolver_ResolvesPerGuildToken(t *testing.T) {
-	lookup := &fakeSecretLookup{byGuild: map[string]DiscordBotSecret{
-		"G_ACME": {AppID: "A_ACME", EncryptedPayload: []byte("env-acme")},
-	}}
-	dec := &fakeDecrypter{payloads: map[string]map[string]any{
-		"env-acme": {"token": "bot-acme-123"},
-	}}
-	r := NewDBCredentialResolver(lookup, dec, nil)
-
-	cred, err := r.Resolve(context.Background(), "G_ACME")
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if lookup.asked != "G_ACME" {
-		t.Errorf("lookup asked for guild %q, want G_ACME", lookup.asked)
-	}
-	if cred.AppSecret != "bot-acme-123" {
-		t.Errorf("token = %q, want bot-acme-123", cred.AppSecret)
-	}
-	if cred.AppID != "A_ACME" {
-		t.Errorf("app id = %q, want A_ACME (from secret metadata)", cred.AppID)
-	}
-}
-
-func TestDBCredentialResolver_AppIDFallsBackToGuild(t *testing.T) {
-	lookup := &fakeSecretLookup{byGuild: map[string]DiscordBotSecret{
-		"G_NOAPP": {EncryptedPayload: []byte("env-noapp")},
-	}}
-	dec := &fakeDecrypter{payloads: map[string]map[string]any{
-		"env-noapp": {"access_token": "bot-noapp"},
-	}}
-	cred, err := NewDBCredentialResolver(lookup, dec, nil).Resolve(context.Background(), "G_NOAPP")
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if cred.AppID != "G_NOAPP" {
-		t.Errorf("app id = %q, want the guild id as fallback", cred.AppID)
-	}
-	if cred.AppSecret != "bot-noapp" {
-		t.Errorf("token = %q, want bot-noapp (access_token key)", cred.AppSecret)
-	}
-}
-
-func TestDBCredentialResolver_UnknownGuildFallsBackToStatic(t *testing.T) {
-	lookup := &fakeSecretLookup{byGuild: map[string]DiscordBotSecret{}} // every guild misses
-	dec := &fakeDecrypter{}
-	fallback := NewStaticCredentialResolver("A_ENV", "bot-env-default")
-	r := NewDBCredentialResolver(lookup, dec, fallback)
-
-	cred, err := r.Resolve(context.Background(), "G_UNKNOWN")
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if cred.AppSecret != "bot-env-default" {
-		t.Errorf("token = %q, want the static env fallback", cred.AppSecret)
-	}
-}
-
-func TestDBCredentialResolver_EmptyGuildUsesFallback(t *testing.T) {
-	lookup := &fakeSecretLookup{byGuild: map[string]DiscordBotSecret{}}
-	r := NewDBCredentialResolver(lookup, &fakeDecrypter{}, NewStaticCredentialResolver("A_ENV", "bot-env"))
-
-	cred, err := r.Resolve(context.Background(), "")
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if cred.AppSecret != "bot-env" {
-		t.Errorf("token = %q, want fallback for empty guild", cred.AppSecret)
-	}
-	if lookup.asked != "" {
-		t.Errorf("empty guild must not hit the store; asked %q", lookup.asked)
-	}
-}
-
-func TestDBCredentialResolver_NoFallbackNoGuildErrors(t *testing.T) {
-	r := NewDBCredentialResolver(&fakeSecretLookup{byGuild: map[string]DiscordBotSecret{}}, &fakeDecrypter{}, nil)
-	if _, err := r.Resolve(context.Background(), ""); !errors.Is(err, errNoBotToken) {
-		t.Fatalf("Resolve(empty, nil fallback) err = %v, want errNoBotToken", err)
-	}
-}
-
-func TestDBCredentialResolver_DecryptFailureSurfaces(t *testing.T) {
-	lookup := &fakeSecretLookup{byGuild: map[string]DiscordBotSecret{
-		"G_BAD": {EncryptedPayload: []byte("corrupt")},
-	}}
-	dec := &fakeDecrypter{decryptErr: errors.New("gcm: message authentication failed")}
-	// A decrypt failure is a real misconfiguration (wrong master key) — it must
-	// NOT silently fall back to the static token.
-	r := NewDBCredentialResolver(lookup, dec, NewStaticCredentialResolver("A", "bot-should-not-be-used"))
-	if _, err := r.Resolve(context.Background(), "G_BAD"); err == nil {
-		t.Fatal("Resolve must surface a decrypt failure, not fall back")
-	}
-}
-
-func TestDBCredentialResolver_EmptyTokenValueErrors(t *testing.T) {
-	lookup := &fakeSecretLookup{byGuild: map[string]DiscordBotSecret{
-		"G_EMPTY": {EncryptedPayload: []byte("env-empty")},
-	}}
-	dec := &fakeDecrypter{payloads: map[string]map[string]any{
-		"env-empty": {"unrelated": "value"}, // no token-shaped key
-	}}
-	r := NewDBCredentialResolver(lookup, dec, nil)
-	if _, err := r.Resolve(context.Background(), "G_EMPTY"); err == nil {
-		t.Fatal("a discord_bot secret with no token value must error")
-	}
-}
-
-// compile-time guard: the static fallback resolver still satisfies the contract.
 var _ channel.CredentialResolver = NewStaticCredentialResolver("", "")

--- a/server/internal/gateway/channel/slack/credentials_test.go
+++ b/server/internal/gateway/channel/slack/credentials_test.go
@@ -6,11 +6,9 @@ import (
 	"testing"
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel/testutil"
 )
 
-// fakeSecretLookup stands in for the store: it returns a canned secret for one
-// team and a not-found error for everything else, recording the team it was
-// asked about so the test can assert the resolver forwarded the right key.
 type fakeSecretLookup struct {
 	byTeam map[string]SlackBotSecret
 	asked  string
@@ -18,141 +16,32 @@ type fakeSecretLookup struct {
 
 func (f *fakeSecretLookup) ResolveSlackBotSecretByTeam(_ context.Context, teamID string) (SlackBotSecret, error) {
 	f.asked = teamID
-	if s, ok := f.byTeam[teamID]; ok {
-		return s, nil
+	if secret, ok := f.byTeam[teamID]; ok {
+		return secret, nil
 	}
 	return SlackBotSecret{}, errors.New("no slack_bot secret for team " + teamID)
 }
 
-// fakeDecrypter maps an opaque envelope back to a cleartext payload by string
-// key, so the resolver's payload→token extraction is exercised without real
-// AES-GCM. A decryptErr forces the decrypt-failure branch.
-type fakeDecrypter struct {
-	payloads   map[string]map[string]any
-	decryptErr error
+func TestDBCredentialResolverContract(t *testing.T) {
+	testutil.RunCredentialResolverContract(t, testutil.CredentialResolverContract{
+		Platform:      "slack",
+		Tenant:        "T_ACME",
+		UnknownTenant: "T_UNKNOWN",
+		NoAppTenant:   "T_NOAPP",
+		BadTenant:     "T_BAD",
+		EmptyTenant:   "T_EMPTY",
+		ResolvedToken: "xoxb-acme-123",
+		FallbackToken: "xoxb-env-default",
+		NewResolver: func(secrets map[string]testutil.CredentialSecret, decrypter *testutil.FakeDecrypter, fallback channel.CredentialResolver) (channel.CredentialResolver, func() string) {
+			lookup := &fakeSecretLookup{byTeam: make(map[string]SlackBotSecret, len(secrets))}
+			for teamID, secret := range secrets {
+				lookup.byTeam[teamID] = SlackBotSecret(secret)
+			}
+			return NewDBCredentialResolver(lookup, decrypter, fallback), func() string { return lookup.asked }
+		},
+		NewFallback:  NewStaticCredentialResolver,
+		MissingToken: errNoBotToken,
+	})
 }
 
-func (f *fakeDecrypter) Decrypt(envelope []byte) (map[string]any, error) {
-	if f.decryptErr != nil {
-		return nil, f.decryptErr
-	}
-	if p, ok := f.payloads[string(envelope)]; ok {
-		return p, nil
-	}
-	return map[string]any{}, nil
-}
-
-func TestDBCredentialResolver_ResolvesPerTeamToken(t *testing.T) {
-	lookup := &fakeSecretLookup{byTeam: map[string]SlackBotSecret{
-		"T_ACME": {AppID: "A_ACME", EncryptedPayload: []byte("env-acme")},
-	}}
-	dec := &fakeDecrypter{payloads: map[string]map[string]any{
-		"env-acme": {"token": "xoxb-acme-123"},
-	}}
-	r := NewDBCredentialResolver(lookup, dec, nil)
-
-	cred, err := r.Resolve(context.Background(), "T_ACME")
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if lookup.asked != "T_ACME" {
-		t.Errorf("lookup asked for team %q, want T_ACME", lookup.asked)
-	}
-	if cred.AppSecret != "xoxb-acme-123" {
-		t.Errorf("token = %q, want xoxb-acme-123", cred.AppSecret)
-	}
-	if cred.AppID != "A_ACME" {
-		t.Errorf("app id = %q, want A_ACME (from secret metadata)", cred.AppID)
-	}
-}
-
-func TestDBCredentialResolver_AppIDFallsBackToTeam(t *testing.T) {
-	// A secret authored without an app_id in metadata still resolves; the
-	// team id stands in as the neutral bot id.
-	lookup := &fakeSecretLookup{byTeam: map[string]SlackBotSecret{
-		"T_NOAPP": {EncryptedPayload: []byte("env-noapp")},
-	}}
-	dec := &fakeDecrypter{payloads: map[string]map[string]any{
-		"env-noapp": {"access_token": "xoxb-noapp"},
-	}}
-	cred, err := NewDBCredentialResolver(lookup, dec, nil).Resolve(context.Background(), "T_NOAPP")
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if cred.AppID != "T_NOAPP" {
-		t.Errorf("app id = %q, want the team id as fallback", cred.AppID)
-	}
-	if cred.AppSecret != "xoxb-noapp" {
-		t.Errorf("token = %q, want xoxb-noapp (access_token key)", cred.AppSecret)
-	}
-}
-
-func TestDBCredentialResolver_UnknownTeamFallsBackToStatic(t *testing.T) {
-	lookup := &fakeSecretLookup{byTeam: map[string]SlackBotSecret{}} // every team misses
-	dec := &fakeDecrypter{}
-	fallback := NewStaticCredentialResolver("A_ENV", "xoxb-env-default")
-	r := NewDBCredentialResolver(lookup, dec, fallback)
-
-	cred, err := r.Resolve(context.Background(), "T_UNKNOWN")
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if cred.AppSecret != "xoxb-env-default" {
-		t.Errorf("token = %q, want the static env fallback", cred.AppSecret)
-	}
-}
-
-func TestDBCredentialResolver_EmptyTeamUsesFallback(t *testing.T) {
-	lookup := &fakeSecretLookup{byTeam: map[string]SlackBotSecret{}}
-	r := NewDBCredentialResolver(lookup, &fakeDecrypter{}, NewStaticCredentialResolver("A_ENV", "xoxb-env"))
-
-	cred, err := r.Resolve(context.Background(), "")
-	if err != nil {
-		t.Fatalf("Resolve: %v", err)
-	}
-	if cred.AppSecret != "xoxb-env" {
-		t.Errorf("token = %q, want fallback for empty team", cred.AppSecret)
-	}
-	if lookup.asked != "" {
-		t.Errorf("empty team must not hit the store; asked %q", lookup.asked)
-	}
-}
-
-func TestDBCredentialResolver_NoFallbackNoTeamErrors(t *testing.T) {
-	// DB-only deployment with no env token: an empty team has nothing to
-	// resolve, so the missing-token error surfaces rather than a silent send.
-	r := NewDBCredentialResolver(&fakeSecretLookup{byTeam: map[string]SlackBotSecret{}}, &fakeDecrypter{}, nil)
-	if _, err := r.Resolve(context.Background(), ""); !errors.Is(err, errNoBotToken) {
-		t.Fatalf("Resolve(empty, nil fallback) err = %v, want errNoBotToken", err)
-	}
-}
-
-func TestDBCredentialResolver_DecryptFailureSurfaces(t *testing.T) {
-	lookup := &fakeSecretLookup{byTeam: map[string]SlackBotSecret{
-		"T_BAD": {EncryptedPayload: []byte("corrupt")},
-	}}
-	dec := &fakeDecrypter{decryptErr: errors.New("gcm: message authentication failed")}
-	// A decrypt failure is a real misconfiguration (wrong master key) — it must
-	// NOT silently fall back to the static token, so we pass a fallback and
-	// assert it is not used.
-	r := NewDBCredentialResolver(lookup, dec, NewStaticCredentialResolver("A", "xoxb-should-not-be-used"))
-	if _, err := r.Resolve(context.Background(), "T_BAD"); err == nil {
-		t.Fatal("Resolve must surface a decrypt failure, not fall back")
-	}
-}
-
-func TestDBCredentialResolver_EmptyTokenValueErrors(t *testing.T) {
-	lookup := &fakeSecretLookup{byTeam: map[string]SlackBotSecret{
-		"T_EMPTY": {EncryptedPayload: []byte("env-empty")},
-	}}
-	dec := &fakeDecrypter{payloads: map[string]map[string]any{
-		"env-empty": {"unrelated": "value"}, // no token-shaped key
-	}}
-	r := NewDBCredentialResolver(lookup, dec, nil)
-	if _, err := r.Resolve(context.Background(), "T_EMPTY"); err == nil {
-		t.Fatal("a slack_bot secret with no token value must error")
-	}
-}
-
-// compile-time guard: the static fallback resolver still satisfies the contract.
 var _ channel.CredentialResolver = NewStaticCredentialResolver("", "")

--- a/server/internal/gateway/channel/testutil/credential_resolver_contract.go
+++ b/server/internal/gateway/channel/testutil/credential_resolver_contract.go
@@ -1,0 +1,148 @@
+package testutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel"
+)
+
+type CredentialSecret struct {
+	AppID            string
+	EncryptedPayload []byte
+}
+
+type CredentialResolverContract struct {
+	Platform      string
+	Tenant        string
+	UnknownTenant string
+	NoAppTenant   string
+	BadTenant     string
+	EmptyTenant   string
+	ResolvedToken string
+	FallbackToken string
+	NewResolver   func(map[string]CredentialSecret, *FakeDecrypter, channel.CredentialResolver) (channel.CredentialResolver, func() string)
+	NewFallback   func(string, string) channel.CredentialResolver
+	MissingToken  error
+}
+
+type FakeDecrypter struct {
+	Payloads   map[string]map[string]any
+	DecryptErr error
+}
+
+func (f *FakeDecrypter) Decrypt(envelope []byte) (map[string]any, error) {
+	if f.DecryptErr != nil {
+		return nil, f.DecryptErr
+	}
+	if payload, ok := f.Payloads[string(envelope)]; ok {
+		return payload, nil
+	}
+	return map[string]any{}, nil
+}
+
+func RunCredentialResolverContract(t *testing.T, contract CredentialResolverContract) {
+	t.Helper()
+
+	t.Run("resolves tenant token", func(t *testing.T) {
+		resolver, asked := contract.NewResolver(map[string]CredentialSecret{
+			contract.Tenant: {AppID: "A_ACME", EncryptedPayload: []byte("env-acme")},
+		}, &FakeDecrypter{Payloads: map[string]map[string]any{
+			"env-acme": {"token": contract.ResolvedToken},
+		}}, nil)
+
+		credential, err := resolver.Resolve(context.Background(), contract.Tenant)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		assertLookupKey(t, asked, contract.Tenant)
+		if credential.AppSecret != contract.ResolvedToken {
+			t.Errorf("token = %q, want %q", credential.AppSecret, contract.ResolvedToken)
+		}
+		if credential.AppID != "A_ACME" {
+			t.Errorf("app id = %q, want A_ACME", credential.AppID)
+		}
+	})
+
+	t.Run("app id falls back to tenant", func(t *testing.T) {
+		resolver, asked := contract.NewResolver(map[string]CredentialSecret{
+			contract.NoAppTenant: {EncryptedPayload: []byte("env-noapp")},
+		}, &FakeDecrypter{Payloads: map[string]map[string]any{
+			"env-noapp": {"access_token": "token-noapp"},
+		}}, nil)
+
+		credential, err := resolver.Resolve(context.Background(), contract.NoAppTenant)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		assertLookupKey(t, asked, contract.NoAppTenant)
+		if credential.AppID != contract.NoAppTenant {
+			t.Errorf("app id = %q, want tenant id %q", credential.AppID, contract.NoAppTenant)
+		}
+		if credential.AppSecret != "token-noapp" {
+			t.Errorf("token = %q, want token-noapp", credential.AppSecret)
+		}
+	})
+
+	t.Run("unknown tenant falls back to static", func(t *testing.T) {
+		resolver, asked := contract.NewResolver(nil, &FakeDecrypter{}, contract.NewFallback("A_ENV", contract.FallbackToken))
+		credential, err := resolver.Resolve(context.Background(), contract.UnknownTenant)
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		assertLookupKey(t, asked, contract.UnknownTenant)
+		if credential.AppSecret != contract.FallbackToken {
+			t.Errorf("token = %q, want fallback %q", credential.AppSecret, contract.FallbackToken)
+		}
+	})
+
+	t.Run("empty tenant uses fallback without lookup", func(t *testing.T) {
+		resolver, asked := contract.NewResolver(nil, &FakeDecrypter{}, contract.NewFallback("A_ENV", contract.FallbackToken))
+		credential, err := resolver.Resolve(context.Background(), "")
+		if err != nil {
+			t.Fatalf("Resolve: %v", err)
+		}
+		assertLookupKey(t, asked, "")
+		if credential.AppSecret != contract.FallbackToken {
+			t.Errorf("token = %q, want fallback %q", credential.AppSecret, contract.FallbackToken)
+		}
+	})
+
+	t.Run("empty tenant without fallback errors", func(t *testing.T) {
+		resolver, asked := contract.NewResolver(nil, &FakeDecrypter{}, nil)
+		if _, err := resolver.Resolve(context.Background(), ""); !errors.Is(err, contract.MissingToken) {
+			t.Fatalf("Resolve(empty, nil fallback) err = %v, want %v", err, contract.MissingToken)
+		}
+		assertLookupKey(t, asked, "")
+	})
+
+	t.Run("decrypt failure surfaces", func(t *testing.T) {
+		resolver, asked := contract.NewResolver(map[string]CredentialSecret{
+			contract.BadTenant: {EncryptedPayload: []byte("corrupt")},
+		}, &FakeDecrypter{DecryptErr: errors.New("gcm: message authentication failed")}, contract.NewFallback("A", "must-not-be-used"))
+		if _, err := resolver.Resolve(context.Background(), contract.BadTenant); err == nil {
+			t.Fatal("Resolve must surface a decrypt failure, not fall back")
+		}
+		assertLookupKey(t, asked, contract.BadTenant)
+	})
+
+	t.Run("empty token value errors", func(t *testing.T) {
+		resolver, asked := contract.NewResolver(map[string]CredentialSecret{
+			contract.EmptyTenant: {EncryptedPayload: []byte("env-empty")},
+		}, &FakeDecrypter{Payloads: map[string]map[string]any{
+			"env-empty": {"unrelated": "value"},
+		}}, nil)
+		if _, err := resolver.Resolve(context.Background(), contract.EmptyTenant); err == nil {
+			t.Fatalf("a %s bot secret with no token value must error", contract.Platform)
+		}
+		assertLookupKey(t, asked, contract.EmptyTenant)
+	})
+}
+
+func assertLookupKey(t *testing.T, asked func() string, want string) {
+	t.Helper()
+	if got := asked(); got != want {
+		t.Errorf("lookup key = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- share the seven Slack and Discord DB credential resolver scenarios through a typed test contract
- keep platform-specific adapters responsible for Slack team and Discord guild lookup types
- assert the exact platform lookup key in every scenario that should query the store, and assert no lookup for empty tenant IDs
- leave production files unchanged

## Size

- 194 insertions, 263 deletions
- net 69 lines removed

## Validation

- `go test ./server/internal/gateway/channel/slack -run Credential -count=3`
- `go test ./server/internal/gateway/channel/discord -run Credential -count=3`
- `go test ./server/internal/gateway/channel/...`
- `git diff --check`
- `make check` reached the known order-dependent `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation` failure; that test passes independently with `go test ./server/internal/store -run TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation -count=3`
