### PR TITLE
feat(web): improve agents management experience

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -936,7 +936,8 @@
       "clone": "Clone",
       "disable": "Disable",
       "enable": "Enable",
-      "delete": "Delete"
+      "delete": "Delete",
+      "more": "More actions"
     },
     "tabs": {
       "all": "All",
@@ -944,10 +945,13 @@
       "issues": "With issues"
     },
     "search": {
-      "placeholder": "Search agent name / description…"
+      "placeholder": "Search name, description, slug, engine, or model…"
     },
     "table": {
       "agent": "Agent",
+      "engine": "Engine",
+      "execution": "Execution",
+      "updated": "Last enabled",
       "status": "Status",
       "connector": "Connector",
       "sandbox": "Sandbox",
@@ -969,7 +973,7 @@
     },
     "status": {
       "active": "Active",
-      "disabled": "Deleted",
+      "disabled": "Disabled",
       "error": "Error"
     },
     "visibility": {
@@ -1151,11 +1155,29 @@
         }
       },
       "config": {
+        "saved": "Agent configuration saved.",
+        "identity": {
+          "title": "Identity",
+          "slug": "Internal ID",
+          "visibility": "Visibility",
+          "agentId": "Agent ID",
+          "created": "Created",
+          "updated": "Updated"
+        },
+        "intelligence": {
+          "title": "Intelligence",
+          "engine": "Agent engine",
+          "systemPrompt": "System prompt"
+        },
         "runtime": {
           "title": "Runtime",
           "model": "Model",
           "runtime": "Runtime",
-          "connector": "Connector"
+          "execution": "Execution",
+          "connector": "Connector",
+          "workdir": "Working directory",
+          "sandboxSize": "Sandbox size",
+          "binding": "Runtime binding"
         },
         "capabilities": {
           "title": "Capabilities",
@@ -1166,6 +1188,10 @@
       },
       "audit": {
         "title": "Audit log"
+      },
+      "loadError": {
+        "title": "Failed to load Agent",
+        "description": "The Agent may not exist or you may not have access."
       },
       "overview": {
         "summary": "Basics",
@@ -1523,10 +1549,11 @@
     },
     "listActions": {
       "cancel": "Cancel",
-      "deleteConfirmTitle": "Delete \"{{name}}\"?",
-      "deleteConfirmDescription": "After deletion, this Agent is no longer available and will not receive new run requests. Historical conversations, runs, and audit records are kept.",
-      "deleteConfirm": "Delete",
-      "deletedToast": "Deleted {{name}}",
+      "disableConfirmTitle": "Disable \"{{name}}\"?",
+      "disableConfirmDescription": "This Agent will stop receiving new run requests. Historical conversations, runs, and audit records are preserved, and you can enable it again later.",
+      "disableConfirm": "Disable",
+      "disabledToast": "Disabled {{name}}",
+      "enabledToast": "Enabled {{name}}",
       "clonedToast": "Cloned as \"{{name}}\""
     },
     "execution": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -936,7 +936,8 @@
       "clone": "复制",
       "disable": "禁用",
       "enable": "启用",
-      "delete": "删除"
+      "delete": "删除",
+      "more": "更多操作"
     },
     "tabs": {
       "all": "全部",
@@ -944,10 +945,13 @@
       "issues": "有异常"
     },
     "search": {
-      "placeholder": "搜索 Agent 名称 / 描述…"
+      "placeholder": "搜索名称、描述、Slug、引擎或模型…"
     },
     "table": {
       "agent": "Agent",
+      "engine": "引擎",
+      "execution": "运行方式",
+      "updated": "最近启用",
       "status": "状态",
       "connector": "连接器",
       "sandbox": "沙盒",
@@ -969,7 +973,7 @@
     },
     "status": {
       "active": "已启用",
-      "disabled": "已删除",
+      "disabled": "已停用",
       "error": "异常"
     },
     "visibility": {
@@ -1151,11 +1155,29 @@
         }
       },
       "config": {
+        "saved": "Agent 配置已保存。",
+        "identity": {
+          "title": "身份",
+          "slug": "内部标识",
+          "visibility": "可见性",
+          "agentId": "Agent ID",
+          "created": "创建时间",
+          "updated": "更新时间"
+        },
+        "intelligence": {
+          "title": "智能配置",
+          "engine": "Agent 引擎",
+          "systemPrompt": "系统提示词"
+        },
         "runtime": {
           "title": "运行环境",
           "model": "模型",
           "runtime": "Runtime",
-          "connector": "Connector"
+          "execution": "运行方式",
+          "connector": "连接器",
+          "workdir": "工作目录",
+          "sandboxSize": "沙盒规格",
+          "binding": "Runtime 绑定"
         },
         "capabilities": {
           "title": "Capabilities",
@@ -1166,6 +1188,10 @@
       },
       "audit": {
         "title": "审计日志"
+      },
+      "loadError": {
+        "title": "无法加载 Agent",
+        "description": "Agent 可能不存在，或当前用户没有访问权限。"
       },
       "overview": {
         "summary": "基本信息",
@@ -1523,10 +1549,11 @@
     },
     "listActions": {
       "cancel": "取消",
-      "deleteConfirmTitle": "删除「{{name}}」？",
-      "deleteConfirmDescription": "删除后，这个 Agent 将不再可用，也不会继续接收新的运行请求；历史对话、运行和审计记录会保留。",
-      "deleteConfirm": "删除",
-      "deletedToast": "已删除 {{name}}",
+      "disableConfirmTitle": "停用「{{name}}」？",
+      "disableConfirmDescription": "这个 Agent 将停止接收新的运行请求。历史对话、运行和审计记录会保留，之后仍可重新启用。",
+      "disableConfirm": "停用",
+      "disabledToast": "已停用 {{name}}",
+      "enabledToast": "已启用 {{name}}",
       "clonedToast": "已复制为「{{name}}」"
     },
     "execution": {

--- a/apps/web/src/lib/agent-view-model.ts
+++ b/apps/web/src/lib/agent-view-model.ts
@@ -1,0 +1,140 @@
+import type { Agent, AgentDetail } from "./api-types"
+
+export type AgentEngine = "claude_code" | "codex" | "pi" | "opencode"
+
+export type AgentExecutionMode = "local_device" | "sandbox" | "external"
+
+export type AgentEngineLabelKey =
+  | "agents.engine.claudeCode.title"
+  | "agents.engine.codex.title"
+  | "agents.engine.pi.title"
+  | "agents.engine.opencode.title"
+
+type AgentSource = Agent | AgentDetail | null | undefined
+type UnknownRecord = Record<string, unknown>
+
+function record(value: unknown): UnknownRecord {
+  return value !== null && typeof value === "object" ? (value as UnknownRecord) : {}
+}
+
+function configOf(agent: AgentSource): UnknownRecord {
+  return record(agent?.config)
+}
+
+function profileOf(agent: AgentSource): UnknownRecord {
+  const config = configOf(agent)
+  return {
+    ...record((agent as AgentDetail | undefined)?.profile),
+    ...record(config.profile),
+  }
+}
+
+function stringValue(...values: unknown[]): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim()
+    if (typeof value === "number" && Number.isFinite(value)) return String(value)
+  }
+  return ""
+}
+
+function normalizeEngine(value: string): AgentEngine | null {
+  switch (value.trim().toLowerCase().replaceAll("-", "_")) {
+    case "claude_code":
+    case "claude":
+      return "claude_code"
+    case "codex":
+      return "codex"
+    case "pi":
+      return "pi"
+    case "opencode":
+    case "open_code":
+      return "opencode"
+    default:
+      return null
+  }
+}
+
+export function agentEngineOf(agent: AgentSource): AgentEngine {
+  const config = configOf(agent)
+  const profile = profileOf(agent)
+  return (
+    normalizeEngine(
+      stringValue(
+        config.agent_kind,
+        config.engine,
+        profile.agent_kind,
+        profile.engine,
+        record(agent).agent_kind,
+        record(agent).engine,
+      ),
+    ) ?? "claude_code"
+  )
+}
+
+export function agentEngineLabel(engine: AgentEngine): AgentEngineLabelKey {
+  switch (engine) {
+    case "claude_code":
+      return "agents.engine.claudeCode.title"
+    case "codex":
+      return "agents.engine.codex.title"
+    case "pi":
+      return "agents.engine.pi.title"
+    case "opencode":
+      return "agents.engine.opencode.title"
+  }
+}
+
+export function agentExecutionModeOf(agent: AgentSource): AgentExecutionMode {
+  const config = configOf(agent)
+  const profile = profileOf(agent)
+  const connector = stringValue(agent?.connector_type).toLowerCase()
+  if (connector === "http" || connector === "http-agent") return "external"
+
+  const daemonMode = stringValue(
+    config.daemon_mode,
+    config.execution_mode,
+    profile.daemon_mode,
+    profile.execution_mode,
+  )
+    .toLowerCase()
+    .replaceAll("-", "_")
+  if (daemonMode === "sandbox") return "sandbox"
+  if (daemonMode === "local" || daemonMode === "local_device") return "local_device"
+
+  if (agent?.runtime === "local") return "local_device"
+  if (agent?.runtime === "sandbox") return "sandbox"
+  return connector === "agent_daemon" ? "sandbox" : "local_device"
+}
+
+export function agentWorkdirOf(agent: AgentSource): string {
+  const config = configOf(agent)
+  const profile = profileOf(agent)
+  return stringValue(
+    config.work_dir,
+    config.workdir,
+    config.working_directory,
+    profile.work_dir,
+    profile.workdir,
+    profile.working_directory,
+  )
+}
+
+export type AgentSandboxSize = "standard" | "xl"
+
+export function agentSandboxSizeOf(agent: AgentSource): AgentSandboxSize {
+  const config = configOf(agent)
+  const profile = profileOf(agent)
+  const value = stringValue(config.sandbox_size, profile.sandbox_size).toLowerCase()
+  return value === "xl" ? "xl" : "standard"
+}
+
+export function agentDefaultModelIDOf(agent: AgentSource): string {
+  const config = configOf(agent)
+  const profile = profileOf(agent)
+  return stringValue(
+    config.default_model_id,
+    config.model_id,
+    profile.default_model_id,
+    profile.model_id,
+  )
+}

