### PR TITLE
Remove unused web API hooks

### DIFF
--- a/apps/web/src/lib/api-capabilities.ts
+++ b/apps/web/src/lib/api-capabilities.ts
@@ -50,17 +50,6 @@ export interface UpdateCapabilityRequest {
   status?: "active" | "disabled"
 }
 
-export interface CreateCapabilityVersionRequest {
-  version: string
-  git_repo_url?: string
-  git_ref?: string
-  path?: string
-  content?: Record<string, unknown>
-  required_credentials?: RequiredCredential[]
-  schema_version?: number
-  canonical_spec?: CanonicalSpec
-}
-
 export function systemPromptCapabilityPayload(input: {
   name: string
   description: string
@@ -90,29 +79,6 @@ export function agentCapabilityVersionID(item: AgentCapability): string {
 
 export function skillVersionRef(version: CapabilityVersion): string {
   return version.git_ref ?? ""
-}
-
-export function skillCapabilityPayload(input: {
-  name: string
-  description: string
-  requiredCredentials: RequiredCredential[]
-  version: string
-  repoURL: string
-  ref: string
-  path: string
-}): CreateCapabilityRequest {
-  return {
-    type: "skill",
-    name: input.name,
-    description: input.description,
-    scope: "private",
-    status: "active",
-    required_credentials: input.requiredCredentials,
-    version: input.version,
-    git_repo_url: input.repoURL,
-    git_ref: input.ref,
-    path: input.path,
-  }
 }
 
 async function listCapabilities(
@@ -169,17 +135,6 @@ async function updateCapability(
   return apiRequest<Capability>(
     `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/capabilities/${encodeURIComponent(capabilityID)}`,
     { method: "PATCH", body }
-  )
-}
-
-async function createCapabilityVersion(
-  workspaceID: string,
-  capabilityID: string,
-  body: CreateCapabilityVersionRequest
-): Promise<CapabilityVersion> {
-  return apiRequest<CapabilityVersion>(
-    `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/capabilities/${encodeURIComponent(capabilityID)}/versions`,
-    { method: "POST", body }
   )
 }
 

--- a/apps/web/src/lib/api-conversations.ts
+++ b/apps/web/src/lib/api-conversations.ts
@@ -307,30 +307,6 @@ export function useAgentRunStream(
   return state
 }
 
-export function useCreateConversation(wsId: string | null) {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: (body: CreateConversationRequest) => {
-      if (!wsId) throw new Error("workspace id is required")
-      return createConversation(wsId, body)
-    },
-    retry: noUnreachableRetry,
-    onSuccess: () => {
-      // New conversation may be bound to any agent, so invalidate every
-      // per-agent slice for this workspace. Predicate matches both
-      // ['admin','conversations',wsId,'_all'] and the per-agent variant.
-      if (wsId) {
-        qc.invalidateQueries({
-          predicate: (q) =>
-            q.queryKey[0] === "admin" &&
-            q.queryKey[1] === "conversations" &&
-            q.queryKey[2] === wsId,
-        })
-      }
-    },
-  })
-}
-
 export function useSendUserMessage(cid: string | null) {
   const qc = useQueryClient()
   return useMutation({

--- a/apps/web/src/lib/api-invitations.ts
+++ b/apps/web/src/lib/api-invitations.ts
@@ -1,5 +1,5 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { apiRequest, noUnreachableRetry } from "./api-client"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { apiRequest } from "./api-client"
 import type { MemberRole } from "./api-types"
 
 export interface CreateInvitationRequest {
@@ -14,16 +14,6 @@ export interface CreateInvitationResponse {
   email: string
   role: MemberRole
   expires_at: string
-}
-
-export interface PendingInvitation {
-  id: string
-  email: string
-  role: MemberRole
-  invited_by: string
-  invited_by_name: string
-  expires_at: string
-  created_at: string
 }
 
 export interface InviteInfoResponse {
@@ -43,11 +33,7 @@ export interface AcceptInviteResponse {
   workspace_id: string
 }
 
-const KEY_INVITATIONS = (wsId: string) =>
-  ["admin", "invitations", wsId] as const
-
 export function useCreateInvitation(wsId: string | null) {
-  const qc = useQueryClient()
   return useMutation({
     mutationFn: async (body: CreateInvitationRequest) => {
       if (!wsId) throw new Error("no workspace selected")
@@ -55,39 +41,6 @@ export function useCreateInvitation(wsId: string | null) {
         `/api/v1/workspaces/${wsId}/invitations`,
         { method: "POST", body }
       )
-    },
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: KEY_INVITATIONS(wsId ?? "_none") })
-    },
-  })
-}
-
-export function usePendingInvitations(wsId: string | null) {
-  return useQuery({
-    queryKey: KEY_INVITATIONS(wsId ?? "_none"),
-    queryFn: () =>
-      apiRequest<PendingInvitation[]>(
-        `/api/v1/workspaces/${wsId}/invitations`,
-        { method: "GET" }
-      ),
-    enabled: !!wsId,
-    retry: noUnreachableRetry,
-    staleTime: 30_000,
-  })
-}
-
-export function useRevokeInvitation(wsId: string | null) {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: async (invitationId: string) => {
-      if (!wsId) throw new Error("no workspace selected")
-      return apiRequest<void>(
-        `/api/v1/workspaces/${wsId}/invitations/${invitationId}`,
-        { method: "DELETE" }
-      )
-    },
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: KEY_INVITATIONS(wsId ?? "_none") })
     },
   })
 }

