### PR TITLE
ci: skip image rebuild for test-only changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -70,6 +70,16 @@ tests/.playwright-report/
 tests/playwright-report/
 tests/playwright/.cache/
 
+# Test files never enter the image. Excludes Go *_test.go and web
+# *.test.ts/.tsx plus any testdata directories, with the runtime
+# crypto wire fixture re-allowed because parsar-server reads it from
+# disk at runtime.
+**/*_test.go
+**/*.test.ts
+**/*.test.tsx
+**/testdata/**
+!internal/runtimecrypto/testdata/**
+
 # Lockfile we DO want: pnpm-lock.yaml stays in the context so the
 # web builder can `pnpm install --frozen-lockfile`. (Don't add it to
 # this ignore list.)

--- a/.github/workflows/parsar-server-release.yml
+++ b/.github/workflows/parsar-server-release.yml
@@ -44,6 +44,16 @@ on:
       - ".dockerignore"
       - "Dockerfile"
       - ".github/workflows/parsar-server-release.yml"
+      # Test-only edits must not rebuild + republish the multi-arch image.
+      # `make check-go` already runs the Go test suite and enforces sqlc
+      # drift, so a push that changes only *_test.go files still has its
+      # signal covered by `check`. GitHub forbids mixing `paths` with
+      # `paths-ignore`, so we negate these patterns inline.
+      - "!server/**/*_test.go"
+      - "!internal/**/*_test.go"
+      - "!apps/**/*_test.go"
+      - "!packages/**/*_test.go"
+      - "!**/testdata/**"
     tags:
       - "parsar-server-v*"
   pull_request:
@@ -63,6 +73,13 @@ on:
       - ".dockerignore"
       - "Dockerfile"
       - ".github/workflows/parsar-server-release.yml"
+      # See push trigger above for why these are negated rather than
+      # split into a separate paths-ignore block.
+      - "!server/**/*_test.go"
+      - "!internal/**/*_test.go"
+      - "!apps/**/*_test.go"
+      - "!packages/**/*_test.go"
+      - "!**/testdata/**"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## What

- `.github/workflows/parsar-server-release.yml`: extend the `push` and
  `pull_request` `paths` filters with inline `!…/*_test.go` and
  `!…/testdata/**` negations. Because GitHub Actions forbids combining
  `paths` with `paths-ignore` on the same event, the negations live
  inside the existing `paths` block.
- `.dockerignore`: add `**/*_test.go`, `**/*.test.ts(x)`, and
  `**/testdata/**` with a single exception
  (`!internal/runtimecrypto/testdata/**`) for the runtime wire fixture
  parsar-server actually reads at runtime.

## Why

`server/**/*_test.go` is the biggest source of unnecessary image
rebuilds. Today any test-only edit pushes a new multi-arch build
(push) and forces PRs through a complete `docker buildx build
linux/amd64,linux/arm64`. With this PR:

- test-only commits skip the image workflow (covered by `check`
  instead, which already runs the Go test suite + sqlc drift check);
- anything that does still trigger the build no longer copies
  hundreds of test files / fixtures into the build context, so
  BuildKit cache hit rate jumps.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7` clean.
- `git diff --check` clean.
- Workflow YAML re-parsed; both events use only `paths` with `!`
  negations, so actionlint accepts them.