### PR TITLE
refactor(daemon): share CLI version probe

### DIFF
--- a/apps/parsar-daemon/internal/agent/claudecode/version.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/version.go
@@ -1,12 +1,10 @@
 package claudecode
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"fmt"
-	"os/exec"
-	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/versionprobe"
 )
 
 // InstallURL points to the official Claude Code install instructions.
@@ -24,32 +22,9 @@ var ErrCLINotFound = errors.New("claude CLI not found")
 // error wraps ErrCLINotFound; on other failures the wrapped error
 // keeps the raw stderr.
 func CheckCLIAvailable(ctx context.Context, binary string) (string, error) {
-	if binary == "" {
-		binary = "claude"
-	}
-
-	if _, lookErr := exec.LookPath(binary); lookErr != nil {
-		return "", fmt.Errorf("%w: %s", ErrCLINotFound, binary)
-	}
-
-	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, binary, "--version")
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		msg := strings.TrimSpace(stderr.String())
-		if msg == "" {
-			msg = err.Error()
-		}
-		return "", fmt.Errorf("claude --version failed: %s", msg)
-	}
-
-	out := strings.TrimSpace(stdout.String())
-	if i := strings.IndexByte(out, '\n'); i >= 0 {
-		out = out[:i]
-	}
-	if out == "" {
-		return "", fmt.Errorf("claude --version returned empty output")
-	}
-	return out, nil
+	return versionprobe.Check(ctx, binary, versionprobe.Config{
+		Name:          "claude",
+		DefaultBinary: "claude",
+		MissingError:  ErrCLINotFound,
+	})
 }

--- a/apps/parsar-daemon/internal/agent/claudecode/version_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/version_test.go
@@ -1,91 +1,17 @@
 package claudecode_test
 
 import (
-	"context"
-	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/claudecode"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/versionprobe/testutil"
 )
 
-func TestCheckCLIAvailableMissingBinaryWrapsErrCLINotFound(t *testing.T) {
-	_, err := claudecode.CheckCLIAvailable(context.Background(), "parsar-daemon-nonexistent-claude-stub")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, claudecode.ErrCLINotFound) {
-		t.Fatalf("error %v does not wrap ErrCLINotFound", err)
-	}
-}
-
-func TestCheckCLIAvailableDefaultsToClaudeBinary(t *testing.T) {
-	// Empty binary should normalise to "claude".
-	_, err := claudecode.CheckCLIAvailable(context.Background(), "")
-	if err == nil {
-		return // claude installed locally; success covered by integration runs.
-	}
-	if !errors.Is(err, claudecode.ErrCLINotFound) {
-		if msg := err.Error(); !contains(msg, "claude") {
-			t.Fatalf("error %q does not mention default binary name", msg)
-		}
-	}
-}
-
-func TestCheckCLIAvailableReturnsTrimmedFirstLine(t *testing.T) {
-	// posix-only stub script; daemon doesn't target Windows.
-	if runtime.GOOS == "windows" {
-		t.Skip("posix-only stub script; daemon doesn't target Windows")
-	}
-
-	dir := t.TempDir()
-	stub := filepath.Join(dir, "fake-claude")
-	body := "#!/bin/sh\nprintf 'fake 9.9.9 (build abc)\\n  extra line\\n'\n"
-	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-
-	ver, err := claudecode.CheckCLIAvailable(context.Background(), stub)
-	if err != nil {
-		t.Fatalf("CheckCLIAvailable: %v", err)
-	}
-	want := "fake 9.9.9 (build abc)"
-	if ver != want {
-		t.Fatalf("version=%q want %q", ver, want)
-	}
-}
-
-func TestCheckCLIAvailableSurfacesNonZeroExit(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("posix-only stub script; daemon doesn't target Windows")
-	}
-
-	dir := t.TempDir()
-	stub := filepath.Join(dir, "broken-claude")
-	body := "#!/bin/sh\necho 'kaboom' 1>&2\nexit 17\n"
-	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-
-	_, err := claudecode.CheckCLIAvailable(context.Background(), stub)
-	if err == nil {
-		t.Fatal("expected non-nil error for broken stub")
-	}
-	if errors.Is(err, claudecode.ErrCLINotFound) {
-		t.Fatalf("broken-but-present binary should not wrap ErrCLINotFound: %v", err)
-	}
-	if !contains(err.Error(), "kaboom") {
-		t.Fatalf("expected stderr %q in error %v", "kaboom", err)
-	}
-}
-
-func contains(haystack, needle string) bool {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
+func TestCheckCLIAvailableContract(t *testing.T) {
+	testutil.RunContract(t, testutil.Contract{
+		Name:          "claude",
+		DefaultBinary: "claude",
+		MissingError:  claudecode.ErrCLINotFound,
+		Check:         claudecode.CheckCLIAvailable,
+	})
 }

--- a/apps/parsar-daemon/internal/agent/opencode/version.go
+++ b/apps/parsar-daemon/internal/agent/opencode/version.go
@@ -1,12 +1,10 @@
 package opencode
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"fmt"
-	"os/exec"
-	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/versionprobe"
 )
 
 // InstallURL points operators at the OpenCode documentation when the
