### PR TITLE
Keep agent processes alive for one-hour idle window

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,10 +148,11 @@ description and keep ownership on the side listed here.
 - Every subprocess must be waited/reaped. Cancellation must close stdin when
   appropriate, send a graceful signal first, and escalate to kill after a
   bounded timeout.
-- A Parsar conversation is not a long-lived OS process. Each prompt turn may
-  start a CLI process, but the adapter must either resume the upstream engine
-  session on the next turn or explicitly document why that engine cannot
-  resume.
+- A completed prompt closes its protocol stream immediately, but daemon-side
+  CLI processes and their background children stay alive until the
+  conversation has received no new prompt for one hour. A new prompt for the
+  same `AgentStateKey` renews that idle window. Explicit cancellation, device
+  shutdown, and daemon shutdown still terminate processes immediately.
 - When an engine supports resume, persist the upstream session id through
   `agent_engine_sessions` and pass `AgentSessionID` plus `AgentStateKey` over
   the daemon protocol. Do not keep resume ids only in adapter memory, files

--- a/apps/parsar-daemon/internal/agent/claudecode/session.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/session.go
@@ -78,6 +78,8 @@ type Session struct {
 
 	out          chan<- proto.Envelope
 	closeOutOnce sync.Once
+	outMu        sync.RWMutex
+	outClosed    bool
 
 	// cancelCtx is a child of parent ctx so Session.Cancel can signal
 	// everyone without racing router shutdown.
@@ -523,7 +525,8 @@ func (s *Session) run(stdout io.Reader) {
 		}
 		if tx.Terminal {
 			terminal = true
-			s.finishAfterTerminal()
+			s.stopAllAskTimers()
+			s.closeOut()
 			break
 		}
 	}
