### PR TITLE
test: share cross-platform text codec contract

### DIFF
--- a/server/internal/gateway/channel/discord/textcodec_test.go
+++ b/server/internal/gateway/channel/discord/textcodec_test.go
@@ -1,90 +1,26 @@
 package discord
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel"
+	channeltest "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel/testutil"
 )
 
-// TestFormat_PassThroughMarkdown asserts Discord's near-pass-through Format:
-// bold/italic/links/strikethrough are already Discord syntax and untouched;
-// only ATX headings fold to bold lines.
-func TestFormat_PassThroughMarkdown(t *testing.T) {
-	c := newTestChannel()
-	cases := []struct{ in, want string }{
-		{"**bold**", "**bold**"},
-		{"*italic*", "*italic*"},
-		{"~~strike~~", "~~strike~~"},
-		{"[t](http://x)", "[t](http://x)"},
-		{"`code`", "`code`"},
-		{"# Head", "**Head**"},
-		{"### Sub", "**Sub**"},
-		{"see [docs](http://d) and **bold**", "see [docs](http://d) and **bold**"},
-		{"plain text", "plain text"},
-	}
-	for _, tc := range cases {
-		if got := c.Format(tc.in); got != tc.want {
-			t.Errorf("Format(%q) = %q, want %q", tc.in, got, tc.want)
-		}
-	}
-}
-
-func TestFormat_LeavesFencedCodeUntouched(t *testing.T) {
-	c := newTestChannel()
-	in := "before\n```\n# not a heading\n```\nafter"
-	want := "before\n```\n# not a heading\n```\nafter"
-	if got := c.Format(in); got != want {
-		t.Errorf("Format with code fence\n got: %q\nwant: %q", got, want)
-	}
-}
-
-func TestExtractMedia(t *testing.T) {
-	c := newTestChannel()
-	media, rest := c.ExtractMedia("a ![alt](http://img/1.png) b")
-	if len(media) != 1 || media[0].URL != "http://img/1.png" || media[0].Kind != "image" {
-		t.Fatalf("media = %+v", media)
-	}
-	if strings.Contains(rest, "![") {
-		t.Errorf("rest still contains image syntax: %q", rest)
-	}
-
-	// Non-image link: text returned unchanged, no media (Discord renders links).
-	media, rest = c.ExtractMedia("just [a link](http://u) here")
-	if len(media) != 0 {
-		t.Errorf("non-image link must not be extracted, got %+v", media)
-	}
-	if rest != "just [a link](http://u) here" {
-		t.Errorf("rest = %q, want unchanged", rest)
-	}
-}
-
-func TestTruncate_ShortTextSingleChunk(t *testing.T) {
-	c := newTestChannel()
-	chunks := c.Truncate("short text")
-	if len(chunks) != 1 || chunks[0] != "short text" {
-		t.Fatalf("chunks = %#v, want single unchanged chunk", chunks)
-	}
-}
-
-// TestSplitPreservingFences forces a split inside a code fence and asserts each
-// chunk has balanced fences (even number of ``` lines) so neither half renders
-// as broken code.
-func TestSplitPreservingFences(t *testing.T) {
-	text := "intro line\n```go\nL1\nL2\nL3\nL4\nL5\n```\noutro"
-	chunks := channel.SplitPreservingFences(text, 20)
-	if len(chunks) < 2 {
-		t.Fatalf("expected multiple chunks, got %d", len(chunks))
-	}
-	for i, ch := range chunks {
-		fences := 0
-		for _, line := range strings.Split(ch, "\n") {
-			if isFence(line) {
-				fences++
-			}
-		}
-		if fences%2 != 0 {
-			t.Errorf("chunk %d has unbalanced fences (%d):\n%s", i, fences, ch)
-		}
-	}
+func TestTextCodec(t *testing.T) {
+	channeltest.RunTextCodecContract(t, channeltest.TextCodecContract{
+		Codec:    newTestChannel(),
+		MaxRunes: discordMaxMessageLen,
+		FormatCases: []channeltest.FormatCase{
+			{Name: "bold", Text: "**bold**", Want: "**bold**"},
+			{Name: "italic", Text: "*italic*", Want: "*italic*"},
+			{Name: "strike", Text: "~~strike~~", Want: "~~strike~~"},
+			{Name: "link", Text: "[t](http://x)", Want: "[t](http://x)"},
+			{Name: "inline code", Text: "`code`", Want: "`code`"},
+			{Name: "heading", Text: "# Head", Want: "**Head**"},
+			{Name: "subheading", Text: "### Sub", Want: "**Sub**"},
+			{Name: "mixed", Text: "see [docs](http://d) and **bold**", Want: "see [docs](http://d) and **bold**"},
+			{Name: "plain", Text: "plain text", Want: "plain text"},
+			{Name: "fenced code", Text: "before\n```\n# not a heading\n```\nafter", Want: "before\n```\n# not a heading\n```\nafter"},
+		},
+	})
 }

--- a/server/internal/gateway/channel/slack/textcodec_test.go
+++ b/server/internal/gateway/channel/slack/textcodec_test.go
@@ -1,86 +1,29 @@
 package slack
 
 import (
-	"strings"
 	"testing"
 
-	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel"
+	channeltest "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel/testutil"
 )
 
-func TestFormat_MarkdownToMrkdwn(t *testing.T) {
-	c := newTestChannel()
-	cases := []struct{ in, want string }{
-		{"**bold**", "*bold*"},
-		{"~~strike~~", "~strike~"},
-		{"[t](http://x)", "<http://x|t>"},
-		{"# Head", "*Head*"},
-		{"## Sub", "*Sub*"},
-		{"see [docs](http://d) and **bold**", "see <http://d|docs> and *bold*"},
-		{"[**t**](http://u)", "<http://u|*t*>"}, // link converted before bold
-		{"plain text", "plain text"},
-	}
-	for _, tc := range cases {
-		if got := c.Format(tc.in); got != tc.want {
-			t.Errorf("Format(%q) = %q, want %q", tc.in, got, tc.want)
-		}
-	}
-}
-
-func TestFormat_LeavesFencedCodeUntouched(t *testing.T) {
-	c := newTestChannel()
-	in := "before **b**\n```\n**not bold** [no](link)\n```\nafter [t](http://u)"
-	want := "before *b*\n```\n**not bold** [no](link)\n```\nafter <http://u|t>"
-	if got := c.Format(in); got != want {
-		t.Errorf("Format with code fence\n got: %q\nwant: %q", got, want)
-	}
-}
-
-func TestExtractMedia(t *testing.T) {
-	c := newTestChannel()
-	media, rest := c.ExtractMedia("a ![alt](http://img/1.png) b")
-	if len(media) != 1 || media[0].URL != "http://img/1.png" || media[0].Kind != "image" {
-		t.Fatalf("media = %+v", media)
-	}
-	if strings.Contains(rest, "![") {
-		t.Errorf("rest still contains image syntax: %q", rest)
-	}
-
-	// No image: text returned unchanged, no media.
-	media, rest = c.ExtractMedia("just [a link](http://u) here")
-	if len(media) != 0 {
-		t.Errorf("non-image link must not be extracted, got %+v", media)
-	}
-	if rest != "just [a link](http://u) here" {
-		t.Errorf("rest = %q, want unchanged", rest)
-	}
-}
-
-func TestTruncate_ShortTextSingleChunk(t *testing.T) {
-	c := newTestChannel()
-	chunks := c.Truncate("short text")
-	if len(chunks) != 1 || chunks[0] != "short text" {
-		t.Fatalf("chunks = %#v, want single unchanged chunk", chunks)
-	}
-}
-
-// TestSplitPreservingFences forces a split inside a code fence and asserts each
-// chunk has balanced fences (even number of ``` lines) so neither half renders
-// as broken code.
-func TestSplitPreservingFences(t *testing.T) {
-	text := "intro line\n```go\nL1\nL2\nL3\nL4\nL5\n```\noutro"
-	chunks := channel.SplitPreservingFences(text, 20)
-	if len(chunks) < 2 {
-		t.Fatalf("expected multiple chunks, got %d", len(chunks))
-	}
-	for i, ch := range chunks {
-		fences := 0
-		for _, line := range strings.Split(ch, "\n") {
-			if isFence(line) {
-				fences++
-			}
-		}
-		if fences%2 != 0 {
-			t.Errorf("chunk %d has unbalanced fences (%d):\n%s", i, fences, ch)
-		}
-	}
+func TestTextCodec(t *testing.T) {
+	channeltest.RunTextCodecContract(t, channeltest.TextCodecContract{
+		Codec:    newTestChannel(),
+		MaxRunes: slackMaxMessageLen,
+		FormatCases: []channeltest.FormatCase{
+			{Name: "bold", Text: "**bold**", Want: "*bold*"},
+			{Name: "strike", Text: "~~strike~~", Want: "~strike~"},
+			{Name: "link", Text: "[t](http://x)", Want: "<http://x|t>"},
+			{Name: "heading", Text: "# Head", Want: "*Head*"},
+			{Name: "subheading", Text: "## Sub", Want: "*Sub*"},
+			{Name: "mixed", Text: "see [docs](http://d) and **bold**", Want: "see <http://d|docs> and *bold*"},
+			{Name: "formatted link label", Text: "[**t**](http://u)", Want: "<http://u|*t*>"},
+			{Name: "plain", Text: "plain text", Want: "plain text"},
+			{
+				Name: "fenced code",
+				Text: "before **b**\n```\n**not bold** [no](link)\n```\nafter [t](http://u)",
+				Want: "before *b*\n```\n**not bold** [no](link)\n```\nafter <http://u|t>",
+			},
+		},
+	})
 }

--- a/server/internal/gateway/channel/teams/textcodec_test.go
+++ b/server/internal/gateway/channel/teams/textcodec_test.go
@@ -1,84 +1,20 @@
 package teams
 
 import (
-	"strings"
 	"testing"
+
+	channeltest "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel/testutil"
 )
 
-func TestFormat_HeadingsToBold(t *testing.T) {
-	in := "# Title\n## Sub\nplain **bold** line"
-	got := newTestChannel().Format(in)
-	if !strings.Contains(got, "**Title**") {
-		t.Errorf("H1 not bolded: %q", got)
-	}
-	if !strings.Contains(got, "**Sub**") {
-		t.Errorf("H2 not bolded: %q", got)
-	}
-	if !strings.Contains(got, "plain **bold** line") {
-		t.Errorf("non-heading line altered: %q", got)
-	}
-}
-
-func TestFormat_LeavesFencedCode(t *testing.T) {
-	in := "```\n# not a heading\n```"
-	got := newTestChannel().Format(in)
-	if !strings.Contains(got, "# not a heading") {
-		t.Errorf("a # inside a fence must not be bolded: %q", got)
-	}
-}
-
-func TestTruncate_ShortPassthrough(t *testing.T) {
-	got := newTestChannel().Truncate("short")
-	if len(got) != 1 || got[0] != "short" {
-		t.Errorf("short text must pass through as one chunk, got %v", got)
-	}
-}
-
-func TestTruncate_SplitsAndPreservesFences(t *testing.T) {
-	// Build a fenced block longer than the budget so the splitter must cut it
-	// and re-open the fence on the next chunk.
-	var b strings.Builder
-	b.WriteString("```go\n")
-	for range teamsMaxMessageLen {
-		b.WriteString("x")
-	}
-	b.WriteString("\nmore\n```")
-	chunks := newTestChannel().Truncate(b.String())
-	if len(chunks) < 2 {
-		t.Fatalf("expected a split, got %d chunk(s)", len(chunks))
-	}
-	// Every chunk must have balanced fences (an even count of ``` lines).
-	for i, ch := range chunks {
-		fences := strings.Count(ch, "```")
-		if fences%2 != 0 {
-			t.Errorf("chunk %d has unbalanced fences (%d ``` tokens)", i, fences)
-		}
-	}
-}
-
-func TestExtractMedia(t *testing.T) {
-	in := "before ![alt](https://img.test/a.png) after [link](https://x.test)"
-	media, rest := newTestChannel().ExtractMedia(in)
-	if len(media) != 1 {
-		t.Fatalf("expected 1 image, got %d", len(media))
-	}
-	if media[0].URL != "https://img.test/a.png" || media[0].Kind != "image" {
-		t.Errorf("media = %+v", media[0])
-	}
-	if strings.Contains(rest, "![alt]") {
-		t.Errorf("image syntax not removed: %q", rest)
-	}
-	if !strings.Contains(rest, "[link](https://x.test)") {
-		t.Errorf("non-image link must survive: %q", rest)
-	}
-}
-
-func TestExtractMedia_NoImages(t *testing.T) {
-	media, rest := newTestChannel().ExtractMedia("no images here")
-	if media != nil {
-		t.Errorf("expected nil media, got %v", media)
-	}
-	if rest != "no images here" {
-		t.Errorf("text altered: %q", rest)
-	}
+func TestTextCodec(t *testing.T) {
+	channeltest.RunTextCodecContract(t, channeltest.TextCodecContract{
+		Codec:    newTestChannel(),
+		MaxRunes: teamsMaxMessageLen,
+		FormatCases: []channeltest.FormatCase{
+			{Name: "heading", Text: "# Title", Want: "**Title**"},
+			{Name: "subheading", Text: "## Sub", Want: "**Sub**"},
+			{Name: "markdown passthrough", Text: "plain **bold** line", Want: "plain **bold** line"},
+			{Name: "fenced code", Text: "```\n# not a heading\n```", Want: "```\n# not a heading\n```"},
+		},
+	})
 }

--- a/server/internal/gateway/channel/testutil/text_codec_contract.go
+++ b/server/internal/gateway/channel/testutil/text_codec_contract.go
@@ -1,0 +1,87 @@
+package testutil
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel"
+)
+
+type FormatCase struct {
+	Name string
+	Text string
+	Want string
+}
+
+type TextCodecContract struct {
+	Codec       channel.TextCodec
+	MaxRunes    int
+	FormatCases []FormatCase
+}
+
+func RunTextCodecContract(t *testing.T, contract TextCodecContract) {
+	t.Helper()
+
+	t.Run("format", func(t *testing.T) {
+		for _, testCase := range contract.FormatCases {
+			t.Run(testCase.Name, func(t *testing.T) {
+				if got := contract.Codec.Format(testCase.Text); got != testCase.Want {
+					t.Errorf("Format(%q) = %q, want %q", testCase.Text, got, testCase.Want)
+				}
+			})
+		}
+	})
+
+	t.Run("short text remains one chunk", func(t *testing.T) {
+		chunks := contract.Codec.Truncate("short text")
+		if len(chunks) != 1 || chunks[0] != "short text" {
+			t.Fatalf("chunks = %#v, want single unchanged chunk", chunks)
+		}
+	})
+
+	t.Run("long fenced text preserves chunk contract", func(t *testing.T) {
+		line := strings.Repeat("x", min(80, contract.MaxRunes/4))
+		text := "intro\n```go\n" + strings.Repeat(line+"\n", contract.MaxRunes/len(line)+2) + "```\noutro"
+		chunks := contract.Codec.Truncate(text)
+		if len(chunks) < 2 {
+			t.Fatalf("expected multiple chunks, got %d", len(chunks))
+		}
+		for index, chunk := range chunks {
+			if utf8.RuneCountInString(chunk) > contract.MaxRunes {
+				t.Errorf("chunk %d has %d runes, limit %d", index, utf8.RuneCountInString(chunk), contract.MaxRunes)
+			}
+			if countFenceLines(chunk)%2 != 0 {
+				t.Errorf("chunk %d has unbalanced fences:\n%s", index, chunk)
+			}
+		}
+		if !strings.HasPrefix(chunks[1], "```go\n") {
+			t.Errorf("second chunk did not reopen the typed fence: %q", chunks[1])
+		}
+	})
+
+	t.Run("extract media", func(t *testing.T) {
+		media, rest := contract.Codec.ExtractMedia("before ![alt](https://img.test/a.png) after [link](https://x.test)")
+		if len(media) != 1 || media[0].Kind != "image" || media[0].URL != "https://img.test/a.png" {
+			t.Fatalf("media = %+v, want one image", media)
+		}
+		if strings.Contains(rest, "![alt]") || !strings.Contains(rest, "[link](https://x.test)") {
+			t.Errorf("remaining text = %q", rest)
+		}
+
+		media, rest = contract.Codec.ExtractMedia("no images here")
+		if media != nil || rest != "no images here" {
+			t.Errorf("no-image result = (%v, %q)", media, rest)
+		}
+	})
+}
+
+func countFenceLines(text string) int {
+	count := 0
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			count++
+		}
+	}
+	return count
+}


### PR DESCRIPTION
## Summary

- share one typed text codec contract across Slack, Discord, and Teams
- keep each platform's formatting cases and message limit explicit
- preserve media extraction, short-text passthrough, chunk limit, balanced fence, and typed fence reopen coverage
- change tests only; production codec code is untouched and does not overlap #128

## Size

- 141 additions, 235 deletions
- net deletion: 94 lines

## Validation

- `go test ./server/internal/gateway/channel/slack -run TextCodec -count=3`
- `go test ./server/internal/gateway/channel/discord -run TextCodec -count=3`
- `go test ./server/internal/gateway/channel/teams -run TextCodec -count=3`
- `go test ./server/internal/gateway/channel/...`
- `git diff --check`
- `make check` reached the known order-dependent `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation` failure; the test passes independently with `go test ./server/internal/store -run TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation -count=3`