@@ -23,30 +21,10 @@ var ErrCLINotFound = errors.New("opencode CLI not found")
 // CheckCLIAvailable runs `<binary> --version` and returns the trimmed
 // first line. The empty binary name defaults to "opencode".
 func CheckCLIAvailable(ctx context.Context, binary string) (string, error) {
-	if strings.TrimSpace(binary) == "" {
-		binary = defaultBinary
-	}
-	if _, lookErr := exec.LookPath(binary); lookErr != nil {
-		return "", fmt.Errorf("%w: %s", ErrCLINotFound, binary)
-	}
-
-	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, binary, "--version")
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		msg := strings.TrimSpace(stderr.String())
-		if msg == "" {
-			msg = err.Error()
-		}
-		return "", fmt.Errorf("opencode --version failed: %s", msg)
-	}
-	out := strings.TrimSpace(stdout.String())
-	if i := strings.IndexByte(out, '\n'); i >= 0 {
-		out = out[:i]
-	}
-	if out == "" {
-		return "", fmt.Errorf("opencode --version returned empty output")
-	}
-	return out, nil
+	return versionprobe.Check(ctx, binary, versionprobe.Config{
+		Name:          "opencode",
+		DefaultBinary: defaultBinary,
+		MissingError:  ErrCLINotFound,
+		TrimBinary:    true,
+	})
 }

--- a/apps/parsar-daemon/internal/agent/opencode/version_test.go
+++ b/apps/parsar-daemon/internal/agent/opencode/version_test.go
@@ -1,78 +1,18 @@
 package opencode_test
 
 import (
-	"context"
-	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/opencode"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/versionprobe/testutil"
 )
 
