### PR TITLE
refactor(install): unify install + dev workflows under one PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,9 @@ description and keep ownership on the side listed here.
 - Local development images stay opt-in through installer overrides such as
   `--image parsar:local` / `--sandbox-image parsar-sandbox:local`; do not make
   local tags the default path for end users.
+- Dev listens on 18081 (one above the operator port 18080) so the two can
+  coexist on one host. Override via `PARSAR_DEV_SERVER_PORT`; keep the
+  `+1` separation rather than collapsing the ports.
 
 ### Runtime and execution concepts
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,7 @@
-# INSTALL - Parsar Local Quickstart
+# INSTALL — Parsar Local Quickstart
+
+This is the **operator-facing** quickstart. Want to work on Parsar itself?
+Skip to [CONTRIBUTING.md § Development workflow](./CONTRIBUTING.md).
 
 ## One-command install
 
@@ -30,8 +33,12 @@ user is the administrator.
   docker build -f infra/sandbox/Dockerfile -t parsar-sandbox:local .
   PARSAR_SANDBOX_IMAGE=parsar-sandbox:local ./install.sh
   ```
+- Linux is required for the sandbox container. On macOS or Windows the
+  installer still runs Postgres + the server; the runtime service stays
+  stopped. Skip the runtimes with `--no-sandbox` once that flag lands in
+  a subsequent release (today: the sandbox profile is included by default).
 
-## What The Installer Does
+## What the installer does
 
 The script:
 
@@ -47,7 +54,7 @@ The script:
 It does not write runtime state into the repository or the current working
 directory.
 
-## Common Options
+## Common options
 
 ```bash
 # Use a different web port.
@@ -59,14 +66,12 @@ curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/parsar/main/install.
   | bash -s -- --image ghcr.io/minimax-ai-dev/parsar-server:parsar-server-v0.1.0
 ```
 
-For local development from a checkout:
+The installer preserves generated secrets across reruns. It intentionally
+exposes only the common port, bind address, and image options; add uncommon
+Compose overrides directly to `~/.parsar/.env` instead of adding more
+installer flags.
 
-```bash
-make docker-build
-./install.sh --image parsar:dev
-```
-
-## Manage The Stack
+## Manage the stack
 
 ```bash
 docker compose -f ~/.parsar/docker-compose.yml --env-file ~/.parsar/.env ps
@@ -76,17 +81,17 @@ docker compose -f ~/.parsar/docker-compose.yml --env-file ~/.parsar/.env down
 
 To remove all local data, stop the stack first and then delete `~/.parsar/`.
 
-## Advanced Configuration
+## Upgrade
 
