### PR TITLE
refactor(store): remove unused internals

### DIFF
--- a/server/internal/store/credential_kinds.go
+++ b/server/internal/store/credential_kinds.go
@@ -29,32 +29,6 @@ var builtInCredentialKindSeeds = []builtInCredentialKindSeed{
 	{Code: "internal_gw_api_key", DisplayName: "Internal Gateway API Key", Description: "Personal credential for the internal LLM gateway", Source: CredentialKindSourcePlatformModel},
 }
 
-var SupportedCredentialKinds = []string{
-	"github_pat",
-	"slack_bot_token",
-	"teams_app_password",
-	"postgres_dsn",
-	"notion_integration",
-	"jira_api_token",
-	"openai_api_key",
-	"anthropic_api_key",
-	"deepseek_api_key",
-	"internal_gw_api_key",
-}
-
-var supportedCredentialKindSet = func() map[string]struct{} {
-	out := make(map[string]struct{}, len(SupportedCredentialKinds))
-	for _, kind := range SupportedCredentialKinds {
-		out[kind] = struct{}{}
-	}
-	return out
-}()
-
-func IsSupportedCredentialKind(kind string) bool {
-	_, ok := supportedCredentialKindSet[strings.ToLower(strings.TrimSpace(kind))]
-	return ok
-}
-
 func normalizeCredentialKindCode(kind string) (string, error) {
 	normalized := strings.ToLower(strings.TrimSpace(kind))
 	if normalized == "" {

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -1956,7 +1956,6 @@ var ErrUnknownModel = errors.New("unknown model")
 var ErrModelDisabled = errors.New("model or provider disabled")
 
 const defaultReadLimit int32 = 100
-const defaultMaxAgentChainDepth int32 = 3
 
 // Every admin / runtime emit in this file uses ActorType: audit.ActorTypeSystem
 // because the dev auth path doesn't yet surface a real caller identity.

--- a/server/internal/store/workspace_im_connectors.go
+++ b/server/internal/store/workspace_im_connectors.go
@@ -76,11 +76,6 @@ type WorkspaceSlackConnectorSnapshot struct {
 	EventMode        string `json:"event_mode"`
 }
 
-func (s WorkspaceSlackConnectorSnapshot) isZero() bool {
-	return !s.Enabled && s.AppID == "" && s.BotTokenRef == "" && s.AppTokenRef == "" &&
-		s.SigningSecretRef == "" && (s.EventMode == "" || s.EventMode == "socket")
-}
-
 // toConfigMap returns only the jsonb-stored fields (column fields excluded).
 func (s WorkspaceSlackConnectorSnapshot) toConfigMap() map[string]any {
 	return map[string]any{
@@ -99,10 +94,6 @@ type WorkspaceDiscordConnectorSnapshot struct {
 	BotTokenRef  string `json:"bot_token_ref"`
 	PublicKeyRef string `json:"public_key_ref"`
 	Intents      string `json:"intents"`
-}
-
-func (s WorkspaceDiscordConnectorSnapshot) isZero() bool {
-	return !s.Enabled && s.AppID == "" && s.BotTokenRef == "" && s.PublicKeyRef == "" && s.Intents == ""
 }
 
 func (s WorkspaceDiscordConnectorSnapshot) toConfigMap() map[string]any {
@@ -145,11 +136,6 @@ type WorkspaceFeishuConnectorSnapshot struct {
 	EncryptKeyRef        string `json:"encrypt_key_ref"`
 	BotOpenID            string `json:"bot_open_id"`
 	EventMode            string `json:"event_mode"`
-}
-
-func (s WorkspaceFeishuConnectorSnapshot) isZero() bool {
-	return !s.Enabled && s.AppID == "" && s.AppSecretRef == "" && s.VerificationTokenRef == "" &&
-		s.EncryptKeyRef == "" && s.BotOpenID == "" && (s.EventMode == "" || s.EventMode == "webhook")
 }
 
 func (s WorkspaceFeishuConnectorSnapshot) toConfigMap() map[string]any {


### PR DESCRIPTION
## Summary

- remove the unused credential-kind allowlist and lookup helper
- remove unused Slack, Discord, and Feishu snapshot `isZero` methods
- remove an unused agent-chain-depth constant

This is a pure deletion of internal store symbols with no schema, generated code, API, or behavior changes. The Teams snapshot `isZero` method remains because store tests still exercise it.

## Validation

- `go test ./server/internal/store/... -count=1`
- `staticcheck -checks=U1000 ./server/internal/store/...`
- `git diff --check`
- `make check` completed all Go packages, then failed when Docker could not create the Compose network because all predefined address pools are exhausted

Full store staticcheck still reports the pre-existing `S1016` at `server/internal/store/store.go:6543`.
