### PR TITLE
refactor(daemon): remove unused compatibility helpers

### DIFF
--- a/apps/parsar-daemon/internal/agent/claudecode/ask.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/ask.go
@@ -166,40 +166,6 @@ func (p *pendingAskTable) Len() int {
 	return len(p.byAskID)
 }
 
-// interceptAskUserQuestion handled the tool_use path historically. It's
-// retained as exported test scaffolding (legacy unit tests still cover
-// the case-by-case payload parsing) — translateAssistant no longer
-// calls it. See parser.go's tool_use branch comment.
-//
-// Returns ok=false (no envelope, fall through to a normal TypeToolCall)
-// when askPending / askMint are missing, the input shape doesn't fit,
-// or the tool_use id is empty.
-func (t *translator) interceptAskUserQuestion(toolUseID string, input map[string]any) (proto.Envelope, bool) {
-	if t.askPending == nil || t.askMint == nil {
-		return proto.Envelope{}, false
-	}
-	if toolUseID == "" {
-		return proto.Envelope{}, false
-	}
-	questions, ok := parseAskUserQuestionInput(input)
-	if !ok {
-		return proto.Envelope{}, false
-	}
-
-	askID := t.askMint()
-	t.askPending.Record(askID, toolUseID, questions)
-
-	env, err := proto.NewEnvelope(proto.TypePromptForUserChoice, t.runID, proto.PromptForUserChoicePayload{
-		AskID:     askID,
-		Questions: questions,
-		ToolUseID: toolUseID,
-	})
-	if err != nil {
-		return proto.Envelope{}, false
-	}
-	return env, true
-}
-
 // interceptAskUserQuestionFromControlRequest is the control_request-
 // path twin. Under --permission-prompt-tool stdio, claude-code wraps
 // AskUserQuestion as a can_use_tool permission check instead of

--- a/apps/parsar-daemon/internal/agent/claudecode/options.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/options.go
@@ -286,10 +286,6 @@ type userContentSource struct {
 	Data      string `json:"data"`
 }
 
-func buildUserMessage(prompt string) ([]byte, error) {
-	return buildUserMessageWithAttachments(prompt, nil)
-}
-
 // buildUserMessageWithAttachments is the multimodal-aware variant. With
 // no attachments, the output is byte-identical to the bare-string
 // Content path so existing log greps for prompt content keep working.

--- a/apps/parsar-daemon/internal/transport/ws_test.go
+++ b/apps/parsar-daemon/internal/transport/ws_test.go
@@ -24,10 +24,9 @@ import (
 type fakeGateway struct {
 	upgrader websocket.Upgrader
 
-	mu       sync.Mutex
-	dialURL  string
-	frames   []proto.Envelope
-	wantAuth bool
+	mu      sync.Mutex
+	dialURL string
+	frames  []proto.Envelope
 
 	connCh chan *websocket.Conn
 }


### PR DESCRIPTION
## Summary

- remove the historical Claude `tool_use` AskUserQuestion interceptor now superseded by the active control-request path
- remove the unused text-only `buildUserMessage` wrapper; sessions use the attachment-aware builder directly
- remove the unread `wantAuth` field from the WebSocket transport test gateway

This is a pure deletion with no new abstraction or behavior change.

## Validation

- `go test ./apps/parsar-daemon/internal/agent/claudecode -run '.' -skip '^TestInstallPlugins_ConcurrentSamePluginNoTruncation$' -count=3`
- `go test ./apps/parsar-daemon/internal/transport -count=3`
- `staticcheck ./apps/parsar-daemon/internal/agent/claudecode`
- `git diff --check`
- `make check` passed all Go packages, then stopped during Docker Compose network creation because the local daemon has exhausted its predefined address pools

## Known baseline issues

- `TestInstallPlugins_ConcurrentSamePluginNoTruncation` fails intermittently on both this branch and `origin/main`; `origin/main` reproduced it twice in 10 runs
- transport package staticcheck reports an existing `S1008` in untouched `apps/parsar-daemon/internal/transport/ws.go`