--- a/apps/web/src/lib/api-models.ts
+++ b/apps/web/src/lib/api-models.ts
@@ -92,26 +92,6 @@ export function useDisableModel(workspaceID: string | null) {
   })
 }
 
-export function useUpdateModel(workspaceID: string | null) {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: async (input: { modelID: string; body: UpdateModelRequest }) => {
-      if (!workspaceID) {
-        throw new ApiError({
-          status: 0,
-          code: "no_workspace",
-          message: "no workspace selected — pick a workspace first",
-          unreachable: false,
-        })
-      }
-      return updateModelRequest(workspaceID, input.modelID, input.body)
-    },
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: KEY_MODELS(workspaceID ?? "_none") })
-    },
-  })
-}
-
 /* --- Inline create -------------------------------------------------------
  *
  * Creating a shared model is a single dialog submit even when no Secret

--- a/apps/web/src/lib/api-registry.ts
+++ b/apps/web/src/lib/api-registry.ts
@@ -1,14 +1,10 @@
 import { useQuery } from "@tanstack/react-query"
 import { apiRequest, noUnreachableRetry } from "./api-client"
-import type {
-  ListConnectorsResponse,
-  ListGatewaysResponse,
-} from "./api-types"
+import type { ListConnectorsResponse } from "./api-types"
 
 /* --- Query keys --------------------------------------------------------- */
 
 const KEY_CONNECTORS = (wsId: string) => ["admin", "connectors", wsId] as const
-const KEY_GATEWAYS = (wsId: string) => ["admin", "gateways", wsId] as const
 
 /* --- Network ------------------------------------------------------------ */
 
@@ -16,13 +12,6 @@ async function listConnectors(wsId: string | null): Promise<ListConnectorsRespon
   if (!wsId) return { connectors: [] }
   return apiRequest<ListConnectorsResponse>(
     `/api/v1/workspaces/${encodeURIComponent(wsId)}/connector-usage`
-  )
-}
-
-async function listGateways(wsId: string | null): Promise<ListGatewaysResponse> {
-  if (!wsId) return { gateways: [] }
-  return apiRequest<ListGatewaysResponse>(
-    `/api/v1/workspaces/${encodeURIComponent(wsId)}/gateways`
   )
 }
 
@@ -34,14 +23,5 @@ export function useWorkspaceConnectors(wsId: string | null) {
     queryFn: () => listConnectors(wsId),
     retry: noUnreachableRetry,
     staleTime: 30_000,
-  })
-}
-
-export function useWorkspaceGateways(wsId: string | null) {
-  return useQuery({
-    queryKey: KEY_GATEWAYS(wsId ?? "_none"),
-    queryFn: () => listGateways(wsId),
-    retry: noUnreachableRetry,
-    staleTime: 60_000,
   })
 }

--- a/apps/web/src/lib/api-scheduled-tasks.ts
+++ b/apps/web/src/lib/api-scheduled-tasks.ts
@@ -24,22 +24,6 @@ export interface ScheduledTask {
   updated_at: string
 }
 
