### PR TITLE
fix(web): restore Feishu provision status icon

### DIFF
--- a/apps/web/src/components/admin/channel-connectors/shared.tsx
+++ b/apps/web/src/components/admin/channel-connectors/shared.tsx
@@ -6,7 +6,7 @@
  * same and any tweak to spacing/colors applies uniformly.
  */
 import type { ReactNode } from "react"
-import { CheckCircle2, ExternalLink } from "lucide-react"
+import { CheckCircle2, ExternalLink, Loader2, QrCode, XCircle } from "lucide-react"
 
 export function Card({
   title,
@@ -131,4 +131,37 @@ export function randomHex(bytes: number): string {
   const values = new Uint8Array(bytes)
   crypto.getRandomValues(values)
   return Array.from(values, (value) => value.toString(16).padStart(2, "0")).join("")
+}
+
+export function ProvisionStatusIcon({
+  status,
+  loading,
+  labels,
+}: {
+  status: "pending" | "success" | "error" | "expired"
+  loading: boolean
+  labels: { waiting: string; connected: string; stopped: string }
+}) {
+  if (status === "success") {
+    return (
+      <p className="inline-flex items-center gap-1 text-success">
+        <CheckCircle2 className="h-3.5 w-3.5" />
+        <span>{labels.connected}</span>
+      </p>
+    )
+  }
+  if (status === "error" || status === "expired") {
+    return (
+      <p className="inline-flex items-center gap-1 text-danger">
+        <XCircle className="h-3.5 w-3.5" />
+        <span>{labels.stopped}</span>
+      </p>
+    )
+  }
+  return (
+    <p className="inline-flex items-center gap-1 text-fg-subtle">
+      {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <QrCode className="h-3.5 w-3.5" />}
+      <span>{labels.waiting}</span>
+    </p>
+  )
 }


### PR DESCRIPTION
## What & why

PR #143 removed `ProvisionStatusIcon` from the shared channel connector
components while `feishuFields.tsx` still imports and renders it.

As a result, the current `main` branch fails both Web typechecking and the
production image build with a missing-export error.

## How

Restore the provision status component and its required Lucide icon imports.
The implementation matches the component that existed before PR #143.

## Verification

- [x] `make check`
- [x] `pnpm --filter @parsar/web build`
- [ ] Relevant E2E target: not applicable
- [ ] Manual smoke: not required for restoring the existing presentation helper

## Notes for reviewers

This is intentionally limited to the single component removed by PR #143.