--- a/apps/web/src/lib/api-agents.ts
+++ b/apps/web/src/lib/api-agents.ts
@@ -2,6 +2,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { ApiError, apiRequest, noUnreachableRetry } from "./api-client"
 import type {
   Agent,
+  AgentDetail,
+  AgentDetailResponse,
   AgentRunEvent,
   AgentRunDetail,
   AgentRunStatus,
@@ -18,6 +20,7 @@ import type {
 /* --- Query keys --------------------------------------------------------- */
 
 const KEY_AGENTS = (workspaceID: string) => ["admin", "agents", workspaceID] as const
+const KEY_AGENT_DETAIL = (workspaceID: string, agentID: string) => ["admin", "agent", workspaceID, agentID] as const
 // Statuses are sorted + joined to a stable string (nil/empty → "_all") so the
 // "in progress" union tab and pagination produce distinct cache entries.
 const KEY_RUNS = (
@@ -56,6 +59,18 @@ async function listAgents(workspaceID: string | null): Promise<ListAgentsRespons
     `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/agents`
   )
   return { ...res, agents: (res.agents ?? []).map(normalizeAgentId) }
+}
+
+export async function getAgentDetailRequest(
+  workspaceID: string | null,
+  agentID: string | null,
+): Promise<AgentDetail | null> {
+  if (!workspaceID || !agentID) return null
+  const response = await apiRequest<AgentDetailResponse>(
+    `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/agents/${encodeURIComponent(agentID)}`,
+  )
+  const detail = "agent" in response ? response.agent : response
+  return normalizeAgentId(detail) as AgentDetail
 }
 
 async function listAgentRuns(
@@ -229,6 +244,16 @@ export function useAgents(workspaceID: string | null) {
   })
 }
 
+export function useAgentDetail(workspaceID: string | null, agentID: string | null) {
+  return useQuery({
+    queryKey: KEY_AGENT_DETAIL(workspaceID ?? "_none", agentID ?? "_none"),
+    queryFn: () => getAgentDetailRequest(workspaceID, agentID),
+    enabled: Boolean(workspaceID && agentID),
+    retry: noUnreachableRetry,
+    staleTime: 30_000,
+  })
+}
+
 export interface UseAgentRunsOptions {
   // admin "in progress" tab passes ["running","queued"]; null/undefined/empty = no filter.
   statuses?: AgentRunStatus[] | null
@@ -397,8 +422,9 @@ export function useUpdateAgent(workspaceID: string | null) {
     }) => {
       return updateAgentRequest(agentID, body)
     },
-    onSuccess: () => {
+    onSuccess: (_change, variables) => {
       void qc.invalidateQueries({ queryKey: KEY_AGENTS(workspaceID ?? "_none") })
+      void qc.invalidateQueries({ queryKey: KEY_AGENT_DETAIL(workspaceID ?? "_none", variables.agentID) })
     },
   })
 }
@@ -420,8 +446,9 @@ export function useUpdateAgentVisibility(workspaceID: string | null) {
     }) => {
       return updateAgentVisibilityRequest(agentID, visibility)
     },
-    onSuccess: () => {
+    onSuccess: (_agent, variables) => {
       void qc.invalidateQueries({ queryKey: KEY_AGENTS(workspaceID ?? "_none") })
+      void qc.invalidateQueries({ queryKey: KEY_AGENT_DETAIL(workspaceID ?? "_none", variables.agentID) })
     },
   })
 }
@@ -633,8 +660,9 @@ export function useSetAgentStatus(workspaceID: string | null) {
       agentID: string
       enabled: boolean
     }) => setAgentStatus(agentID, enabled),