-export interface ScheduledTaskRun {
-  id: string
-  conversation_id: string
-  agent_id: string
-  connector_type: string
-  status: string
-  failure_reason: string
-  trigger_source: string
-  trigger_channel: string
-  trigger_ref_id: string
-  created_at: string
-  started_at: string | null
-  finished_at: string | null
-  updated_at: string
-}
-
 export interface ScheduledTaskCreateRequest {
   name: string
   prompt: string
@@ -77,9 +61,6 @@ const KEY_TASKS_BY_WORKSPACE_PREFIX = (workspaceID: string) =>
   ["admin", "scheduledTasksByWorkspace", workspaceID] as const
 const KEY_TASKS_BY_WORKSPACE = (workspaceID: string, offset: number, limit: number) =>
   [...KEY_TASKS_BY_WORKSPACE_PREFIX(workspaceID), offset, limit] as const
-const KEY_TASK_RUNS = (taskID: string) =>
-  ["admin", "scheduledTaskRuns", taskID] as const
-
 /* --- Network ------------------------------------------------------------ */
 
 async function listTasksByWorkspace(
@@ -91,13 +72,6 @@ async function listTasksByWorkspace(
   return apiRequest<ScheduledTasksByWorkspaceResponse>(
     `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/scheduled-tasks`,
     { query: { limit, offset } },
-  )
-}
-
-async function listTaskRuns(taskID: string | null): Promise<ScheduledTaskRun[]> {
-  if (!taskID) return []
-  return apiRequest<ScheduledTaskRun[]>(
-    `/api/v1/scheduled-tasks/${encodeURIComponent(taskID)}/runs`,
   )
 }
 
@@ -116,16 +90,6 @@ export function useScheduledTasksByWorkspace(
     staleTime: 15_000,
     // Keep the previous page on screen while the next one fetches.
     placeholderData: (prev) => prev,
-  })
-}
-
-export function useScheduledTaskRuns(taskID: string | null) {
-  return useQuery({
-    queryKey: KEY_TASK_RUNS(taskID ?? "_none"),
-    queryFn: () => listTaskRuns(taskID),
-    enabled: Boolean(taskID),
-    retry: noUnreachableRetry,
-    staleTime: 10_000,
   })
 }
 
@@ -181,9 +145,8 @@ export function useRunScheduledTaskNow(workspaceID: string | null) {
         `/api/v1/scheduled-tasks/${encodeURIComponent(taskID)}/run-now`,
         { method: "POST", body: {} },
       ),
-    onSuccess: (_res, taskID) => {
+    onSuccess: () => {
       void qc.invalidateQueries({ queryKey: KEY_TASKS_BY_WORKSPACE_PREFIX(workspaceID ?? "_none") })
-      void qc.invalidateQueries({ queryKey: KEY_TASK_RUNS(taskID) })
     },
   })
 }

--- a/apps/web/src/lib/workspace.ts
+++ b/apps/web/src/lib/workspace.ts
@@ -4,7 +4,7 @@
  * Resolution order: URL param `?ws=<uuid>` → localStorage `parsar.ws` →
  * null (UI shows "no workspace" empty state).
  */
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useState } from "react"
 
 const WS_KEY = "parsar.ws"
 const WS_PARAM = "ws"
@@ -80,13 +80,4 @@ export function useWorkspaceId(): string | null {
     }
   }, [])
   return ws
-}
-
-/**
- * Whether a real workspace is currently bound. False ⇒ pages should show
- * "pick a workspace" empty state.
- */
-export function useHasWorkspace(): boolean {
-  const ws = useWorkspaceId()
-  return useMemo(() => isUUID(ws), [ws])
 }


### PR DESCRIPTION
## Summary

- remove zero-reference frontend API hooks and helpers from seven existing modules
- remove only private request/query-key/type support that became unreachable with those exports
- keep backend endpoints and still-consumed direct request helpers unchanged

## Evidence

TypeScript Language Service `findReferences` reported zero non-definition references for:

- `skillCapabilityPayload`
- `createCapabilityVersion`
- `useCreateConversation`
- `usePendingInvitations`
- `useRevokeInvitation`
- `useUpdateModel`
- `useWorkspaceGateways`
- `useScheduledTaskRuns`
- `useHasWorkspace`

## Validation

- `pnpm --filter @parsar/web typecheck`
- `pnpm --filter @parsar/web build`
- `git diff --check`
- `pnpm --filter @parsar/web lint` — branch has 8 existing errors / 37 warnings; latest `origin/main` has 21 errors / 38 warnings, so this change introduces no lint regression
- `make check` — all Go package tests passed; the check then stopped when Docker could not create its network because all predefined address pools were exhausted

## Size

- 7 files changed
- 5 insertions
- 207 deletions
- net -202 lines
