### PR TITLE
test: remove unused OTLP helpers

### DIFF
--- a/server/internal/otlp/middleware_test.go
+++ b/server/internal/otlp/middleware_test.go
@@ -2,16 +2,12 @@ package otlp
 
 import (
 	"bytes"
-	"context"
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/MiniMax-AI-Dev/parsar/server/internal/audit"
 )
 
 // TestExtractBearer tables the RFC 7235 §2.1 happy + unhappy shapes
@@ -302,19 +298,3 @@ func (r *recordingResponseWriter) WriteHeader(status int) {
 }
 
 var _ http.ResponseWriter = (*recordingResponseWriter)(nil)
-
-func dummyMiddlewareLog() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
-}
-
-func _testCtx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 2*time.Second)
-}
-
-func _ensureIngesterAlive() audit.Ingester { return audit.Ingester{} }
-
-var (
-	_ = dummyMiddlewareLog
-	_ = _testCtx
-	_ = _ensureIngesterAlive
-)


### PR DESCRIPTION
## Summary
- remove three zero-reference OTLP test helpers
- remove their dedicated imports and fake keepalive references
- preserve all existing OTLP assertions and test cases

## Validation
- `go test ./server/internal/otlp -count=3`
- `staticcheck -checks=U1000 ./server/internal/otlp/...`
- `git diff --check`
- `make check` passed every Go package, then stopped when Docker could not create the check network because all predefined address pools were fully subnetted

Full-package `staticcheck ./server/internal/otlp/...` still reports three pre-existing ST1005 findings in `middleware.go`, reproduced on `origin/main`.