-func TestCheckCLIAvailableMissingBinaryWrapsErrCLINotFound(t *testing.T) {
-	_, err := opencode.CheckCLIAvailable(context.Background(), "parsar-daemon-nonexistent-opencode-stub")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, opencode.ErrCLINotFound) {
-		t.Fatalf("error %v does not wrap ErrCLINotFound", err)
-	}
-}
-
-func TestCheckCLIAvailableDefaultsToOpenCodeBinary(t *testing.T) {
-	_, err := opencode.CheckCLIAvailable(context.Background(), "")
-	if err == nil {
-		return
-	}
-	if !errors.Is(err, opencode.ErrCLINotFound) && !strings.Contains(err.Error(), "opencode") {
-		t.Fatalf("error %q does not mention default binary name", err.Error())
-	}
-}
-
-func TestCheckCLIAvailableReturnsTrimmedFirstLine(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("posix-only stub script; daemon doesn't target Windows")
-	}
-
-	dir := t.TempDir()
-	stub := filepath.Join(dir, "fake-opencode")
-	body := "#!/bin/sh\nprintf 'opencode 9.9.9\\nextra line\\n'\n"
-	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-
-	ver, err := opencode.CheckCLIAvailable(context.Background(), stub)
-	if err != nil {
-		t.Fatalf("CheckCLIAvailable: %v", err)
-	}
-	if ver != "opencode 9.9.9" {
-		t.Fatalf("version = %q, want opencode 9.9.9", ver)
-	}
-}
-
-func TestCheckCLIAvailableSurfacesNonZeroExit(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("posix-only stub script; daemon doesn't target Windows")
-	}
-
-	dir := t.TempDir()
-	stub := filepath.Join(dir, "broken-opencode")
-	body := "#!/bin/sh\necho 'opencode kaboom' 1>&2\nexit 17\n"
-	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-
-	_, err := opencode.CheckCLIAvailable(context.Background(), stub)
-	if err == nil {
-		t.Fatal("expected non-nil error for broken stub")
-	}
-	if errors.Is(err, opencode.ErrCLINotFound) {
-		t.Fatalf("broken-but-present binary should not wrap ErrCLINotFound: %v", err)
-	}
-	if !strings.Contains(err.Error(), "opencode kaboom") {
-		t.Fatalf("expected stderr in error, got %v", err)
-	}
+func TestCheckCLIAvailableContract(t *testing.T) {
+	testutil.RunContract(t, testutil.Contract{
+		Name:               "opencode",
+		DefaultBinary:      "opencode",
+		MissingError:       opencode.ErrCLINotFound,
+		Check:              opencode.CheckCLIAvailable,
+		WhitespaceDefaults: true,
+	})
 }

--- a/apps/parsar-daemon/internal/agent/pi/version.go
+++ b/apps/parsar-daemon/internal/agent/pi/version.go
@@ -1,12 +1,10 @@
 package pi
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"fmt"
-	"os/exec"
-	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/versionprobe"
 )
 
 // InstallURL points operators at the pi documentation when the daemon
@@ -23,34 +21,11 @@ var ErrCLINotFound = errors.New("pi CLI not found")
 // CheckCLIAvailable runs `<binary> --version` and returns the trimmed
 // first line. The empty binary name defaults to "pi".
 func CheckCLIAvailable(ctx context.Context, binary string) (string, error) {
-	if strings.TrimSpace(binary) == "" {
-		binary = defaultBinary
-	}
-	if _, lookErr := exec.LookPath(binary); lookErr != nil {
-		return "", fmt.Errorf("%w: %s", ErrCLINotFound, binary)
-	}
-
-	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, binary, "--version")
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		msg := strings.TrimSpace(stderr.String())
-		if msg == "" {
-			msg = err.Error()
-		}
-		return "", fmt.Errorf("pi --version failed: %s", msg)
-	}
-	out := strings.TrimSpace(stdout.String())
-	if out == "" {
-		// pi writes version to stderr
-		out = strings.TrimSpace(stderr.String())
-	}
-	if i := strings.IndexByte(out, '\n'); i >= 0 {
-		out = out[:i]
-	}
-	if out == "" {
-		return "", fmt.Errorf("pi --version returned empty output")
-	}
-	return out, nil
+	return versionprobe.Check(ctx, binary, versionprobe.Config{
+		Name:           "pi",
+		DefaultBinary:  defaultBinary,
+		MissingError:   ErrCLINotFound,
+		TrimBinary:     true,
+		StderrFallback: true,
+	})
 }

--- a/apps/parsar-daemon/internal/agent/pi/version_test.go
+++ b/apps/parsar-daemon/internal/agent/pi/version_test.go
@@ -2,127 +2,29 @@ package pi_test
 
 import (
 	"context"
-	"errors"
-	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/pi"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/versionprobe/testutil"
 )
 
