### PR TITLE
fix(feishu): scope shared agent list to workspace

### DIFF
--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -90,7 +90,7 @@ type RuntimeStore interface {
 	UpdateAgentFeishuConnector(ctx context.Context, input store.UpdateAgentFeishuConnectorInput, actorID string) (store.AgentFeishuConnectorChange, error)
 	GetAgentByFeishuAppID(ctx context.Context, appID string) (store.FeishuAgentRoute, error)
 	GetAgentByID(ctx context.Context, agentID string) (store.FeishuAgentRoute, error)
-	ListFeishuSharedBotAgents(ctx context.Context, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error)
+	ListFeishuSharedBotAgents(ctx context.Context, workspaceID string, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error)
 	UpsertGatewaySessionSelection(ctx context.Context, input store.GatewaySessionSelectionInput) error
 	GetGatewaySessionSelection(ctx context.Context, platform, externalID, externalThreadID string) (string, error)
 	// ClearGatewaySessionSelection wipes a stored selection — see the

--- a/server/internal/dev/routes_test.go
+++ b/server/internal/dev/routes_test.go
@@ -2325,7 +2325,7 @@ func (stubRuntimeStore) GetAgentByID(ctx context.Context, agentID string) (store
 	}
 }
 
-func (stubRuntimeStore) ListFeishuSharedBotAgents(ctx context.Context, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error) {
+func (stubRuntimeStore) ListFeishuSharedBotAgents(ctx context.Context, workspaceID string, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error) {
 	return []store.FeishuSharedBotAgent{{
 		AgentID:       "00000000-0000-0000-0000-000000000902",
 		WorkspaceID:   "00000000-0000-0000-0000-000000000002",

--- a/server/internal/gateway/inbound/manager.go
+++ b/server/internal/gateway/inbound/manager.go
@@ -14,13 +14,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway"
+	sharedrouter "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/router"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	"github.com/larksuite/oapi-sdk-go/v3/ws"
-	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway"
-	sharedrouter "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/router"
-	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 )
 
 // Logger is the small logging surface Manager uses. *slog.Logger satisfies it.
@@ -39,7 +39,7 @@ type Storer interface {
 	ListFeishuWebSocketAgents(ctx context.Context) ([]store.FeishuAgentRoute, error)
 	GetAgentByFeishuAppID(ctx context.Context, appID string) (store.FeishuAgentRoute, error)
 	GetAgentByID(ctx context.Context, agentID string) (store.FeishuAgentRoute, error)
-	ListFeishuSharedBotAgents(ctx context.Context, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error)
+	ListFeishuSharedBotAgents(ctx context.Context, workspaceID string, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error)
 	UpsertGatewaySessionSelection(ctx context.Context, input store.GatewaySessionSelectionInput) error
 	GetGatewaySessionSelection(ctx context.Context, platform, externalID, externalThreadID string) (string, error)
 	ClearGatewaySessionSelection(ctx context.Context, platform, externalID, externalThreadID string) error

--- a/server/internal/gateway/inbound/manager_test.go
+++ b/server/internal/gateway/inbound/manager_test.go
@@ -14,9 +14,9 @@ import (
 	"sync/atomic"
 	"testing"
 
-	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 )
 
 func strptr(s string) *string { return &s }
@@ -277,12 +277,12 @@ type replaceUserCredentialsCall struct {
 
 func newInboundFakeStore() *inboundFakeStore {
 	return &inboundFakeStore{
-		agentsByAppID:  make(map[string]store.FeishuAgentRoute),
-		agentsByID:     make(map[string]store.FeishuAgentRoute),
-		selections:     make(map[string]string),
-		users:          make(map[string]string),
-		secrets:        make(map[string]store.SecretPayload),
-		cardsByPermReq: make(map[string]store.ConversationInflightCards),
+		agentsByAppID:                 make(map[string]store.FeishuAgentRoute),
+		agentsByID:                    make(map[string]store.FeishuAgentRoute),
+		selections:                    make(map[string]string),
+		users:                         make(map[string]string),
+		secrets:                       make(map[string]store.SecretPayload),
+		cardsByPermReq:                make(map[string]store.ConversationInflightCards),
 		cardsByPromptForUserChoiceReq: make(map[string]store.ConversationInflightCards),
 		inflightByConv:                make(map[string]store.ConversationInflightCards),
 		pendingAskByChat:              make(map[string]inboundFakeChatAsk),
@@ -316,7 +316,7 @@ func (f *inboundFakeStore) GetAgentByID(_ context.Context, agentID string) (stor
 	return route, nil
 }
 
-func (f *inboundFakeStore) ListFeishuSharedBotAgents(_ context.Context, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error) {
+func (f *inboundFakeStore) ListFeishuSharedBotAgents(_ context.Context, workspaceID string, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.sharedListCalls++
@@ -1598,7 +1598,7 @@ func TestQuotedChainText_MergeForwardChatListFallback(t *testing.T) {
 				chatID:  "oc_chat",
 				// No inline subs — forces fallback.
 			},
-			"om_c1": {msgType: "text", content: `{"text":"fallback line"}`, upperID: "om_mf"},
+			"om_c1":        {msgType: "text", content: `{"text":"fallback line"}`, upperID: "om_mf"},
 			"om_unrelated": {msgType: "text", content: `{"text":"noise"}`, upperID: "om_other_mf"},
 		},
 		map[string][]string{

--- a/server/internal/gateway/router/commands.go
+++ b/server/internal/gateway/router/commands.go
@@ -12,7 +12,7 @@ import (
 
 func handleList(ctx context.Context, st Store, host gateway.FeishuRouteAgent, event gateway.InboundEvent, reply ReplyFunc, senderUserID string) (Outcome, error) {
 	current, _ := st.GetGatewaySessionSelection(ctx, eventPlatform(event), event.ExternalChatID, "")
-	agents, err := st.ListFeishuSharedBotAgents(ctx, senderUserID, host.AgentID, 20)
+	agents, err := st.ListFeishuSharedBotAgents(ctx, host.WorkspaceID, senderUserID, host.AgentID, 20)
 	if err != nil {
 		return Outcome{}, err
 	}
@@ -23,7 +23,7 @@ func handleSelect(ctx context.Context, st Store, host gateway.FeishuRouteAgent, 
 	if len(args) == 0 || strings.TrimSpace(args[0]) == "" {
 		return replyAndStop(ctx, reply, host, event, "Usage: /select <agent-slug>", "select_usage")
 	}
-	agents, err := st.ListFeishuSharedBotAgents(ctx, senderUserID, host.AgentID, 50)
+	agents, err := st.ListFeishuSharedBotAgents(ctx, host.WorkspaceID, senderUserID, host.AgentID, 50)
 	if err != nil {
 		return Outcome{}, err
 	}

--- a/server/internal/gateway/router/router.go
+++ b/server/internal/gateway/router/router.go
@@ -13,7 +13,7 @@ import (
 
 type Store interface {
 	CreateInboundIMMessage(ctx context.Context, input store.CreateInboundIMMessageInput) (store.CreateInboundIMMessageResult, error)
-	ListFeishuSharedBotAgents(ctx context.Context, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error)
+	ListFeishuSharedBotAgents(ctx context.Context, workspaceID string, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error)
 	UpsertGatewaySessionSelection(ctx context.Context, input store.GatewaySessionSelectionInput) error
 	GetGatewaySessionSelection(ctx context.Context, platform, externalID, externalThreadID string) (string, error)
 	// Wipes the stored selection so the next inbound has to /select again;

--- a/server/internal/gateway/router/router_test.go
+++ b/server/internal/gateway/router/router_test.go
@@ -11,14 +11,15 @@ import (
 )
 
 type fakeSharedStore struct {
-	agents       []store.FeishuSharedBotAgent
-	routes       map[string]store.FeishuAgentRoute
-	userByUnion  map[string]string
-	memberships  map[string]bool
-	selections   map[string]string
-	created      []store.CreateInboundIMMessageInput
-	lastListUser string
-	lastExclude  string
+	agents            []store.FeishuSharedBotAgent
+	routes            map[string]store.FeishuAgentRoute
+	userByUnion       map[string]string
+	memberships       map[string]bool
+	selections        map[string]string
+	created           []store.CreateInboundIMMessageInput
+	lastListWorkspace string
+	lastListUser      string
+	lastExclude       string
 	// createErr forces CreateInboundIMMessage to return this error
 	// instead of the success path. Tests covering the binding-loss
 	// degrade branch set this to store.ErrUnknownMention.
@@ -59,6 +60,15 @@ func newFakeSharedStore() *fakeSharedStore {
 				WorkspaceSlug: "demo",
 				AgentName:     "Backend Agent",
 				AgentSlug:     "backend-agent",
+				Visibility:    "workspace",
+			},
+			{
+				AgentID:       "agent-other-workspace",
+				WorkspaceID:   "workspace-2",
+				WorkspaceName: "Other Workspace",
+				WorkspaceSlug: "other",
+				AgentName:     "Other Agent",
+				AgentSlug:     "other-agent",
 				Visibility:    "workspace",
 			},
 		},
@@ -109,12 +119,13 @@ func (f *fakeSharedStore) CreateInboundIMMessage(ctx context.Context, input stor
 	return store.CreateInboundIMMessageResult{MessageID: "message-1", RunIDs: []string{"run-1"}}, nil
 }
 
-func (f *fakeSharedStore) ListFeishuSharedBotAgents(ctx context.Context, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error) {
+func (f *fakeSharedStore) ListFeishuSharedBotAgents(ctx context.Context, workspaceID string, senderUserID string, excludeAgentID string, limit int32) ([]store.FeishuSharedBotAgent, error) {
+	f.lastListWorkspace = workspaceID
 	f.lastListUser = senderUserID
 	f.lastExclude = excludeAgentID
 	out := make([]store.FeishuSharedBotAgent, 0, len(f.agents))
 	for _, agent := range f.agents {
-		if agent.AgentID == excludeAgentID {
+		if agent.WorkspaceID != workspaceID || agent.AgentID == excludeAgentID {
 			continue
 		}
 		out = append(out, agent)
@@ -209,8 +220,8 @@ func TestHandleInboundListRepliesWithSelectableAgents(t *testing.T) {
 	if !outcome.Handled || outcome.Accepted || !outcome.Replied || outcome.Reason != "list" {
 		t.Fatalf("unexpected outcome: %+v", outcome)
 	}
-	if st.lastListUser != "user-1" || st.lastExclude != "agent-host" {
-		t.Fatalf("list did not use sender/host exclusion: user=%q exclude=%q", st.lastListUser, st.lastExclude)
+	if st.lastListWorkspace != "workspace-1" || st.lastListUser != "user-1" || st.lastExclude != "agent-host" {
+		t.Fatalf("list did not use workspace/sender/host exclusion: workspace=%q user=%q exclude=%q", st.lastListWorkspace, st.lastListUser, st.lastExclude)
 	}
 	if len(replies) != 1 {
 		t.Fatalf("expected one /list reply, got %#v", replies)
@@ -224,6 +235,9 @@ func TestHandleInboundListRepliesWithSelectableAgents(t *testing.T) {
 	}
 	if !strings.Contains(reply, "backend-agent (Backend Agent — demo)") {
 		t.Fatalf("/list reply missing backend-agent row: %q", reply)
+	}
+	if strings.Contains(reply, "other-agent") {
+		t.Fatalf("/list reply leaked an agent from another workspace: %q", reply)
 	}
 	if !strings.Contains(reply, "/select <agent-slug>") {
 		t.Fatalf("/list reply missing select hint: %q", reply)

--- a/server/internal/store/feishu_routing_test.go
+++ b/server/internal/store/feishu_routing_test.go
@@ -269,7 +269,7 @@ func TestListFeishuSharedBotAgentsRespectsVisibility(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	registered, err := st.ListFeishuSharedBotAgents(ctx, ids.UserID, ids.ProductAgentID, 20)
+	registered, err := st.ListFeishuSharedBotAgents(ctx, ids.WorkspaceID, ids.UserID, ids.ProductAgentID, 20)
 	if err != nil {
 		t.Fatalf("ListFeishuSharedBotAgents registered: %v", err)
 	}
@@ -281,7 +281,15 @@ func TestListFeishuSharedBotAgentsRespectsVisibility(t *testing.T) {
 		t.Fatalf("registered workspace member should see backend+test, got %+v", registered)
 	}
 
-	guest, err := st.ListFeishuSharedBotAgents(ctx, "", ids.ProductAgentID, 20)
+	otherWorkspace, err := st.ListFeishuSharedBotAgents(ctx, "00000000-0000-0000-0000-000000000099", ids.UserID, ids.ProductAgentID, 20)
+	if err != nil {
+		t.Fatalf("ListFeishuSharedBotAgents other workspace: %v", err)
+	}
+	if len(otherWorkspace) != 0 {
+		t.Fatalf("agent list leaked rows outside the requested workspace: %+v", otherWorkspace)
+	}
+
+	guest, err := st.ListFeishuSharedBotAgents(ctx, ids.WorkspaceID, "", ids.ProductAgentID, 20)
 	if err != nil {
 		t.Fatalf("ListFeishuSharedBotAgents guest: %v", err)
 	}
@@ -314,7 +322,7 @@ func TestListFeishuSharedBotAgentsExcludesDedicatedBotBindings(t *testing.T) {
 		t.Fatalf("UpdateAgentFeishuConnector direct: %v", err)
 	}
 
-	agents, err := st.ListFeishuSharedBotAgents(ctx, ids.UserID, ids.ProductAgentID, 20)
+	agents, err := st.ListFeishuSharedBotAgents(ctx, ids.WorkspaceID, ids.UserID, ids.ProductAgentID, 20)
 	if err != nil {
 		t.Fatalf("ListFeishuSharedBotAgents: %v", err)
 	}

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -1306,13 +1306,17 @@ func (s *Store) GetAgentByID(ctx context.Context, agentID string) (FeishuAgentRo
 	return route, nil
 }
 
-// ListFeishuSharedBotAgents returns active Agents the Feishu sender may
-// select from a shared Bot. Guests see public Agents only; registered users
-// also see tenant Agents + Agents in workspaces they belong to. Agents with
-// their own active Feishu Bot binding are excluded.
-func (s *Store) ListFeishuSharedBotAgents(ctx context.Context, senderUserID string, excludeAgentID string, limit int32) ([]FeishuSharedBotAgent, error) {
+// ListFeishuSharedBotAgents returns active Agents in the host workspace that
+// the Feishu sender may select from a shared Bot. Guests see public Agents
+// only; registered users also see tenant Agents and workspace members see
+// workspace Agents. Agents with their own active Feishu Bot binding are excluded.
+func (s *Store) ListFeishuSharedBotAgents(ctx context.Context, workspaceID string, senderUserID string, excludeAgentID string, limit int32) ([]FeishuSharedBotAgent, error) {
 	if limit <= 0 || limit > 50 {
 		limit = 20
+	}
+	workspaceUUID, err := uuid(workspaceID)
+	if err != nil {
+		return nil, err
 	}
 	var senderParam any
 	if strings.TrimSpace(senderUserID) != "" {
@@ -1342,23 +1346,24 @@ func (s *Store) ListFeishuSharedBotAgents(ctx context.Context, senderUserID stri
 		from agents a
 		join workspaces w on w.id = a.workspace_id
 		left join workspace_members wm on wm.workspace_id = a.workspace_id
-		  and wm.user_id = $1::uuid
+		  and wm.user_id = $2::uuid
 		  and wm.deleted_at is null
 		where a.status = 'active'
 		  and a.deleted_at is null
 		  and w.deleted_at is null
-		  and ($2::uuid is null or a.id <> $2::uuid)
+		  and a.workspace_id = $1::uuid
+		  and ($3::uuid is null or a.id <> $3::uuid)
 		  and not (
 		    coalesce((a.config->'connectors'->'feishu'->>'enabled')::boolean, false) = true
 		    and coalesce(a.config->'connectors'->'feishu'->>'app_id', '') <> ''
 		  )
 		  and (
-		    ($1::uuid is null and a.visibility = 'public')
-		    or ($1::uuid is not null and (a.visibility in ('tenant', 'public') or wm.user_id is not null))
+		    ($2::uuid is null and a.visibility = 'public')
+		    or ($2::uuid is not null and (a.visibility in ('tenant', 'public') or wm.user_id is not null))
 		  )
 		order by a.id, w.name asc, a.name asc
-		limit $3
-	`, senderParam, excludeParam, limit)
+		limit $4
+	`, workspaceUUID, senderParam, excludeParam, limit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

The Feishu shared-bot `/list` and `/select` commands can expose Agents from workspaces unrelated to the current Bot workspace.

## Fix

- Pass the current host workspace ID through the Feishu list/select call chain.
- Restrict shared-bot Agent queries to that workspace while preserving sender visibility checks.
- Keep the existing exclusion for the current Agent and Agents with their own Feishu Bot binding.

## Testing

- `gofmt` on all changed Go files
- `go test ./server/internal/dev ./server/internal/gateway/inbound ./server/internal/gateway/router ./server/internal/store`
- `git diff --check`

## Compatibility

No API or database schema changes. Shared-bot Agent selection remains subject to the existing sender visibility rules, with workspace isolation added.