-    onSuccess: () => {
+    onSuccess: (_agent, variables) => {
       void qc.invalidateQueries({ queryKey: KEY_AGENTS(workspaceID ?? "_none") })
+      void qc.invalidateQueries({ queryKey: KEY_AGENT_DETAIL(workspaceID ?? "_none", variables.agentID) })
     },
   })
 }
@@ -649,8 +677,9 @@ export function useUpdateAgentProfile(workspaceID: string | null) {
       agentID: string
       body: UpdateAgentProfileRequest
     }) => updateAgentProfileRequest(agentID, body),
-    onSuccess: () => {
+    onSuccess: (_result, variables) => {
       void qc.invalidateQueries({ queryKey: KEY_AGENTS(workspaceID ?? "_none") })
+      void qc.invalidateQueries({ queryKey: KEY_AGENT_DETAIL(workspaceID ?? "_none", variables.agentID) })
     },
   })
 }

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -152,6 +152,15 @@ export interface Agent {
   sandbox_status?: string
 }
 
+export interface AgentDetail extends Agent {
+  agent_id?: string
+  profile?: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export type AgentDetailResponse = AgentDetail | { agent: AgentDetail }
+
 export interface ListAgentsResponse {
   agents: Agent[]
 }

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -4,12 +4,8 @@ import * as Tooltip from "@radix-ui/react-tooltip"
 import {
   ArrowUpRight,
   Bot,
-  Copy,
   Loader2,
-  MessageSquare,
-  Pencil,
   Plus,
-  Trash2,
   Search,
 } from "lucide-react"
 
@@ -18,7 +14,6 @@ import { PageHeader } from "../../components/layout/PageHeader"
 import { ScopeRequiredState } from "../../components/admin/ScopeRequiredState"
 import { ResourceAuditTimeline } from "../../components/admin/ResourceAuditTimeline"
 import { SandboxPanel } from "../../components/admin/SandboxPanel"
-import { ActionIconButton, RowActions } from "../../components/ui/action-button"
 import { Badge } from "../../components/ui/badge"
 import { Button } from "../../components/ui/button"
 import { EmptyState } from "../../components/ui/empty-state"
@@ -61,6 +56,7 @@ import { ApiError } from "../../lib/api-client"
 import { createConversation } from "../../lib/api-conversations"
 import {
   useCreateAgent,
+  useAgentDetail,
   useAgents,
   useSetAgentStatus,
   useUpdateAgent,
@@ -82,13 +78,18 @@ import { useMyCredentials } from "../../lib/api-credentials"
 import { useMyWorkspaces } from "../../lib/api-workspaces"
 import { useMarketplaceList } from "../../lib/api-marketplace"
 import { agentExecutionPlacement } from "../../lib/agent-runtime"
-import type { Agent, AgentCapability, AgentRunStatus, AgentRunSummary, Capability, CapabilityVersion, Model, UserCredential } from "../../lib/api-types"
+import { agentDefaultModelIDOf, agentEngineLabel, agentEngineOf } from "../../lib/agent-view-model"
+import type { Agent, AgentCapability, AgentDetail, AgentRunStatus, AgentRunSummary, Capability, CapabilityVersion, Model, UserCredential } from "../../lib/api-types"
 import { useWorkspaceId } from "../../lib/workspace"
 import { useRelativeTime } from "../../lib/relative-time"
 import { CreateAgentDialog } from "./CreateAgentDialog"
 import { CapabilityTypeBadge } from "./CapabilitiesPage"
 import { UpgradeCapabilityDialog } from "./capabilities/UpgradeCapabilityDialog"
 import { credentialKindLabel } from "./capability-ui"
+import { AgentConfigSummary } from "./agents/AgentConfigSummary"
+import { AgentDetailActions } from "./agents/AgentDetailActions"
+import { AgentRowActions } from "./agents/AgentRowActions"
+import { AgentStatusBadge } from "./agents/AgentStatusBadge"
 
 /* ------------------------------------------------------------------ */
 /*  View-model derived from Agent                              */
@@ -100,9 +101,7 @@ import { credentialKindLabel } from "./capability-ui"
  * `model_id` / `profile.model_id` shapes for older rows.
  */
 function defaultModelOf(a: Agent, models: Model[], unavailableLabel: string): string {
-  const cfg = (a.config as Record<string, unknown> | undefined) ?? {}
-  const profile = (cfg.profile ?? {}) as Record<string, unknown>
-  const id = String(cfg.default_model_id ?? cfg.model_id ?? profile.model_id ?? "")
+  const id = agentDefaultModelIDOf(a)
   if (!id) return "—"
   const found = models.find((m) => m.id === id)
   if (!found) return unavailableLabel
@@ -133,13 +132,6 @@ function starterConversationTitle(agentName: string, language: string): string {
 /* ------------------------------------------------------------------ */
 /*  Status badge                                                       */
 /* ------------------------------------------------------------------ */
-
-function AgentStatusBadge({ status }: { status: Agent["status"] }) {
-  const { t } = useTranslation("admin")
-  if (status === "active") return <Badge variant="success" dot>{t("agents.status.active")}</Badge>
-  if (status === "error") return <Badge variant="destructive" dot>{t("agents.status.error")}</Badge>
-  return <Badge variant="neutral">{t("agents.status.disabled")}</Badge>
-}
 
 /* ------------------------------------------------------------------ */
 /*  Runtime cell                                                       */
@@ -291,10 +283,11 @@ export function AgentsPage() {
   const [createOpen, setCreateOpen] = useState(false)
   const [editAgent, setEditAgent] = useState<Agent | null>(null)
   const [cloneAgent, setCloneAgent] = useState<Agent | null>(null)
-  const [deleteTarget, setDeleteTarget] = useState<Agent | null>(null)
+  const [disableTarget, setDisableTarget] = useState<Agent | null>(null)
   const [toast, setToast] = useState<string | null>(null)
   // Spinning row icon + double-click guard for the Chat button.
   const [chatPendingID, setChatPendingID] = useState<string | null>(null)
+  const fmtAgo = useRelativeTime()
 
   const query = useAgents(wid)
   const createMut = useCreateAgent(wid)
@@ -318,7 +311,13 @@ export function AgentsPage() {
   const filtered = agents.filter((a) => {
     if (!keyword) return true
     const q = keyword.toLowerCase()
-    return a.name.toLowerCase().includes(q) || a.description.toLowerCase().includes(q)
+    const engine = t(agentEngineLabel(agentEngineOf(a))).toLowerCase()
+    const model = defaultModelOf(a, modelsQ.data?.models ?? [], t("agents.modelUnavailable")).toLowerCase()
+    return a.name.toLowerCase().includes(q)
+      || a.description.toLowerCase().includes(q)
+      || a.slug.toLowerCase().includes(q)
+      || engine.includes(q)
+      || model.includes(q)
   })
 
   // Spawns a fresh conversation rather than grafting onto unrelated
@@ -427,10 +426,11 @@ export function AgentsPage() {
                 <TableHeader>
                   <TableRow>
                     <TableHead>{t("agents.table.agent")}</TableHead>
-                    <TableHead>{t("agents.table.runtime")}</TableHead>
+                    <TableHead>{t("agents.table.engine")}</TableHead>
                     <TableHead>{t("agents.table.model")}</TableHead>
-                    <TableHead>{t("agents.table.visibility")}</TableHead>
-                    <TableHead>{t("agents.table.creator")}</TableHead>
+                    <TableHead>{t("agents.table.execution")}</TableHead>
+                    <TableHead>{t("agents.table.status")}</TableHead>
+                    <TableHead>{t("agents.table.updated")}</TableHead>
                     <TableHead className="text-right pr-4">{t("agents.table.actions")}</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -442,45 +442,41 @@ export function AgentsPage() {
                       onClick={() => navigate("agents", { id: a.id })}
                     >
                       <TableCell>
-                        <div className="flex items-center gap-2">
-                          <Bot className="h-3.5 w-3.5 shrink-0 text-fg-faint" strokeWidth={1.75} />
-                          <span className="text-base font-medium text-fg">{a.name}</span>
+                        <div className="flex min-w-0 items-start gap-2">
+                          <Bot className="mt-0.5 h-3.5 w-3.5 shrink-0 text-fg-faint" strokeWidth={1.75} />
+                          <div className="min-w-0">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <span className="text-base font-medium text-fg">{a.name}</span>
+                              <Badge variant="neutral">{t(`agents.visibility.${a.visibility ?? "workspace"}`)}</Badge>
+                            </div>
+                            <p className="mt-0.5 max-w-md truncate text-sm text-fg-subtle">{a.description || a.slug}</p>
+                          </div>
                         </div>
                       </TableCell>
-                      <TableCell><RuntimeCell agent={a} /></TableCell>
+                      <TableCell className="text-sm font-medium text-fg-muted">{t(agentEngineLabel(agentEngineOf(a)))}</TableCell>
                       <TableCell className="font-mono text-sm text-fg-muted">{defaultModelOf(a, modelsQ.data?.models ?? [], t("agents.modelUnavailable"))}</TableCell>
-                      <TableCell className="text-sm text-fg-subtle">
-                        {t(`agents.visibility.${a.visibility ?? "workspace"}`)}
-                      </TableCell>
-                      <TableCell className="text-sm text-fg-muted">{a.created_by_name || "—"}</TableCell>
+                      <TableCell><RuntimeCell agent={a} /></TableCell>
+                      <TableCell><AgentStatusBadge status={a.status} /></TableCell>
+                      <TableCell className="whitespace-nowrap text-sm text-fg-subtle">{a.enabled_at ? fmtAgo(a.enabled_at) : "—"}</TableCell>
                       <TableCell className="pr-4">
-                        <RowActions>
-                          <ActionIconButton
-                            icon={MessageSquare}
-                            label={t("agents.actions.chat")}
-                            tone="primary"
-                            disabled={a.status !== "active" || !wid}
-                            busy={chatPendingID === a.id}
-                            onClick={() => void startChatWith(a)}
-                          />
-                          <ActionIconButton
-                            icon={Pencil}
-                            label={t("agents.actions.edit")}
-                            onClick={() => setEditAgent(a)}
-                          />
-                          <ActionIconButton
-                            icon={Copy}
-                            label={t("agents.actions.clone")}
-                            onClick={() => setCloneAgent(a)}
-                          />
-                          <ActionIconButton
-                            icon={Trash2}
-                            label={t("agents.actions.delete")}
-                            tone="danger"
-                            disabled={a.status !== "active"}
-                            onClick={() => setDeleteTarget(a)}
-                          />
-                        </RowActions>
+                        <AgentRowActions
+                          agent={a}
+                          chatPending={chatPendingID === a.id}
+                          statusPending={statusMut.isPending}
+                          onChat={() => void startChatWith(a)}
+                          onEdit={() => setEditAgent(a)}
+                          onClone={() => setCloneAgent(a)}
+                          onStatusChange={(enabled) => {
+                            if (!enabled) {
+                              setDisableTarget(a)
+                              return
+                            }
+                            statusMut.mutate(
+                              { agentID: a.id, enabled: true },
+                              { onSuccess: () => setToast(t("agents.listActions.enabledToast", { name: a.name })) },
+                            )
+                          }}
+                        />
                       </TableCell>
                     </TableRow>
                   ))}
@@ -590,13 +586,13 @@ export function AgentsPage() {
         }}
       />
 
-      <AlertDialog open={deleteTarget !== null} onOpenChange={(open) => {
-        if (!open && !statusMut.isPending) setDeleteTarget(null)
+      <AlertDialog open={disableTarget !== null} onOpenChange={(open) => {
+        if (!open && !statusMut.isPending) setDisableTarget(null)
       }}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{t("agents.listActions.deleteConfirmTitle", { name: deleteTarget?.name ?? "" })}</AlertDialogTitle>
-            <AlertDialogDescription>{t("agents.listActions.deleteConfirmDescription")}</AlertDialogDescription>
+            <AlertDialogTitle>{t("agents.listActions.disableConfirmTitle", { name: disableTarget?.name ?? "" })}</AlertDialogTitle>
+            <AlertDialogDescription>{t("agents.listActions.disableConfirmDescription")}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel asChild>
@@ -605,22 +601,22 @@ export function AgentsPage() {
             <Button
               variant="destructive"
               size="sm"
-              disabled={!deleteTarget || statusMut.isPending}
+              disabled={!disableTarget || statusMut.isPending}
               onClick={() => {
-                if (!deleteTarget) return
+                if (!disableTarget) return
                 statusMut.mutate(
-                  { agentID: deleteTarget.id, enabled: false },
+                  { agentID: disableTarget.id, enabled: false },
                   {
                     onSuccess: () => {
-                      setToast(t("agents.listActions.deletedToast", { name: deleteTarget.name }))
-                      setDeleteTarget(null)
+                      setToast(t("agents.listActions.disabledToast", { name: disableTarget.name }))
+                      setDisableTarget(null)
                     },
                   },
                 )
               }}
             >
               {statusMut.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
-              {t("agents.listActions.deleteConfirm")}
+              {t("agents.listActions.disableConfirm")}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -662,14 +658,12 @@ export function AgentDetailPage({ id }: { id: string }) {
   const [toast, setToast] = useState<string | null>(null)
   const pendingCapabilityID = new URLSearchParams(window.location.search).get("pendingCapability")
 
-  // Detail reads from the cached list; no per-agent endpoint surfaced
-  // in admin scope yet.
-  const query = useAgents(wid)
+  const query = useAgentDetail(wid, id)
   const modelsQ = useModels(wid)
   const workspacesQ = useMyWorkspaces()
-  const agents = query.data?.agents ?? []
-  const agent = agents.find((a) => a.id === id) ?? agents[0]
-  const workspaceRole = workspacesQ.data?.workspaces.find((w) => w.id === wid)?.role
+  const agent = query.data
+  const currentWorkspace = workspacesQ.data?.workspaces.find((w) => w.id === wid)
+  const workspaceRole = currentWorkspace?.role
 
   const agentCapabilitiesQ = useAgentCapabilitiesQuery(wid, agent?.id ?? null)
   const workspaceCapabilitiesQ = useCapabilitiesQuery(wid)
@@ -679,6 +673,18 @@ export function AgentDetailPage({ id }: { id: string }) {
     return (
       <AdminLayout activeMenu="agents">
         <AgentsLoadingSkeleton />
+      </AdminLayout>
+    )
+  }
+
+  if (query.error) {
+    return (
+      <AdminLayout activeMenu="agents">
+        <ErrorState
+          title={t("agents.detail.loadError.title")}
+          description={query.error instanceof Error ? query.error.message : t("agents.detail.loadError.description")}
+          onRetry={() => void query.refetch()}
+        />
       </AdminLayout>
     )
   }
@@ -711,7 +717,19 @@ export function AgentDetailPage({ id }: { id: string }) {
         }
         title={agent.name}
         description={agent.description}
-        action={<AgentStatusBadge status={agent.status} />}
+        action={
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <AgentStatusBadge status={agent.status} />
+            <AgentDetailActions
+              agent={agent}
+              workspaceID={wid}
+              workspaceName={currentWorkspace?.name}
+              workspaceRole={workspaceRole}
+              models={modelsQ.data?.models ?? []}
+              onToast={setToast}
+            />
+          </div>
+        }
       />
 
       {toast && (
@@ -726,7 +744,10 @@ export function AgentDetailPage({ id }: { id: string }) {
         </div>
       )}
 
-      <Tabs defaultValue={requestedTab ?? "dynamics"}>
+      <Tabs
+        value={requestedTab ?? "dynamics"}
+        onValueChange={(tab) => navigate("agents", { id: agent.id, tab })}
+      >
         <TabsList>
           <TabsTrigger value="dynamics">{t("agents.detail.tabs.dynamics")}</TabsTrigger>
           <TabsTrigger value="config">{t("agents.detail.tabs.config")}</TabsTrigger>
@@ -763,15 +784,6 @@ export function AgentDetailPage({ id }: { id: string }) {
         </TabsContent>
       </Tabs>
     </AdminLayout>
-  )
-}
-
-function Field({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
-  return (
-    <div className="mb-2 last:mb-0">
-      <dt className="mb-0.5 text-xs uppercase tracking-wider text-fg-faint">{label}</dt>
-      <dd className={`text-sm text-fg-emphasis ${mono ? "font-mono" : ""}`}>{value}</dd>
-    </div>
   )
 }
 
@@ -1573,7 +1585,7 @@ function AgentConfigTab({
   capabilitiesError,
   onToast,
 }: {
-  agent: Agent
+  agent: AgentDetail
   workspaceID: string | null
   workspaceRole?: string
   modelLabel: string
@@ -1584,7 +1596,7 @@ function AgentConfigTab({
   capabilitiesError: unknown
   onToast: (message: string) => void
 }) {
-  const { t, i18n } = useTranslation("admin")
+  const { i18n } = useTranslation("admin")
   const credentialsQ = useMyCredentials()
   const credentials = credentialsQ.data?.credentials ?? []
   const installedIDs = new Set(installedCapabilities.map((item) => item.capability_id))
@@ -1604,26 +1616,7 @@ function AgentConfigTab({
 
   return (
     <div className="space-y-4">
-      <Card title={t("agents.detail.config.runtime.title")}>
-        <Field label={t("agents.detail.config.runtime.model")} value={modelLabel} mono />
-        <Field
-          label={t("agents.detail.config.runtime.runtime")}
-          value={
-            <Badge variant={runtimeOf(agent) === "sandbox" ? "success" : "neutral"} dot>
-              {t(`agents.runtime.${runtimeOf(agent)}`)}
-            </Badge>
-          }
-        />
-        <Field
-          label={t("agents.detail.config.runtime.connector")}
-          value={
-            <span>
-              {connectorLabel}
-              <span className="ml-1 text-sm text-fg-subtle">· {agent.connector_type}</span>
-            </span>
-          }
-        />
-      </Card>
+      <AgentConfigSummary agent={agent} modelLabel={modelLabel} connectorLabel={connectorLabel} />
 
       {/* Sandbox panel lives under the runtime card because for      */}
       {/* sandbox-mode agents it IS the runtime surface. Skipped for  */}

--- a/apps/web/src/pages/admin/agents/AgentConfigSummary.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigSummary.tsx
@@ -1,0 +1,134 @@
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "../../../components/ui/badge"
+import {
+  agentEngineLabel,
+  agentEngineOf,
+  agentExecutionModeOf,
+  agentSandboxSizeOf,
+  agentWorkdirOf,
+} from "../../../lib/agent-view-model"
+import type { AgentDetail } from "../../../lib/api-types"
+
+export function AgentConfigSummary({
+  agent,
+  modelLabel,
+  connectorLabel,
+}: {
+  agent: AgentDetail
+  modelLabel: string
+  connectorLabel: string
+}) {
+  const { t, i18n } = useTranslation("admin")
+  const config = agent.config ?? {}
+  const profile = (config.profile ?? {}) as Record<string, unknown>
+  const systemPrompt = String(config.system_prompt ?? profile.system_prompt ?? "").trim()
+  const executionMode = agentExecutionModeOf(agent)
+
+  return (
+    <>
+      <SummaryCard title={t("agents.detail.config.identity.title")}>
+        <SummaryField label={t("agents.detail.config.identity.slug")} value={agent.slug} mono />
+        <SummaryField
+          label={t("agents.detail.config.identity.visibility")}
+          value={t(`agents.visibility.${agent.visibility ?? "workspace"}`)}
+        />
+        <SummaryField label={t("agents.detail.config.identity.agentId")} value={agent.id} mono />
+        <SummaryField
+          label={t("agents.detail.config.identity.created")}
+          value={formatDate(agent.created_at, i18n.language)}
+        />
+        <SummaryField
+          label={t("agents.detail.config.identity.updated")}
+          value={formatDate(agent.updated_at, i18n.language)}
+        />
+      </SummaryCard>
+
+      <SummaryCard title={t("agents.detail.config.intelligence.title")}>
+        <SummaryField
+          label={t("agents.detail.config.intelligence.engine")}
+          value={t(agentEngineLabel(agentEngineOf(agent)))}
+        />
+        <SummaryField label={t("agents.detail.config.runtime.model")} value={modelLabel} mono />
+        <SummaryField
+          label={t("agents.detail.config.intelligence.systemPrompt")}
+          value={
+            systemPrompt ? (
+              <p className="whitespace-pre-wrap break-words text-fg-muted">{systemPrompt}</p>
+            ) : (
+              <span className="text-fg-faint">—</span>
+            )
+          }
+        />
+      </SummaryCard>
+
+      <SummaryCard title={t("agents.detail.config.runtime.title")}>
+        <SummaryField
+          label={t("agents.detail.config.runtime.execution")}
+          value={
+            <Badge variant={executionMode === "sandbox" ? "success" : "neutral"} dot>
+              {t(
+                `agents.execution.${executionMode === "local_device" ? "localDevice" : executionMode}.title`,
+              )}
+            </Badge>
+          }
+        />
+        <SummaryField
+          label={t("agents.detail.config.runtime.connector")}
+          value={
+            <span>
+              {connectorLabel}
+              <span className="ml-1 text-sm text-fg-subtle">· {agent.connector_type}</span>
+            </span>
+          }
+        />
+        <SummaryField
+          label={t("agents.detail.config.runtime.workdir")}
+          value={agentWorkdirOf(agent) || "—"}
+          mono
+        />
+        {executionMode === "sandbox" && (
+          <SummaryField
+            label={t("agents.detail.config.runtime.sandboxSize")}
+            value={t(`agents.form.sandboxSize.${agentSandboxSizeOf(agent)}`)}
+          />
+        )}
+        <SummaryField
+          label={t("agents.detail.config.runtime.binding")}
+          value={agent.runtime_name || agent.runtime_id || "—"}
+          mono
+        />
+      </SummaryCard>
+    </>
+  )
+}
+
+function SummaryCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-lg border border-line bg-surface p-4">
+      <h3 className="mb-3 text-base font-semibold text-fg">{title}</h3>
+      <dl>{children}</dl>
+    </section>
+  )
+}
+
+function SummaryField({
+  label,
+  value,
+  mono,
+}: {
+  label: string
+  value: React.ReactNode
+  mono?: boolean
+}) {
+  return (
+    <div className="mb-2 last:mb-0">
+      <dt className="mb-0.5 text-xs uppercase tracking-wider text-fg-faint">{label}</dt>
+      <dd className={`text-sm text-fg-emphasis ${mono ? "font-mono" : ""}`}>{value}</dd>
+    </div>
+  )
+}
+
+function formatDate(value: string | undefined, language: string): string {
+  return value ? new Date(value).toLocaleString(language) : "—"
+}

--- a/apps/web/src/pages/admin/agents/AgentDetailActions.tsx
+++ b/apps/web/src/pages/admin/agents/AgentDetailActions.tsx
@@ -1,0 +1,188 @@
+import { useState } from "react"
+import { Loader2, MessageSquare, Pencil, Power, PowerOff } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../../../components/ui/alert-dialog"
+import { Button } from "../../../components/ui/button"
+import { useSetAgentStatus, useUpdateAgent, useUpdateAgentProfile } from "../../../lib/api-agents"
+import { createConversation } from "../../../lib/api-conversations"
+import type { Agent, Model, UserWorkspace } from "../../../lib/api-types"
+import { useAdminView } from "../../../lib/admin-router"
+import { CreateAgentDialog } from "../CreateAgentDialog"
+
+export function AgentDetailActions({
+  agent,
+  workspaceID,
+  workspaceName,
+  workspaceRole,
+  models,
+  onToast,
+}: {
+  agent: Agent
+  workspaceID: string | null
+  workspaceName?: string
+  workspaceRole?: UserWorkspace["role"]
+  models: Model[]
+  onToast: (message: string) => void
+}) {
+  const { t, i18n } = useTranslation("admin")
+  const { navigate } = useAdminView()
+  const [editOpen, setEditOpen] = useState(false)
+  const [disableOpen, setDisableOpen] = useState(false)
+  const [chatPending, setChatPending] = useState(false)
+  const updateMut = useUpdateAgent(workspaceID)
+  const updateProfileMut = useUpdateAgentProfile(workspaceID)
+  const statusMut = useSetAgentStatus(workspaceID)
+
+  async function startChat() {
+    if (!workspaceID || chatPending) return
+    setChatPending(true)
+    try {
+      const conversation = await createConversation(workspaceID, {
+        title: conversationTitle(agent.name, i18n.language),
+        surface: "web",
+        form: "thread",
+        agent_id: agent.id,
+      })
+      navigate("conversations", { id: conversation.id, focus: "compose" })
+    } finally {
+      setChatPending(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={agent.status !== "active" || chatPending}
+        onClick={() => void startChat()}
+      >
+        {chatPending ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <MessageSquare className="h-3.5 w-3.5" />
+        )}
+        {t("agents.actions.chat")}
+      </Button>
+      <Button size="sm" onClick={() => setEditOpen(true)}>
+        <Pencil className="h-3.5 w-3.5" />
+        {t("agents.actions.edit")}
+      </Button>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={statusMut.isPending}
+        onClick={() => {
+          if (agent.status === "active") {
+            setDisableOpen(true)
+            return
+          }
+          statusMut.mutate(
+            { agentID: agent.id, enabled: true },
+            {
+              onSuccess: () => onToast(t("agents.listActions.enabledToast", { name: agent.name })),
+            },
+          )
+        }}
+      >
+        {agent.status === "active" ? (
+          <PowerOff className="h-3.5 w-3.5" />
+        ) : (
+          <Power className="h-3.5 w-3.5" />
+        )}
+        {t(agent.status === "active" ? "agents.actions.disable" : "agents.actions.enable")}
+      </Button>
+
+      <CreateAgentDialog
+        open={editOpen}
+        mode="edit"
+        workspaceID={workspaceID}
+        workspaceName={workspaceName}
+        workspaceRole={workspaceRole}
+        models={models}
+        agent={agent}
+        pending={updateMut.isPending || updateProfileMut.isPending}
+        error={updateMut.error ?? updateProfileMut.error}
+        onOpenChange={(open) => {
+          setEditOpen(open)
+          if (!open) {
+            updateMut.reset()
+            updateProfileMut.reset()
+          }
+        }}
+        onSubmit={({ agentID, body, agentProfile }) => {
+          if (!agentID) return
+          void (async () => {
+            try {
+              await updateMut.mutateAsync({ agentID, body })
+              if (agentProfile) await updateProfileMut.mutateAsync({ agentID, body: agentProfile })
+              setEditOpen(false)
+              onToast(t("agents.detail.config.saved"))
+            } catch {
+              return
+            }
+          })()
+        }}
+      />
+
+      <AlertDialog
+        open={disableOpen}
+        onOpenChange={(open) => {
+          if (!statusMut.isPending) setDisableOpen(open)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {t("agents.listActions.disableConfirmTitle", { name: agent.name })}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("agents.listActions.disableConfirmDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel asChild>
+              <Button variant="outline" size="sm" disabled={statusMut.isPending}>
+                {t("agents.listActions.cancel")}
+              </Button>
+            </AlertDialogCancel>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={statusMut.isPending}
+              onClick={() =>
+                statusMut.mutate(
+                  { agentID: agent.id, enabled: false },
+                  {
+                    onSuccess: () => {
+                      setDisableOpen(false)
+                      onToast(t("agents.listActions.disabledToast", { name: agent.name }))
+                    },
+                  },
+                )
+              }
+            >
+              {statusMut.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+              {t("agents.listActions.disableConfirm")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+function conversationTitle(agentName: string, language: string): string {
+  const name = agentName.trim()
+  if (!name) return ""
+  return language.startsWith("zh") ? `和 ${name} 对话` : `Chat with ${name}`
+}

--- a/apps/web/src/pages/admin/agents/AgentRowActions.tsx
+++ b/apps/web/src/pages/admin/agents/AgentRowActions.tsx
@@ -1,0 +1,104 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
+import { Copy, Loader2, MessageSquare, MoreHorizontal, Pencil, Power, PowerOff } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "../../../components/ui/button"
+import type { Agent } from "../../../lib/api-types"
+
+export function AgentRowActions({
+  agent,
+  chatPending,
+  statusPending,
+  onChat,
+  onEdit,
+  onClone,
+  onStatusChange,
+}: {
+  agent: Agent
+  chatPending: boolean
+  statusPending: boolean
+  onChat: () => void
+  onEdit: () => void
+  onClone: () => void
+  onStatusChange: (enabled: boolean) => void
+}) {
+  const { t } = useTranslation("admin")
+  const enabled = agent.status === "active"
+
+  return (
+    <div
+      className="flex min-h-9 items-center justify-end gap-2"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <Button variant="outline" size="sm" disabled={!enabled || chatPending} onClick={onChat}>
+        {chatPending ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" strokeWidth={1.8} />
+        ) : (
+          <MessageSquare className="h-3.5 w-3.5" strokeWidth={1.8} />
+        )}
+        {t("agents.actions.chat")}
+      </Button>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <button
+            type="button"
+            aria-label={t("agents.actions.more")}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-md text-fg-muted transition-colors hover:bg-surface-muted hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong data-[state=open]:bg-surface-muted"
+          >
+            <MoreHorizontal className="h-4 w-4" strokeWidth={1.8} />
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            align="end"
+            sideOffset={6}
+            className="z-50 min-w-[180px] overflow-hidden rounded-md border border-line bg-surface p-1 text-sm text-fg-muted shadow-lg"
+          >
+            <MenuItem icon={Pencil} label={t("agents.actions.edit")} onSelect={onEdit} />
+            <MenuItem icon={Copy} label={t("agents.actions.clone")} onSelect={onClone} />
+            <DropdownMenu.Separator className="my-1 h-px bg-line" />
+            <MenuItem
+              icon={enabled ? PowerOff : Power}
+              label={t(enabled ? "agents.actions.disable" : "agents.actions.enable")}
+              tone={enabled ? "danger" : "success"}
+              disabled={statusPending}
+              onSelect={() => onStatusChange(!enabled)}
+            />
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+    </div>
+  )
+}
+
+function MenuItem({
+  icon: Icon,
+  label,
+  tone = "default",
+  disabled,
+  onSelect,
+}: {
+  icon: typeof Pencil
+  label: string
+  tone?: "default" | "danger" | "success"
+  disabled?: boolean
+  onSelect: () => void
+}) {
+  const toneClass =
+    tone === "danger"
+      ? "text-danger data-[highlighted]:bg-danger-subtle data-[highlighted]:text-danger-emphasis"
+      : tone === "success"
+        ? "text-success data-[highlighted]:bg-success-subtle data-[highlighted]:text-success-emphasis"
+        : "text-fg-muted data-[highlighted]:bg-surface-muted data-[highlighted]:text-fg"
+
+  return (
+    <DropdownMenu.Item
+      disabled={disabled}
+      onSelect={onSelect}
+      className={`flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-45 ${toneClass}`}
+    >
+      <Icon className="h-3.5 w-3.5" strokeWidth={1.75} />
+      <span>{label}</span>
+    </DropdownMenu.Item>
+  )
+}

--- a/apps/web/src/pages/admin/agents/AgentStatusBadge.tsx
+++ b/apps/web/src/pages/admin/agents/AgentStatusBadge.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "../../../components/ui/badge"
+import type { Agent } from "../../../lib/api-types"
+
+export function AgentStatusBadge({ status }: { status: Agent["status"] }) {
+  const { t } = useTranslation("admin")
+  if (status === "active")
+    return (
+      <Badge variant="success" dot>
+        {t("agents.status.active")}
+      </Badge>
+    )
+  if (status === "error")
+    return (
+      <Badge variant="destructive" dot>
+        {t("agents.status.error")}
+      </Badge>
+    )
+  return <Badge variant="neutral">{t("agents.status.disabled")}</Badge>
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1270,6 +1270,36 @@ definitions:
       why:
         type: string
     type: object
+  store.AgentSummary:
+    properties:
+      capabilities:
+        items:
+          type: string
+        type: array
+      config:
+        additionalProperties: {}
+        type: object
+      connector_type:
+        type: string
+      created_at:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      slug:
+        type: string
+      status:
+        type: string
+      updated_at:
+        type: string
+      visibility:
+        type: string
+      workspace_id:
+        type: string
+    type: object
   store.CredentialKindRead:
     properties:
       built_in:
@@ -4243,6 +4273,57 @@ paths:
               type: string
             type: object
       summary: Create an agent in a workspace
+      tags:
+      - agents
+  /api/v1/workspaces/{workspaceID}/agents/{agentID}:
+    get:
+      description: Returns the complete agent summary and persisted config. The caller
+        must be an active member of the workspace, and the agent must belong to that
+        workspace.
+      operationId: getDevAgent
+      parameters:
+      - description: Workspace UUID
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: Agent UUID
+        in: path
+        name: agentID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Complete agent summary and config
+          schema:
+            $ref: '#/definitions/store.AgentSummary'
+        "400":
+          description: Invalid UUID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Caller is forbidden from accessing the workspace
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Workspace membership or agent not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Database-backed read APIs are disabled
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get an agent in a workspace
       tags:
       - agents
   /api/v1/workspaces/{workspaceID}/agents/{agentID}/builtin-capabilities/{key}:

--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -651,6 +651,7 @@ func RegisterRoutesWithStore(r chi.Router, runtimeStore RuntimeStore, opts ...Ro
 			r.Post("/workspaces/{workspaceID}/models/{modelID}/test", testModelConnectivity(runtimeStore))
 			r.Post("/conversations/{conversationID}/external-ref", configureConversationExternalRef(runtimeStore))
 			r.Get("/workspaces/{workspaceID}/agents", listWorkspaceEnabledAgents(runtimeStore))
+			r.Get("/workspaces/{workspaceID}/agents/{agentID}", getWorkspaceAgent(runtimeStore))
 			r.Get("/workspaces/{workspaceID}/agent-runs", listWorkspaceAgentRuns(runtimeStore))
 			r.Get("/workspaces/{workspaceID}/agents/{agentID}/metrics", getAgentMetrics(runtimeStore))
 			r.Get("/workspaces/{workspaceID}/agent-runs/{runID}/events", listAgentRunEvents(runtimeStore))

--- a/server/internal/dev/routes_agents.go
+++ b/server/internal/dev/routes_agents.go
@@ -849,6 +849,57 @@ func listWorkspaceEnabledAgents(runtimeStore RuntimeStore) http.HandlerFunc {
 	}
 }
 
+// getWorkspaceAgent returns one Agent after workspace membership and ownership checks.
+//
+//	@Summary		Get an agent in a workspace
+//	@Description	Returns the complete agent summary and persisted config. The caller must be an active member of the workspace, and the agent must belong to that workspace.
+//	@Tags			agents
+//	@ID			getDevAgent
+//	@Produce		json
+//	@Param			workspaceID	path	string	true	"Workspace UUID"
+//	@Param			agentID		path	string	true	"Agent UUID"
+//	@Success		200 {object} store.AgentSummary "Complete agent summary and config"
+//	@Failure		400 {object} map[string]string "Invalid UUID"
+//	@Failure		403 {object} map[string]string "Caller is forbidden from accessing the workspace"
+//	@Failure		404 {object} map[string]string "Workspace membership or agent not found"
+//	@Failure		503 {object} map[string]string "Database-backed read APIs are disabled"
+//	@Router			/api/v1/workspaces/{workspaceID}/agents/{agentID} [get]
+func getWorkspaceAgent(runtimeStore RuntimeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if runtimeStore == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed read APIs are disabled"})
+			return
+		}
+
+		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
+		if !isUUID(workspaceID) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
+			return
+		}
+		agentID := strings.TrimSpace(chi.URLParam(r, "agentID"))
+		if !isUUID(agentID) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "agent_id must be a valid uuid"})
+			return
+		}
+		if err := requireWorkspaceMember(r, runtimeStore, workspaceID); err != nil {
+			writeRBACError(w, err)
+			return
+		}
+
+		agent, err := runtimeStore.GetAgent(r.Context(), agentID)
+		if err != nil {
+			writeStoreAgentError(w, err)
+			return
+		}
+		if agent.WorkspaceID != workspaceID {
+			writeStoreAgentError(w, fmt.Errorf("%w: %s", store.ErrUnknownAgent, agentID))
+			return
+		}
+
+		writeJSON(w, http.StatusOK, agent)
+	}
+}
+
 // getAgentMetrics returns aggregated run-history counters for
 // a single agent over a sliding window. Powers the agent-detail
 // "Last N days performance" panel: completion count, success rate, average duration.

--- a/server/internal/dev/routes_agents_detail_test.go
+++ b/server/internal/dev/routes_agents_detail_test.go
@@ -1,0 +1,113 @@
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+type agentDetailRouteStore struct {
+	stubRuntimeStore
+	agent store.AgentSummary
+	role  string
+}
+
+func (s agentDetailRouteStore) GetAgent(context.Context, string) (store.AgentSummary, error) {
+	return s.agent, nil
+}
+
+func (s agentDetailRouteStore) GetWorkspaceMemberRole(context.Context, string, string) (string, error) {
+	if s.role == "" {
+		return "owner", nil
+	}
+	if s.role == "not_member" {
+		return "", store.ErrNotMember
+	}
+	return s.role, nil
+}
+
+func TestGetWorkspaceAgentReturnsCompleteSummary(t *testing.T) {
+	workspaceID := testWorkspaceID
+	agentID := "00000000-0000-0000-0000-000000000901"
+	runtimeStore := agentDetailRouteStore{
+		agent: store.AgentSummary{
+			ID:            agentID,
+			WorkspaceID:   workspaceID,
+			Name:          "Research Agent",
+			Slug:          "research-agent",
+			Description:   "Researches and summarizes findings",
+			ConnectorType: "agent_daemon",
+			Visibility:    "workspace",
+			Status:        "active",
+			Capabilities:  []string{"web_search"},
+			Config: map[string]any{
+				"agent_kind": "codex",
+				"model_id":   "gpt-5",
+				"workdir":    "/workspace",
+			},
+		},
+	}
+
+	r := testRouterForAgentDetail(runtimeStore)
+	req := withTestUser(httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/"+workspaceID+"/agents/"+agentID, nil))
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+
+	if res.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", res.Code, res.Body.String())
+	}
+	var got store.AgentSummary
+	if err := json.NewDecoder(res.Body).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.ID != agentID || got.WorkspaceID != workspaceID || got.Config["agent_kind"] != "codex" {
+		t.Fatalf("unexpected agent detail: %+v", got)
+	}
+}
+
+func TestGetWorkspaceAgentRejectsNonMember(t *testing.T) {
+	workspaceID := testWorkspaceID
+	agentID := "00000000-0000-0000-0000-000000000901"
+	r := testRouterForAgentDetail(agentDetailRouteStore{
+		stubRuntimeStore: stubRuntimeStore{},
+		agent:            store.AgentSummary{ID: agentID, WorkspaceID: workspaceID},
+		role:             "not_member",
+	})
+	req := withTestUser(httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/"+workspaceID+"/agents/"+agentID, nil))
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-member, got %d: %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "not a member") {
+		t.Fatalf("expected membership error, got %s", res.Body.String())
+	}
+}
+
+func TestGetWorkspaceAgentHidesCrossWorkspaceAgent(t *testing.T) {
+	workspaceID := testWorkspaceID
+	agentID := "00000000-0000-0000-0000-000000000901"
+	r := testRouterForAgentDetail(agentDetailRouteStore{
+		agent: store.AgentSummary{ID: agentID, WorkspaceID: "00000000-0000-0000-0000-000000000003"},
+	})
+	req := withTestUser(httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/"+workspaceID+"/agents/"+agentID, nil))
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+
+	if res.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for cross-workspace agent, got %d: %s", res.Code, res.Body.String())
+	}
+}
+
+func testRouterForAgentDetail(runtimeStore RuntimeStore) http.Handler {
+	r := chi.NewRouter()
+	RegisterRoutesWithStore(r, runtimeStore)
+	return r
+}


### PR DESCRIPTION
## Summary

- enrich the Agents list with engine, model, execution mode, status, and last-enabled context
- add search coverage for agent identity and runtime configuration fields
- add dedicated agent detail loading instead of falling back to the first list item
- expose clearer Chat, Edit, Enable, and Disable actions across list and detail views
- expand the Config summary with identity, engine/model, prompt, execution, workdir, sandbox, and runtime binding
- add the workspace agent detail API endpoint, OpenAPI contract, and backend coverage
- extract shared agent view-model and action components from the oversized page

## Validation

- `pnpm --filter @parsar/web typecheck`
- `pnpm --filter @parsar/web build`
- targeted ESLint for new agent components and shared helpers
- `go test ./internal/dev -count=1`
- `go test ./internal/store -run '^TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation$' -count=1`
- `git diff --check`
- locally built `parsar:local` and `parsar-sandbox:local`
- started the full Docker Compose stack and verified server, PostgreSQL, and runtime health

## Known Check Flake

`make check` reaches the store suite but intermittently fails `TestGetEnabledCapabilitiesForAgent_LatestFreezesOnDeprecation` when run with the full suite. The same test passes when run alone. This is existing suite concurrency/flakiness and is unrelated to the Agents changes.

The full-file ESLint run for `AgentsPage.tsx` also reports three existing `react-hooks/set-state-in-effect` findings outside this change's scope; targeted lint for the newly added components and helpers passes.