-func TestCheckCLIAvailableMissingBinaryWrapsErrCLINotFound(t *testing.T) {
-	_, err := pi.CheckCLIAvailable(context.Background(), "parsar-daemon-nonexistent-pi-stub")
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	if !errors.Is(err, pi.ErrCLINotFound) {
-		t.Fatalf("error %v does not wrap ErrCLINotFound", err)
-	}
+func TestCheckCLIAvailableContract(t *testing.T) {
+	testutil.RunContract(t, testutil.Contract{
+		Name:               "pi",
+		DefaultBinary:      "pi",
+		MissingError:       pi.ErrCLINotFound,
+		Check:              pi.CheckCLIAvailable,
+		WhitespaceDefaults: true,
+	})
 }
 
-func TestCheckCLIAvailableDefaultsToPiBinary(t *testing.T) {
-	_, err := pi.CheckCLIAvailable(context.Background(), "")
-	if err == nil {
-		return
-	}
-	if !errors.Is(err, pi.ErrCLINotFound) && !strings.Contains(err.Error(), "pi") {
-		t.Fatalf("error %q does not mention default binary name", err.Error())
-	}
-}
-
-func TestCheckCLIAvailableReturnsTrimmedFirstLine(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("posix-only stub script; daemon doesn't target Windows")
-	}
-
-	dir := t.TempDir()
-	stub := filepath.Join(dir, "fake-pi")
-	body := "#!/bin/sh\nprintf 'pi 9.9.9\\nextra line\\n'\n"
-	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-
-	ver, err := pi.CheckCLIAvailable(context.Background(), stub)
-	if err != nil {
-		t.Fatalf("CheckCLIAvailable: %v", err)
-	}
-	if ver != "pi 9.9.9" {
-		t.Fatalf("version = %q, want pi 9.9.9", ver)
-	}
-}
-
-func TestCheckCLIAvailableSurfacesNonZeroExit(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("posix-only stub script; daemon doesn't target Windows")
-	}
-
-	dir := t.TempDir()
-	stub := filepath.Join(dir, "broken-pi")
-	body := "#!/bin/sh\necho 'pi kaboom' 1>&2\nexit 17\n"
-	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-
-	_, err := pi.CheckCLIAvailable(context.Background(), stub)
-	if err == nil {
-		t.Fatal("expected non-nil error for broken stub")
-	}
-	if errors.Is(err, pi.ErrCLINotFound) {
-		t.Fatalf("broken-but-present binary should not wrap ErrCLINotFound: %v", err)
-	}
-	if !strings.Contains(err.Error(), "pi kaboom") {
-		t.Fatalf("expected stderr in error, got %v", err)
-	}
-}
-
-// TestCheckCLIAvailableFallsBackToStderr locks in the workaround for
-// pi 0.74.2, which prints its version banner to STDERR (not stdout).
-// Without the fallback the daemon's preflight sees empty stdout, exit=0,
-// and falsely reports the CLI unavailable.
 func TestCheckCLIAvailableFallsBackToStderr(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("posix-only stub script; daemon doesn't target Windows")
-	}
-
-	dir := t.TempDir()
-	stub := filepath.Join(dir, "stderr-pi")
-	body := "#!/bin/sh\necho 'pi 0.74.2' 1>&2\nexit 0\n"
-	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-
-	ver, err := pi.CheckCLIAvailable(context.Background(), stub)
+	stub := testutil.WriteStub(t, "stderr-pi", "#!/bin/sh\nprintf '  pi 0.74.2\\nextra line  \\n' 1>&2\n")
+	version, err := pi.CheckCLIAvailable(context.Background(), stub)
 	if err != nil {
-		t.Fatalf("CheckCLIAvailable: %v", err)
+		t.Fatalf("check CLI: %v", err)
 	}