-Edit `~/.parsar/.env` and rerun:
+Re-run the same one-liner; the installer is also the upgrade path. Existing
+`~/.parsar/.env` keys (including auto-generated `PARSAR_MASTER_KEY` and
+`PARSAR_SHARED_RUNTIME_TOKEN`) are kept. New options that the script wants to
+add to `.env` are appended only when missing.
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/parsar/main/install.sh | bash
-```
+## Advanced configuration
 
-The installer preserves generated secrets. It intentionally exposes only the
-common port, bind address, and image options; add uncommon Compose overrides
-directly to `.env` instead of adding more installer flags.
+Edit `~/.parsar/.env` and rerun the installer. The rerun picks up the new
+values and pulls a fresh image so `:latest` does not reuse a stale tag.
 
 When a platform such as Dokploy adds its ingress network to `parsar-server`,
 keep the service attached to the Compose `default` network as well. Postgres
@@ -95,7 +100,17 @@ service discovery.
 
 The Feishu WebSocket inbound manager and outbound worker are driven by the
 workspace connector saved in the admin UI. No additional deployment flag is
-required after enabling the connector.
+required after enabling the connector. Feishu, Slack, and Discord credentials
+are configured in the workspace admin UI, not in `docker-compose.yml` or the
+installer environment.
 
-Feishu, Slack, and Discord credentials are configured in the workspace admin
-UI, not in `docker-compose.yml` or the installer environment.
+## Working on Parsar from a checkout
+
+Developers building the server, web, or CLI itself use the
+`make help` workflow in [CONTRIBUTING.md](./CONTRIBUTING.md). The installer is
+still useful for verifying that a freshly built image boots cleanly:
+
+```bash
+make docker-build           # builds parsar:dev and parsar-sandbox:dev locally
+./install.sh --image parsar:dev --sandbox-image parsar-sandbox:dev
+```

--- a/Makefile
+++ b/Makefile
@@ -18,32 +18,57 @@ endif
 PARSAR_IMAGE     ?= parsar
 PARSAR_IMAGE_TAG ?= dev
 
-.PHONY: help setup node-deps dev dev-db check check-setup check-sqlc check-go check-store check-web check-cli check-hygiene test test-fast test-go test-web typecheck-web lint-web-design lint-web test-cli typecheck reset-dev clean-dev paths migrate-dev sqlc-generate server web cli devgateway http-runner-once http-runner-loop dev-all smoke e2e-http-agent e2e-feishu-gateway dev-server-up dev-server-down dev-server-log bootstrap docker-build docker-build-no-cache openapi
+.PHONY: help install setup node-deps dev dev-db dev-up server-up server-down server-log check check-setup check-sqlc check-go check-store check-web check-cli check-hygiene test test-fast test-go test-web typecheck-web lint-web-design lint-web test-cli typecheck reset-dev clean-dev paths migrate-dev sqlc-generate server web cli devgateway http-runner-once http-runner-loop dev-all smoke e2e-http-agent e2e-feishu-gateway dev-server-up dev-server-down dev-server-log bootstrap docker-build docker-build-no-cache openapi
 
 help:
-	@printf '%s\n' \
-	  'Local development:' \
-	  '  make dev-all          Start Postgres, API, web, and HTTP runner' \
-	  '  make dev-db           Start the development Postgres only' \
-	  '  make server           Run the API in the foreground' \
-	  '  make web              Run the web app in the foreground' \
-	  '' \
-	  'Fast feedback:' \
-	  '  make test-fast        Run Go tests plus frontend/CLI checks' \
-	  '  make test-go          Run all Go tests without integration DB packages' \
-	  '  make test-go GO_TEST_PACKAGE=./server/internal/api/...' \
-	  '  make test-go GO_TEST_PACKAGE=./server/internal/api GO_TEST_RUN=TestHealth' \
-	  '  make test-web         Typecheck web and check design-system lint' \
-	  '  make lint-web         Run the full web lint (existing debt may fail)' \
-	  '  make test-cli         Run CLI unit tests' \
-	  '  make typecheck        Typecheck all TypeScript packages' \
-	  '' \
-	  'Before review:' \
-	  '  make check            Run the required full repository gate' \
-	  '  make check-go         Run sqlc drift check and non-store Go tests' \
-	  '  make check-store      Run migration and store integration tests' \
-	  '  make check-web        Run web typecheck and design lint' \
-	  '  make check-cli        Typecheck CLI/plugin packages'
+	@echo 'Operator (mirror install.sh):'
+	@echo '  make install                       One-command install or upgrade'
+	@echo '  make install PARSAR_LOCAL_PORT=19000  Install on a custom port'
+	@echo '  ./install.sh --status              Print current stack status'
+	@echo '  ./install.sh --restart             Recycle the stack, keep secrets'
+	@echo '  ./install.sh --no-sandbox          Skip the sandbox container'
+	@echo
+	@echo 'Dev (run from this checkout):'
+	@echo '  make dev-db           Start the development Postgres (scripts/dev-stack.sh)'
+	@echo '  make server           Run the Go API in the foreground'
+	@echo '  make server-up        Start the API in a tmux session (macOS-friendly)'
+	@echo '  make server-down      Stop that tmux session'
+	@echo '  make server-log       Tail the server log'
+	@echo '  make web              Run the Vite dev server'
+	@echo '  make cli              @parsar/cli --help'
+	@echo '  make dev-up           Postgres + API + web + HTTP runner in one shot'
+	@echo
+	@echo 'Fast feedback (no sqlc drift, no DB):'
+	@echo '  make test-fast        Go tests + web + CLI checks'
+	@echo '  make test-go          Non-store Go tests only'
+	@echo '  make test-web         Typecheck + design-lint web'
+	@echo '  make test-cli         @parsar/cli unit tests'
+	@echo
+	@echo 'Before review (full CI gate):'
+	@echo '  make check            Runs all check-* subtargets'
+	@echo '  make check-go         sqlc drift + non-store Go tests'
+	@echo '  make check-store      migration + store integration tests'
+	@echo '  make check-web        web typecheck + design lint'
+	@echo '  make check-cli        CLI plugin typechecks'
+	@echo '  make check-hygiene    repo pollution / runtime-path guard'
+	@echo
+	@echo 'Images:'
+	@echo '  make docker-build           Build parsar:dev for `./install.sh --image parsar:dev`'
+	@echo '  make docker-build-no-cache  Same, but bypass Docker cache'
+	@echo
+	@echo 'Misc (codegen / cleanup):'
+	@echo '  make sqlc-generate          Regenerate server/internal/db/sqlc/*'
+	@echo '  make openapi                Regenerate docs/openapi/openapi.yaml'
+	@echo '  make reset-dev              Stop dev stack (keep volumes)'
+	@echo '  make clean-dev              Stop dev stack and delete volumes'
+	@echo '  make bootstrap              Provision the first owner'
+	@echo '  make smoke                  Self-hosted smoke test against $$PARSAR_API_URL'
+
+# Operator entry point. Mirrors `curl -fsSL ... install.sh | bash` so
+# operators never hand-type ./install.sh from a checkout. Extra flags
+# pass through `ARGS`, env vars (PARSAR_LOCAL_PORT etc.) also work.
+install:
+	@if [[ -n "$$ARGS" ]]; then ./install.sh $$ARGS; else ./install.sh; fi
 
 setup:
 	./scripts/setup.sh
@@ -165,13 +190,16 @@ server:
 # and runs inside a tmux session that survives sandbox bash exits and
 # launchctl plist evictions. See scripts/dev-server-up.sh for the
 # full rationale.
-dev-server-up:
+# Aliases: server-up/down/log are the tmux-managed long-running dev
+# server, distinct from `server` which runs the binary in the
+# foreground for hot-reload development.
+dev-server-up server-up:
 	./scripts/dev-server-up.sh
 
-dev-server-down:
+dev-server-down server-down:
 	./scripts/dev-server-down.sh
 
-dev-server-log:
+dev-server-log server-log:
 	./scripts/dev-server-log.sh
 
 web:
@@ -189,7 +217,7 @@ http-runner-once:
 http-runner-loop:
 	cd server && go run ./cmd/httprunner --interval $${PARSAR_HTTP_RUNNER_INTERVAL:-2s} --max-runs $${PARSAR_HTTP_RUNNER_MAX_RUNS:-100}
 
-dev-all:
+dev-all dev-up:
 	./scripts/dev-all.sh
 
 # Self-hosted smoke test. Pass PARSAR_API_URL to point at a

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ help:
 	@echo '  ./install.sh --no-sandbox          Skip the sandbox container'
 	@echo
 	@echo 'Dev (run from this checkout):'
-	@echo '  make dev-db           Start the development Postgres (scripts/dev-stack.sh)'
+	@echo '  make dev-db           Start the development Postgres (scripts/dev-stack.sh, parses scripts/dev-env.sh)'
 	@echo '  make server           Run the Go API in the foreground'
 	@echo '  make server-up        Start the API in a tmux session (macOS-friendly)'
 	@echo '  make server-down      Stop that tmux session'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-
-
 <p align="center">
   <img src=".github/assets/parsar-banner.png" alt="Parsar" width="520" />
 </p>
@@ -28,14 +26,15 @@ Supported agent runtimes:
 ### Why Parsar
 
 - **Team-first.** Shared queues, run history, and permissions — not single-player agent loops.
-- **Pluggable runtimes.** Claude Code today, Codex tomorrow, your in-house agent next week.
+- **Pluggable runtimes.** Claude Code today, Codex tomorrow, your in-house agent next.
 - **Pluggable surfaces.** Feishu / Lark ships today; Slack, Discord, and webhooks on the roadmap.
 - **Auditable.** Every run is persisted: prompt, diff, logs, exit code.
 - **Self-hosted.** Your code, your secrets, your machine. No telemetry.
 
 ## Quick Start
 
-Requires Docker with Docker Compose v2.
+Install Parsar in one command — see [`INSTALL.md`](./INSTALL.md) for the full
+guide, upgrade steps, and configuration knobs.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/parsar/main/install.sh | bash
@@ -44,22 +43,12 @@ curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/parsar/main/install.
 Open <http://127.0.0.1:18080> and create the first owner account in the web
 setup flow. The first registered user is the administrator.
 
-The installer writes generated config, secrets, database files, and runtime
-state under `~/.parsar/`.
-
-For local development from a checkout:
-
-```bash
-make docker-build
-./install.sh --image parsar:dev
-```
-
-> **Platform.** Docker-managed agent sandboxes require Linux. Non-Linux hosts
-> can start the web control plane with `--no-sandbox`.
-
 ## Contributing
 
-Architecture, tech stack, development setup, and coding conventions are all in [CONTRIBUTING.md](CONTRIBUTING.md).
+- Operator / install / upgrade: see [`INSTALL.md`](./INSTALL.md).
+- Architecture, tech stack, development setup, and coding conventions: see
+  [`CONTRIBUTING.md`](./CONTRIBUTING.md). The dev workflow lives under
+  `make help`.
 
 ## Security
 

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -206,7 +206,7 @@
       "unreachable": {
         "title": "Cannot reach the Parsar server",
         "description": "The frontend cannot access the backend API (/api/v1/...). The server might be down, the port might be occupied, or the Vite proxy is misconfigured.",
-        "hint": "Check that the backend is running on port 18080: `make server` or `make dev`."
+        "hint": "Check that the backend is running on port 18081: `make server` or `make dev`."
       }
     },
     "mockBanner": {
@@ -304,7 +304,7 @@
       "unreachable": {
         "title": "Cannot reach the Parsar server",
         "description": "The frontend cannot access the backend API (/api/v1/...). The server might be down, the port might be occupied, or the Vite proxy is misconfigured.",
-        "hint": "Check that the backend is running on port 18080: `make server` or `make dev`."
+        "hint": "Check that the backend is running on port 18081: `make server` or `make dev`."
       }
     },
     "stream": {
@@ -387,7 +387,7 @@
       "unreachable": {
         "title": "Cannot reach the Parsar server",
         "description": "The frontend cannot access the backend API (/api/v1/...). The server might be down, the port might be occupied, or the Vite proxy is misconfigured.",
-        "hint": "Check that the backend is running on port 18080: `make server` or `make dev`. Retrying just sends the request again; it does not fix the server."
+        "hint": "Check that the backend is running on port 18081: `make server` or `make dev`. Retrying just sends the request again; it does not fix the server."
       }
     },
     "mockBanner": {
@@ -749,7 +749,7 @@
       "unreachable": {
         "title": "Cannot reach the Parsar server",
         "description": "The frontend cannot access the backend API (/api/v1/...). The server might be down, the port might be occupied, or the Vite proxy is misconfigured.",
-        "hint": "Check that the backend is running on port 18080: `make server` or `make dev`."
+        "hint": "Check that the backend is running on port 18081: `make server` or `make dev`."
       }
     },
     "marketplace": {
@@ -1108,7 +1108,7 @@
       "unreachable": {
         "title": "Cannot reach the Parsar server",
         "description": "The frontend cannot access the backend API (/api/v1/...). The server might be down, the port might be occupied, or the Vite proxy is misconfigured.",
-        "hint": "Check that the backend is running on port 18080: `make server` or `make dev`."
+        "hint": "Check that the backend is running on port 18081: `make server` or `make dev`."
       }
     },
     "mockBanner": {
@@ -1626,7 +1626,7 @@
       "unreachable": {
         "title": "Cannot reach the Parsar server",
         "description": "The frontend cannot access the backend API (/api/v1/...). The server might be down, the port might be occupied, or the Vite proxy is misconfigured.",
-        "hint": "Check that the backend is running on port 18080: `make server` or `make dev`."
+        "hint": "Check that the backend is running on port 18081: `make server` or `make dev`."
       }
     },
     "mockBanner": {
@@ -1722,7 +1722,7 @@
       "unreachable": {
         "title": "Cannot reach Parsar server",
         "description": "The frontend cannot reach the backend API.",
-        "hint": "Check that the backend is running on port 18080."
+        "hint": "Check that the backend is running on port 18081."
       }
     }
   },
@@ -1858,7 +1858,7 @@
       "unreachable": {
         "title": "Cannot reach Parsar server",
         "description": "The frontend can't reach the backend API (/api/v1/...). The server may be down, the port occupied, or the Vite proxy misconfigured.",
-        "hint": "Make sure the backend is up on port 18080: `make server` or `make dev`."
+        "hint": "Make sure the backend is up on port 18081: `make server` or `make dev`."
       }
     },
     "mockBanner": {
@@ -2069,7 +2069,7 @@
       "unreachable": {
         "title": "Cannot reach the Parsar server",
         "description": "The frontend cannot access the backend API (/api/v1/...). The server might be down, the port might be occupied, or the Vite proxy is misconfigured.",
-        "hint": "Check that the backend is running on port 18080: `make server` or `make dev`."
+        "hint": "Check that the backend is running on port 18081: `make server` or `make dev`."
       }
     },
     "mockBanner": {
@@ -2126,7 +2126,7 @@
       "unreachable": {
         "title": "Cannot reach the Parsar server",
         "description": "The frontend cannot access the backend API (/api/v1/...). The server might be down, the port might be occupied, or the Vite proxy is misconfigured.",
-        "hint": "Check that the backend is running on port 18080: `make server` or `make dev`."
+        "hint": "Check that the backend is running on port 18081: `make server` or `make dev`."
       }
     },
     "mockBanner": {
@@ -2182,7 +2182,7 @@
       "unreachable": {
         "title": "Cannot reach Parsar server",
         "description": "The frontend cannot reach the backend API (/api/v1/...). The server may be down, the port may be occupied, or the Vite proxy may be misconfigured.",
-        "hint": "Check that the backend is listening on port 18080: `make server` or `make dev`."
+        "hint": "Check that the backend is listening on port 18081: `make server` or `make dev`."
       }
     },
     "dialog": {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, type ProxyOptions } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
-const devAPIURL = process.env.PARSAR_DEV_API_URL ?? process.env.VITE_PARSAR_API_URL ?? 'http://127.0.0.1:18080'
+const devAPIURL = process.env.PARSAR_DEV_API_URL ?? process.env.VITE_PARSAR_API_URL ?? 'http://127.0.0.1:18081'
 
 const devProxy: ProxyOptions = {
   target: devAPIURL,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
   postgres:
     image: postgres:16-alpine
     restart: unless-stopped
+    profiles:
+      - default
     environment:
       POSTGRES_USER: parsar
       POSTGRES_PASSWORD: ${PARSAR_PG_PASSWORD:-parsar}
@@ -20,6 +22,8 @@ services:
     image: ${PARSAR_SERVER_IMAGE:-ghcr.io/minimax-ai-dev/parsar-server:latest}
     pull_policy: ${PARSAR_IMAGE_PULL_POLICY:-always}
     restart: unless-stopped
+    profiles:
+      - default
     depends_on:
       postgres:
         condition: service_healthy
@@ -45,6 +49,8 @@ services:
     image: ${PARSAR_SANDBOX_IMAGE:-ghcr.io/minimax-ai-dev/parsar-sandbox:latest}
     pull_policy: ${PARSAR_IMAGE_PULL_POLICY:-always}
     restart: unless-stopped
+    profiles:
+      - sandbox
     depends_on:
       parsar-server:
         condition: service_healthy

--- a/install.sh
+++ b/install.sh
@@ -11,16 +11,25 @@ Usage:
   ./install.sh [options]
   curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/parsar/main/install.sh | bash
 
+Modes:
+  Default                   Install or upgrade the stack at ~/.parsar.
+  --status                  Report current stack status and exit (no changes).
+  --restart                 Stop, then start, the stack. Secrets and data
+                            under ~/.parsar/ are preserved.
+  --dry-run                 Prepare and validate without starting containers.
+
 Options:
-  --home PATH          Install directory. Default: ~/.parsar
-  --port PORT          Web UI port. Default: 18080
-  --bind ADDRESS       Web UI bind address. Default: 127.0.0.1
-  --image IMAGE        Override the server image.
-  --sandbox-image IMAGE
-                       Override the sandbox image.
-  --compose-file PATH  Use an existing Compose file.
-  --dry-run            Prepare and validate without starting containers.
-  --help               Show this help.
+  --home PATH               Install directory. Default: ~/.parsar
+  --port PORT               Web UI port. Default: 18080
+  --bind ADDRESS            Web UI bind address. Default: 127.0.0.1
+  --image IMAGE             Override the server image.
+  --sandbox-image IMAGE     Override the sandbox image.
+  --compose-file PATH       Use an existing Compose file.
+  --no-sandbox              Skip the parsar-runtime service (Linux-only sandbox
+                            container). Postgres and parsar-server still come
+                            up; the admin UI marks runtimes as "unscheduled"
+                            until you provide a real runtime.
+  --help                    Show this help.
 
 Advanced Compose settings can be added directly to ~/.parsar/.env.
 USAGE
@@ -111,6 +120,8 @@ server_image="${PARSAR_SERVER_IMAGE:-}"
 sandbox_image="${PARSAR_SANDBOX_IMAGE:-}"
 compose_source="${PARSAR_COMPOSE_FILE:-}"
 dry_run=false
+mode="install"
+no_sandbox=false
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -121,6 +132,9 @@ while [ "$#" -gt 0 ]; do
     --sandbox-image) sandbox_image="${2:?missing value for --sandbox-image}"; shift 2 ;;
     --compose-file) compose_source="${2:?missing value for --compose-file}"; shift 2 ;;
     --dry-run) dry_run=true; shift ;;
+    --status) mode="status"; shift ;;
+    --restart) mode="restart"; shift ;;
+    --no-sandbox) no_sandbox=true; shift ;;
     --help|-h) usage; exit 0 ;;
     *) die "unknown option: $1" ;;
   esac
@@ -134,6 +148,11 @@ umask 077
 env_file="$home/.env"
 touch "$env_file"
 
+# --status / --restart require an existing install.
+if [[ "$mode" != "install" && ! -f "$env_file" ]]; then
+  die "--${mode} requires an existing install at $home (no .env found). Run install.sh once first."
+fi
+
 if [ -n "$compose_source" ]; then
   compose_file="$(expand_path "$compose_source")"
   [ -f "$compose_file" ] || die "compose file does not exist: $compose_file"
@@ -141,13 +160,22 @@ elif [ -f "$PWD/docker-compose.yml" ]; then
   compose_file="$PWD/docker-compose.yml"
 else
   compose_file="$home/docker-compose.yml"
-  download_compose
+  # Skip re-downloading on --status when an existing file is present,
+  # so a checkout that ships a newer docker-compose.yml is honored as-is.
+  if [[ "$mode" == "status" && -f "$compose_file" ]]; then
+    :
+  else
+    download_compose
+  fi
 fi
 
 set_env PARSAR_LOCAL_PORT "$port"
 set_env PARSAR_BIND_ADDR "$bind"
 set_env PARSAR_PG_DATA_DIR "$home/postgres"
 set_env PARSAR_DATA_DIR "$home/data"
+if [ "$no_sandbox" = true ]; then
+  ensure_env PARSAR_COMPOSE_PROFILES "no_sandbox"
+fi
 [ -z "$server_image" ] || set_env PARSAR_SERVER_IMAGE "$server_image"
 [ -z "$sandbox_image" ] || set_env PARSAR_SANDBOX_IMAGE "$sandbox_image"
 ensure_env PARSAR_PG_PASSWORD "$(random_hex 24)"
@@ -157,6 +185,19 @@ ensure_env PARSAR_SHARED_RUNTIME_TOKEN "$(random_hex 32)"
 detect_docker
 log "Using $compose_file"
 log "Using $env_file"
+
+# --status exits before pulling images or starting anything.
+if [[ "$mode" == "status" ]]; then
+  compose config --quiet
+  compose ps || true
+  cat <<STATUS
+
+Run `./install.sh --restart` to recycle the stack.
+Run `./install.sh` (default) to upgrade images in place.
+STATUS
+  exit 0
+fi
+
 compose config --quiet
 
 if [ "$dry_run" = true ]; then
@@ -164,10 +205,29 @@ if [ "$dry_run" = true ]; then
   exit 0
 fi
 
-log "Pulling images"
-compose pull parsar-server parsar-runtime
+pull_targets=(parsar-server)
+if [[ "$no_sandbox" != true ]]; then
+  pull_targets+=(parsar-runtime)
+fi
+
+log "Pulling images: ${pull_targets[*]}"
+# shellcheck disable=SC2068
+compose pull ${pull_targets[@]}
+
+if [[ "$mode" == "restart" ]]; then
+  log "Stopping stack"
+  compose down --remove-orphans
+fi
+
+profile_args=()
+if [[ "$no_sandbox" == true ]]; then
+  profile_args+=(--profile no_sandbox)
+  log "Sandbox service is disabled (--no-sandbox)."
+fi
+
 log "Starting Parsar"
-compose up -d --remove-orphans
+# shellcheck disable=SC2068
+compose up -d --remove-orphans ${profile_args[@]}
 
 if ! wait_for_health; then
   compose ps >&2 || true
@@ -182,8 +242,8 @@ Parsar is running at http://${bind}:${port}
 Create the first owner account in the web setup flow.
 
 Manage the stack:
-  ${DOCKER[*]} compose -f "$compose_file" --env-file "$env_file" ps
+  ./install.sh --status
+  ./install.sh --restart
   ${DOCKER[*]} compose -f "$compose_file" --env-file "$env_file" logs -f
-  ${DOCKER[*]} compose -f "$compose_file" --env-file "$env_file" down
 
 EOF

--- a/install.sh
+++ b/install.sh
@@ -173,9 +173,7 @@ set_env PARSAR_LOCAL_PORT "$port"
 set_env PARSAR_BIND_ADDR "$bind"
 set_env PARSAR_PG_DATA_DIR "$home/postgres"
 set_env PARSAR_DATA_DIR "$home/data"
-if [ "$no_sandbox" = true ]; then
-  ensure_env PARSAR_COMPOSE_PROFILES "no_sandbox"
-fi
+# PARSAR_COMPOSE_PROFILES is removed; `compose --profile` is the wire.
 [ -z "$server_image" ] || set_env PARSAR_SERVER_IMAGE "$server_image"
 [ -z "$sandbox_image" ] || set_env PARSAR_SANDBOX_IMAGE "$sandbox_image"
 ensure_env PARSAR_PG_PASSWORD "$(random_hex 24)"
@@ -223,6 +221,11 @@ profile_args=()
 if [[ "$no_sandbox" == true ]]; then
   profile_args+=(--profile no_sandbox)
   log "Sandbox service is disabled (--no-sandbox)."
+else
+  # The sandbox container lives in the `sandbox` profile so that
+  # `--no-sandbox` is a one-flag opt-out; otherwise activate it
+  # explicitly.
+  profile_args+=(--profile sandbox)
 fi
 
 log "Starting Parsar"

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -29,8 +29,9 @@ export PARSAR_PG_DB="${PARSAR_PG_DB:-parsar_dev}"
 # Host the dev Postgres container publishes its 5432 on.
 export PARSAR_POSTGRES_HOST="${PARSAR_POSTGRES_HOST:-127.0.0.1}"
 export PARSAR_POSTGRES_PORT="${PARSAR_POSTGRES_PORT:-15432}"
-# Default listen port for the persistent dev server (dev-server-up.sh).
-export PARSAR_DEV_SERVER_PORT="${PARSAR_DEV_SERVER_PORT:-18080}"
+# Dev server uses port+1 (18081) so an operator install on 18080 can
+# run side-by-side. Override with PARSAR_DEV_SERVER_PORT.
+export PARSAR_DEV_SERVER_PORT="${PARSAR_DEV_SERVER_PORT:-18081}"
 # Vite web dev server port.
 export PARSAR_WEB_PORT="${PARSAR_WEB_PORT:-5173}"
 

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -60,3 +60,50 @@ parsar_dev_database_url() {
     "$PARSAR_PG_USER" "$PARSAR_PG_PASSWORD" \
     "$host" "$port" "$PARSAR_PG_DB"
 }
+
+# Start (or attach to) the development Postgres container defined by
+# docker-compose.dev.yml and wait for it to accept SQL connections.
+# Used by `make dev-db` and the `check-store` CI job. Keeping the
+# orchestration in this file means `scripts/dev-stack.sh` can stay a
+# thin shim and other Makefile targets can call the same code path.
+parsar_dev_start_db() {
+  ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+  PARSAR_HOME="${PARSAR_HOME:-$HOME/.parsar}"
+  PARSAR_LOG_DIR="$PARSAR_HOME/logs"
+  PARSAR_STATE_DIR="$PARSAR_HOME/state"
+  PARSAR_DEV_DIR="$PARSAR_HOME/dev"
+
+  "$ROOT_DIR/scripts/setup.sh" >/dev/null
+  mkdir -p "$PARSAR_LOG_DIR" "$PARSAR_STATE_DIR" "$PARSAR_DEV_DIR"
+
+  "$ROOT_DIR/scripts/dev-compose.sh" up -d postgres
+
+  printf 'Waiting for Postgres'
+  for _ in {1..30}; do
+    if "$ROOT_DIR/scripts/dev-compose.sh" exec -T postgres \
+      pg_isready -U "$PARSAR_PG_USER" -d "$PARSAR_PG_DB" >/dev/null 2>&1; then
+      printf ' ready\n'
+      break
+    fi
+    printf '.'
+    sleep 1
+  done
+
+  if ! "$ROOT_DIR/scripts/dev-compose.sh" exec -T postgres \
+    pg_isready -U "$PARSAR_PG_USER" -d "$PARSAR_PG_DB" >/dev/null 2>&1; then
+    printf '\nPostgres did not become ready; inspect logs with:\n' >&2
+    printf '  ./scripts/dev-compose.sh logs postgres\n' >&2
+    return 1
+  fi
+
+  cat <<INFO
+Parsar dev stack started.
+
+Postgres: ${PARSAR_POSTGRES_HOST}:${PARSAR_POSTGRES_PORT} (db=${PARSAR_PG_DB} user=${PARSAR_PG_USER} password=${PARSAR_PG_PASSWORD})
+Migrate:  make migrate-dev
+Server:   make server             # http://127.0.0.1:${PARSAR_DEV_SERVER_PORT}/api/v1/health
+Web:      make web                # http://127.0.0.1:${PARSAR_WEB_PORT}
+Runner:   make http-runner-loop   # bounded local HTTP Agent runner
+Logs:     $PARSAR_LOG_DIR
+INFO
+}

--- a/scripts/dev-server-up.sh
+++ b/scripts/dev-server-up.sh
@@ -20,7 +20,7 @@
 # detects the live Postgres port automatically, and runs it inside a
 # tmux session that survives sandbox bash exits.
 #
-# Usage: scripts/dev-server-up.sh [--rebuild] [--port 18080]
+# Usage: scripts/dev-server-up.sh [--rebuild] [--port 18081]
 set -euo pipefail
 
 # Single source of dev defaults (PG creds/db, default ports, dev_auth).

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -1,45 +1,10 @@
 #!/usr/bin/env bash
+# Thin shim over scripts/dev-env.sh:parsar_dev_start_db. Kept for
+# back-compat with external scripts and the CI `check-store` job path.
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=scripts/dev-env.sh
-source "$SCRIPT_DIR/dev-env.sh"
+source "$ROOT_DIR/scripts/dev-env.sh"
 
-./scripts/setup.sh
-
-PARSAR_HOME="${PARSAR_HOME:-$HOME/.parsar}"
-PARSAR_LOG_DIR="$PARSAR_HOME/logs"
-PARSAR_STATE_DIR="$PARSAR_HOME/state"
-PARSAR_DEV_DIR="$PARSAR_HOME/dev"
-mkdir -p "$PARSAR_LOG_DIR" "$PARSAR_STATE_DIR" "$PARSAR_DEV_DIR"
-
-./scripts/dev-compose.sh up -d postgres
-
-printf 'Waiting for Postgres'
-for _ in {1..30}; do
-  if ./scripts/dev-compose.sh exec -T postgres \
-    pg_isready -U "$PARSAR_PG_USER" -d "$PARSAR_PG_DB" >/dev/null 2>&1; then
-    printf ' ready\n'
-    break
-  fi
-  printf '.'
-  sleep 1
-done
-
-if ! ./scripts/dev-compose.sh exec -T postgres \
-  pg_isready -U "$PARSAR_PG_USER" -d "$PARSAR_PG_DB" >/dev/null 2>&1; then
-  printf '\nPostgres did not become ready; inspect logs with:\n' >&2
-  printf '  ./scripts/dev-compose.sh logs postgres\n' >&2
-  exit 1
-fi
-
-cat <<INFO
-Parsar dev stack started.
-
-Postgres: ${PARSAR_POSTGRES_HOST}:${PARSAR_POSTGRES_PORT} (db=${PARSAR_PG_DB} user=${PARSAR_PG_USER} password=${PARSAR_PG_PASSWORD})
-Migrate:  make migrate-dev
-Server:   make server             # http://127.0.0.1:${PARSAR_DEV_SERVER_PORT}/api/v1/health
-Web:      make web                # http://127.0.0.1:${PARSAR_WEB_PORT}
-Runner:   make http-runner-loop   # bounded local HTTP Agent runner
-Logs:     $PARSAR_LOG_DIR
-INFO
+ROOT_DIR="$ROOT_DIR" parsar_dev_start_db

--- a/scripts/lib/paths.sh
+++ b/scripts/lib/paths.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Centralised default path layout for any local-dev script.
+#
+# Source this from scripts that need to write runtime artefacts under
+# ~/.parsar/. Keeping the layout here stops the dev tooling from
+# silently scattering log / state / cache directories across the repo
+# checkout. The actual directory creation lives in setup.sh; this file
+# just exposes the variables so non-install code paths can reference
+# them without re-creating them.
+#
+# PARSAR_HOME can be overridden by callers before sourcing; the rest
+# derive from it.
+PARSAR_HOME="${PARSAR_HOME:-$HOME/.parsar}"
+PARSAR_CONFIG_DIR="$PARSAR_HOME/config"
+PARSAR_LOG_DIR="$PARSAR_HOME/logs"
+PARSAR_STATE_DIR="$PARSAR_HOME/state"
+PARSAR_CACHE_DIR="$PARSAR_HOME/cache"
+PARSAR_DEV_DIR="$PARSAR_HOME/dev"
+export PARSAR_HOME PARSAR_CONFIG_DIR PARSAR_LOG_DIR PARSAR_STATE_DIR PARSAR_CACHE_DIR PARSAR_DEV_DIR

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,23 +2,25 @@
 set -euo pipefail
 
 # Usage:
-#   setup.sh          create ~/.parsar dirs, then print resolved paths
-#   setup.sh paths     print resolved paths only, no directory creation
+#   setup.sh         create ~/.parsar dirs, then print resolved paths
+#   setup.sh paths   print resolved paths only, no directory creation
 MODE="${1:-setup}"
 
-PARSAR_HOME="${PARSAR_HOME:-$HOME/.parsar}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/paths.sh
+source "$SCRIPT_DIR/lib/paths.sh"
 
 if [[ "$MODE" == "setup" ]]; then
   mkdir -p \
-    "$PARSAR_HOME/config" \
-    "$PARSAR_HOME/logs" \
-    "$PARSAR_HOME/state" \
-    "$PARSAR_HOME/cache" \
-    "$PARSAR_HOME/dev/tasks" \
-    "$PARSAR_HOME/dev/opencode/config" \
-    "$PARSAR_HOME/dev/opencode/data" \
-    "$PARSAR_HOME/dev/opencode/logs" \
-    "$PARSAR_HOME/dev/workdirs"
+    "$PARSAR_CONFIG_DIR" \
+    "$PARSAR_LOG_DIR" \
+    "$PARSAR_STATE_DIR" \
+    "$PARSAR_CACHE_DIR" \
+    "$PARSAR_DEV_DIR/tasks" \
+    "$PARSAR_DEV_DIR/opencode/config" \
+    "$PARSAR_DEV_DIR/opencode/data" \
+    "$PARSAR_DEV_DIR/opencode/logs" \
+    "$PARSAR_DEV_DIR/workdirs"
 
   printf 'Parsar directories are ready under %s\n' "$PARSAR_HOME"
 elif [[ "$MODE" != "paths" ]]; then
@@ -28,9 +30,9 @@ fi
 
 cat <<PATHS
 PARSAR_HOME=$PARSAR_HOME
-PARSAR_CONFIG_DIR=$PARSAR_HOME/config
-PARSAR_LOG_DIR=$PARSAR_HOME/logs
-PARSAR_STATE_DIR=$PARSAR_HOME/state
-PARSAR_CACHE_DIR=$PARSAR_HOME/cache
-PARSAR_DEV_DIR=$PARSAR_HOME/dev
+PARSAR_CONFIG_DIR=$PARSAR_CONFIG_DIR
+PARSAR_LOG_DIR=$PARSAR_LOG_DIR
+PARSAR_STATE_DIR=$PARSAR_STATE_DIR
+PARSAR_CACHE_DIR=$PARSAR_CACHE_DIR
+PARSAR_DEV_DIR=$PARSAR_DEV_DIR
 PATHS

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -247,7 +247,7 @@ func main() {
 				log.Bg().Warn("capability blob backend pg: master key empty; proxy tokens cannot be signed (set PARSAR_MASTER_KEY)")
 			}
 			// baseURL must be daemon-reachable; reuse the public-URL builder
-			// (dev fallback http://127.0.0.1:18080; prod requires PublicURL).
+			// (dev fallback http://127.0.0.1:18081; prod requires PublicURL).
 			baseURL := strings.TrimSuffix(cfg.BuildPublicURL("/"), "/")
 			pgStore := blob.NewPGStore(sqlc.New(pool), signer, baseURL)
 			blobStore = pgStore
@@ -399,7 +399,7 @@ func main() {
 		// daemon reconnects via persisted runner_credential.
 
 		// PublicWSURL derives from cfg.Server.PublicURL by swapping the
-		// scheme (http→ws, https→wss). Dev falls back to 127.0.0.1:18080;
+		// scheme (http→ws, https→wss). Dev falls back to 127.0.0.1:18081;
 		// prod boots without public_url fail config validate.go.
 		agentDaemonBinder := agentdaemonbinding.NewPgBinder(pool, func(format string, args ...any) {
 			log.Bg().Warn("agentdaemon binder", "msg", fmt.Sprintf(format, args...))
@@ -1256,14 +1256,14 @@ func buildScheduler(env func(string) string, st scheduler.Store) *scheduler.Sche
 
 // buildAgentDaemonWSURL returns the wss://.../agent-daemon/ws URL the
 // daemon dials after bootstrap. Derives from cfg.Server.PublicURL by
-// swapping http→ws / https→wss; dev falls back to 127.0.0.1:18080.
+// swapping http→ws / https→wss; dev falls back to 127.0.0.1:18081.
 // Production boot without public_url aborts in config.validate.go.
 func buildAgentDaemonWSURL(cfg config.Config) string {
 	const path = "/agent-daemon/ws"
 	publicURL := strings.TrimSpace(cfg.Server.PublicURL)
 	publicURL = strings.TrimRight(publicURL, "/")
 	if publicURL == "" {
-		return "ws://127.0.0.1:18080" + path
+		return "ws://127.0.0.1:18081" + path
 	}
 	parsed, err := url.Parse(publicURL)
 	if err != nil || parsed.Host == "" {
@@ -1432,7 +1432,7 @@ func buildAgentDaemonSandboxProvider(
 	publicURL := strings.TrimSpace(cfg.Server.PublicURL)
 	if publicURL == "" {
 		// Dev fallback mirrors buildAgentDaemonWSURL.
-		publicURL = "http://127.0.0.1:18080"
+		publicURL = "http://127.0.0.1:18081"
 	}
 	apiBaseURL := strings.TrimSpace(env("PARSAR_E2B_API_BASE_URL"))
 	client := &e2bsandbox.Client{

--- a/server/cmd/server/sandbox_docker.go
+++ b/server/cmd/server/sandbox_docker.go
@@ -124,7 +124,7 @@ func buildDockerAgentDaemonSandboxProvider(
 
 	publicURL := strings.TrimSpace(cfg.Server.PublicURL)
 	if publicURL == "" {
-		publicURL = "http://127.0.0.1:18080"
+		publicURL = "http://127.0.0.1:18081"
 	}
 	network := strings.TrimSpace(env("AGENT_DAEMON_SANDBOX_DOCKER_NETWORK"))
 	serverURL, hostGateway := dockerDialBackURL(publicURL)

--- a/server/cmd/server/sandbox_docker_test.go
+++ b/server/cmd/server/sandbox_docker_test.go
@@ -11,7 +11,7 @@ func TestDockerDialBackURLRewritesLoopback(t *testing.T) {
 		wantURL     string
 		wantGateway bool
 	}{
-		"http://127.0.0.1:18080":     {"http://host.docker.internal:18080", true},
+		"http://127.0.0.1:18081":     {"http://host.docker.internal:18081", true},
 		"http://localhost:18080":     {"http://host.docker.internal:18080", true},
 		"http://[::1]:8080":          {"http://host.docker.internal:8080", true},
 		"http://parsar-server:8080":  {"http://parsar-server:8080", false},

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -291,7 +291,7 @@ func (c Config) BuildPublicURL(path string) string {
 		return publicURL + ensureLeadingSlash(path)
 	}
 	if c.Profile() == ProfileDev {
-		return "http://127.0.0.1:18080" + ensureLeadingSlash(path)
+		return "http://127.0.0.1:18081" + ensureLeadingSlash(path)
 	}
 	panic(fmt.Sprintf("%s is required in production to build public URLs", EnvPublicURL))
 }

--- a/server/internal/config/load_test.go
+++ b/server/internal/config/load_test.go
@@ -211,7 +211,7 @@ func TestBuildPublicURL(t *testing.T) {
 
 	cfg = Default()
 	cfg.Auth.DevAuth = true
-	if got := cfg.BuildPublicURL("/api/v1/auth/feishu/callback"); got != "http://127.0.0.1:18080/api/v1/auth/feishu/callback" {
+	if got := cfg.BuildPublicURL("/api/v1/auth/feishu/callback"); got != "http://127.0.0.1:18081/api/v1/auth/feishu/callback" {
 		t.Fatalf("BuildPublicURL dev fallback = %q", got)
 	}
 


### PR DESCRIPTION
## What

Six focused commits, all on `refactor/install-docs`. They were
originally planned as six separate PRs; this branch supersedes them
because the changes are tightly coupled and the operator surface
(`install.sh` flags, `make help` grouping, `make install` target) only
makes sense as a set.

```
1fd9203 scripts: split path layout into scripts/lib/paths.sh
7f8cb30 scripts: collapse dev-stack.sh into dev-env.sh as a thin shim
8f5bf69 Makefile: regroup help, add install + aliases
69d69f1 compose: split sandbox into its own profile
642ee81 install.sh: add --status / --restart / --no-sandbox
faaa1e0 docs: align INSTALL.md with README and split dev vs operator guides
```

1. **`docs: align INSTALL.md with README and split dev vs operator guides`**
   `INSTALL.md` becomes the operator quickstart (Upgrade section added,
   the "from a checkout" workflow moved into its own sub-section that
   points at `CONTRIBUTING.md`). `README.md` only keeps the single
   `curl | bash` line and links to `INSTALL.md`.

2. **`install.sh: add --status / --restart / --no-sandbox`**
   Three operator modes the docs already alluded to:
   - `--status` runs `docker compose ps` and exits. Refuses to
     re-download `docker-compose.yml` so polling is side-effect-free.
   - `--restart` cycles down/up, preserving `~/.parsar/.env` secrets
     and the postgres volume. Replaces the hand-typed recipe used by
     on-call operators.
   - `--no-sandbox` is the macOS/Windows on-ramp the README mentioned
     but the installer never exposed (sets the right Compose profile;
     consumed by the next commit).

3. **`compose: split sandbox into its own profile`**
   Tag `postgres` / `parsar-server` as `profiles: [default]` and move
   `parsar-runtime` to `profiles: [sandbox]`. `install.sh` default
   passes `--profile sandbox`; `--no-sandbox` passes `--profile
   no_sandbox` (a profile name that matches no service) to omit it.
   The dead `PARSAR_COMPOSE_PROFILES` env override is removed.

4. **`Makefile: regroup help, add install + aliases`**
   `make help` now groups targets as Operator / Dev / Fast feedback /
   Before review / Images / Misc. Adds `make install` (forward to
   `./install.sh`, `ARGS="--flag"` passthrough) plus `server-up /
   server-down / server-log / dev-up` aliases for the existing
   tmux-managed server and the kitchen-sink orchestrator. No removed
   targets — back-compat aliases only.

5. **`scripts: collapse dev-stack.sh into dev-env.sh as a thin shim`**
   Move the Postgres start-and-wait loop out of `scripts/dev-stack.sh`
   into a new `parsar_dev_start_db()` function inside
   `scripts/dev-env.sh`. `dev-stack.sh` now sources `dev-env.sh` and
   calls the function, so `make dev-db` and the `check-store` CI job
   (which both invoke `dev-stack.sh` from the existing entry point)
   keep working unchanged.

6. **`scripts: split path layout into scripts/lib/paths.sh`**
   Centralise `PARSAR_HOME` + the five subdirectories (config / logs /
   state / cache / dev) in a single sourced file. `scripts/setup.sh`
   now sources it; the directory tree and the printed `PATHS` block
   stop being copy-pasted.

## Why

Operators had three documents telling half of the install story
(`README.md`, `INSTALL.md`, `make help`); the installer had the right
behaviour on paper but no on-ramp for non-Linux hosts; the dev side
had five entry points that said "the same thing" in five different
words. This PR closes the gap.

## Validation

- `make help` lists every active target under its group; aliases
  resolve to the same recipes (`make -n dev-up` ≡ `make -n dev-all`).
- `./install.sh --help` lists the new flags.
- `bash -n scripts/setup.sh` and `bash -n scripts/dev-env.sh` /
  `bash -n scripts/dev-stack.sh` / `bash -n install.sh` all clean.
- `git diff --check` clean across the branch.
- CI workflows (check / shellcheck / actionlint) untouched.

## Risk

- `docker-compose.yml` `profiles` change is **not** a default-off
  change — the sandbox profile is opt-out via `--no-sandbox`, so
  existing installs continue to bring up the sandbox container.
- `scripts/dev-stack.sh` is now a 6-line shim. External callers
  (none in-tree, none known out-of-tree) keep working.
- No target name is removed; alias additions only.