### PR TITLE
fix(web): keep agent dialog open when canceling device pairing

### DIFF
--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -991,8 +991,23 @@ export function CreateAgentDialog({
 
   return (
     <>
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[86vh] flex-col overflow-hidden sm:max-w-2xl">
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Keep the Agent form open while the nested pairing modal is active.
+        if (!next && pairDialogOpen) return
+        onOpenChange(next)
+      }}
+    >
+      <DialogContent
+        className="flex max-h-[86vh] flex-col overflow-hidden sm:max-w-2xl"
+        onPointerDownOutside={(event) => {
+          if (pairDialogOpen) event.preventDefault()
+        }}
+        onInteractOutside={(event) => {
+          if (pairDialogOpen) event.preventDefault()
+        }}
+      >
         <DialogHeader className="shrink-0">
           <DialogTitle>{mode === "edit" ? t("agents.form.title.edit") : t("agents.form.title.create")}</DialogTitle>
         </DialogHeader>
@@ -1576,21 +1591,21 @@ export function CreateAgentDialog({
             </Button>
           )}
         </DialogFooter>
+        {workspaceID && (
+          <PairDaemonDialog
+            open={pairDialogOpen}
+            onClose={() => setPairDialogOpen(false)}
+            workspaceID={workspaceID}
+            onPaired={(runtimeID) => {
+              setDeviceID(runtimeID)
+              // DevicePicker's list query doesn't poll; nudge it so the freshly
+              // paired daemon shows up without waiting for the next mount.
+              void queryClient.invalidateQueries({ queryKey: ["admin", "runtimes", workspaceID] })
+            }}
+          />
+        )}
       </DialogContent>
     </Dialog>
-    {workspaceID && (
-      <PairDaemonDialog
-        open={pairDialogOpen}
-        onClose={() => setPairDialogOpen(false)}
-        workspaceID={workspaceID}
-        onPaired={(runtimeID) => {
-          setDeviceID(runtimeID)
-          // DevicePicker's list query doesn't poll; nudge it so the freshly
-          // paired daemon shows up without waiting for the next mount.
-          void queryClient.invalidateQueries({ queryKey: ["admin", "runtimes", workspaceID] })
-        }}
-      />
-    )}
     </>
   )
 }


### PR DESCRIPTION
## Description

Canceling the Pair Device dialog can also close the parent Agent configuration dialog.

## Fix

- Render `PairDaemonDialog` inside the Agent dialog content so Radix treats it as a nested modal.
- Prevent the parent dialog from handling outside interactions while device pairing is active.

## Testing

- `pnpm --filter @parsar/web typecheck`
- `pnpm --filter @parsar/web build`
- `git diff --check`

## Compatibility

No API or backend changes. Existing dialog behavior is unchanged when device pairing is not active.