-	if ver != "pi 0.74.2" {
-		t.Fatalf("version = %q, want %q (stderr fallback broken)", ver, "pi 0.74.2")
-	}
-}
-
-// TestCheckCLIAvailableEmptyBothStreams rejects a binary that exits 0
-// with no output on either stream — indistinguishable from a broken
-// install, so the daemon should flag it as unusable rather than record
-// an empty version string.
-func TestCheckCLIAvailableEmptyBothStreams(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("posix-only stub script; daemon doesn't target Windows")
-	}
-
-	dir := t.TempDir()
-	stub := filepath.Join(dir, "silent-pi")
-	body := "#!/bin/sh\nexit 0\n"
-	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-
-	_, err := pi.CheckCLIAvailable(context.Background(), stub)
-	if err == nil {
-		t.Fatal("expected error for empty output on both streams")
-	}
-	if !strings.Contains(err.Error(), "empty") {
-		t.Fatalf("expected 'empty output' in error, got %v", err)
+	if version != "pi 0.74.2" {
+		t.Fatalf("version = %q, want %q", version, "pi 0.74.2")
 	}
 }

--- a/apps/parsar-daemon/internal/agent/versionprobe/testutil/testutil.go
+++ b/apps/parsar-daemon/internal/agent/versionprobe/testutil/testutil.go
@@ -1,0 +1,120 @@
+package testutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// CheckFunc is an adapter CLI availability check.
+type CheckFunc func(context.Context, string) (string, error)
+
+// Contract describes the shared behavior expected from a CLI version probe.
+type Contract struct {
+	Name               string
+	DefaultBinary      string
+	MissingError       error
+	Check              CheckFunc
+	WhitespaceDefaults bool
+}
+
+// RunContract verifies an adapter's shared CLI version probe behavior.
+func RunContract(t *testing.T, contract Contract) {
+	t.Helper()
+
+	t.Run("missing binary wraps exported sentinel", func(t *testing.T) {
+		binary := "parsar-daemon-nonexistent-" + contract.Name + "-stub"
+		_, err := contract.Check(context.Background(), binary)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, contract.MissingError) {
+			t.Fatalf("error %v does not wrap %v", err, contract.MissingError)
+		}
+		want := fmt.Sprintf("%s: %s", contract.MissingError, binary)
+		if err.Error() != want {
+			t.Fatalf("error = %q, want %q", err, want)
+		}
+	})
+
+	t.Run("empty binary uses adapter default", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		_, err := contract.Check(context.Background(), "")
+		want := fmt.Sprintf("%s: %s", contract.MissingError, contract.DefaultBinary)
+		if err == nil || err.Error() != want {
+			t.Fatalf("error = %v, want %q", err, want)
+		}
+	})
+
+	t.Run("whitespace binary preserves adapter behavior", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		_, err := contract.Check(context.Background(), "   ")
+		binary := "   "
+		if contract.WhitespaceDefaults {
+			binary = contract.DefaultBinary
+		}
+		want := fmt.Sprintf("%s: %s", contract.MissingError, binary)
+		if err == nil || err.Error() != want {
+			t.Fatalf("error = %v, want %q", err, want)
+		}
+	})
+
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	t.Run("returns trimmed first stdout line", func(t *testing.T) {
+		stub := writeStub(t, "fake-"+contract.Name, "#!/bin/sh\nprintf '  "+contract.Name+" 9.9.9\\nextra line  \\n'\n")
+		version, err := contract.Check(context.Background(), stub)
+		if err != nil {
+			t.Fatalf("check CLI: %v", err)
+		}
+		want := contract.Name + " 9.9.9"
+		if version != want {
+			t.Fatalf("version = %q, want %q", version, want)
+		}
+	})
+
+	t.Run("surfaces adapter-specific nonzero error", func(t *testing.T) {
+		stub := writeStub(t, "broken-"+contract.Name, "#!/bin/sh\necho 'kaboom' 1>&2\nexit 17\n")
+		_, err := contract.Check(context.Background(), stub)
+		want := contract.Name + " --version failed: kaboom"
+		if err == nil || err.Error() != want {
+			t.Fatalf("error = %v, want %q", err, want)
+		}
+		if errors.Is(err, contract.MissingError) {
+			t.Fatalf("broken present binary wraps missing sentinel: %v", err)
+		}
+	})
+
+	t.Run("rejects empty output with adapter-specific error", func(t *testing.T) {
+		stub := writeStub(t, "silent-"+contract.Name, "#!/bin/sh\nexit 0\n")
+		_, err := contract.Check(context.Background(), stub)
+		want := contract.Name + " --version returned empty output"
+		if err == nil || err.Error() != want {
+			t.Fatalf("error = %v, want %q", err, want)
+		}
+	})
+}
+
+// WriteStub creates a POSIX executable for adapter-specific tests.
+func WriteStub(t *testing.T, name, body string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX-only stub script; daemon does not target Windows")
+	}
+	return writeStub(t, name, body)
+}
+
+func writeStub(t *testing.T, name, body string) string {
+	t.Helper()
+	stub := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(stub, []byte(body), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return stub
+}

--- a/apps/parsar-daemon/internal/agent/versionprobe/versionprobe.go
+++ b/apps/parsar-daemon/internal/agent/versionprobe/versionprobe.go
@@ -1,0 +1,52 @@
+package versionprobe
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Config describes an adapter's CLI version command and error contract.
+type Config struct {
+	Name           string
+	DefaultBinary  string
+	MissingError   error
+	TrimBinary     bool
+	StderrFallback bool
+}
+
+// Check runs `<binary> --version` and returns its trimmed first output line.
+func Check(ctx context.Context, binary string, config Config) (string, error) {
+	if (config.TrimBinary && strings.TrimSpace(binary) == "") || (!config.TrimBinary && binary == "") {
+		binary = config.DefaultBinary
+	}
+	if _, err := exec.LookPath(binary); err != nil {
+		return "", fmt.Errorf("%w: %s", config.MissingError, binary)
+	}
+
+	var stdout, stderr bytes.Buffer
+	command := exec.CommandContext(ctx, binary, "--version")
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message == "" {
+			message = err.Error()
+		}
+		return "", fmt.Errorf("%s --version failed: %s", config.Name, message)
+	}
+
+	output := strings.TrimSpace(stdout.String())
+	if output == "" && config.StderrFallback {
+		output = strings.TrimSpace(stderr.String())
+	}
+	if index := strings.IndexByte(output, '\n'); index >= 0 {
+		output = output[:index]
+	}
+	if output == "" {
+		return "", fmt.Errorf("%s --version returned empty output", config.Name)
+	}
+	return output, nil
+}


### PR DESCRIPTION
## Summary
- extract the duplicated Claude Code, OpenCode, and Pi `--version` probe into `internal/agent/versionprobe`
- replace adapter-local test duplication with a shared contract test helper
- preserve exported missing-CLI sentinels, adapter-specific defaults/errors, whitespace behavior, first-line trimming, and Pi's stderr fallback

## Gate
- 227 additions / 359 deletions
- net deletion: 132 lines (required: at least 100)

## Validation
- `go test -count=3 -run 'CheckCLIAvailable|TestProbe' ./apps/parsar-daemon/internal/agent/versionprobe/... ./apps/parsar-daemon/internal/agent/claudecode ./apps/parsar-daemon/internal/agent/opencode ./apps/parsar-daemon/internal/agent/pi` ✅
- `git diff --check` ✅
- `go test ./apps/parsar-daemon/internal/agent/...` ⚠️ blocked by untouched `TestInstallPlugins_ConcurrentSamePluginNoTruncation`; reproduced on pristine `origin/main`
- `make check` ⚠️ blocked twice by untouched `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation`; focused test passes with `-count=3` on both this branch and pristine `origin/main`
