### PR TITLE
Simplify local password policy

### DIFF
--- a/apps/web/src/i18n/locales/en-US/common.json
+++ b/apps/web/src/i18n/locales/en-US/common.json
@@ -133,6 +133,16 @@
     "ssoButton": "Sign in with {{provider}}",
     "noAccountHint": "First time here? Ask your admin for an invite."
   },
+  "passwordPolicy": {
+    "placeholder": "8 characters or more",
+    "hint": "Use at least 8 characters.",
+    "errors": {
+      "required": "Enter a password",
+      "too_short": "Use at least 8 characters",
+      "too_long": "Password is too long",
+      "too_common": "Choose a password that’s harder to guess"
+    }
+  },
   "setup": {
     "title": "Welcome to Parsar",
     "subtitle": "This install has no owner yet. Create the first account to get started — you will become the workspace owner.",
@@ -143,8 +153,6 @@
     "workspaceLabel": "Workspace name",
     "workspacePlaceholder": "Acme",
     "passwordLabel": "Password",
-    "passwordPlaceholder": "At least 12 characters, mix words + numbers",
-    "passwordHint": "Choose a longer password. A memorable phrase with 4 or more words works well.",
     "submitButton": "Create owner account",
     "submitting": "Creating your account...",
     "closedTitle": "Setup already complete",

--- a/apps/web/src/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/i18n/locales/zh-CN/common.json
@@ -133,6 +133,16 @@
     "ssoButton": "使用 {{provider}} 登录",
     "noAccountHint": "首次访问?请联系管理员发送邀请。"
   },
