### PR TITLE
chore(web): clear frontend lint warnings

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,10 +3,8 @@ import { useTranslation } from "react-i18next"
 import { AdminRouter } from "./pages/admin/AdminRouter"
 import { LoginPage } from "./pages/LoginPage"
 import { OnboardingPage } from "./pages/OnboardingPage"
-import {
-  JoinWorkspaceLanding,
-  popPendingJoinIntent,
-} from "./pages/JoinWorkspaceLanding"
+import { JoinWorkspaceLanding } from "./pages/JoinWorkspaceLanding"
+import { popPendingJoinIntent } from "./lib/join-intent"
 import { InviteAcceptPage } from "./pages/InviteAcceptPage"
 import { AuthProvider, useAuth } from "./lib/auth-context"
 import { ThemeProvider } from "./lib/theme-provider"
@@ -87,4 +85,3 @@ export function App() {
     </ThemeProvider>
   )
 }
-

--- a/apps/web/src/components/admin/FeishuConnectorPanel.tsx
+++ b/apps/web/src/components/admin/FeishuConnectorPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from "../../lib/api-agents"
 import { useCreateSecret } from "../../lib/api-secrets"
 import type { CreateSecretRequest } from "../../lib/api-types"
+import { randomHex } from "../../lib/random"
 
 function Card({
   title,
@@ -806,12 +807,6 @@ function createFeishuSecretBody(spec: FeishuSecretFieldSpec, plaintext: string):
   }
 }
 
-function randomHex(bytes: number): string {
-  const values = new Uint8Array(bytes)
-  crypto.getRandomValues(values)
-  return Array.from(values, (value) => value.toString(16).padStart(2, "0")).join("")
-}
-
 function configEqual(a: FeishuConnectorConfig, b: FeishuConnectorConfig): boolean {
   return (
     a.enabled === b.enabled &&
@@ -823,25 +818,4 @@ function configEqual(a: FeishuConnectorConfig, b: FeishuConnectorConfig): boolea
     a.event_mode === b.event_mode &&
     a.routing_mode === b.routing_mode
   )
-}
-
-/** Extract the current Feishu connector config from an Agent's
- *  config jsonb; undefined when never wired. */
-export function readFeishuConfigFromAgent(
-  agentConfig: Record<string, unknown> | undefined,
-): FeishuConnectorConfig | undefined {
-  if (!agentConfig) return undefined
-  const connectors = agentConfig["connectors"] as Record<string, unknown> | undefined
-  const feishu = connectors?.["feishu"] as Record<string, unknown> | undefined
-  if (!feishu) return undefined
-  return {
-    enabled: Boolean(feishu["enabled"]),
-    app_id: (feishu["app_id"] as string) ?? "",
-    app_secret_ref: (feishu["app_secret_ref"] as string) ?? "",
-    verification_token_ref: (feishu["verification_token_ref"] as string) ?? "",
-    encrypt_key_ref: (feishu["encrypt_key_ref"] as string) ?? "",
-    bot_open_id: (feishu["bot_open_id"] as string) ?? "",
-    event_mode: feishu["event_mode"] === "websocket" ? "websocket" : "webhook",
-    routing_mode: feishu["routing_mode"] === "shared" ? "shared" : "direct",
-  }
 }

