### PR TITLE
fix: correct Agent model selection and catalog visibility

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -962,6 +962,7 @@
       "unbound": "No runtime bound",
       "pending": "Not allocated"
     },
+    "modelUnavailable": "Unavailable model",
     "sandbox": {
       "running": "Running"
     },
@@ -1419,6 +1420,7 @@
         "nameConflict": "An Agent with this name already exists. Pick another name.",
         "slugConflict": "The internal identifier is already taken. Pick another name.",
         "modelRequired": "Pick a model first.",
+        "modelUnavailable": "The current model is unavailable. Select an active model.",
         "generatedIdConflict": "This name generates an internal identifier that is already taken. Pick another name.",
         "generatedIdInvalid": "Name needs at least one letter, number, or Chinese character.",
         "deviceRequired": "Select a local device.",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -962,6 +962,7 @@
       "unbound": "未绑定 Runtime",
       "pending": "待分配"
     },
+    "modelUnavailable": "模型不可用",
     "sandbox": {
       "running": "运行中"
     },
@@ -1419,6 +1420,7 @@
         "nameConflict": "已有同名 Agent，请换一个",
         "slugConflict": "内部标识已被占用，请换一个名称。",
         "modelRequired": "请选择一个模型",
+        "modelUnavailable": "当前模型已不可用，请重新选择一个可用模型。",
         "generatedIdConflict": "这个名称生成的内部标识已被占用，请换一个名称。",
         "generatedIdInvalid": "名称需要包含至少一个字母、数字或中文。",
         "deviceRequired": "请选择一台本地设备。",

--- a/apps/web/src/lib/api-models.ts
+++ b/apps/web/src/lib/api-models.ts
@@ -69,6 +69,10 @@ export function useModels(workspaceID: string | null) {
     queryFn: () => listModels(workspaceID),
     retry: noUnreachableRetry,
     staleTime: 30_000,
+    // The model catalog can be changed from another admin session. Refresh
+    // when the Agents/Models page mounts so the picker does not keep an old
+    // cached inventory after navigation.
+    refetchOnMount: "always",
   })
 }
 

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -99,13 +99,13 @@ import { credentialKindLabel } from "./capability-ui"
  * `default_model_id` (a UUID); falls back through legacy
  * `model_id` / `profile.model_id` shapes for older rows.
  */