@@ -594,6 +597,11 @@ func (s *Session) doneMetaForCancel() map[string]any {
 }
 
 func (s *Session) trySend(env proto.Envelope) {
+	s.outMu.RLock()
+	defer s.outMu.RUnlock()
+	if s.outClosed {
+		return
+	}
 	select {
 	case s.out <- env:
 	case <-time.After(2 * time.Second):
@@ -603,19 +611,12 @@ func (s *Session) trySend(env proto.Envelope) {
 }
 
 func (s *Session) closeOut() {
-	s.closeOutOnce.Do(func() { close(s.out) })
-}
-
-func (s *Session) finishAfterTerminal() {
-	s.stdinMu.Lock()
-	if s.stdin != nil {
-		_ = s.stdin.Close()
-		s.stdin = nil
-	}
-	s.stdinMu.Unlock()
-	if s.proc != nil {
-		s.proc.Cancel()
-	}
+	s.closeOutOnce.Do(func() {
+		s.outMu.Lock()
+		s.outClosed = true
+		close(s.out)
+		s.outMu.Unlock()
+	})
 }
 
 // resolveSessionWorkDir returns the directory that BOTH plugin installs

--- a/apps/parsar-daemon/internal/agent/claudecode/session_export_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/session_export_test.go
@@ -32,3 +32,7 @@ func NewSessionForTest(ctx context.Context, req proto.PromptRequestPayload, out 
 func (s *Session) SubmitPromptForUserChoiceForTest(askID string, decision proto.PromptForUserChoiceDecisionPayload) error {
 	return s.SubmitPromptForUserChoice(context.Background(), askID, decision)
 }
+
+func (s *Session) ProcessDoneForTest() <-chan struct{} {
+	return s.proc.Done()
+}

--- a/apps/parsar-daemon/internal/agent/claudecode/session_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/session_test.go
@@ -62,6 +62,19 @@ func runFakeClaude(role string) {
 			"usage":      map[string]int{"input_tokens": 5, "output_tokens": 2},
 		})
 
+	case "terminal-wait":
+		_ = enc.Encode(map[string]any{
+			"type": "system", "subtype": "init",
+			"session_id": "sess_terminal_wait",
+		})
+		_ = enc.Encode(map[string]any{
+			"type": "result", "subtype": "success",
+			"result":     "background work started",
+			"session_id": "sess_terminal_wait",
+		})
+		for stdin.Scan() {
+		}
+
 	case "echo-error":
 		_ = enc.Encode(map[string]any{
 			"type": "result", "subtype": "error_during_execution",
@@ -239,6 +252,36 @@ func TestSessionEndToEndSuccess(t *testing.T) {
 		if e.ID != "run_s" {
 			t.Errorf("env type=%s ID=%q, want run_s", e.Type, e.ID)
 		}
+	}
+}
+
+func TestTerminalResultKeepsProcessAliveUntilCancel(t *testing.T) {
+	out := make(chan proto.Envelope, 16)
+	sess, err := claudecode.NewSessionForTest(context.Background(),
+		helperReq("run_terminal_wait", "start background work", "terminal-wait"), out, helperConfig())
+	if err != nil {
+		t.Fatalf("NewSessionForTest: %v", err)
+	}
+
+	got, closed := drain(t, out, 5*time.Second)
+	if !closed {
+		t.Fatalf("out did not close, drained %d envelopes", len(got))
+	}
+	mustContain(t, envTypes(got), proto.TypeDone)
+
+	select {
+	case <-sess.ProcessDoneForTest():
+		t.Fatal("terminal result killed the CLI process before the idle timeout")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if err := sess.Cancel(context.Background()); err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	select {
+	case <-sess.ProcessDoneForTest():
+	case <-time.After(2 * time.Second):
+		t.Fatal("CLI process did not exit after explicit cancel")
 	}
 }
 

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -39,8 +39,9 @@ func defaultSessionConfig() sessionConfig {
 }
 
 // Factory implements agent.Factory for agent_kind="codex". Spawns one
-// codex app-server child per prompt; the child is torn down when the
-// turn completes or the parent context is cancelled.
+// codex app-server child per prompt. The run stream closes when the turn
+// completes; the router retains the child until the conversation's idle
+// window expires or cancellation shuts it down sooner.
 func Factory(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
 	return newSession(ctx, req, out, defaultSessionConfig())
 }
@@ -65,6 +66,8 @@ type Session struct {
 
 	cancelOnce   sync.Once
 	closeOutOnce sync.Once
+	outMu        sync.RWMutex
+	outClosed    bool
 	waitDone     chan struct{}
 	cleanup      func()
 
@@ -192,7 +195,6 @@ func (s *Session) SubmitPromptForUserChoice(_ context.Context, _ string, _ proto
 
 func (s *Session) run(plan SessionPlan, req proto.PromptRequestPayload) {
 	defer close(s.waitDone)
-	defer func() { _ = s.rpc.Close() }()
 	defer s.cleanup()
 	defer s.closeOut()
 
@@ -655,6 +657,11 @@ func (s *Session) emitTerminal(message string, asError bool) {
 }
 
 func (s *Session) trySend(env proto.Envelope) {
+	s.outMu.RLock()
+	defer s.outMu.RUnlock()
+	if s.outClosed {
+		return
+	}
 	select {
 	case s.out <- env:
 	case <-s.cancelCtx.Done():
@@ -664,16 +671,16 @@ func (s *Session) trySend(env proto.Envelope) {
 }
 
 func (s *Session) closeOut() {
-	s.closeOutOnce.Do(func() { close(s.out) })
+	s.closeOutOnce.Do(func() {
+		s.outMu.Lock()
+		s.outClosed = true
+		close(s.out)
+		s.outMu.Unlock()
+	})
 }
 
 func (s *Session) finishAfterTerminal() {
-	if s.cancelFn != nil {
-		s.cancelFn()
-	}
-	if s.rpc != nil {
-		_ = s.rpc.Close()
-	}
+	s.closeOut()
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/parsar-daemon/internal/agent/codex/session_log_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_log_test.go
@@ -173,7 +173,7 @@ func TestOnTurnFailed_LogsBufferedError(t *testing.T) {
 	}
 }
 
-func TestTerminalTurnClosesRPCAndCancelsSession(t *testing.T) {
+func TestTerminalTurnKeepsRPCAliveUntilSessionCancel(t *testing.T) {
 	tests := []struct {
 		name string
 		run  func(*Session)
@@ -219,14 +219,15 @@ func TestTerminalTurnClosesRPCAndCancelsSession(t *testing.T) {
 
 			tt.run(s)
 
-			if rpc.Alive() {
-				t.Fatal("terminal turn must close the codex RPC client")
+			if !rpc.Alive() {
+				t.Fatal("terminal turn must keep the codex RPC client alive during the idle window")
 			}
 			select {
 			case <-ctx.Done():
+				t.Fatal("terminal turn must not cancel the session context")
 			default:
-				t.Fatal("terminal turn must cancel the session context")
 			}
+
 		})
 	}
 }

--- a/apps/parsar-daemon/internal/agent/registry.go
+++ b/apps/parsar-daemon/internal/agent/registry.go
@@ -6,9 +6,10 @@
 //
 //   - Factory takes an out chan<- proto.Envelope owned by the dispatch
 //     router. The agent SENDS upstream events on it and OWNS the
-//     close: it MUST close(out) exactly once when the session is
-//     fully done, AFTER emitting a terminal "done" or "error" frame.
-//     The router uses the close as the "session terminated" signal.
+//     close: it MUST close(out) exactly once after emitting the current
+//     run's terminal "done" or "error" frame. The underlying CLI may
+//     remain alive during the router's idle window and is terminated
+//     through Session.Cancel.
 //
 //   - Session.Cancel is best-effort and idempotent: a session that
 //     already finished naturally must accept a Cancel call without
@@ -36,8 +37,9 @@ import (
 // doc). ctx is cancelled by the router to wind the session down.
 type Factory func(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (Session, error)
 
-// Session is one in-flight prompt run. Completion is signalled by
-// closing the out channel passed to its Factory.
+// Session owns one prompt run and any CLI process retained after that
+// run. Run completion is signalled by closing out; process teardown is
+// signalled separately through Cancel.
 type Session interface {
 	// Cancel signals the session to abort. Idempotent. Actual teardown
 	// happens asynchronously and is signalled via the out channel close.

--- a/apps/parsar-daemon/internal/dispatch/router.go
+++ b/apps/parsar-daemon/internal/dispatch/router.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
 	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
@@ -33,13 +34,15 @@ type Router struct {
 	sender   Sender
 	log      *slog.Logger
 
-	mu         sync.Mutex
-	sessions   map[string]*sessionState // RunID → state
-	permIndex  map[string]string        // permID  → RunID
-	askIndex   map[string]string        // askID   → RunID
-	shutdownCh chan struct{}            // closed by Shutdown
-	shutdownWG sync.WaitGroup           // waits for all pump goroutines
-	closed     bool
+	mu          sync.Mutex
+	sessions    map[string]*sessionState // RunID → state
+	idle        map[string]map[*sessionState]struct{}
+	permIndex   map[string]string // permID  → RunID
+	askIndex    map[string]string // askID   → RunID
+	shutdownCh  chan struct{}     // closed by Shutdown
+	shutdownWG  sync.WaitGroup    // waits for all pump goroutines
+	idleTimeout time.Duration
+	closed      bool
 }
 
 // sessionState is the dispatcher's per-run bookkeeping. The agent
@@ -49,21 +52,28 @@ type Router struct {
 // frontend → server → daemon → agent → server attribution.
 type sessionState struct {
 	runID       string
+	stateKey    string
 	session     agent.Session
 	out         chan proto.Envelope
 	ctxCancel   context.CancelFunc
 	pendingIDs  map[string]struct{}
 	pendingAsks map[string]struct{}
 	traceparent string
+	idleTimer   *time.Timer
+	idleLease   uint64
+	retain      bool
 }
 
 // Config is the constructor input. Registry and Sender are required;
 // Log is optional (defaults to slog.Default()).
 type Config struct {
-	Registry *agent.Registry
-	Sender   Sender
-	Log      *slog.Logger
+	Registry    *agent.Registry
+	Sender      Sender
+	Log         *slog.Logger
+	IdleTimeout time.Duration
 }
+
+const defaultIdleTimeout = time.Hour
 
 // New returns a Router ready to Handle inbound frames.
 func New(cfg Config) (*Router, error) {
@@ -78,14 +88,20 @@ func New(cfg Config) (*Router, error) {
 		log = obslog.Bg()
 	}
 	log = log.With("component", "dispatch")
+	idleTimeout := cfg.IdleTimeout
+	if idleTimeout <= 0 {
+		idleTimeout = defaultIdleTimeout
+	}
 	return &Router{
-		registry:   cfg.Registry,
-		sender:     cfg.Sender,
-		log:        log,
-		sessions:   make(map[string]*sessionState),
-		permIndex:  make(map[string]string),
-		askIndex:   make(map[string]string),
-		shutdownCh: make(chan struct{}),
+		registry:    cfg.Registry,
+		sender:      cfg.Sender,
+		log:         log,
+		sessions:    make(map[string]*sessionState),
+		idle:        make(map[string]map[*sessionState]struct{}),
+		permIndex:   make(map[string]string),
+		askIndex:    make(map[string]string),
+		shutdownCh:  make(chan struct{}),
+		idleTimeout: idleTimeout,
 	}, nil
 }
 
@@ -152,8 +168,19 @@ func (r *Router) Shutdown(ctx context.Context) error {
 	close(r.shutdownCh)
 	victims := make([]*sessionState, 0, len(r.sessions))
 	for _, s := range r.sessions {
+		s.retain = false
 		victims = append(victims, s)
 	}
+	for _, states := range r.idle {
+		for s := range states {
+			s.retain = false
+			if s.idleTimer != nil {
+				s.idleTimer.Stop()
+			}
+			victims = append(victims, s)
+		}
+	}
+	r.idle = make(map[string]map[*sessionState]struct{})
 	r.mu.Unlock()
 
 	cancelSessions(ctx, victims, r.log)
@@ -236,6 +263,8 @@ func (r *Router) handlePromptRequest(callerCtx context.Context, env proto.Envelo
 		r.log.WarnContext(callerCtx, "ignoring duplicate prompt_request", "run_id", runID)
 		return nil
 	}
+	stateKey := sessionStateKey(req)
+	r.touchIdleLocked(stateKey)
 	sessionCtx, sessionCancel := context.WithCancel(context.Background())
 	// Re-attach the inbound trace so every log under this run shows
 	// the same trace_id as the prompt_request that started it.
@@ -245,11 +274,13 @@ func (r *Router) handlePromptRequest(callerCtx context.Context, env proto.Envelo
 	out := make(chan proto.Envelope, 64)
 	state := &sessionState{
 		runID:       runID,
+		stateKey:    stateKey,
 		out:         out,
 		ctxCancel:   sessionCancel,
 		pendingIDs:  make(map[string]struct{}),
 		pendingAsks: make(map[string]struct{}),
 		traceparent: env.Trace,
+		retain:      stateKey != "",
 	}
 	r.sessions[runID] = state
 	r.mu.Unlock()
@@ -280,6 +311,9 @@ func (r *Router) handlePromptRequest(callerCtx context.Context, env proto.Envelo
 func (r *Router) handlePromptCancel(ctx context.Context, env proto.Envelope) error {
 	r.mu.Lock()
 	state, ok := r.sessions[env.ID]
+	if ok {
+		state.retain = false
+	}
 	r.mu.Unlock()
 	if !ok {
 		// Cancelling an unknown / already-finished run is a no-op.
@@ -337,7 +371,8 @@ func (r *Router) handlePermissionDecision(ctx context.Context, env proto.Envelop
 // inside the session don't currently call back into the router, so
 // those entries linger until cleanupSession — acceptable because they
 // can't double-fire (the session's own pendingAskTable.Take already
-// guards that) and the session is short-lived.
+// guards that); cleanupSession removes the routing entry when the run
+// stream closes, even if the underlying CLI remains in the idle pool.
 func (r *Router) handlePromptForUserChoiceDecision(ctx context.Context, env proto.Envelope) error {
 	if env.ID == "" {
 		return errors.New("dispatch: prompt_for_user_choice_decision missing ask id (Envelope.ID empty)")
@@ -394,8 +429,19 @@ func (r *Router) handleDeviceShutdown(ctx context.Context, env proto.Envelope) e
 	r.mu.Lock()
 	victims := make([]*sessionState, 0, len(r.sessions))
 	for _, s := range r.sessions {
+		s.retain = false
 		victims = append(victims, s)
 	}
+	for _, states := range r.idle {
+		for s := range states {
+			s.retain = false
+			if s.idleTimer != nil {
+				s.idleTimer.Stop()
+			}
+			victims = append(victims, s)
+		}
+	}
+	r.idle = make(map[string]map[*sessionState]struct{})
 	r.mu.Unlock()
 	cancelSessions(ctx, victims, r.log)
 	return nil
@@ -473,6 +519,9 @@ func (r *Router) pump(s *sessionState) {
 				// but KEEP draining out so the agent's goroutines
 				// don't block on a full channel.
 				r.log.ErrorContext(pumpCtx, "send envelope failed", "type", env.Type, "run_id", env.ID, "err", err)
+				r.mu.Lock()
+				s.retain = false
+				r.mu.Unlock()
 				s.ctxCancel()
 				r.drain(s.out)
 				return
@@ -480,6 +529,9 @@ func (r *Router) pump(s *sessionState) {
 		case <-r.shutdownCh:
 			// Router shutdown — cancel + drain so the session's
 			// goroutines unblock and close out cleanly.
+			r.mu.Lock()
+			s.retain = false
+			r.mu.Unlock()
 			s.ctxCancel()
 			r.drain(s.out)
 			return
@@ -534,13 +586,68 @@ func (r *Router) drain(ch <-chan proto.Envelope) {
 // pump's defer so it runs exactly once.
 func (r *Router) cleanupSession(s *sessionState) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	delete(r.sessions, s.runID)
 	for permID := range s.pendingIDs {
 		delete(r.permIndex, permID)
 	}
 	for askID := range s.pendingAsks {
 		delete(r.askIndex, askID)
+	}
+	if !s.retain || s.session == nil || s.stateKey == "" || r.closed {
+		r.mu.Unlock()
+		return
+	}
+	states := r.idle[s.stateKey]
+	if states == nil {
+		states = make(map[*sessionState]struct{})
+		r.idle[s.stateKey] = states
+	}
+	states[s] = struct{}{}
+	r.scheduleIdleLocked(s)
+	r.mu.Unlock()
+}
+
+func sessionStateKey(req proto.PromptRequestPayload) string {
+	return req.AgentStateKey
+}
+
+func (r *Router) touchIdleLocked(stateKey string) {
+	if stateKey == "" {
+		return
+	}
+	for state := range r.idle[stateKey] {
+		r.scheduleIdleLocked(state)
+	}
+}
+
+func (r *Router) scheduleIdleLocked(state *sessionState) {
+	if state.idleTimer != nil {
+		state.idleTimer.Stop()
+	}
+	state.idleLease++
+	lease := state.idleLease
+	state.idleTimer = time.AfterFunc(r.idleTimeout, func() {
+		r.expireIdle(state, lease)
+	})
+}
+
+func (r *Router) expireIdle(state *sessionState, lease uint64) {
+	r.mu.Lock()
+	states := r.idle[state.stateKey]
+	if _, ok := states[state]; !ok || state.idleLease != lease {
+		r.mu.Unlock()
+		return
+	}
+	delete(states, state)
+	if len(states) == 0 {
+		delete(r.idle, state.stateKey)
+	}
+	state.retain = false
+	r.mu.Unlock()
+
+	state.ctxCancel()
+	if err := state.session.Cancel(context.Background()); err != nil {
+		r.log.Warn("idle session cancel failed", "run_id", state.runID, "state_key", state.stateKey, "err", err)
 	}
 }
 

--- a/apps/parsar-daemon/internal/dispatch/router_test.go
+++ b/apps/parsar-daemon/internal/dispatch/router_test.go
@@ -68,6 +68,7 @@ type fakeSession struct {
 	out                 chan<- proto.Envelope
 	closeOutOnCancelMu  sync.Once
 	postCancelEnvelopes []proto.Envelope // emitted to out after Cancel fires
+	ctx                 context.Context
 }
 
 type permCall struct {
@@ -139,6 +140,10 @@ type harness struct {
 }
 
 func newHarness(t *testing.T) *harness {
+	return newHarnessWithIdleTimeout(t, time.Hour)
+}
+
+func newHarnessWithIdleTimeout(t *testing.T, idleTimeout time.Duration) *harness {
 	t.Helper()
 	h := &harness{
 		sender:  &recSender{},
@@ -146,18 +151,72 @@ func newHarness(t *testing.T) *harness {
 		gotReq:  make(chan proto.PromptRequestPayload, 16),
 		gotSess: make(chan *fakeSession, 16),
 	}
-	h.reg.Register("claude_code", func(_ context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
-		sess := &fakeSession{out: out}
+	h.reg.Register("claude_code", func(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+		sess := &fakeSession{out: out, ctx: ctx}
 		h.gotReq <- req
 		h.gotSess <- sess
 		return sess, nil
 	})
-	r, err := dispatch.New(dispatch.Config{Registry: h.reg, Sender: h.sender})
+	r, err := dispatch.New(dispatch.Config{Registry: h.reg, Sender: h.sender, IdleTimeout: idleTimeout})
 	if err != nil {
 		t.Fatalf("dispatch.New: %v", err)
 	}
 	h.router = r
 	return h
+}
+
+func TestCompletedSessionCancelsAfterIdleTimeout(t *testing.T) {
+	h := newHarnessWithIdleTimeout(t, 40*time.Millisecond)
+	defer h.router.Shutdown(context.Background())
+
+	env := mustEnv(t, proto.TypePromptRequest, "run_idle", proto.PromptRequestPayload{
+		AgentKind: "claude_code", ConversationID: "conv-idle", AgentStateKey: "conv-idle/agent/claude_code",
+	})
+	if err := h.router.Handle(context.Background(), env); err != nil {
+		t.Fatalf("Handle prompt_request: %v", err)
+	}
+	sess := <-h.gotSess
+	close(sess.out)
+	waitFor(t, func() bool { return h.router.ActiveRuns() == 0 }, "active run cleanup")
+
+	select {
+	case <-sess.ctx.Done():
+		t.Fatal("completed session cancelled before idle timeout")
+	case <-time.After(15 * time.Millisecond):
+	}
+	waitFor(t, func() bool { return sess.cancels() == 1 }, "idle session cancellation")
+}
+
+func TestNewPromptResetsCompletedSessionIdleTimeout(t *testing.T) {
+	h := newHarnessWithIdleTimeout(t, 80*time.Millisecond)
+	defer h.router.Shutdown(context.Background())
+
+	stateKey := "conv-renew/agent/claude_code"
+	first := mustEnv(t, proto.TypePromptRequest, "run_first", proto.PromptRequestPayload{
+		AgentKind: "claude_code", ConversationID: "conv-renew", AgentStateKey: stateKey,
+	})
+	if err := h.router.Handle(context.Background(), first); err != nil {
+		t.Fatalf("Handle first prompt: %v", err)
+	}
+	firstSession := <-h.gotSess
+	close(firstSession.out)
+	waitFor(t, func() bool { return h.router.ActiveRuns() == 0 }, "first run cleanup")
+	time.Sleep(50 * time.Millisecond)
+
+	second := mustEnv(t, proto.TypePromptRequest, "run_second", proto.PromptRequestPayload{
+		AgentKind: "claude_code", ConversationID: "conv-renew", AgentStateKey: stateKey,
+	})
+	if err := h.router.Handle(context.Background(), second); err != nil {
+		t.Fatalf("Handle second prompt: %v", err)
+	}
+	secondSession := <-h.gotSess
+
+	time.Sleep(45 * time.Millisecond)
+	if firstSession.cancels() != 0 {
+		t.Fatal("new prompt did not renew the completed session idle timeout")
+	}
+	close(secondSession.out)
+	waitFor(t, func() bool { return firstSession.cancels() == 1 }, "renewed idle session cancellation")
 }
 
 func mustEnv(t *testing.T, typ, id string, payload any) proto.Envelope {


### PR DESCRIPTION
## Summary

- stop terminating Claude Code and Codex subprocesses as soon as a prompt emits its terminal result
- close each run's protocol stream immediately while retaining the underlying CLI process
- retain completed sessions by `AgentStateKey` and cancel them only after one hour with no new prompt for the same state key
- reset the idle window whenever a new prompt arrives for that state key
- keep explicit prompt cancellation, device shutdown, daemon shutdown, and transport failure as immediate teardown paths

## Root cause

PR #103 added terminal cleanup that called `Process.Cancel` / closed the Codex RPC client immediately after each response. That correctly removed leaked foreground CLI processes, but it also killed background work started by the agent as soon as the response finished.

## Validation

- real fake-Claude subprocess test verifies the result stream closes while the CLI remains alive until `Cancel`
- Codex test verifies terminal completion leaves the RPC child and session context alive
- dispatch tests verify idle cancellation and renewal by a subsequent prompt
- focused race tests pass for Claude, Codex, and dispatch lifecycle paths
- affected package tests pass; the unrelated known Claude plugin concurrency test remains flaky in the full package run
- `make check` passed all Go packages, then stopped because the local Docker daemon exhausted its predefined network address pools
- `git diff --check`
