### PR TITLE
feat(web): improve friendly form defaults

### DIFF
--- a/apps/web/src/components/admin/ScopeRequiredState.tsx
+++ b/apps/web/src/components/admin/ScopeRequiredState.tsx
@@ -6,7 +6,9 @@ import {
   useCreateWorkspace,
   useMyWorkspaces,
 } from "../../lib/api-workspaces"
+import { useAuth } from "../../lib/auth-context"
 import { setWorkspaceId } from "../../lib/workspace"
+import { workspaceOwnerName } from "../../lib/workspace-defaults"
 import { Button } from "../ui/button"
 import { EmptyState } from "../ui/empty-state"
 import { WorkspaceFormDialog } from "../layout/WorkspaceCrudDialogs"
@@ -18,8 +20,13 @@ interface ScopeRequiredStateProps {
 
 export function ScopeRequiredState({ resourceName }: ScopeRequiredStateProps) {
   const { t } = useTranslation("admin")
+  const { user } = useAuth()
   const workspacesQ = useMyWorkspaces()
   const workspaces = workspacesQ.data?.workspaces ?? []
+  const workspaceOwner = workspaceOwnerName(user)
+  const defaultWorkspaceName = workspaceOwner
+    ? t("workspaceDefaults.personal", { ns: "common", name: workspaceOwner })
+    : t("workspaceDefaults.generic", { ns: "common" })
 
   const [createWsOpen, setCreateWsOpen] = useState(false)
   const createWorkspaceMut = useCreateWorkspace()
@@ -55,6 +62,7 @@ export function ScopeRequiredState({ resourceName }: ScopeRequiredStateProps) {
           setCreateWsOpen(open)
         }}
         mode="create"
+        initialName={defaultWorkspaceName}
         pending={createWorkspaceMut.isPending}
         error={createWorkspaceMut.error}
         onSubmit={({ name }) => {

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1415,7 +1415,8 @@
       "defaults": {
         "workspaceName": "My Workspace",
         "name": "{{workspace}}'s agent",
-        "description": "General-purpose assistant for {{workspace}}."
+        "description": "General-purpose assistant for {{workspace}}.",
+        "systemPrompt": "You are a helpful AI assistant for this team. Be concise and accurate."
       },
       "errors": {
         "nameConflict": "An Agent with this name already exists. Pick another name.",

--- a/apps/web/src/i18n/locales/en-US/common.json
+++ b/apps/web/src/i18n/locales/en-US/common.json
@@ -159,6 +159,10 @@
     "closedBody": "This install already has an owner. Sign in with your existing account.",
     "goToLogin": "Go to sign in"
   },
+  "workspaceDefaults": {
+    "personal": "{{name}}'s workspace",
+    "generic": "My workspace"
+  },
   "onboarding": {
     "title": "Create your first workspace",
     "subtitle": "A workspace is a shared space where your team collaborates on agents. You'll be its Owner.",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1415,7 +1415,8 @@
       "defaults": {
         "workspaceName": "当前 Workspace",
         "name": "{{workspace}} 的 Agent",
-        "description": "{{workspace}} 的通用助手。"
+        "description": "{{workspace}} 的通用助手。",
+        "systemPrompt": "你是这个团队的 AI 助手。请保持简洁、准确，并优先提供可执行的建议。"
       },
       "errors": {
         "nameConflict": "已有同名 Agent，请换一个",

--- a/apps/web/src/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/i18n/locales/zh-CN/common.json
@@ -159,6 +159,10 @@
     "closedBody": "本实例已经存在拥有者。请使用已有账号登录。",
     "goToLogin": "前往登录"
   },
+  "workspaceDefaults": {
+    "personal": "{{name}}的工作区",
+    "generic": "我的工作区"
+  },
   "onboarding": {
     "title": "创建你的第一个工作区",
     "subtitle": "工作区是团队协作处理 Agent 的共享空间。你将自动成为它的 Owner。",

--- a/apps/web/src/lib/workspace-defaults.ts
+++ b/apps/web/src/lib/workspace-defaults.ts
@@ -1,0 +1,14 @@
+export interface WorkspaceOwnerIdentity {
+  name?: string | null
+  email?: string | null
+}
+
+export function workspaceOwnerName(identity?: WorkspaceOwnerIdentity | null): string {
+  const name = identity?.name?.trim()
+  if (name) return name
+
+  const email = identity?.email?.trim()
+  if (!email) return ""
+
+  return email.split("@", 1)[0]?.trim() ?? ""
+}

--- a/apps/web/src/pages/OnboardingPage.tsx
+++ b/apps/web/src/pages/OnboardingPage.tsx
@@ -6,7 +6,9 @@ import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ApiError } from "../lib/api-client"
 import { useCreateWorkspace } from "../lib/api-workspaces"
+import { useAuth } from "../lib/auth-context"
 import { setWorkspaceId } from "../lib/workspace"
+import { workspaceOwnerName } from "../lib/workspace-defaults"
 import { Button } from "../components/ui/button"
 import { Input } from "../components/ui/input"
 
@@ -21,7 +23,13 @@ function extractErrorMessage(err: unknown): string | null {
 
 export function OnboardingPage() {
   const { t } = useTranslation("common")
-  const [name, setName] = useState("")
+  const { user } = useAuth()
+  const owner = workspaceOwnerName(user)
+  const [name, setName] = useState(() =>
+    owner
+      ? t("workspaceDefaults.personal", { name: owner })
+      : t("workspaceDefaults.generic")
+  )
   const create = useCreateWorkspace()
   const errMsg = extractErrorMessage(create.error)
 

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import { ApiError } from "../lib/api-client"
 import { useRegisterFirstOwner } from "../lib/api-bootstrap"
 import { validateNewPassword } from "../lib/password-policy"
+import { workspaceOwnerName } from "../lib/workspace-defaults"
 
 /**
  * SetupPage — first-owner registration.
@@ -24,8 +25,30 @@ export function SetupPage() {
 
   const [email, setEmail] = useState("")
   const [name, setName] = useState("")
-  const [workspace, setWorkspace] = useState("My Workspace")
+  const [workspace, setWorkspace] = useState(() => t("workspaceDefaults.generic"))
+  const [workspaceEdited, setWorkspaceEdited] = useState(false)
   const [password, setPassword] = useState("")
+
+  function suggestedWorkspaceName(nextName: string, nextEmail: string): string {
+    const owner = workspaceOwnerName({ name: nextName, email: nextEmail })
+    return owner
+      ? t("workspaceDefaults.personal", { name: owner })
+      : t("workspaceDefaults.generic")
+  }
+
+  function updateName(nextName: string) {
+    setName(nextName)
+    if (!workspaceEdited) {
+      setWorkspace(suggestedWorkspaceName(nextName, email))
+    }
+  }
+
+  function updateEmail(nextEmail: string) {
+    setEmail(nextEmail)
+    if (!workspaceEdited) {
+      setWorkspace(suggestedWorkspaceName(name, nextEmail))
+    }
+  }
 
   const submitting = register.isPending
   const errorMsg =
@@ -81,7 +104,7 @@ export function SetupPage() {
             label={t("setup.nameLabel")}
             placeholder={t("setup.namePlaceholder")}
             value={name}
-            onChange={setName}
+            onChange={updateName}
             autoComplete="name"
             required={false}
           />
@@ -90,7 +113,7 @@ export function SetupPage() {
             label={t("setup.emailLabel")}
             placeholder={t("setup.emailPlaceholder")}
             value={email}
-            onChange={setEmail}
+            onChange={updateEmail}
             autoComplete="email"
             required
           />
@@ -98,7 +121,10 @@ export function SetupPage() {
             label={t("setup.workspaceLabel")}
             placeholder={t("setup.workspacePlaceholder")}
             value={workspace}
-            onChange={setWorkspace}
+            onChange={(value) => {
+              setWorkspaceEdited(true)
+              setWorkspace(value)
+            }}
             autoComplete="organization"
             required
           />

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -37,7 +37,6 @@ import type {
   UserWorkspace,
 } from "../../lib/api-types"
 
-const DEFAULT_PROMPT = "You are a helpful AI assistant for this team. Be concise and accurate."
 const DEFAULT_WORK_DIR = "/workspace"
 
 type ExecutionMode = "sandbox" | "local_device" | "external"
@@ -134,9 +133,13 @@ function modelIDFromAgent(a?: Agent | null): string {
   return String(cfg.default_model_id ?? cfg.model_id ?? profile.model_id ?? "")
 }
 
-function promptFromAgent(a?: Agent | null): string {
+function promptFromAgent(a: Agent | null | undefined, fallback: string): string {
   const cfg = agentConfig(a)
-  return String(cfg.system_prompt ?? DEFAULT_PROMPT)
+  return String(cfg.system_prompt ?? fallback)
+}
+
+function defaultWorkDir(executionMode: ExecutionMode): string {
+  return executionMode === "sandbox" ? DEFAULT_WORK_DIR : ""
 }
 
 function capabilitiesFromAgent(a?: Agent | null): string[] {
@@ -208,6 +211,7 @@ export function CreateAgentDialog({
   const workspaceDisplayName = (workspaceName ?? "").trim() || t("agents.form.defaults.workspaceName")
   const defaultAgentName = t("agents.form.defaults.name", { workspace: workspaceDisplayName })
   const defaultAgentDescription = t("agents.form.defaults.description", { workspace: workspaceDisplayName })
+  const defaultSystemPrompt = t("agents.form.defaults.systemPrompt")
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
   const [executionMode, setExecutionMode] = useState<ExecutionMode>("local_device")
@@ -217,7 +221,7 @@ export function CreateAgentDialog({
   const [modelSearch, setModelSearch] = useState("")
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false)
   const [highlightedModelID, setHighlightedModelID] = useState<string | null>(null)
-  const [systemPrompt, setSystemPrompt] = useState(DEFAULT_PROMPT)
+  const [systemPrompt, setSystemPrompt] = useState(defaultSystemPrompt)
   const [capabilities, setCapabilities] = useState<string[]>([])
   const [selectedCapabilityIDs, setSelectedCapabilityIDs] = useState<string[]>([])
   // capabilityVersionChoices keys on capability_id and stores the user's
@@ -456,14 +460,15 @@ export function CreateAgentDialog({
       const cloneSuffix = cloneSource?.name ? " (Copy)" : ""
       setName(params.get("agent_name") ?? (cloneSource ? `${cloneSource.name}${cloneSuffix}` : defaultAgentName))
       setDescription(params.get("agent_description") ?? cloneSource?.description ?? defaultAgentDescription)
-      setExecutionMode(cloneSource ? executionModeFromAgent(cloneSource) : "local_device")
+      const initialExecutionMode = cloneSource ? executionModeFromAgent(cloneSource) : "local_device"
+      setExecutionMode(initialExecutionMode)
       setAgentEngine(cloneSource ? agentEngineFromAgent(cloneSource) : "claude_code")
       setSandboxSize(cloneSource ? sandboxSizeFromAgent(cloneSource) : "standard")
       setModelID(cloneSource ? modelIDFromAgent(cloneSource) : "")
       setModelSearch("")
       setModelDropdownOpen(false)
       setHighlightedModelID(null)
-      setSystemPrompt(params.get("agent_prompt") ?? (cloneSource ? promptFromAgent(cloneSource) : DEFAULT_PROMPT))
+      setSystemPrompt(params.get("agent_prompt") ?? (cloneSource ? promptFromAgent(cloneSource, defaultSystemPrompt) : defaultSystemPrompt))
       setCapabilities(cloneSource ? capabilitiesFromAgent(cloneSource) : [])
       // Capability IDs aren't prefilled on clone: mapping installed names back
       // to IDs needs an extra round-trip, so users re-pick from the marketplace.
@@ -473,7 +478,7 @@ export function CreateAgentDialog({
       // Creation is locked to public; the visibility selector is hidden.
       setVisibility("public")
       setDeviceID(cloneSource ? deviceIDFromAgent(cloneSource) : "")
-      setWorkDir(cloneSource ? workDirFromAgent(cloneSource) || DEFAULT_WORK_DIR : DEFAULT_WORK_DIR)
+      setWorkDir(cloneSource ? workDirFromAgent(cloneSource) || defaultWorkDir(initialExecutionMode) : defaultWorkDir(initialExecutionMode))
       // Clones explicitly drop the source agent's credential bindings: the
       // copy is a fresh agent and the user re-picks. Without these resets a
       // previous clone's bindings would leak across dialog opens.
@@ -494,7 +499,7 @@ export function CreateAgentDialog({
       setModelSearch("")
       setModelDropdownOpen(false)
       setHighlightedModelID(null)
-      setSystemPrompt(promptFromAgent(agent))
+      setSystemPrompt(promptFromAgent(agent, defaultSystemPrompt))
       setCapabilities(capabilitiesFromAgent(agent))
       setSelectedCapabilityIDs([])
       // capabilityVersionChoices for edit mode is hydrated by a separate
@@ -537,7 +542,14 @@ export function CreateAgentDialog({
     setPairDialogOpen(false)
     setStep(1)
     setCapabilityTypeFilter("all")
-  }, [open, mode, agent?.id, defaultAgentDescription, defaultAgentName, firstModelID])
+  }, [open, mode, agent?.id, defaultAgentDescription, defaultAgentName, defaultSystemPrompt, firstModelID])
+
+  function selectExecutionMode(nextMode: ExecutionMode) {
+    setExecutionMode(nextMode)
+    setWorkDir((current) =>
+      current === defaultWorkDir(executionMode) ? defaultWorkDir(nextMode) : current
+    )
+  }
 
   // Hydrate edit-mode binding choices when the listAgentCapabilities
   // response lands. We only seed entries the user hasn't touched (i.e.
@@ -987,14 +999,14 @@ export function CreateAgentDialog({
                         title={t("agents.execution.localDevice.title")}
                         description={t("agents.execution.localDevice.description")}
                         selected={executionMode === "local_device"}
-                        onSelect={() => setExecutionMode("local_device")}
+                        onSelect={() => selectExecutionMode("local_device")}
                       />
                       <ChoiceCard
                         icon={<Cloud className="h-4 w-4" />}
                         title={t("agents.execution.sandbox.title")}
                         description={t("agents.execution.sandbox.description")}
                         selected={executionMode === "sandbox"}
-                        onSelect={() => setExecutionMode("sandbox")}
+                        onSelect={() => selectExecutionMode("sandbox")}
                       />
                       {mode === "create" && (
                         <ChoiceCard
@@ -1002,7 +1014,7 @@ export function CreateAgentDialog({
                           title={t("agents.execution.external.title")}
                           description={t("agents.execution.external.description")}
                           selected={executionMode === "external"}
-                          onSelect={() => setExecutionMode("external")}
+                          onSelect={() => selectExecutionMode("external")}
                           disabled
                         />
                       )}


### PR DESCRIPTION
## Summary

- personalize first-workspace names from the user's display name or email prefix
- preserve manual workspace-name edits instead of continuing to overwrite them
- localize the default Agent system prompt for English and Chinese
- leave local-device Agent working directories empty while retaining `/workspace` for sandboxes
- keep existing contextual defaults unchanged where they already have clear product or safety semantics

## Validation

- `make test-web`
- `pnpm --filter @parsar/web build`
- `git diff --check`

## Full check note

`make check` was run twice before rebasing. Both runs were blocked by the unchanged store test `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation`; the same test passed when run independently three consecutive times.