-function defaultModelOf(a: Agent, models: Model[]): string {
+function defaultModelOf(a: Agent, models: Model[], unavailableLabel: string): string {
   const cfg = (a.config as Record<string, unknown> | undefined) ?? {}
   const profile = (cfg.profile ?? {}) as Record<string, unknown>
   const id = String(cfg.default_model_id ?? cfg.model_id ?? profile.model_id ?? "")
   if (!id) return "—"
   const found = models.find((m) => m.id === id)
-  if (!found) return id // model deleted or workspace mismatch — show id over silent "—"
+  if (!found) return unavailableLabel
   return found.name || found.model_key || id
 }
 
@@ -448,7 +448,7 @@ export function AgentsPage() {
                         </div>
                       </TableCell>
                       <TableCell><RuntimeCell agent={a} /></TableCell>
-                      <TableCell className="font-mono text-sm text-fg-muted">{defaultModelOf(a, modelsQ.data?.models ?? [])}</TableCell>
+                      <TableCell className="font-mono text-sm text-fg-muted">{defaultModelOf(a, modelsQ.data?.models ?? [], t("agents.modelUnavailable"))}</TableCell>
                       <TableCell className="text-sm text-fg-subtle">
                         {t(`agents.visibility.${a.visibility ?? "workspace"}`)}
                       </TableCell>
@@ -695,7 +695,7 @@ export function AgentDetailPage({ id }: { id: string }) {
     )
   }
 
-  const model = defaultModelOf(agent, modelsQ.data?.models ?? [])
+  const model = defaultModelOf(agent, modelsQ.data?.models ?? [], t("agents.modelUnavailable"))
   const connector = connectorLabel(agent.connector_type)
 
   return (

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -695,7 +695,8 @@ export function CreateAgentDialog({
   const connector = mode === "edit" && agent ? agent.connector_type : connectorForExecutionMode(executionMode)
   const hasModel = activeModels.length > 0
   const requiresModel = connector !== "agent_daemon" || agentEngine === "claude_code" || agentEngine === "codex" || agentEngine === "pi"
-  const hasRequiredModel = !requiresModel || (hasModel && selectedModelID !== "")
+  const selectedModelUnavailable = mode === "edit" && requiresModel && selectedModelID !== "" && selectedModel === null
+  const hasRequiredModel = !requiresModel || (selectedModel !== null && !incompatibleModelIDs.has(selectedModel.id))
   // Create opens model binding on a pending "shared" pick because secrets may
   // still be loading; once they land, resolve to the first existing one. Gated
   // on the credential_ref UI so no-credential models stay untouched; with zero
@@ -774,7 +775,7 @@ export function CreateAgentDialog({
 
   async function submit() {
     setSubmitAttempted(true)
-    if (requiresModel && (!hasModel || !selectedModelID)) {
+    if (!hasRequiredModel) {
       modelFieldRef.current?.scrollIntoView({ behavior: "smooth", block: "center" })
       return
     }
@@ -804,18 +805,14 @@ export function CreateAgentDialog({
         : (cap.latest_version_id as string)
       return { capability_version_id: versionID, pinning_mode: pinningMode }
     })
+    const profile = {
+      ...(requiresModel ? { model_id: selectedModelID } : {}),
+      capabilities: capabilityNames,
+      skills: capabilityNames,
+    }
     const mergedConfig: Record<string, unknown> = {
       ...configBaseForSubmit(agent, connector),
-      // The edit flow updates the agent config twice: the main agent PATCH
-      // and, for agent_daemon rows, the profile update below. Keep the
-      // canonical model field in the second payload too, otherwise its
-      // stale value can overwrite the newly selected model.
-      ...(requiresModel ? { default_model_id: selectedModelID } : {}),
-      profile: {
-        ...(requiresModel ? { model_id: selectedModelID } : {}),
-        capabilities: capabilityNames,
-        skills: capabilityNames,
-      },
+      profile,
       ...(connector === "agent_daemon" ? {
         agent_kind: agentEngine,
         ...(executionMode === "sandbox" ? { daemon_mode: "sandbox", sandbox_size: sandboxSize } : {}),
@@ -825,6 +822,14 @@ export function CreateAgentDialog({
         // per-conversation scratch dir on the daemon side.
         ...(trimmedWorkDir !== "" ? { work_dir: trimmedWorkDir } : {}),
       } : {}),
+    }
+    const agentProfileConfig: Record<string, unknown> = {
+      profile,
+      agent_kind: agentEngine,
+      daemon_mode: executionMode === "sandbox" ? "sandbox" : "local",
+      sandbox_size: executionMode === "sandbox" ? sandboxSize : null,
+      device_id: executionMode === "local_device" ? deviceID : null,
+      work_dir: trimmedWorkDir || null,
     }
     // Embed credential_bindings + model_credential_binding into the agent
     // config so the runtime resolver and visibility-bindings validator
@@ -875,7 +880,7 @@ export function CreateAgentDialog({
       ? {
           ...(requiresModel ? { model_id: selectedModelID } : {}),
           system_prompt: systemPrompt.trim() || undefined,
-          config: mergedConfig,
+          config: agentProfileConfig,
         } satisfies UpdateAgentProfileRequest
       : undefined
     // In edit mode, sync per-binding pinning_mode / version against the
@@ -976,7 +981,7 @@ export function CreateAgentDialog({
     }
     setSubmitAttempted(true)
     if (step === 1 && !step1Valid) {
-      if (requiresModel && !selectedModelID) {
+      if (!hasRequiredModel) {
         modelFieldRef.current?.scrollIntoView({ behavior: "smooth", block: "center" })
       }
       return
@@ -1154,7 +1159,16 @@ export function CreateAgentDialog({
                 </Field>
               )}
               {requiresModel && (
-                <Field ref={modelFieldRef} label={t("agents.form.fields.model")} required error={submitAttempted && !selectedModelID ? t("agents.form.errors.modelRequired") : undefined}>
+                <Field
+                  ref={modelFieldRef}
+                  label={t("agents.form.fields.model")}
+                  required
+                  error={selectedModelUnavailable
+                    ? t("agents.form.errors.modelUnavailable")
+                    : submitAttempted && !hasRequiredModel
+                      ? t("agents.form.errors.modelRequired")
+                      : undefined}
+                >
                 {hasModel ? (
                   <div ref={modelComboboxRef} className="relative">
                     <Search className="pointer-events-none absolute left-2.5 top-1/2 z-10 h-3.5 w-3.5 -translate-y-1/2 text-fg-faint" />

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -806,6 +806,11 @@ export function CreateAgentDialog({
     })
     const mergedConfig: Record<string, unknown> = {
       ...configBaseForSubmit(agent, connector),
+      // The edit flow updates the agent config twice: the main agent PATCH
+      // and, for agent_daemon rows, the profile update below. Keep the
+      // canonical model field in the second payload too, otherwise its
+      // stale value can overwrite the newly selected model.
+      ...(requiresModel ? { default_model_id: selectedModelID } : {}),
       profile: {
         ...(requiresModel ? { model_id: selectedModelID } : {}),
         capabilities: capabilityNames,

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -2118,7 +2118,7 @@ where id = @id::uuid
   and deleted_at is null;
 
 -- name: ListModels :many
--- List all active models. Company-wide shared, no longer filtered by workspace.
+-- List active, non-deleted models. Company-wide shared, no longer filtered by workspace.
 select
   id::text, slug, name, provider_type, adapter, base_url, model_key,
   credential_mode,
@@ -2128,6 +2128,7 @@ select
   created_at, updated_at
 from models
 where deleted_at is null
+  and status = 'active'
 order by created_at desc, id desc
 limit @item_limit;
 

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -7875,6 +7875,7 @@ select
   created_at, updated_at
 from models
 where deleted_at is null
+  and status = 'active'
 order by created_at desc, id desc
 limit $1
 `
@@ -7897,7 +7898,7 @@ type ListModelsRow struct {
 	UpdatedAt          pgtype.Timestamptz `json:"updated_at"`
 }
 
-// List all active models. Company-wide shared, no longer filtered by workspace.
+// List active, non-deleted models. Company-wide shared, no longer filtered by workspace.
 func (q *Queries) ListModels(ctx context.Context, itemLimit int32) ([]ListModelsRow, error) {
 	rows, err := q.db.Query(ctx, listModels, itemLimit)
 	if err != nil {

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -2152,25 +2152,69 @@ func (s *Store) ConfigureAgentProfile(ctx context.Context, input ConfigureAgentP
 	if err != nil {
 		return ConfigureDevAgentConnectorResult{}, err
 	}
-	config := nonNilMap(input.Config)
+	tx, err := beginTx(ctx, s.db)
+	if err != nil {
+		return ConfigureDevAgentConnectorResult{}, err
+	}
+	defer tx.Rollback(ctx)
+	queries := sqlc.New(tx)
+	current, err := queries.GetAgentForUpdate(ctx, agentID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ConfigureDevAgentConnectorResult{}, fmt.Errorf("%w: %s", ErrUnknownAgent, input.AgentID)
+		}
+		return ConfigureDevAgentConnectorResult{}, err
+	}
+	// Agent edits call this endpoint after the main PATCH. Merge only fields
+	// owned by the profile request so its older snapshot cannot roll back model,
+	// capability, or credential changes already committed by UpdateAgent.
+	config := decodeJSONMap(current.Config)
+	profileConfig := nonNilMap(input.Config)
+	if raw, ok := profileConfig["profile"]; ok {
+		profile, ok := raw.(map[string]any)
+		if !ok || len(profile) == 0 {
+			delete(config, "profile")
+		} else {
+			config["profile"] = cloneAnyMap(profile)
+		}
+	}
+	for _, key := range []string{"agent_kind", "daemon_mode", "sandbox_size", "device_id"} {
+		raw, ok := profileConfig[key]
+		if !ok {
+			continue
+		}
+		value, _ := raw.(string)
+		if value = strings.TrimSpace(value); value == "" {
+			delete(config, key)
+		} else {
+			config[key] = value
+		}
+	}
+	var profileWorkdir any
+	var profileWorkdirSet bool
+	for _, key := range []string{"work_dir", "workdir", "working_directory"} {
+		if value, ok := profileConfig[key]; ok {
+			profileWorkdir = value
+			profileWorkdirSet = true
+			break
+		}
+	}
+	if profileWorkdirSet {
+		delete(config, "work_dir")
+		delete(config, "workdir")
+		delete(config, "working_directory")
+		if workdir, ok := profileWorkdir.(string); ok {
+			if workdir = strings.TrimSpace(workdir); workdir != "" {
+				config["work_dir"] = workdir
+			}
+		}
+	}
 	if modelID := strings.TrimSpace(input.ModelID); modelID != "" {
 		modelUUID, err := uuid(modelID)
 		if err != nil {
 			return ConfigureDevAgentConnectorResult{}, err
 		}
-		workspaceID, err := sqlc.New(s.db).GetAgentWorkspace(ctx, agentID)
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return ConfigureDevAgentConnectorResult{}, fmt.Errorf("%w: %s", ErrUnknownAgent, input.AgentID)
-			}
-			return ConfigureDevAgentConnectorResult{}, err
-		}
-		workspaceUUID, err := uuid(workspaceID)
-		if err != nil {
-			return ConfigureDevAgentConnectorResult{}, err
-		}
-		_ = workspaceUUID
-		status, err := sqlc.New(s.db).GetModelStatus(ctx, modelUUID)
+		status, err := queries.GetModelStatus(ctx, modelUUID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return ConfigureDevAgentConnectorResult{}, fmt.Errorf("%w: %s", ErrUnknownModel, modelID)
@@ -2183,20 +2227,33 @@ func (s *Store) ConfigureAgentProfile(ctx context.Context, input ConfigureAgentP
 		config["model_id"] = modelID
 	}
 	if workdir := strings.TrimSpace(input.Workdir); workdir != "" {
-		config["workdir"] = workdir
+		delete(config, "workdir")
+		delete(config, "working_directory")
+		config["work_dir"] = workdir
 	}
 	if systemPrompt := strings.TrimSpace(input.SystemPrompt); systemPrompt != "" {
 		config["system_prompt"] = systemPrompt
+	}
+	if _, daemonModeSet := profileConfig["daemon_mode"]; daemonModeSet {
+		switch stringFromMap(config, "daemon_mode") {
+		case "sandbox":
+			delete(config, "device_id")
+		case "local":
+			delete(config, "sandbox_size")
+		}
 	}
 	encoded, err := json.Marshal(config)
 	if err != nil {
 		return ConfigureDevAgentConnectorResult{}, err
 	}
-	row, err := sqlc.New(s.db).ConfigureAgentProfile(ctx, sqlc.ConfigureAgentProfileParams{AgentID: agentID, AgentConfig: encoded, Now: timestamptz(time.Now().UTC())})
+	row, err := queries.ConfigureAgentProfile(ctx, sqlc.ConfigureAgentProfileParams{AgentID: agentID, AgentConfig: encoded, Now: timestamptz(time.Now().UTC())})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ConfigureDevAgentConnectorResult{}, fmt.Errorf("%w: %s", ErrUnknownAgent, input.AgentID)
 		}
+		return ConfigureDevAgentConnectorResult{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
 		return ConfigureDevAgentConnectorResult{}, err
 	}
 	return ConfigureDevAgentConnectorResult{AgentID: row.AgentID, Name: row.Name, Slug: row.Slug, ConnectorType: row.ConnectorType, AgentConfig: decodeJSONMap(row.AgentConfig)}, nil

--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -2300,6 +2300,185 @@ func TestConfigureAgentProfileChecksModelStatus(t *testing.T) {
 	}
 }
 
+func TestConfigureAgentProfilePreservesAgentPatchFields(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	store := New(db)
+	ids := mustSeedDevFixture(t, ctx, store)
+
+	model, err := store.CreateModel(ctx, CreateModelInput{
+		Name:               "Profile Merge Model",
+		ProviderType:       "openai",
+		Adapter:            "@ai-sdk/openai",
+		BaseURL:            "https://example.test/v1",
+		ModelKey:           "profile-merge-1",
+		CredentialMode:     "credential_ref",
+		CredentialKindCode: "openai_api_key",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	capability, err := store.CreateCapability(ctx, CreateCapabilityInput{
+		WorkspaceID: ids.WorkspaceID,
+		Type:        "skill",
+		Name:        "Profile Merge Capability",
+		CreatorID:   ids.UserID,
+		InitialVersion: &CreateCapabilityVersionInput{
+			Version:             "1.0.0",
+			Content:             map[string]any{"kind": "skill"},
+			RequiredCredentials: []RequiredCredential{{Kind: "github_pat", Required: true}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(ctx, `
+		update agents
+		set config = '{
+			"default_model_id":"old-model",
+			"model_id":"old-model",
+			"capabilities":["Old Capability"],
+			"credential_bindings":{"github_pat":{"source":"shared","secret_id":"00000000-0000-0000-0000-000000000101"}},
+			"model_credential_binding":{"source":"shared","secret_id":"00000000-0000-0000-0000-000000000102"},
+			"profile":{"model_id":"old-model","capabilities":["Old Capability"]},
+			"agent_kind":"claude_code",
+			"daemon_mode":"sandbox",
+			"sandbox_size":"xl",
+			"workdir":"/old/workdir",
+			"working_directory":"/older/workdir"
+		}'::jsonb
+		where id = $1::uuid
+	`, ids.BackendAgentID); err != nil {
+		t.Fatal(err)
+	}
+
+	modelID := model.ID
+	if _, _, err := store.UpdateAgent(ctx, UpdateAgentInput{
+		AgentID:         ids.BackendAgentID,
+		ActorID:         ids.UserID,
+		DefaultModelID:  &modelID,
+		Capabilities:    []string{capability.Name},
+		CapabilitiesSet: true,
+		ConfigSet:       true,
+		Config: map[string]any{
+			"credential_bindings": map[string]any{
+				"github_pat": map[string]any{"source": "shared", "secret_id": "00000000-0000-0000-0000-000000000201"},
+			},
+			"model_credential_binding": map[string]any{"source": "shared", "secret_id": "00000000-0000-0000-0000-000000000202"},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := store.ConfigureAgentProfile(ctx, ConfigureAgentProfileInput{
+		AgentID:      ids.BackendAgentID,
+		ModelID:      model.ID,
+		SystemPrompt: "updated prompt",
+		Config: map[string]any{
+			"default_model_id": "stale-model",
+			"capabilities":     []any{"Stale Capability"},
+			"credential_bindings": map[string]any{
+				"github_pat": map[string]any{"source": "shared", "secret_id": "00000000-0000-0000-0000-000000000301"},
+			},
+			"model_credential_binding": map[string]any{"source": "shared", "secret_id": "00000000-0000-0000-0000-000000000302"},
+			"profile": map[string]any{
+				"model_id":     model.ID,
+				"capabilities": []any{capability.Name},
+				"skills":       []any{capability.Name},
+			},
+			"agent_kind":   "codex",
+			"daemon_mode":  "local",
+			"sandbox_size": "standard",
+			"device_id":    "00000000-0000-0000-0000-000000000401",
+			"work_dir":     nil,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := result.AgentConfig
+	if config["default_model_id"] != model.ID || config["model_id"] != model.ID {
+		t.Fatalf("model fields were not preserved: %#v", config)
+	}
+	capabilities, _ := config["capabilities"].([]any)
+	if len(capabilities) != 1 || capabilities[0] != capability.Name {
+		t.Fatalf("capabilities were overwritten: %#v", config["capabilities"])
+	}
+	bindings, _ := config["credential_bindings"].(map[string]any)
+	githubBinding, _ := bindings["github_pat"].(map[string]any)
+	if githubBinding["secret_id"] != "00000000-0000-0000-0000-000000000201" {
+		t.Fatalf("credential bindings were overwritten: %#v", config["credential_bindings"])
+	}
+	modelBinding, _ := config["model_credential_binding"].(map[string]any)
+	if modelBinding["secret_id"] != "00000000-0000-0000-0000-000000000202" {
+		t.Fatalf("model credential binding was overwritten: %#v", config["model_credential_binding"])
+	}
+	if config["agent_kind"] != "codex" || config["daemon_mode"] != "local" || config["device_id"] != "00000000-0000-0000-0000-000000000401" {
+		t.Fatalf("profile-owned daemon fields were not updated: %#v", config)
+	}
+	if config["system_prompt"] != "updated prompt" {
+		t.Fatalf("system prompt was not updated: %#v", config["system_prompt"])
+	}
+	for _, key := range []string{"sandbox_size", "work_dir", "workdir", "working_directory"} {
+		if _, ok := config[key]; ok {
+			t.Fatalf("expected %s to be cleared: %#v", key, config)
+		}
+	}
+}
+
+func TestListModelsExcludesDisabledModelsButGetModelReturnsThem(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	store := New(db)
+	ids := mustSeedDevFixture(t, ctx, store)
+
+	createModel := func(name, key string) ModelRead {
+		t.Helper()
+		model, err := store.CreateModel(ctx, CreateModelInput{
+			Name:               name,
+			ProviderType:       "openai",
+			Adapter:            "@ai-sdk/openai",
+			BaseURL:            "https://example.test/v1",
+			ModelKey:           key,
+			CredentialMode:     "credential_ref",
+			CredentialKindCode: "openai_api_key",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return model
+	}
+	active := createModel("Active Catalog Model", "active-catalog-1")
+	disabled := createModel("Disabled Catalog Model", "disabled-catalog-1")
+	if _, err := store.DisableModel(ctx, ids.WorkspaceID, disabled.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	models, err := store.ListModels(ctx, ids.WorkspaceID, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var foundActive bool
+	for _, model := range models {
+		if model.ID == disabled.ID {
+			t.Fatalf("disabled model remained in catalog: %#v", model)
+		}
+		if model.ID == active.ID {
+			foundActive = true
+		}
+	}
+	if !foundActive {
+		t.Fatalf("active model missing from catalog: %#v", models)
+	}
+	got, err := store.GetModel(ctx, disabled.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != "disabled" {
+		t.Fatalf("GetModel status = %q, want disabled", got.Status)
+	}
+}
+
 func TestCompleteAgentRunSanitizesMessageAndStoresTranscript(t *testing.T) {
 	db := openTestDB(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Description

This PR fixes two related model administration issues: Agent edits could lose newly selected model, capability, and credential settings when the follow-up `/profile` request replaced the full config with an older frontend snapshot, and disabled models remained visible in the shared model catalog.

## Fix

- Refresh the model catalog whenever the Models or Agents page mounts so changes from other admin sessions are not hidden by a stale cache.
- Restrict `ListModels` to active, non-deleted rows while keeping disabled records available through `GetModel` for audit and historical reads.
- Make `ConfigureAgentProfile` lock and read the current Agent config, then merge only profile-owned fields instead of replacing the entire config.
- Send a scoped profile payload from the Agent editor so `default_model_id`, top-level capabilities, `credential_bindings`, and `model_credential_binding` remain owned by the main Agent PATCH.
- Clear stale execution-mode fields when switching between local and sandbox modes, and canonicalize working-directory updates.
- Block edits that still reference an unavailable model, show an immediate active-model selection error, and display an unavailable label instead of a raw model UUID in Agent views.
- Add regression coverage for the two-request final database state and disabled-model catalog behavior.

## Testing

- `make check`
- `pnpm --filter @parsar/web build`
- `git diff --check`

`make check` includes SQLC generation drift checks, Go tests, a fresh Postgres migration plus database-backed store integration tests, monorepo TypeScript checks, and the web design-system lint gate.

## Compatibility

Backward compatible. No database migration or API contract change is required.