+  "passwordPolicy": {
+    "placeholder": "8 个字符或更多",
+    "hint": "至少使用 8 个字符。",
+    "errors": {
+      "required": "请输入密码",
+      "too_short": "至少使用 8 个字符",
+      "too_long": "密码过长",
+      "too_common": "请使用更难猜的密码"
+    }
+  },
   "setup": {
     "title": "欢迎使用 Parsar",
     "subtitle": "本实例尚未创建拥有者。请注册第一位账号 — 你将成为工作区 Owner。",
@@ -143,8 +153,6 @@
     "workspaceLabel": "工作区名称",
     "workspacePlaceholder": "Acme",
     "passwordLabel": "密码",
-    "passwordPlaceholder": "至少 12 位,词组 + 数字混合",
-    "passwordHint": "建议使用更长、好记的密码。4 个以上词组成的短语就很合适。",
     "submitButton": "创建管理员账号",
     "submitting": "正在创建...",
     "closedTitle": "已完成初始化",

--- a/apps/web/src/lib/password-policy.ts
+++ b/apps/web/src/lib/password-policy.ts
@@ -1,0 +1,86 @@
+export type PasswordPolicyError = "required" | "too_short" | "too_long" | "too_common"
+
+export const PASSWORD_MIN_CHARACTERS = 8
+export const PASSWORD_MAX_BYTES = 72
+
+const commonWeakPasswords = new Set([
+  "00000000",
+  "11111111",
+  "11223344",
+  "123123123",
+  "12341234",
+  "12345678",
+  "123456789",
+  "1234567890",
+  "1q2w3e4r",
+  "abc12345",
+  "abcdefgh",
+  "admin123",
+  "admin1234",
+  "changeme",
+  "iloveyou",
+  "letmein",
+  "monkey123",
+  "password",
+  "password1",
+  "password12",
+  "password123",
+  "passw0rd",
+  "p@ssw0rd",
+  "qwerty12",
+  "qwerty123",
+  "qwertyui",
+  "welcome1",
+  "welcome123",
+])
+
+const encoder = new TextEncoder()
+
+export function validateNewPassword(password: string): PasswordPolicyError | null {
+  const chars = Array.from(password)
+  if (chars.length === 0) return "required"
+  if (chars.length < PASSWORD_MIN_CHARACTERS) return "too_short"
+  if (encoder.encode(password).length > PASSWORD_MAX_BYTES) return "too_long"
+  if (isCommonWeakPassword(password)) return "too_common"
+  return null
+}
+
+function isCommonWeakPassword(password: string): boolean {
+  const normalized = password.trim().toLowerCase()
+  if (normalized === "") return true
+  return (
+    commonWeakPasswords.has(normalized) ||
+    hasOneRepeatedCharacter(normalized) ||
+    isSimpleSequence(normalized)
+  )
+}
+
+function hasOneRepeatedCharacter(value: string): boolean {
+  const chars = Array.from(value)
+  if (chars.length === 0) return false
+  return chars.every((char) => char === chars[0])
+}
+
+function isSimpleSequence(value: string): boolean {
+  const chars = Array.from(value)
+  if (chars.length < PASSWORD_MIN_CHARACTERS) return false
+  const digits = chars.every((char) => char >= "0" && char <= "9")
+  if (digits) {
+    let ascending = true
+    let descending = true
+    for (let i = 1; i < chars.length; i++) {
+      const prev = chars[i - 1].charCodeAt(0)
+      const current = chars[i].charCodeAt(0)
+      if (current !== prev + 1) ascending = false
+      if (current !== prev - 1) descending = false
+    }
+    if (ascending || descending) return true
+  }
+  return ["abcdefghijklmnopqrstuvwxyz", "qwertyuiop", "asdfghjkl", "zxcvbnm"].some(
+    (sequence) => sequence.includes(value) || reverse(sequence).includes(value),
+  )
+}
+
+function reverse(value: string): string {
+  return Array.from(value).reverse().join("")
+}

--- a/apps/web/src/pages/InviteAcceptPage.tsx
+++ b/apps/web/src/pages/InviteAcceptPage.tsx
@@ -1,14 +1,22 @@
 import { useState } from "react"
+import { useTranslation } from "react-i18next"
 import { Button } from "../components/ui/button"
 import { useInviteInfo, useAcceptInvite } from "../lib/api-invitations"
+import { validateNewPassword } from "../lib/password-policy"
 import { setWorkspaceId } from "../lib/workspace"
 
 export function InviteAcceptPage({ token }: { token: string }) {
+  const { t } = useTranslation("common")
   const infoQ = useInviteInfo(token)
   const acceptMut = useAcceptInvite()
   const [password, setPassword] = useState("")
   const [confirm, setConfirm] = useState("")
   const [errMsg, setErrMsg] = useState<string | null>(null)
+  const passwordPolicyError = validateNewPassword(password)
+  const passwordPolicyErrorMsg =
+    password === "" || passwordPolicyError === null
+      ? null
+      : t(`passwordPolicy.errors.${passwordPolicyError}`)
 
   if (infoQ.isLoading) {
     return (
@@ -40,8 +48,8 @@ export function InviteAcceptPage({ token }: { token: string }) {
       setErrMsg("Passwords do not match")
       return
     }
-    if (password.length < 8) {
-      setErrMsg("Password must be at least 8 characters")
+    if (passwordPolicyError !== null) {
+      setErrMsg(t(`passwordPolicy.errors.${passwordPolicyError}`))
       return
     }
     try {
@@ -57,12 +65,10 @@ export function InviteAcceptPage({ token }: { token: string }) {
     <main className="grid min-h-screen place-items-center bg-surface">
       <div className="w-full max-w-sm space-y-4 rounded-lg border border-line p-6">
         <div className="space-y-1">
-          <h1 className="text-base font-semibold text-fg">
-            Join {workspace_name}
-          </h1>
+          <h1 className="text-base font-semibold text-fg">Join {workspace_name}</h1>
           <p className="text-sm text-fg-subtle">
-            You've been invited as <span className="font-medium">{role}</span>.
-            Set a password to activate your account.
+            You've been invited as <span className="font-medium">{role}</span>. Set a password to
+            activate your account.
           </p>
         </div>
 
@@ -83,12 +89,16 @@ export function InviteAcceptPage({ token }: { token: string }) {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="Set your password"
+              placeholder={t("passwordPolicy.placeholder")}
               required
               autoFocus
               autoComplete="new-password"
               className="w-full rounded-md border border-line bg-surface px-3 py-2 text-sm text-fg placeholder:text-fg-faint focus:border-line-strong focus:outline-none focus:ring-1 focus:ring-slate-200"
             />
+            <p className="text-xs leading-4 text-fg-faint">{t("passwordPolicy.hint")}</p>
+            {passwordPolicyErrorMsg && (
+              <p className="text-xs leading-4 text-danger">{passwordPolicyErrorMsg}</p>
+            )}
           </div>
 
           <div className="space-y-1">
@@ -112,7 +122,7 @@ export function InviteAcceptPage({ token }: { token: string }) {
 
           <Button
             type="submit"
-            disabled={acceptMut.isPending}
+            disabled={acceptMut.isPending || passwordPolicyError !== null}
             size="lg"
             className="w-full"
           >

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 
 import { ApiError } from "../lib/api-client"
 import { useRegisterFirstOwner } from "../lib/api-bootstrap"
+import { validateNewPassword } from "../lib/password-policy"
 
 /**
  * SetupPage — first-owner registration.
@@ -13,12 +14,9 @@ import { useRegisterFirstOwner } from "../lib/api-bootstrap"
  * AuthProvider re-reads the session and drops the caller into
  * AuthedRoot.
  *
- * Field policy mirrors coder's SetupPageView (email + password with
- * name/workspace tacked on). Password strength is validated server-
- * side by password.Validate; the client just enforces "non-empty +
- * >= 12 chars" as a friendly-first-line hint. The server's error
- * envelope (bootstrap_weak_password) is surfaced inline when the
- * client hint passes but the server bcrypt policy still rejects.
+ * Password policy is validated server-side by password.Validate. The client
+ * mirrors the same simple checks so users get immediate feedback before the
+ * server's bootstrap_weak_password envelope is surfaced inline.
  */
 export function SetupPage() {
   const { t } = useTranslation("common")
@@ -30,13 +28,19 @@ export function SetupPage() {
   const [password, setPassword] = useState("")
 
   const submitting = register.isPending
-  const errorMsg = register.error instanceof ApiError
-    ? register.error.envelope.message
-    : register.error instanceof Error
-      ? register.error.message
-      : ""
+  const errorMsg =
+    register.error instanceof ApiError
+      ? register.error.envelope.message
+      : register.error instanceof Error
+        ? register.error.message
+        : ""
 
-  const invalid = email.trim() === "" || workspace.trim() === "" || password.length < 12
+  const passwordPolicyError = validateNewPassword(password)
+  const passwordPolicyErrorMsg =
+    password === "" || passwordPolicyError === null
+      ? undefined
+      : t(`passwordPolicy.errors.${passwordPolicyError}`)
+  const invalid = email.trim() === "" || workspace.trim() === "" || passwordPolicyError !== null
 
   async function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -101,12 +105,13 @@ export function SetupPage() {
           <Field
             type="password"
             label={t("setup.passwordLabel")}
-            placeholder={t("setup.passwordPlaceholder")}
+            placeholder={t("passwordPolicy.placeholder")}
             value={password}
             onChange={setPassword}
             autoComplete="new-password"
             required
-            hint={t("setup.passwordHint")}
+            hint={t("passwordPolicy.hint")}
+            error={passwordPolicyErrorMsg}
           />
 
           {errorMsg && (
@@ -140,6 +145,7 @@ interface FieldProps {
   autoComplete?: string
   required?: boolean
   hint?: string
+  error?: string
 }
 
 function Field({
@@ -151,6 +157,7 @@ function Field({
   autoComplete,
   required,
   hint,
+  error,
 }: FieldProps) {
   return (
     <label className="flex flex-col gap-1.5">
@@ -167,7 +174,11 @@ function Field({
         required={required}
         className="h-10 rounded-md border border-line bg-surface px-3 text-base text-fg placeholder:text-fg-faint focus:border-fg/40 focus:outline-none focus:ring-1 focus:ring-fg/20"
       />
-      {hint && <span className="text-xs leading-4 text-fg-faint">{hint}</span>}
+      {error ? (
+        <span className="text-xs leading-4 text-danger">{error}</span>
+      ) : (
+        hint && <span className="text-xs leading-4 text-fg-faint">{hint}</span>
+      )}
     </label>
   )
 }

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/pressly/goose/v3 v3.27.2
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/slack-go/slack v0.27.0
-	github.com/wagslane/go-password-validator v0.3.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	golang.org/x/crypto v0.54.0
 	google.golang.org/protobuf v1.36.11

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/wagslane/go-password-validator v0.3.0 h1:vfxOPzGHkz5S146HDpavl0cw1DSVP061Ry2PX0/ON6I=
-github.com/wagslane/go-password-validator v0.3.0/go.mod h1:TI1XJ6T5fRdRnHqHt14pvy1tNVnrwe7m3/f1f2fDphQ=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -53,6 +53,30 @@ if [[ "$pg_connect_ready" -ne 1 ]]; then
   exit 1
 fi
 
+host_port_ready=0
+for _ in $(seq 1 60); do
+  if python3 - "$PARSAR_POSTGRES_HOST" "$PARSAR_POSTGRES_PORT" <<'PY'
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+with socket.create_connection((host, port), timeout=1):
+    pass
+PY
+  then
+    host_port_ready=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$host_port_ready" -ne 1 ]]; then
+  echo "Postgres host port ${PARSAR_POSTGRES_HOST}:${PARSAR_POSTGRES_PORT} did not accept TCP connections within 60s" >&2
+  docker compose -f docker-compose.dev.yml logs --tail=80 postgres >&2 || true
+  exit 1
+fi
+
 (
   cd server
   DATABASE_URL="$PARSAR_CHECK_DATABASE_URL" PARSAR_MIGRATIONS_DIR="$PWD/migrations" go run ./cmd/migrate

--- a/server/internal/auth/password/password.go
+++ b/server/internal/auth/password/password.go
@@ -1,4 +1,4 @@
-// Package password wraps bcrypt and go-password-validator so the
+// Package password wraps bcrypt and password policy checks so the
 // rest of the codebase has one place to hash, verify and validate
 // local email/password credentials.
 //
@@ -11,9 +11,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
-	"unicode/utf8"
+	"strings"
+	"unicode"
 
-	passwordvalidator "github.com/wagslane/go-password-validator"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -31,15 +31,45 @@ const (
 	// two-character edit if we ever want to slow attackers further.
 	bcryptCost = 12
 
-	// minEntropyBits rejects "password", "12345678", "qwertyui" etc.
-	// 60 bits ≈ "correct-horse-battery" territory. coder uses 52.
-	minEntropyBits = 60
+	// minPasswordRunes keeps the product rule easy to explain to users.
+	minPasswordRunes = 8
 
 	// maxPasswordLen is bcrypt's hard limit (72 bytes). We reject
 	// longer inputs at the door so callers get a clean 400 rather
 	// than a silently-truncated hash.
 	maxPasswordLen = 72
 )
+
+var commonWeakPasswords = map[string]struct{}{
+	"00000000":    {},
+	"11111111":    {},
+	"11223344":    {},
+	"123123123":   {},
+	"12341234":    {},
+	"12345678":    {},
+	"123456789":   {},
+	"1234567890":  {},
+	"1q2w3e4r":    {},
+	"abc12345":    {},
+	"abcdefgh":    {},
+	"admin123":    {},
+	"admin1234":   {},
+	"changeme":    {},
+	"iloveyou":    {},
+	"letmein":     {},
+	"monkey123":   {},
+	"password":    {},
+	"password1":   {},
+	"password12":  {},
+	"password123": {},
+	"passw0rd":    {},
+	"p@ssw0rd":    {},
+	"qwerty12":    {},
+	"qwerty123":   {},
+	"qwertyui":    {},
+	"welcome1":    {},
+	"welcome123":  {},
+}
 
 // dummyHash is a fixed, valid bcrypt hash used by Compare when the
 // stored hash is empty. Comparing against it burns the same CPU as
@@ -97,18 +127,94 @@ func Compare(hashed, plain string) error {
 	return nil
 }
 
-// Validate enforces our password policy: bcrypt byte-length ceiling
-// and a minimum entropy floor. Returns a plain-English error suitable
-// for surfacing to the client as a form validation message.
+// Validate enforces our password policy: at least 8 characters, bcrypt's
+// byte-length ceiling, and a small denylist of common weak passwords and
+// obvious sequences. Returns a plain-English error suitable for surfacing to
+// the client as a form validation message.
 func Validate(plain string) error {
-	if utf8.RuneCountInString(plain) == 0 {
+	runes := []rune(plain)
+	if len(runes) == 0 {
 		return errors.New("password is required")
+	}
+	if len(runes) < minPasswordRunes {
+		return errors.New("password must be at least 8 characters")
 	}
 	if len(plain) > maxPasswordLen {
 		return errors.New("password must be at most 72 bytes")
 	}
-	if err := passwordvalidator.Validate(plain, minEntropyBits); err != nil {
-		return err
+	if isCommonWeakPassword(plain) {
+		return errors.New("password is too common or easy to guess")
 	}
 	return nil
+}
+
+func isCommonWeakPassword(plain string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(plain))
+	if normalized == "" {
+		return true
+	}
+	if _, ok := commonWeakPasswords[normalized]; ok {
+		return true
+	}
+	if hasOneRepeatedRune(normalized) {
+		return true
+	}
+	if isSimpleSequence(normalized) {
+		return true
+	}
+	return false
+}
+
+func hasOneRepeatedRune(s string) bool {
+	var first rune
+	for i, r := range s {
+		if i == 0 {
+			first = r
+			continue
+		}
+		if r != first {
+			return false
+		}
+	}
+	return s != ""
+}
+
+func isSimpleSequence(s string) bool {
+	runes := []rune(s)
+	if len(runes) < minPasswordRunes {
+		return false
+	}
+	ascending := true
+	descending := true
+	for i := 1; i < len(runes); i++ {
+		if !unicode.IsDigit(runes[i-1]) || !unicode.IsDigit(runes[i]) {
+			ascending = false
+			descending = false
+			break
+		}
+		if runes[i] != runes[i-1]+1 {
+			ascending = false
+		}
+		if runes[i] != runes[i-1]-1 {
+			descending = false
+		}
+	}
+	if ascending || descending {
+		return true
+	}
+
+	for _, seq := range []string{"abcdefghijklmnopqrstuvwxyz", "qwertyuiop", "asdfghjkl", "zxcvbnm"} {
+		if strings.Contains(seq, s) || strings.Contains(reverse(seq), s) {
+			return true
+		}
+	}
+	return false
+}
+
+func reverse(s string) string {
+	runes := []rune(s)
+	for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
+		runes[i], runes[j] = runes[j], runes[i]
+	}
+	return string(runes)
 }

--- a/server/internal/auth/password/password_test.go
+++ b/server/internal/auth/password/password_test.go
@@ -48,10 +48,17 @@ func TestCompareEmptyHashBurnsTime(t *testing.T) {
 func TestValidateRejectsWeak(t *testing.T) {
 	cases := []string{
 		"",
+		"short",
 		"password",
+		"        ",
 		"12345678",
-		"qwertyui",
+		"87654321",
 		"aaaaaaaaaaaa",
+		"abcdefghi",
+		"zyxwvuts",
+		"qwertyui",
+		"password123",
+		"P@ssw0rd",
 	}
 	for _, in := range cases {
 		if err := Validate(in); err == nil {
@@ -62,6 +69,8 @@ func TestValidateRejectsWeak(t *testing.T) {
 
 func TestValidateAcceptsStrong(t *testing.T) {
 	cases := []string{
+		"blue desk 42",
+		"OpenRoad7",
 		"correct horse battery staple",
 		"Tr0ub4dor&3-really-long-passphrase",
 		"MyP@ssw0rd!ButLonger42",


### PR DESCRIPTION
## Summary
- replace entropy-based local password validation with an easy-to-explain 8-character policy plus common weak-password checks
- add shared web password policy validation and align setup/invite password copy
- wait for the host-published Postgres port in the migration smoke check to avoid Docker port-mapping races

## Validation
- go test ./server/internal/auth/password ./server/internal/bootstrap ./server/internal/dev
- pnpm --filter @parsar/web typecheck
- PARSAR_POSTGRES_PORT=15432 make check (fails in existing store test: TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation returns v2 instead of expected frozen v1)