### PR TITLE
Show API protocol in models list

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -77,6 +77,7 @@
         "providerType": "Provider type",
         "providerSearch": "Search providers…",
         "providerEmpty": "No matching providers",
+        "protocol": "API protocol",
         "baseURL": "Base URL",
         "adapterHint": "Adapter package: {{adapter}}",
         "apiKey": "API key",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -77,6 +77,7 @@
         "providerType": "供应商类型",
         "providerSearch": "搜索供应商…",
         "providerEmpty": "无匹配的供应商",
+        "protocol": "API 协议",
         "baseURL": "服务地址",
         "adapterHint": "Adapter 包: {{adapter}}",
         "apiKey": "API Key",

--- a/apps/web/src/lib/model-protocol.ts
+++ b/apps/web/src/lib/model-protocol.ts
@@ -1,0 +1,51 @@
+import type { Model } from "./api-types"
+
+export type WireProtocol = "anthropic" | "openai" | "google"
+
+/** Classify a model's wire protocol from its provider_type / adapter.
+ * Mirrors the allow-lists in
+ * server/internal/connector/agentdaemon/model_injection.go
+ * (isAnthropicRuntime / isOpenAICompatibleRuntime / piAPIProtocol) — keep the
+ * case values in sync so the UI filter matches what the daemon will accept. */
+export function modelProtocol(m: Pick<Model, "provider_type" | "adapter">): WireProtocol | null {
+  for (const v of [m.provider_type, m.adapter]) {
+    switch (v.trim().toLowerCase()) {
+      case "anthropic":
+      case "anthropic-compatible":
+      case "anthropic_compatible":
+      case "@ai-sdk/anthropic":
+        return "anthropic"
+      case "openai":
+      case "openai-compatible":
+      case "openai_compatible":
+      case "azure-openai":
+      case "azure_openai":
+      case "@ai-sdk/openai":
+      case "@ai-sdk/openai-compatible":
+      case "@ai-sdk/azure":
+        return "openai"
+      case "google":
+      case "gemini":
+      case "google-generative-ai":
+      case "google_generative_ai":
+      case "@ai-sdk/google":
+        return "google"
+    }
+  }
+  return null
+}
+
+/** Display label for a model's own wire protocol. null protocol = unknown
+ * adapter, shown as a dash. */
+export function protocolLabel(protocol: WireProtocol | null): string {
+  switch (protocol) {
+    case "anthropic":
+      return "Anthropic"
+    case "openai":
+      return "OpenAI"
+    case "google":
+      return "Google"
+    default:
+      return "—"
+  }
+}

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -1,7 +1,7 @@
 import { Fragment, forwardRef, useEffect, useId, useMemo, useRef, useState, type ChangeEvent, type KeyboardEvent, type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 import { useQueryClient } from "@tanstack/react-query"
-import { AlertTriangle, ArrowUpRight, Bot, Check, ChevronDown, Cloud, Cpu, Eye, EyeOff, Laptop, Network, Search, Server, Sparkles } from "lucide-react"
+import { ArrowUpRight, Bot, Check, ChevronDown, Cloud, Cpu, Eye, EyeOff, Laptop, Network, Search, Server, Sparkles } from "lucide-react"
 
 import { Badge } from "../../components/ui/badge"
 import { Button } from "../../components/ui/button"
@@ -17,6 +17,7 @@ import {
 import { Input } from "../../components/ui/input"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
+import { modelProtocol, protocolLabel, type WireProtocol } from "../../lib/model-protocol"
 import { useCapabilitiesQuery, aggregateRequiredCredentials, aggregateRequiredCredentialsByID, useCapabilityVersionsQuery, useAgentCapabilitiesQuery, useEnableAgentCapabilityMutation } from "../../lib/api-capabilities"
 import { CredentialCheckPanel } from "../../components/admin/CredentialCheckPanel"
 import { useSecrets } from "../../lib/api-secrets"
@@ -28,7 +29,6 @@ import type {
   Capability,
   CapabilityType,
   CreateAgentRequest,
-  MarketplaceCapability,
   Model,
   Agent,
   RequiredCredential,
@@ -68,41 +68,6 @@ function agentEngineFromAgent(a?: Agent | null): AgentEngine {
   return "claude_code"
 }
 
-type WireProtocol = "anthropic" | "openai" | "google"
-
-/** Classify a model's wire protocol from its provider_type / adapter.
- * Mirrors the allow-lists in
- * server/internal/connector/agentdaemon/model_injection.go
- * (isAnthropicRuntime / isOpenAICompatibleRuntime / piAPIProtocol) — keep the
- * case values in sync so the UI filter matches what the daemon will accept. */
-function modelProtocol(m: Pick<Model, "provider_type" | "adapter">): WireProtocol | null {
-  for (const v of [m.provider_type, m.adapter]) {
-    switch (v.trim().toLowerCase()) {
-      case "anthropic":
-      case "anthropic-compatible":
-      case "anthropic_compatible":
-      case "@ai-sdk/anthropic":
-        return "anthropic"
-      case "openai":
-      case "openai-compatible":
-      case "openai_compatible":
-      case "azure-openai":
-      case "azure_openai":
-      case "@ai-sdk/openai":
-      case "@ai-sdk/openai-compatible":
-      case "@ai-sdk/azure":
-        return "openai"
-      case "google":
-      case "gemini":
-      case "google-generative-ai":
-      case "google_generative_ai":
-      case "@ai-sdk/google":
-        return "google"
-    }
-  }
-  return null
-}
-
 /** Which wire protocols an agent engine can drive. Mirrors the per-engine
  * injector gating in model_injection.go: claude_code→Anthropic only,
  * codex→OpenAI only, pi→any of the three, opencode→any adapter. */
@@ -116,22 +81,6 @@ function engineSupportsProtocol(engine: AgentEngine, protocol: WireProtocol | nu
       return protocol === "anthropic" || protocol === "openai" || protocol === "google"
     case "opencode":
       return true
-  }
-}
-
-/** Display label for a model's own wire protocol, shown on every model row so
- * the user sees each model's protocol (and, on greyed-out rows, WHY it's
- * unavailable). null protocol = unknown adapter, shown as a dash. */
-function protocolLabel(protocol: WireProtocol | null): string {
-  switch (protocol) {
-    case "anthropic":
-      return "Anthropic"
-    case "openai":
-      return "OpenAI"
-    case "google":
-      return "Google"
-    default:
-      return "—"
   }
 }
 

--- a/apps/web/src/pages/admin/ModelsPage.tsx
+++ b/apps/web/src/pages/admin/ModelsPage.tsx
@@ -54,6 +54,7 @@ import {
   TabsTrigger,
 } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
+import { modelProtocol, protocolLabel } from "../../lib/model-protocol"
 import {
   useCreateModel,
   useDisableModel,
@@ -150,6 +151,16 @@ function ProviderCompatibilityCell({ type }: { type: string }) {
       <Icon className="h-3.5 w-3.5 shrink-0 text-fg-faint" />
       <span className="truncate">{label}</span>
     </span>
+  )
+}
+
+function ModelProtocolCell({ model }: { model: Model }) {
+  const { t } = useTranslation("admin")
+  const protocol = modelProtocol(model)
+  return (
+    <Badge variant="neutral" title={t("models.createProvider.fields.protocol")}>
+      {protocolLabel(protocol)}
+    </Badge>
   )
 }
 
@@ -309,23 +320,25 @@ function ModelsTable({
     <div className="overflow-hidden rounded-lg border border-line bg-surface">
       <Table className="table-fixed">
         <colgroup>
-          {/* name | model_key | compatibility | credential | status | actions
-             Actions column gets 14% because it now hosts four icon-only
+          {/* name | model_key | compatibility | protocol | credential | status | actions
+             Actions column gets 12% because it now hosts four icon-only
              buttons inline (test / edit / copy / disable). With the old
              10% the row contents would push the table past its container
              and trigger horizontal scroll on a regular laptop width. */}
+          <col className="w-[20%]" />
           <col className="w-[22%]" />
-          <col className="w-[26%]" />
-          <col className="w-[16%]" />
+          <col className="w-[15%]" />
           <col className="w-[12%]" />
-          <col className="w-[10%]" />
-          <col className="w-[14%]" />
+          <col className="w-[11%]" />
+          <col className="w-[8%]" />
+          <col className="w-[12%]" />
         </colgroup>
         <TableHeader>
           <TableRow>
             <TableHead>{t("models.table.model")}</TableHead>
             <TableHead>{t("models.table.modelKey")}</TableHead>
             <TableHead>{t("models.table.compatibility")}</TableHead>
+            <TableHead>{t("models.createProvider.fields.protocol")}</TableHead>
             <TableHead>{t("models.table.credentialMode")}</TableHead>
             <TableHead>{t("models.table.status")}</TableHead>
             <TableHead className="pr-3 text-right">{t("models.table.actions")}</TableHead>
@@ -357,6 +370,9 @@ function ModelsTable({
                 </TableCell>
                 <TableCell className="overflow-hidden">
                   <ProviderCompatibilityCell type={m.provider_type} />
+                </TableCell>
+                <TableCell>
+                  <ModelProtocolCell model={m} />
                 </TableCell>
                 <TableCell>
                   <CredentialModeBadge mode={m.credential_mode} />


### PR DESCRIPTION
## Summary
- Add an API protocol column to the Models list
- Extract shared protocol detection and labels into `apps/web/src/lib/model-protocol.ts`
- Reuse the same protocol label in the Agent create dialog

## Verification
- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web exec eslint src/pages/admin/ModelsPage.tsx src/pages/admin/CreateAgentDialog.tsx src/lib/model-protocol.ts`
- `make check` currently fails on an existing server test: `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation`