--- a/apps/web/src/components/admin/PairDaemonDialog.tsx
+++ b/apps/web/src/components/admin/PairDaemonDialog.tsx
@@ -11,11 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../ui/dialog"
-import {
-  useCreateRuntimePairing,
-  useWorkspaceRuntimes,
-  type Runtime,
-} from "../../lib/api-runtimes"
+import { useCreateRuntimePairing, useWorkspaceRuntimes } from "../../lib/api-runtimes"
 import { useBootstrapStatus } from "../../lib/api-bootstrap"
 
 interface PairDaemonDialogProps {

--- a/apps/web/src/components/admin/channel-connectors/discordFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/discordFields.tsx
@@ -9,7 +9,8 @@ import {
 } from "../../../lib/api-connectors"
 import { useCreateSecret } from "../../../lib/api-secrets"
 import type { CreateSecretRequest } from "../../../lib/api-types"
-import { Card, Field, SecretInput, randomHex } from "./shared"
+import { Card, Field, SecretInput } from "./shared"
+import { randomHex } from "../../../lib/random"
 
 const EMPTY_CONFIG: DiscordConnectorInput = {
   enabled: false,

--- a/apps/web/src/components/admin/channel-connectors/shared.tsx
+++ b/apps/web/src/components/admin/channel-connectors/shared.tsx
@@ -2,7 +2,7 @@
  * Shared UI primitives + tiny helpers for all channel-connector panels
  * (Feishu / Slack / Discord). Each platform-specific fields module owns its
  * own SecretFieldSpec + config-equal logic, but the visual shell — Card,
- * Field, SecretInput, randomHex — lives here so all three panels look the
+ * Field and SecretInput live here so all three panels look the
  * same and any tweak to spacing/colors applies uniformly.
  */
 import type { ReactNode } from "react"
@@ -125,12 +125,6 @@ export function SecretInput({
       />
     </Field>
   )
-}
-
-export function randomHex(bytes: number): string {
-  const values = new Uint8Array(bytes)
-  crypto.getRandomValues(values)
-  return Array.from(values, (value) => value.toString(16).padStart(2, "0")).join("")
 }
 
 export function ProvisionStatusIcon({

--- a/apps/web/src/components/admin/channel-connectors/slackFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/slackFields.tsx
@@ -9,7 +9,8 @@ import {
 } from "../../../lib/api-connectors"
 import { useCreateSecret } from "../../../lib/api-secrets"
 import type { CreateSecretRequest } from "../../../lib/api-types"
-import { Card, Field, SecretInput, randomHex } from "./shared"
+import { Card, Field, SecretInput } from "./shared"
+import { randomHex } from "../../../lib/random"
 
 const EMPTY_CONFIG: SlackConnectorInput = {
   enabled: false,

--- a/apps/web/src/components/admin/channel-connectors/teamsFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/teamsFields.tsx
@@ -9,7 +9,8 @@ import {
 } from "../../../lib/api-connectors"
 import { useCreateSecret } from "../../../lib/api-secrets"
 import type { CreateSecretRequest } from "../../../lib/api-types"
-import { Card, Field, SecretInput, randomHex } from "./shared"
+import { Card, Field, SecretInput } from "./shared"
+import { randomHex } from "../../../lib/random"
 
 const EMPTY_CONFIG: TeamsConnectorInput = {
   enabled: false,

--- a/apps/web/src/components/conversation/StepDisplay.tsx
+++ b/apps/web/src/components/conversation/StepDisplay.tsx
@@ -35,7 +35,7 @@ const SUMMARY_MAX = 80
 
 /** Picks the most informative single field from a tool's args payload.
  *  Returns "" when nothing usable; callers hide the detail line then. */
-export function summarizeArgs(name: string, args?: Record<string, unknown>): string {
+function summarizeArgs(name: string, args?: Record<string, unknown>): string {
   if (!args) return ""
   const key = name.toLowerCase()
   const FIELDS: Record<string, string[]> = {

--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
 import { cn } from "../../lib/utils"

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -60,5 +60,3 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   },
 )
 Button.displayName = "Button"
-
-export { buttonVariants }

--- a/apps/web/src/components/ui/collapsible.tsx
+++ b/apps/web/src/components/ui/collapsible.tsx
@@ -1,4 +1,3 @@
-import * as React from "react"
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
 
 export const Collapsible = CollapsiblePrimitive.Root

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 import { cn } from "../../lib/utils"

--- a/apps/web/src/lib/api-capabilities.ts
+++ b/apps/web/src/lib/api-capabilities.ts
@@ -50,17 +50,6 @@ export interface UpdateCapabilityRequest {
   status?: "active" | "disabled"
 }
 
-export interface CreateCapabilityVersionRequest {
-  version: string
-  git_repo_url?: string
-  git_ref?: string
-  path?: string
-  content?: Record<string, unknown>
-  required_credentials?: RequiredCredential[]
-  schema_version?: number
-  canonical_spec?: CanonicalSpec
-}
-
 export function systemPromptCapabilityPayload(input: {
   name: string
   description: string
@@ -169,17 +158,6 @@ async function updateCapability(
   return apiRequest<Capability>(
     `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/capabilities/${encodeURIComponent(capabilityID)}`,
     { method: "PATCH", body }
-  )
-}
-
-async function createCapabilityVersion(
-  workspaceID: string,
-  capabilityID: string,
-  body: CreateCapabilityVersionRequest
-): Promise<CapabilityVersion> {
-  return apiRequest<CapabilityVersion>(
-    `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/capabilities/${encodeURIComponent(capabilityID)}/versions`,
-    { method: "POST", body }
   )
 }
 

--- a/apps/web/src/lib/api-models.ts
+++ b/apps/web/src/lib/api-models.ts
@@ -8,17 +8,12 @@ import type {
   UpdateModelRequest,
   Secret,
 } from "./api-types"
+import { randomHex } from "./random"
 
 const KEY_MODELS = (workspaceID: string) =>
   ["admin", "models", workspaceID] as const
 const KEY_SECRETS = (workspaceID: string) =>
   ["admin", "secrets", workspaceID] as const
-
-function randomHex(bytes: number): string {
-  const values = new Uint8Array(bytes)
-  crypto.getRandomValues(values)
-  return Array.from(values, (v) => v.toString(16).padStart(2, "0")).join("")
-}
 
 /**
  * Model catalog is org-global; `workspaceID` only scopes the URL for RBAC.

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -363,7 +363,7 @@ export interface MarketplaceCapability {
   self_published: boolean
 }
 
-export interface GetCapabilityResponse extends Capability {}
+export type GetCapabilityResponse = Capability
 
 export interface ListCapabilityVersionsResponse {
   capability_id: string

--- a/apps/web/src/lib/auth-context.tsx
+++ b/apps/web/src/lib/auth-context.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createContext, useContext, type ReactNode } from "react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { ApiError, noUnreachableRetry } from "./api-client"

--- a/apps/web/src/lib/join-intent.ts
+++ b/apps/web/src/lib/join-intent.ts
@@ -1,0 +1,13 @@
+export const JOIN_INTENT_KEY = "parsar.joinWorkspaceIntent"
+
+export function popPendingJoinIntent(): string | null {
+  try {
+    const stash = sessionStorage.getItem(JOIN_INTENT_KEY)
+    if (!stash) return null
+    sessionStorage.removeItem(JOIN_INTENT_KEY)
+    if (!stash.startsWith("/join-workspace")) return null
+    return stash
+  } catch {
+    return null
+  }
+}

--- a/apps/web/src/lib/random.ts
+++ b/apps/web/src/lib/random.ts
@@ -1,0 +1,5 @@
+export function randomHex(bytes: number): string {
+  const values = new Uint8Array(bytes)
+  crypto.getRandomValues(values)
+  return Array.from(values, (value) => value.toString(16).padStart(2, "0")).join("")
+}

--- a/apps/web/src/pages/JoinWorkspaceLanding.tsx
+++ b/apps/web/src/pages/JoinWorkspaceLanding.tsx
@@ -12,6 +12,7 @@ import {
   useWithdrawJoinRequest,
 } from "../lib/api-workspaces"
 import type { DiscoverableWorkspace } from "../lib/api-types"
+import { JOIN_INTENT_KEY } from "../lib/join-intent"
 
 /**
  * Landing page for the Feishu rejection card's "Join" link. Reads
@@ -60,24 +61,6 @@ export function JoinWorkspaceLanding({ workspaceId }: { workspaceId: string }) {
   }
 
   return <Authenticated workspaceId={workspaceId} />
-}
-
-const JOIN_INTENT_KEY = "parsar.joinWorkspaceIntent"
-
-/**
- * Returns and clears the URL stashed during the unauthenticated → OAuth
- * bounce. Used by main.tsx's `Root` post-OAuth callback.
- */
-export function popPendingJoinIntent(): string | null {
-  try {
-    const stash = sessionStorage.getItem(JOIN_INTENT_KEY)
-    if (!stash) return null
-    sessionStorage.removeItem(JOIN_INTENT_KEY)
-    if (!stash.startsWith("/join-workspace")) return null
-    return stash
-  } catch {
-    return null
-  }
 }
 
 function Authenticated({ workspaceId }: { workspaceId: string }) {

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -885,7 +885,7 @@ function CapabilityCard({
     .filter((rc) => rc.required && !credentials.some((cred) => cred.kind === rc.kind))
     .map((rc) => rc.kind)
   const versionsQ = useCapabilityVersionsQuery(workspaceID, capability?.id ?? null)
-  const versions = versionsQ.data?.versions ?? []
+  const versions = useMemo(() => versionsQ.data?.versions ?? [], [versionsQ.data?.versions])
   const boundVersion = versions.find((version) => version.id === binding?.capability_version_id) ?? (binding?.capability_version_id && capability?.pinned_version ? { id: binding.capability_version_id, capability_id: capability.id, version: capability.pinned_version, created_at: capability.latest_version_created_at ?? capability.created_at } as CapabilityVersion : undefined)
   const marketplaceLatest = capability?.latest_version_id ? { id: capability.latest_version_id, capability_id: capability.id, version: capability.latest_version ?? capability.latest_published_version ?? "—", created_at: capability.latest_version_created_at ?? capability.created_at ?? new Date().toISOString() } as CapabilityVersion : undefined
   const latest = latestVersion(versions) ?? marketplaceLatest
@@ -1134,10 +1134,27 @@ function EnableCapabilityDialog({
   const [allCredentialsSatisfied, setAllCredentialsSatisfied] = useState(true)
   const versionsQ = useCapabilityVersionsQuery(workspaceID, open ? capability.id : null)
   const mut = useEnableAgentCapabilityMutation(workspaceID, agent.id)
-  const versions = versionsQ.data?.versions ?? []
+  const versions = useMemo(() => versionsQ.data?.versions ?? [], [versionsQ.data?.versions])
   const requiredCreds = capability.required_credentials ?? []
   const requiredKinds = requiredCreds.filter((rc) => rc.required)
-  const marketplaceFallbackVersion = capability.latest_version_id ? { id: capability.latest_version_id, capability_id: capability.id, version: capability.latest_version ?? "—", created_at: capability.latest_version_created_at ?? capability.created_at } as CapabilityVersion : undefined
+  const marketplaceFallbackVersion = useMemo(
+    () =>
+      capability.latest_version_id
+        ? ({
+            id: capability.latest_version_id,
+            capability_id: capability.id,
+            version: capability.latest_version ?? "—",
+            created_at: capability.latest_version_created_at ?? capability.created_at,
+          } as CapabilityVersion)
+        : undefined,
+    [
+      capability.id,
+      capability.latest_version,
+      capability.latest_version_created_at,
+      capability.latest_version_id,
+      capability.created_at,
+    ],
+  )
   const selectedVersion = versions.find((version) => version.id === selected) ?? latestVersion(versions) ?? marketplaceFallbackVersion
   const canEnable = !!selectedVersion && (requiredKinds.length === 0 || allCredentialsSatisfied) && !mut.isPending
 
@@ -1220,7 +1237,7 @@ function SwitchVersionDialog({
   const [selected, setSelected] = useState(binding.capability_version_id)
   const versionsQ = useCapabilityVersionsQuery(workspaceID, open ? capability.id : null)
   const mut = useEnableAgentCapabilityMutation(workspaceID, agent.id)
-  const versions = versionsQ.data?.versions ?? []
+  const versions = useMemo(() => versionsQ.data?.versions ?? [], [versionsQ.data?.versions])
   const selectedVersion = versions.find((version) => version.id === selected)
   const canSwitch = !!selectedVersion && selected !== binding.capability_version_id && !mut.isPending
 

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -542,7 +542,7 @@ export function CreateAgentDialog({
     setPairDialogOpen(false)
     setStep(1)
     setCapabilityTypeFilter("all")
-  }, [open, mode, agent?.id, defaultAgentDescription, defaultAgentName, defaultSystemPrompt, firstModelID])
+  }, [open, mode, agent, agent?.id, defaultAgentDescription, defaultAgentName, defaultSystemPrompt, firstModelID])
 
   function selectExecutionMode(nextMode: ExecutionMode) {
     setExecutionMode(nextMode)

--- a/apps/web/src/pages/admin/ModelKeyCombobox.tsx
+++ b/apps/web/src/pages/admin/ModelKeyCombobox.tsx
@@ -32,8 +32,6 @@ export function ModelKeyCombobox({ value, onChange, models, placeholder, id }: P
   const listRef = useRef<HTMLDivElement>(null)
   useWheelScroll(listRef)
 
-  const selected = useMemo(() => models.find((m) => m.id === value), [models, value])
-
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase()
     if (!q) return models

--- a/apps/web/src/pages/admin/ModelsPage.tsx
+++ b/apps/web/src/pages/admin/ModelsPage.tsx
@@ -504,7 +504,7 @@ export function ModelsPage() {
     void kindsQ.refetch()
   }
 
-  const allModels = modelsQ.data?.models ?? []
+  const allModels = useMemo(() => modelsQ.data?.models ?? [], [modelsQ.data?.models])
   const filteredModels = useMemo(() => {
     if (ownership === "all") return allModels
     if (!currentUserID) return allModels

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -931,8 +931,11 @@ function Card({ title, actions, className, children }: { title: string; actions?
 function RunSteps({ events, loading }: { events: AgentRunEvent[]; loading: boolean }) {
   const { t } = useTranslation("admin")
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set())
-  const translateStep = (key: string, options?: Record<string, unknown>) => t(key as never, options as never) as unknown as string
-  const steps = useMemo(() => buildSteps(events, translateStep), [events, translateStep])
+  const steps = useMemo(() => {
+    const translateStep = (key: string, options?: Record<string, unknown>) =>
+      t(key as never, options as never) as unknown as string
+    return buildSteps(events, translateStep)
+  }, [events, t])
   const expandable = useMemo(() => steps.filter((s) => s.rawEvents.length > 0), [steps])
   const allOpen = expandable.length > 0 && expandable.every((s) => expandedKeys.has(s.key))
   const toggle = (key: string) => {
@@ -1125,5 +1128,3 @@ function ArtifactRow({ medium, kind, name, meta }: { medium: string; kind: strin
     </button>
   )
 }
-
-export const _runsRefs = { Wrench }

--- a/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
@@ -156,7 +156,7 @@ export function AddCapabilityVersionDialog({
   const pluginHasUsableArtifact =
     kind !== "plugin"
       ? true
-      : !!pluginUpload.ossKey
+      : pluginUpload.ossKey
         ? pluginUpload.validation?.valid ?? false
         : !!inheritedOssLabel
 
@@ -370,7 +370,6 @@ export function AddCapabilityVersionDialog({
           ) : (
             <ImportPluginForm
               workspaceID={workspaceID}
-              value={spec}
               onChange={setSpec}
               onUploadStateChange={setPluginUpload}
               onSuggestedName={() => {}}

--- a/apps/web/src/pages/admin/capabilities/CredentialKindCombobox.tsx
+++ b/apps/web/src/pages/admin/capabilities/CredentialKindCombobox.tsx
@@ -43,7 +43,7 @@ export function CredentialKindCombobox({
   const listRef = useRef<HTMLDivElement>(null)
   useWheelScroll(listRef)
 
-  const items = kindsQ.data?.items ?? []
+  const items = useMemo(() => kindsQ.data?.items ?? [], [kindsQ.data?.items])
   const selected = useMemo(() => items.find((k) => k.code === value), [items, value])
 
   // Server already returns built-ins first (ORDER BY built_in DESC).

--- a/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
@@ -355,7 +355,6 @@ export function ImportCapabilityDialog({
             {kind === "plugin" && (
               <ImportPluginForm
                 workspaceID={workspaceID}
-                value={spec}
                 onChange={setSpec}
                 onUploadStateChange={setPluginUpload}
                 onSuggestedName={onSuggestedName}

--- a/apps/web/src/pages/admin/capabilities/ImportPluginForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportPluginForm.tsx
@@ -25,9 +25,6 @@ import type {
 
 interface Props {
   workspaceID: string | null
-  /** The spec passed through to the dialog's commit payload. Null until
-   *  preview succeeds; null also when the user clears the upload. */
-  value: CanonicalSpec | null
   onChange: (spec: CanonicalSpec | null) => void
   /** Called with the ossKey when upload + preview succeed; the dialog
    *  attaches it to the commit body so the server can re-fetch and
@@ -51,7 +48,6 @@ const MAX_BYTES = 32 * 1024 * 1024 // mirror server-side cap
 
 export function ImportPluginForm({
   workspaceID,
-  value,
   onChange,
   onUploadStateChange,
   onSuggestedName,

--- a/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
@@ -30,7 +30,7 @@ export function MarketplaceTab({ itemID, onSelectItem, onInstall }: MarketplaceT
   const [query, setQuery] = useState("")
   const [hideInstalled, setHideInstalled] = useState(true)
 
-  const items = marketplaceQ.data ?? []
+  const items = useMemo(() => marketplaceQ.data ?? [], [marketplaceQ.data])
   const selected = items.find((item) => item.id === itemID) ?? null
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase()

--- a/apps/web/src/pages/admin/capabilities/SkillFileTree.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillFileTree.tsx
@@ -27,7 +27,7 @@ interface Props {
 
 export function SkillFileTree({ skill }: Props) {
   const { t } = useTranslation("admin")
-  const files = skill.files ?? []
+  const files = useMemo(() => skill.files ?? [], [skill.files])
 
   const grouped = useMemo(() => groupFiles(files), [files])
 

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -153,12 +153,15 @@ export function CapabilitiesPage() {
     window.history.pushState({}, "", url.toString())
     window.dispatchEvent(new Event("admin:navigate"))
   }
-  const ownCapabilities = capsQ.data?.capabilities ?? []
+  const ownCapabilities = useMemo(() => capsQ.data?.capabilities ?? [], [capsQ.data?.capabilities])
   // In paginated mode the server returns the page-sliced marketplace installs
   // alongside the page-sliced own capabilities, so we use those instead of
   // the separate full-list endpoint. The standalone endpoint stays mounted to
   // compute totals (and as a fallback if paginated mode is off).
-  const pageInstalls = (capsQ.data?.marketplace_installs ?? []) as TargetMarketplaceInstall[]
+  const pageInstalls = useMemo(
+    () => (capsQ.data?.marketplace_installs ?? []) as TargetMarketplaceInstall[],
+    [capsQ.data?.marketplace_installs],
+  )
   const allInstalls = marketplaceInstallsQ.data ?? []
   const usingServerPage = capsQ.data?.total !== undefined
   const allCapabilities = useMemo(

--- a/apps/web/src/pages/admin/credentials/OrgSecretsTab.tsx
+++ b/apps/web/src/pages/admin/credentials/OrgSecretsTab.tsx
@@ -70,7 +70,7 @@ export function OrgSecretsTab({ workspaceID }: OrgSecretsTabProps) {
   const [createOpen, setCreateOpen] = useState(false)
   const [confirmTarget, setConfirmTarget] = useState<Secret | null>(null)
 
-  const secrets = secretsQ.data?.secrets ?? []
+  const secrets = useMemo(() => secretsQ.data?.secrets ?? [], [secretsQ.data?.secrets])
   const modelKeys = useMemo(() => secrets.filter((s) => s.kind === "model_provider"), [secrets])
   const runtimeKeys = useMemo(() => secrets.filter((s) => s.kind === "runtime" || s.provider === "e2b"), [secrets])
   const otherKeys = useMemo(() => secrets.filter((s) => s.kind !== "model_provider" && s.kind !== "runtime" && s.provider !== "e2b"), [secrets])

--- a/apps/web/src/pages/admin/credentials/PersonalCredentialsTab.tsx
+++ b/apps/web/src/pages/admin/credentials/PersonalCredentialsTab.tsx
@@ -64,7 +64,7 @@ export function PersonalCredentialsTab({ standalone = false }: PersonalCredentia
   const wsId = useWorkspaceId()
   const credentialsQ = useMyCredentials()
   const workspacesQ = useMyWorkspaces()
-  const workspaces = workspacesQ.data?.workspaces ?? []
+  const workspaces = useMemo(() => workspacesQ.data?.workspaces ?? [], [workspacesQ.data?.workspaces])
   const capabilitiesScan = useCapabilitiesPerWorkspace(workspaces)
   // Model catalog is org-global; the endpoint still needs a workspace in
   // the URL for RBAC but the response shape is workspace-independent.
@@ -82,7 +82,7 @@ export function PersonalCredentialsTab({ standalone = false }: PersonalCredentia
   const [pendingKind, setPendingKind] = useState<string | null>(null)
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
 
-  const credentials = credentialsQ.data?.credentials ?? []
+  const credentials = useMemo(() => credentialsQ.data?.credentials ?? [], [credentialsQ.data?.credentials])
 
   const requestedKind = standalone ? route.credentialKind : null
   const initialPrefill = standalone ? route.credentialPrefill : null
@@ -125,7 +125,7 @@ export function PersonalCredentialsTab({ standalone = false }: PersonalCredentia
     return () => window.clearTimeout(timer)
   }, [highlightedID])
 
-  const models = modelsQ.data?.models ?? []
+  const models = useMemo(() => modelsQ.data?.models ?? [], [modelsQ.data?.models])
   const missing = useMemo(
     () => computeMissingCredentials(workspaces, capabilitiesScan.byWorkspace, models, credentials),
     [workspaces, capabilitiesScan.byWorkspace, models, credentials],

--- a/apps/web/src/pages/admin/credentials/shared.ts
+++ b/apps/web/src/pages/admin/credentials/shared.ts
@@ -121,6 +121,7 @@ export function useCapabilitiesPerWorkspace(workspaces: UserWorkspace[]): {
     })),
   })
 
+  const queryStateKey = queries.map((q) => `${q.dataUpdatedAt}:${q.isLoading}:${q.isError}`).join("|")
   return useMemo(() => {
     const byWorkspace: Record<string, Capability[] | undefined> = {}
     let isLoading = false
@@ -135,10 +136,7 @@ export function useCapabilitiesPerWorkspace(workspaces: UserWorkspace[]): {
     return { byWorkspace, isLoading, isError }
     // Memo key tracks per-query state; workspaces identity is memoized by parent.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    queries.map((q) => `${q.dataUpdatedAt}:${q.isLoading}:${q.isError}`).join("|"),
-    workspaces,
-  ])
+  }, [queryStateKey, workspaces])
 }
 
 /**


### PR DESCRIPTION
## Summary
- clear all remaining frontend ESLint warnings
- stabilize derived collection dependencies for React hooks
- move shared random and join-intent helpers into lib
- mark Radix UI primitive exports as intentional Fast Refresh exceptions

## Validation
- `pnpm --filter web lint` (0 warnings, 0 errors)
- `pnpm --filter web typecheck`
- `git diff --check`