### PR TITLE
fix(web): surface agent model picker earlier

### DIFF
--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -1028,7 +1028,7 @@ export function CreateAgentDialog({
                   <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t("agents.form.placeholders.description")} />
                 </Field>
               </section>
-              <section className="space-y-3">
+              <section className="flex flex-col space-y-3">
               {showExecutionChoices ? (
                 <>
                   <Field label={t("agents.form.fields.executionMode")} required>
@@ -1159,16 +1159,17 @@ export function CreateAgentDialog({
                 </Field>
               )}
               {requiresModel && (
-                <Field
-                  ref={modelFieldRef}
-                  label={t("agents.form.fields.model")}
-                  required
-                  error={selectedModelUnavailable
-                    ? t("agents.form.errors.modelUnavailable")
-                    : submitAttempted && !hasRequiredModel
-                      ? t("agents.form.errors.modelRequired")
-                      : undefined}
-                >
+                <div className="order-first">
+                  <Field
+                    ref={modelFieldRef}
+                    label={t("agents.form.fields.model")}
+                    required
+                    error={selectedModelUnavailable
+                      ? t("agents.form.errors.modelUnavailable")
+                      : submitAttempted && !hasRequiredModel
+                        ? t("agents.form.errors.modelRequired")
+                        : undefined}
+                  >
                 {hasModel ? (
                   <div ref={modelComboboxRef} className="relative">
                     <Search className="pointer-events-none absolute left-2.5 top-1/2 z-10 h-3.5 w-3.5 -translate-y-1/2 text-fg-faint" />
@@ -1242,7 +1243,8 @@ export function CreateAgentDialog({
                 ) : (
                   <DependencyCard title={t("agents.form.emptyModel.title")} description={t("agents.form.emptyModel.description")} href={prefillQuery("models")} cta={t("agents.form.emptyModel.cta")} />
                 )}
-                </Field>
+                  </Field>
+                </div>
               )}
               {requiresModel && selectedModel && selectedModel.credential_mode === "credential_ref" && (
                 <Field label={t("credentialCheck.modelBindingTitle")}>


### PR DESCRIPTION
## Description
The Agent configuration dialog places the model picker after several other configuration sections, so users must scroll before they can see and select a model.

## Fix
- Make the configuration section a vertical flex container.
- Render the model field first within that section.
- Keep existing model search, keyboard navigation, validation, filtering, and selection behavior unchanged.

## Testing
- `git diff --check` passed.
- `pnpm --filter @parsar/web typecheck` is currently blocked by the existing missing `ProvisionStatusIcon` export in `src/components/admin/channel-connectors/feishuFields.tsx:7` (tracked separately in PR #178).
- `pnpm --filter @parsar/web build` is blocked by the same existing export error.
- Web lint currently reports existing repository-wide errors unrelated to this change.

## Compatibility
No behavior or API changes. This only changes the visual order of the model field in the Agent configuration dialog.