### PR TITLE
refactor(web): remove unused agent API hooks

### DIFF
--- a/apps/web/src/lib/api-agents.ts
+++ b/apps/web/src/lib/api-agents.ts
@@ -8,7 +8,6 @@ import type {
   AgentSummary,
   CreateAgentRequest,
   CreateAgentResponse,
-  DeleteAgentResponse,
   ListAgentRunEventsResponse,
   ListAgentRunsResponse,
   ListAgentsResponse,
@@ -99,13 +98,6 @@ async function listAgentRunEvents(
   )
 }
 
-async function requeueRunRequest(runID: string, reason?: string) {
-  return apiRequest<unknown>(
-    `/api/v1/agent-runs/${encodeURIComponent(runID)}/requeue`,
-    { method: "POST", body: reason ? { reason } : {} }
-  )
-}
-
 async function cancelRunRequest(runID: string, reason?: string) {
   return apiRequest<unknown>(
     `/api/v1/agent-runs/${encodeURIComponent(runID)}/cancel`,
@@ -181,13 +173,6 @@ async function updateAgentVisibilityRequest(
     { method: "PATCH", body: { visibility } }
   )
   return res.visibility
-}
-
-async function deleteAgentRequest(agentID: string): Promise<DeleteAgentResponse> {
-  return apiRequest<DeleteAgentResponse>(
-    `/api/v1/agents/${encodeURIComponent(agentID)}`,
-    { method: "DELETE" }
-  )
 }
 
 async function setAgentStatus(
@@ -322,21 +307,6 @@ export function useAgentRunEvents(
   })
 }
 
-export function useRequeueRun(workspaceID: string | null) {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: async ({ runID, reason }: { runID: string; reason?: string }) => {
-      if (!workspaceID) throw noWorkspaceError()
-      return requeueRunRequest(runID, reason)
-    },
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ["admin", "agentRuns"] })
-      void qc.invalidateQueries({ queryKey: ["admin", "agentRun"] })
-      void qc.invalidateQueries({ queryKey: ["admin", "agentRunEvents"] })
-    },
-  })
-}
-
 export function useCancelRun(workspaceID: string | null) {
   const qc = useQueryClient()
   return useMutation({
@@ -451,16 +421,6 @@ export function useUpdateAgentProfile(workspaceID: string | null) {
       agentID: string
       body: UpdateAgentProfileRequest
     }) => updateAgentProfileRequest(agentID, body),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: KEY_AGENTS(workspaceID ?? "_none") })
-    },
-  })
-}
-
-export function useDeleteAgent(workspaceID: string | null) {
-  const qc = useQueryClient()
-  return useMutation({
-    mutationFn: async (agentID: string) => deleteAgentRequest(agentID),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: KEY_AGENTS(workspaceID ?? "_none") })
     },


### PR DESCRIPTION
## Summary

- remove the unused `useRequeueRun` mutation and its private request helper
- remove the unused `useDeleteAgent` mutation, private request helper, and now-unused response import
- keep all backend requeue/delete endpoints and active frontend cancel/visibility APIs unchanged

## Evidence

TypeScript Language Service `findReferences` reports zero non-definition references for both exported hooks. Each private request helper was referenced only by its corresponding hook.

This change does not overlap the Feishu API block removed by #145 or the files changed by #144. A real `--no-commit` merge rehearsal with the #145 branch completed automatically without conflicts.

## Validation

- `pnpm --filter @parsar/web typecheck`
- `pnpm --filter @parsar/web build`
- `pnpm --filter @parsar/web exec eslint src/lib/api-agents.ts`
- `git diff --check`
- `make check` — all Go packages passed; Docker setup then failed because the local daemon exhausted its predefined address pools (`all predefined address pools have been fully subnetted`)
- full web lint still reports the existing main-branch 9 errors / 37 warnings; the changed file passes targeted lint
