### PR TITLE
refactor(web): remove unused approvals copy

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -157,62 +157,6 @@
     "cancelled": "Cancelled",
     "interrupted": "Interrupted"
   },
-  "approvals": {
-    "page": {
-      "title": "Inbox / Approvals",
-      "description": "Where Agent actions that need human judgment land. Keeps risky moves out of IM threads and into a place you can audit."
-    },
-    "tabs": {
-      "pending": "Pending",
-      "decided": "Decided",
-      "expired": "Expired / Cancelled"
-    },
-    "risk": {
-      "high": "High risk",
-      "medium": "Medium risk",
-      "low": "Low risk"
-    },
-    "actions": {
-      "allowOnce": "Allow once",
-      "deny": "Deny"
-    },
-    "detail": {
-      "agent": "Agent",
-      "conversation": "Conversation",
-      "requestedBy": "Requested by",
-      "resource": "Target resource",
-      "payload": "Payload preview",
-      "createdAt": "Created",
-      "expiresIn": "Expires in",
-      "decision": "Decision",
-      "allow": "Allowed",
-      "deny": "Denied",
-      "alreadyDecided": "This approval has been handled — actions are no longer available.",
-      "relatedLinks": "Related",
-      "openRun": "Open Run Detail",
-      "openConversation": "Open Conversation",
-      "openIM": "Open in IM thread",
-      "empty": "Select an approval to see details"
-    },
-    "empty": {
-      "title": "No approvals",
-      "description": "When an Agent tries a high-risk action, it lands here for your call."
-    },
-    "loadError": {
-      "title": "Failed to load approvals",
-      "description": "Backend returned an error.",
-      "hint": "Make sure the server is running and the current workspace exists.",
-      "unreachable": {
-        "title": "Cannot reach the Parsar server",
-        "description": "The frontend cannot access the backend API (/api/v1/...). The server might be down, the port might be occupied, or the Vite proxy is misconfigured.",
-        "hint": "Check that the backend is running on port 18080: `make server` or `make dev`."
-      }
-    },
-    "mockBanner": {
-      "title": "Choose a data scope",
-      "hint": "Choose the matching Workspace in the header."
-    }
-  },
   "conversations": {
     "page": {
       "title": "Conversations",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -157,62 +157,6 @@
     "cancelled": "已取消",
     "interrupted": "已中断"
   },
-  "approvals": {
-    "page": {
-      "title": "收件箱 / 审批",
-      "description": "集中处理需要人类判断的事项。Agent 想做高风险动作时会落到这里，不让风险动作散落在 IM thread 里。"
-    },
-    "tabs": {
-      "pending": "待审批",
-      "decided": "已处理",
-      "expired": "已过期 / 已取消"
-    },
-    "risk": {
-      "high": "高风险",
-      "medium": "中风险",
-      "low": "低风险"
-    },
-    "actions": {
-      "allowOnce": "允许一次",
-      "deny": "拒绝"
-    },
-    "detail": {
-      "agent": "Agent",
-      "conversation": "关联对话",
-      "requestedBy": "请求者",
-      "resource": "目标资源",
-      "payload": "Payload 摘要",
-      "createdAt": "创建于",
-      "expiresIn": "剩余时间",
-      "decision": "决定",
-      "allow": "已允许",
-      "deny": "已拒绝",
-      "alreadyDecided": "这条审批已经处理过，不能再操作。",
-      "relatedLinks": "关联跳转",
-      "openRun": "打开 Run Detail",
-      "openConversation": "打开 Conversation",
-      "openIM": "跳回 IM thread",
-      "empty": "选一条审批查看详情"
-    },
-    "empty": {
-      "title": "暂时没有审批",
-      "description": "Agent 触发高风险动作时会落到这里需要你裁决。"
-    },
-    "loadError": {
-      "title": "无法加载审批列表",
-      "description": "后端返回错误。",
-      "hint": "确认 server 在跑、且当前工作区存在。",
-      "unreachable": {
-        "title": "无法连接到 Parsar server",
-        "description": "前端无法访问后端 API（/api/v1/...）。可能 server 没启动、端口被占用，或者 Vite proxy 配置不对。",
-        "hint": "检查后端是否在 18080 端口运行：`make server` 或 `make dev`。"
-      }
-    },
-    "mockBanner": {
-      "title": "选择数据范围",
-      "hint": "请在顶部选择对应的 Workspace。"
-    }
-  },
   "conversations": {
     "page": {
       "title": "对话",


### PR DESCRIPTION
## Summary

- remove the unused `approvals` localization namespace from both admin locales
- preserve the active approvals navigation, which currently renders the generic `StubPage` copy
- leave active sandbox renew and per-agent Feishu copy untouched

## Evidence

- TypeScript AST tracing covered static `t(...)`, `i18n.t(...)`, `Trans i18nKey`, template keys, conditional keys, and dynamic key prefixes
- no code references `approvals.*` or dynamically constructs the `approvals` prefix
- English and Chinese locale trees remain key-for-key identical
- no open PR modifies either admin locale file

## Validation

- JSON parse and locale key parity: passed
- `pnpm --filter @parsar/web typecheck`: passed
- `pnpm --filter @parsar/web build`: passed
- `git diff --check`: passed
- `make check`: all Go packages passed; Compose setup was blocked by the local Docker daemon error `all predefined address pools have been fully subnetted`
