### PR TITLE
Deduplicate SpecFragment row mappers

### DIFF
--- a/server/internal/store/spec_fragments.go
+++ b/server/internal/store/spec_fragments.go
@@ -240,66 +240,28 @@ func (s *Store) SoftDeleteSpecFragment(ctx context.Context, idRaw string, now ti
 }
 
 func specFragmentFromInsertRow(r sqlc.InsertSpecFragmentRow) SpecFragmentRead {
-	return SpecFragmentRead{
-		ID:          r.ID,
-		WorkspaceID: r.WorkspaceID,
-		Title:       r.Title,
-		Body:        r.Body,
-		Tags:        r.Tags,
-		Source:      r.Source,
-		CreatedBy:   pgUUIDString(r.CreatedBy),
-		AgentActor:  r.AgentActor,
-		CreatedAt:   pgTime(r.CreatedAt),
-		UpdatedAt:   pgTime(r.UpdatedAt),
-	}
+	return specFragmentFromRow(specFragmentRow(r))
 }
 
 func specFragmentFromGetRow(r sqlc.GetSpecFragmentRow) SpecFragmentRead {
-	return SpecFragmentRead{
-		ID:          r.ID,
-		WorkspaceID: r.WorkspaceID,
-		Title:       r.Title,
-		Body:        r.Body,
-		Tags:        r.Tags,
-		Source:      r.Source,
-		CreatedBy:   pgUUIDString(r.CreatedBy),
-		AgentActor:  r.AgentActor,
-		CreatedAt:   pgTime(r.CreatedAt),
-		UpdatedAt:   pgTime(r.UpdatedAt),
-	}
+	return specFragmentFromRow(specFragmentRow(r))
 }
 
 func specFragmentFromListRow(r sqlc.ListWorkspaceSpecFragmentsRow) SpecFragmentRead {
-	return SpecFragmentRead{
-		ID:          r.ID,
-		WorkspaceID: r.WorkspaceID,
-		Title:       r.Title,
-		Body:        r.Body,
-		Tags:        r.Tags,
-		Source:      r.Source,
-		CreatedBy:   pgUUIDString(r.CreatedBy),
-		AgentActor:  r.AgentActor,
-		CreatedAt:   pgTime(r.CreatedAt),
-		UpdatedAt:   pgTime(r.UpdatedAt),
-	}
+	return specFragmentFromRow(specFragmentRow(r))
 }
 
 func specFragmentFromListSinceRow(r sqlc.ListWorkspaceSpecFragmentsSinceRow) SpecFragmentRead {
-	return SpecFragmentRead{
-		ID:          r.ID,
-		WorkspaceID: r.WorkspaceID,
-		Title:       r.Title,
-		Body:        r.Body,
-		Tags:        r.Tags,
-		Source:      r.Source,
-		CreatedBy:   pgUUIDString(r.CreatedBy),
-		AgentActor:  r.AgentActor,
-		CreatedAt:   pgTime(r.CreatedAt),
-		UpdatedAt:   pgTime(r.UpdatedAt),
-	}
+	return specFragmentFromRow(specFragmentRow(r))
 }
 
 func specFragmentFromUpdateRow(r sqlc.UpdateSpecFragmentRow) SpecFragmentRead {
+	return specFragmentFromRow(specFragmentRow(r))
+}
+
+type specFragmentRow sqlc.GetSpecFragmentRow
+
+func specFragmentFromRow(r specFragmentRow) SpecFragmentRead {
 	return SpecFragmentRead{
 		ID:          r.ID,
 		WorkspaceID: r.WorkspaceID,

--- a/server/internal/store/spec_fragments_mapper_test.go
+++ b/server/internal/store/spec_fragments_mapper_test.go
@@ -1,0 +1,24 @@
+package store
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
+)
+
+func TestSpecFragmentRowMappers(t *testing.T) {
+	row := specFragmentRow{ID: "fragment-id", WorkspaceID: "workspace-id", Tags: []string{"tag"}}
+	expected := specFragmentFromRow(row)
+	for name, actual := range map[string]SpecFragmentRead{
+		"insert": specFragmentFromInsertRow(sqlc.InsertSpecFragmentRow(row)), "get": specFragmentFromGetRow(sqlc.GetSpecFragmentRow(row)),
+		"list": specFragmentFromListRow(sqlc.ListWorkspaceSpecFragmentsRow(row)), "list since": specFragmentFromListSinceRow(sqlc.ListWorkspaceSpecFragmentsSinceRow(row)),
+		"update": specFragmentFromUpdateRow(sqlc.UpdateSpecFragmentRow(row)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !reflect.DeepEqual(actual, expected) {
+				t.Errorf("mapper result = %#v, want %#v", actual, expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- route all five SpecFragment sqlc row conversions through one structural mapper
- retain named wrappers and explicit sqlc-to-local type conversions
- add focused equivalence coverage for insert, get, list, list-since, and update rows

## Validation

- `go test ./server/internal/store -run 'SpecFragment' -count=3`
- `go test ./server/internal/specmemory -count=3`
- `go test ./server/internal/api/specmem -count=3`
- `go test ./server/internal/store`
- `git diff --check`
- `make check` reached and passed all Go package tests, then hit the known dev PostgreSQL readiness race: migration attempted before the container accepted connections (`dial tcp 127.0.0.1:<port>: connect: connection refused`)
