### PR TITLE
Remove unused frontend helpers and types

### DIFF
--- a/apps/web/src/components/admin/channel-connectors/shared.tsx
+++ b/apps/web/src/components/admin/channel-connectors/shared.tsx
@@ -6,7 +6,7 @@
  * same and any tweak to spacing/colors applies uniformly.
  */
 import type { ReactNode } from "react"
-import { CheckCircle2, ExternalLink, Loader2, QrCode, XCircle } from "lucide-react"
+import { CheckCircle2, ExternalLink } from "lucide-react"
 
 export function Card({
   title,
@@ -131,41 +131,4 @@ export function randomHex(bytes: number): string {
   const values = new Uint8Array(bytes)
   crypto.getRandomValues(values)
   return Array.from(values, (value) => value.toString(16).padStart(2, "0")).join("")
-}
-
-/** ProvisionStatusIcon is Feishu-specific (it has the QR device-flow). Slack
- *  and Discord don't have an equivalent inline provisioning UI yet, but the
- *  icon helper is generic enough that all three can reuse it once they grow
- *  one. Keeping it exported from shared so the surface is uniform. */
-export function ProvisionStatusIcon({
-  status,
-  loading,
-  labels,
-}: {
-  status: "pending" | "success" | "error" | "expired"
-  loading: boolean
-  labels: { waiting: string; connected: string; stopped: string }
-}) {
-  if (status === "success") {
-    return (
-      <p className="inline-flex items-center gap-1 text-success">
-        <CheckCircle2 className="h-3.5 w-3.5" />
-        <span>{labels.connected}</span>
-      </p>
-    )
-  }
-  if (status === "error" || status === "expired") {
-    return (
-      <p className="inline-flex items-center gap-1 text-danger">
-        <XCircle className="h-3.5 w-3.5" />
-        <span>{labels.stopped}</span>
-      </p>
-    )
-  }
-  return (
-    <p className="inline-flex items-center gap-1 text-fg-subtle">
-      {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <QrCode className="h-3.5 w-3.5" />}
-      <span>{labels.waiting}</span>
-    </p>
-  )
 }

--- a/apps/web/src/lib/api-marketplace.ts
+++ b/apps/web/src/lib/api-marketplace.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 
 import { apiRequest, noUnreachableRetry } from "./api-client"
 import { KEY_AGENT_CAPABILITIES, KEY_CAPABILITIES_WORKSPACE, KEY_CAPABILITY_VERSIONS } from "./api-capabilities"
-import type { Agent, Capability, CapabilityVersion } from "./api-types"
+import type { Capability } from "./api-types"
 
 export interface MarketplaceCapability extends Capability {
   capability_id?: string
@@ -279,22 +279,4 @@ export function useUpgrade(workspaceID: string | null, agentID: string | null) {
 
 export function marketplaceSourceName(capability: Partial<MarketplaceCapability | TargetMarketplaceInstall>): string {
   return capability.source_workspace_name ?? ""
-}
-
-export function pinnedVersionOf(capability: Partial<MarketplaceCapability | TargetMarketplaceInstall>): string | undefined {
-  return capability.pinned_version ?? capability.latest_version
-}
-
-export function latestVersionOf(capability: Partial<MarketplaceCapability | TargetMarketplaceInstall>, versions?: CapabilityVersion[]): CapabilityVersion | undefined {
-  if (capability.latest_version_id && versions) {
-    const byID = versions.find((version) => version.id === capability.latest_version_id)
-    if (byID) return byID
-  }
-  return versions?.[0]
-}
-
-export function agentDisplayID(agent: Agent | EnabledMarketplaceAgent): string {
-  if ("agent_id" in agent && agent.agent_id) return agent.agent_id
-  if ("id" in agent && agent.id) return agent.id
-  return ""
 }

--- a/apps/web/src/lib/api-runtime.ts
+++ b/apps/web/src/lib/api-runtime.ts
@@ -21,7 +21,6 @@ import { ApiError, apiRequest, noUnreachableRetry } from "./api-client"
  *                          (env no longer drives runtime selection).
  */
 
-export type RuntimeMode = "sandbox" | "local"
 export type RuntimeProfile = "oss" | "managed" | "selfhost"
 export type RuntimeConfiguredBy = "ops" | "self"
 

--- a/apps/web/src/lib/api-runtimes.ts
+++ b/apps/web/src/lib/api-runtimes.ts
@@ -169,9 +169,6 @@ const KEY_LIST = (workspaceID: string, type?: RuntimeType, filters?: RuntimeList
     filters?.agentKind ?? "",
   ] as const
 
-const KEY_DETAIL = (workspaceID: string, runtimeID: string) =>
-  ["admin", "runtimes", workspaceID, "detail", runtimeID] as const
-
 let cachedDevUserID: string | null | undefined
 
 async function devAuthHeaders(): Promise<Record<string, string>> {
@@ -283,8 +280,4 @@ export function useDeleteRuntime(workspaceID: string) {
       qc.invalidateQueries({ queryKey: ["admin", "runtimes", workspaceID] })
     },
   })
-}
-
-export function getRuntimeDetailKey(workspaceID: string, runtimeID: string): readonly unknown[] {
-  return KEY_DETAIL(workspaceID, runtimeID)
 }

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -543,10 +543,6 @@ export interface ListAgentRunEventsResponse {
   events: AgentRunEvent[]
 }
 
-export interface RequeueAgentRunResponse {
-  run: AgentRunSummary
-}
-
 export interface StartAgentRunResponse {
   run_id: string
   status: "running" | string
@@ -663,8 +659,6 @@ export interface ListConversationsResponse {
   conversations: ConversationListItem[]
 }
 
-export type ConversationVisibility = "workspace" | "private"
-
 export interface CreateConversationRequest {
   title: string
   /** Origin channel. Defaults to `web` server-side when omitted. */
@@ -681,9 +675,6 @@ export interface CreateConversationRequest {
   agent_id?: string
   metadata?: Record<string, unknown>
 }
-
-export type ConversationSummary = Conversation
-export type MessageSummary = ConversationTimelineMessage
 
 /**
  * Timeline returned by GET /api/v1/conversations/{id}/timeline.

--- a/apps/web/src/lib/model-presets.ts
+++ b/apps/web/src/lib/model-presets.ts
@@ -93,10 +93,6 @@ export function loadProviderCatalog(): Promise<ProviderPreset[]> {
   return providerCatalogPromise
 }
 
-export function findProvider(key: string): ProviderPreset | undefined {
-  return providerCatalogSnapshot.find((p) => p.key === key)
-}
-
 /** Short "200K · $0.14/$0.28" caption for a model, omitting null parts. */
 export function modelCaption(m: ModelPreset): string {
   const parts: string[] = []


### PR DESCRIPTION
## Summary

- remove unused channel connector provisioning icon helper
- remove unreferenced marketplace/runtime/model helpers
- remove unused frontend wire aliases and response type
- remove imports and query-key support made dead by those deletions

This changes no backend API and no active frontend call site. Each removed symbol had no TypeScript consumer, re-export, dynamic import, or string-based lookup. The similarly named `ProvisionStatusIcon` in the legacy Feishu panel is a separate file-local component and remains unchanged.

## Size

- 2 additions
- 78 deletions
- net deletion: 76 lines

## Validation

- `pnpm --filter @parsar/web typecheck`
- `pnpm --filter @parsar/web build`
- changed-file ESLint: no errors; one existing Fast Refresh warning in `channel-connectors/shared.tsx`
- full web lint: fails on the existing main-branch baseline (11 errors / 37 warnings); the two errors exposed by this deletion were removed with dead imports/support
- `git diff --check`
- `make check`: all Go packages passed; deployment phase was blocked by the local Docker daemon error `all predefined address pools have been fully subnetted`
