### PR TITLE
feat: support env-driven OIDC SSO providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,27 @@ PARSAR_FEISHU_VERIFICATION_TOKEN=
 PARSAR_FEISHU_ENCRYPT_KEY=
 
 # -----------------------------------------------------------------------------
+# Auth — generic OIDC SSO (optional)
+# -----------------------------------------------------------------------------
+# Supports multiple OpenID Connect identity providers such as Google,
+# Microsoft Entra ID, Okta, Auth0, Keycloak, or an internal corporate IdP.
+# Provider ids must match: ^[a-z][a-z0-9_-]{0,62}$
+#
+# Example:
+#   PARSAR_AUTH_OIDC_PROVIDERS=google,company
+#   PARSAR_AUTH_OIDC_GOOGLE_LABEL=Google
+#   PARSAR_AUTH_OIDC_GOOGLE_ISSUER_URL=https://accounts.google.com
+#   PARSAR_AUTH_OIDC_GOOGLE_CLIENT_ID=
+#   PARSAR_AUTH_OIDC_GOOGLE_CLIENT_SECRET=
+#   PARSAR_AUTH_OIDC_GOOGLE_SCOPES=openid email profile
+#   PARSAR_AUTH_OIDC_GOOGLE_ALLOWED_DOMAINS=example.com
+#   PARSAR_AUTH_OIDC_GOOGLE_TOKEN_AUTH_METHOD=client_secret_post
+#
+# If PARSAR_AUTH_OIDC_<ID>_REDIRECT_URI is omitted, Parsar derives:
+#   ${PARSAR_PUBLIC_URL}/api/v1/auth/oidc/<id>/callback
+PARSAR_AUTH_OIDC_PROVIDERS=
+
+# -----------------------------------------------------------------------------
 # Database
 # -----------------------------------------------------------------------------
 # `make dev` starts a Postgres container and exports this URL for you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,43 @@ description and keep ownership on the side listed here.
   are committed artifacts, but never the source of truth. Change annotations
   or SQL first, then regenerate.
 
+### Auth Provider Configuration
+
+- Email/password login is always available after bootstrap.
+- Feishu login remains the Feishu-specific adapter because its token exchange
+  needs a Feishu app access token and is not a generic OAuth/OIDC exchange.
+- Generic third-party SSO uses env-driven OIDC providers. List enabled
+  provider ids with `PARSAR_AUTH_OIDC_PROVIDERS`, for example
+  `PARSAR_AUTH_OIDC_PROVIDERS=google,company`.
+- Provider ids must match `^[a-z][a-z0-9_-]{0,62}$`. The id becomes part of
+  the login routes and identity key:
+  `/api/v1/auth/oidc/{providerID}/start`,
+  `/api/v1/auth/oidc/{providerID}/callback`, and
+  `auth_identities.provider = "oidc:{providerID}"`.
+- Per-provider env names use the uppercased provider id with non-alphanumeric
+  characters converted to `_`: `company-sso` uses
+  `PARSAR_AUTH_OIDC_COMPANY_SSO_*`.
+- Required per-provider env:
+  `PARSAR_AUTH_OIDC_<ID>_ISSUER_URL`,
+  `PARSAR_AUTH_OIDC_<ID>_CLIENT_ID`,
+  `PARSAR_AUTH_OIDC_<ID>_CLIENT_SECRET`.
+- Optional per-provider env:
+  `PARSAR_AUTH_OIDC_<ID>_LABEL`,
+  `PARSAR_AUTH_OIDC_<ID>_REDIRECT_URI`,
+  `PARSAR_AUTH_OIDC_<ID>_SCOPES`,
+  `PARSAR_AUTH_OIDC_<ID>_ALLOWED_DOMAINS`,
+  `PARSAR_AUTH_OIDC_<ID>_TOKEN_AUTH_METHOD`,
+  `PARSAR_AUTH_OIDC_<ID>_REQUIRE_VERIFIED_EMAIL`.
+- If `REDIRECT_URI` is omitted, Parsar derives it from `PARSAR_PUBLIC_URL` as
+  `{public_url}/api/v1/auth/oidc/{providerID}/callback` (or the dev loopback
+  public URL when running in dev profile).
+- `TOKEN_AUTH_METHOD` may be `client_secret_basic` or `client_secret_post`.
+  When omitted, Parsar follows discovery metadata and falls back to
+  `client_secret_basic`.
+- OIDC login must validate discovery metadata, ID token signature, issuer,
+  audience, expiration, nonce, verified email by default, and allowed email
+  domains when configured.
+
 ## Code quality & architecture
 
 Parsar favors small, single-purpose files and reused helpers over growing

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -88,6 +88,24 @@ PARSAR_FEISHU_AUTHORIZE_BASE=
 PARSAR_FEISHU_API_BASE=
 
 # -----------------------------------------------------------------------------
+# Generic OIDC SSO (optional)
+# -----------------------------------------------------------------------------
+# Multiple providers can be enabled without DB/admin configuration. Examples:
+# Google, Microsoft Entra ID, Okta, Auth0, Keycloak, or an internal IdP.
+#
+# Register this callback in each provider:
+#   https://<your-parsar-host>/api/v1/auth/oidc/<provider-id>/callback
+#
+# Example:
+#   PARSAR_AUTH_OIDC_PROVIDERS=google,company
+#   PARSAR_AUTH_OIDC_GOOGLE_LABEL=Google
+#   PARSAR_AUTH_OIDC_GOOGLE_ISSUER_URL=https://accounts.google.com
+#   PARSAR_AUTH_OIDC_GOOGLE_CLIENT_ID=
+#   PARSAR_AUTH_OIDC_GOOGLE_CLIENT_SECRET=
+#   PARSAR_AUTH_OIDC_GOOGLE_ALLOWED_DOMAINS=example.com
+PARSAR_AUTH_OIDC_PROVIDERS=
+
+# -----------------------------------------------------------------------------
 # GitHub personal account connection (OAuth App)
 # -----------------------------------------------------------------------------
 # Creates/rotates the signed-in user's github_pat credential after OAuth.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2694,6 +2694,91 @@ paths:
       summary: Log out the current session
       tags:
       - auth
+  /api/v1/auth/oidc/{providerID}/callback:
+    get:
+      description: Verifies CSRF state and OIDC nonce, exchanges the authorization
+        code, upserts the user identity, creates a session cookie, and redirects to
+        the login-success URL.
+      operationId: callbackOIDCOAuth
+      parameters:
+      - description: OIDC provider ID
+        in: path
+        name: providerID
+        required: true
+        type: string
+      - description: CSRF state minted at /start
+        in: query
+        name: state
+        required: true
+        type: string
+      - description: OAuth authorization code returned by the OIDC provider
+        in: query
+        name: code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "302":
+          description: Redirect to login-success URL
+        "400":
+          description: Missing state/code or state/nonce mismatch
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: OIDC provider is not configured
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: User upsert or session creation failed
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "502":
+          description: OIDC exchange failed
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Handle generic OIDC callback
+      tags:
+      - auth
+  /api/v1/auth/oidc/{providerID}/start:
+    get:
+      description: Mints CSRF and nonce cookies and redirects the browser to the configured
+        OIDC provider authorize URL.
+      operationId: startOIDCOAuth
+      parameters:
+      - description: OIDC provider ID
+        in: path
+        name: providerID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "302":
+          description: Redirect to OIDC authorize URL
+        "404":
+          description: OIDC provider is not configured
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: State minting or discovery failed
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Start generic OIDC login
+      tags:
+      - auth
   /api/v1/auth/providers:
     get:
       description: Returns the login providers the public login page may render. Sensitive

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/feishu"
 	authgithub "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/github"
+	authoidc "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/oidc"
 	authpassword "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/password"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/bootstrap"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/config"
@@ -346,10 +347,15 @@ func main() {
 	// must publish into the same broker the UI /stream is subscribing
 	// to, otherwise events land in a per-call broker and the UI hangs.
 	runStreamBroker := runstream.NewBroker(runstream.DefaultBufferSize)
+	oidcPublicURL := strings.TrimRight(cfg.BuildPublicURL("/"), "/")
+	oidcClients, oidcStatuses, oidcErr := authoidc.NewClientsFromEnv(authoidc.EnvFunc(envLookup), oidcPublicURL)
+	if oidcErr != nil {
+		log.Bg().Warn("OIDC auth providers disabled", "error", oidcErr)
+	}
 	opts := []dev.RouterOption{
 		dev.WithDispatchContext(serverRootCtx),
 		dev.WithRunStreamBroker(runStreamBroker),
-		dev.WithAuthProviders(buildAuthProviderRegistry(envLookup, cfg, feishuDecision)),
+		dev.WithAuthProviders(buildAuthProviderRegistry(envLookup, cfg, feishuDecision, oidcStatuses)),
 	}
 	if shouldRegisterFeishuAppProvisioning(cfg) {
 		if regClient, err := gatewaypkg.NewFeishuAppRegistrationClient(gatewaypkg.FeishuAppRegistrationClientOptions{
@@ -635,27 +641,32 @@ func main() {
 			CookieSecure: cfg.Auth.Cookie.Secure,
 		}))
 
-		if feishuDecision.RegisterOAuthHandlers {
+		if feishuDecision.RegisterOAuthHandlers || len(oidcClients) > 0 {
+			loginRedirect := strings.TrimSpace(cfg.Gateway.Feishu.LoginRedirectURL)
+			cookieSecure := cfg.Auth.Cookie.Secure
+			deps := dev.OAuthHandlerDeps{
+				OIDC:             oidcClients,
+				Sessions:         sessionStore,
+				Store:            dbStore,
+				CookieSecure:     cookieSecure,
+				LoginRedirectURL: loginRedirect,
+			}
 			feishuClient, err := feishu.NewClientFromEnv(envLookup)
-			if err != nil {
+			if feishuDecision.RegisterOAuthHandlers && err != nil {
 				log.Bg().Warn("feishu OIDC client not registered", "error", err)
-			} else {
-				// CookieSecure driven by Config.Auth.Cookie.Secure; we
-				// do not sniff request scheme because proxies lie.
-				cookieSecure := cfg.Auth.Cookie.Secure
-				// loginRedirect: default "/" for prod / single-origin
-				// where the server serves the SPA; `make dev` points
-				// at the Vite origin (e.g. http://127.0.0.1:5173/).
-				loginRedirect := strings.TrimSpace(cfg.Gateway.Feishu.LoginRedirectURL)
-				opts = append(opts, dev.WithOAuthHandlers(dev.OAuthHandlerDeps{
-					Feishu:           feishuClient,
-					Sessions:         sessionStore,
-					Store:            dbStore,
-					CookieSecure:     cookieSecure,
-					LoginRedirectURL: loginRedirect,
-				}))
+			}
+			if err == nil {
+				deps.Feishu = feishuClient
+			}
+			opts = append(opts, dev.WithOAuthHandlers(deps))
+			if deps.Feishu != nil {
 				log.Bg().Info("feishu OIDC handlers registered",
 					"mode", feishuDecision.Mode, "mock", feishuClient.IsMock(), "cookie_secure", cookieSecure,
+					"login_redirect", loginRedirect)
+			}
+			if len(oidcClients) > 0 {
+				log.Bg().Info("OIDC auth handlers registered",
+					"providers", len(oidcClients), "cookie_secure", cookieSecure,
 					"login_redirect", loginRedirect)
 			}
 		}
@@ -1062,7 +1073,7 @@ func decideFeishuStartup(env func(string) string) feishuStartupDecision {
 	}
 }
 
-func buildAuthProviderRegistry(env func(string) string, cfg config.Config, feishuDecision feishuStartupDecision) dev.AuthProviderRegistry {
+func buildAuthProviderRegistry(env func(string) string, cfg config.Config, feishuDecision feishuStartupDecision, oidcStatuses []authoidc.ProviderEnvStatus) dev.AuthProviderRegistry {
 	if env == nil {
 		env = os.Getenv
 	}
@@ -1105,6 +1116,26 @@ func buildAuthProviderRegistry(env func(string) string, cfg config.Config, feish
 		feishuProvider.LoginURL = "/api/v1/auth/feishu/start"
 	}
 	providers = append(providers, feishuProvider)
+
+	for _, status := range oidcStatuses {
+		providerID := status.Config.ID
+		enabled := len(status.MissingEnv) == 0
+		provider := dev.AuthProvider{
+			ID:          "oidc:" + providerID,
+			Type:        dev.AuthProviderTypeOIDC,
+			Label:       status.Config.Label,
+			Enabled:     enabled,
+			Configured:  enabled,
+			CallbackURL: status.Config.RedirectURI,
+			RequiredEnv: status.RequiredEnv,
+			MissingEnv:  status.MissingEnv,
+			DocsURL:     "CONTRIBUTING.md#auth-provider-configuration",
+		}
+		if provider.Enabled {
+			provider.LoginURL = "/api/v1/auth/oidc/" + providerID + "/start"
+		}
+		providers = append(providers, provider)
+	}
 
 	return dev.AuthProviderRegistry{Providers: providers}
 }

--- a/server/cmd/server/main_test.go
+++ b/server/cmd/server/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/feishu"
+	authoidc "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/oidc"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/config"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 )
@@ -74,6 +75,7 @@ func TestBuildAuthProviderRegistry(t *testing.T) {
 		env              map[string]string
 		wantFeishuEnable bool
 		wantMissing      []string
+		wantProviderIDs  []string
 	}{
 		{
 			name: "default password only and feishu diagnostic disabled",
@@ -83,6 +85,7 @@ func TestBuildAuthProviderRegistry(t *testing.T) {
 				feishu.EnvAppSecret,
 				feishu.EnvRedirectURI,
 			},
+			wantProviderIDs: []string{"password", "feishu"},
 		},
 		{
 			name: "feishu oauth configured",
@@ -92,6 +95,7 @@ func TestBuildAuthProviderRegistry(t *testing.T) {
 				feishu.EnvRedirectURI: "https://parsar.example/api/v1/auth/feishu/callback",
 			},
 			wantFeishuEnable: true,
+			wantProviderIDs:  []string{"password", "feishu"},
 		},
 		{
 			name: "mock feishu configured",
@@ -99,14 +103,47 @@ func TestBuildAuthProviderRegistry(t *testing.T) {
 				feishu.EnvMock: "true",
 			},
 			wantFeishuEnable: true,
+			wantProviderIDs:  []string{"password", "feishu"},
+		},
+		{
+			name: "multiple oidc providers",
+			env: map[string]string{
+				authoidc.EnvProviders:                             "google,company",
+				"PARSAR_AUTH_OIDC_GOOGLE_LABEL":                   "Google",
+				"PARSAR_AUTH_OIDC_GOOGLE_ISSUER_URL":              "https://accounts.google.com",
+				"PARSAR_AUTH_OIDC_GOOGLE_CLIENT_ID":               "google-client",
+				"PARSAR_AUTH_OIDC_GOOGLE_CLIENT_SECRET":           "google-secret",
+				"PARSAR_AUTH_OIDC_COMPANY_LABEL":                  "Company SSO",
+				"PARSAR_AUTH_OIDC_COMPANY_ISSUER_URL":             "https://idp.example.com",
+				"PARSAR_AUTH_OIDC_COMPANY_CLIENT_ID":              "company-client",
+				"PARSAR_AUTH_OIDC_COMPANY_CLIENT_SECRET":          "company-secret",
+				"PARSAR_AUTH_OIDC_COMPANY_ALLOWED_DOMAINS":        "example.com",
+				"PARSAR_AUTH_OIDC_COMPANY_REQUIRE_VERIFIED_EMAIL": "true",
+			},
+			wantMissing: []string{
+				feishu.EnvAppID,
+				feishu.EnvAppSecret,
+				feishu.EnvRedirectURI,
+			},
+			wantProviderIDs: []string{"password", "feishu", "oidc:google", "oidc:company"},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			env := func(k string) string { return tc.env[k] }
-			registry := buildAuthProviderRegistry(env, cfg, decideFeishuStartup(env))
-			if len(registry.Providers) != 2 {
-				t.Fatalf("provider count = %d, want 2", len(registry.Providers))
+			oidcStatuses, err := authoidc.LoadProviderStatuses(env, cfg.Server.PublicURL)
+			if err != nil {
+				t.Fatalf("LoadProviderStatuses: %v", err)
+			}
+			registry := buildAuthProviderRegistry(env, cfg, decideFeishuStartup(env), oidcStatuses)
+			wantProviderIDs := tc.wantProviderIDs
+			if len(registry.Providers) != len(wantProviderIDs) {
+				t.Fatalf("provider count = %d, want %d", len(registry.Providers), len(wantProviderIDs))
+			}
+			for i, wantID := range wantProviderIDs {
+				if registry.Providers[i].ID != wantID {
+					t.Fatalf("provider[%d] id = %q, want %q", i, registry.Providers[i].ID, wantID)
+				}
 			}
 			if registry.Providers[0].ID != "password" || !registry.Providers[0].Enabled {
 				t.Fatalf("password provider = %+v, want enabled password", registry.Providers[0])

--- a/server/internal/auth/oidc/client.go
+++ b/server/internal/auth/oidc/client.go
@@ -1,0 +1,515 @@
+package oidc
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type Client interface {
+	ID() string
+	Label() string
+	RedirectURI() string
+	AuthorizeURL(ctx context.Context, state, nonce string) (string, error)
+	ExchangeCode(ctx context.Context, code, nonce string) (UserProfile, error)
+}
+
+type UserProfile struct {
+	Provider   string
+	Subject    string
+	Email      string
+	Name       string
+	AvatarURL  string
+	Issuer     string
+	Claims     map[string]any
+	UserInfo   map[string]any
+	ProviderID string
+}
+
+type httpClient struct {
+	cfg        ProviderConfig
+	http       *http.Client
+	refreshTTL time.Duration
+
+	mu        sync.RWMutex
+	discovery discoveryDocument
+	keys      map[string]any
+	refreshed time.Time
+}
+
+type discoveryDocument struct {
+	Issuer                string   `json:"issuer"`
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	UserinfoEndpoint      string   `json:"userinfo_endpoint"`
+	JWKSURI               string   `json:"jwks_uri"`
+	IDTokenAlgs           []string `json:"id_token_signing_alg_values_supported"`
+	TokenAuthMethods      []string `json:"token_endpoint_auth_methods_supported"`
+}
+
+func NewClient(cfg ProviderConfig) (Client, error) {
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+	return &httpClient{
+		cfg:        cfg,
+		http:       &http.Client{Timeout: 10 * time.Second},
+		refreshTTL: 12 * time.Hour,
+		keys:       map[string]any{},
+	}, nil
+}
+
+func (c *httpClient) ID() string          { return c.cfg.ID }
+func (c *httpClient) Label() string       { return c.cfg.Label }
+func (c *httpClient) RedirectURI() string { return c.cfg.RedirectURI }
+
+func (c *httpClient) AuthorizeURL(ctx context.Context, state, nonce string) (string, error) {
+	doc, err := c.discoveryDocument(ctx)
+	if err != nil {
+		return "", err
+	}
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", c.cfg.ClientID)
+	q.Set("redirect_uri", c.cfg.RedirectURI)
+	q.Set("scope", strings.Join(c.cfg.Scopes, " "))
+	q.Set("state", state)
+	q.Set("nonce", nonce)
+	return doc.AuthorizationEndpoint + "?" + q.Encode(), nil
+}
+
+func (c *httpClient) ExchangeCode(ctx context.Context, code, nonce string) (UserProfile, error) {
+	doc, err := c.discoveryDocument(ctx)
+	if err != nil {
+		return UserProfile{}, err
+	}
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", strings.TrimSpace(code))
+	form.Set("redirect_uri", c.cfg.RedirectURI)
+	authMethod := c.tokenAuthMethod(doc)
+	if authMethod == "client_secret_post" {
+		form.Set("client_id", c.cfg.ClientID)
+		form.Set("client_secret", c.cfg.ClientSecret)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, doc.TokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return UserProfile{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if authMethod == "client_secret_basic" {
+		req.SetBasicAuth(c.cfg.ClientID, c.cfg.ClientSecret)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return UserProfile{}, fmt.Errorf("oidc: token exchange: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return UserProfile{}, fmt.Errorf("oidc: token endpoint returned %d", resp.StatusCode)
+	}
+	var token tokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&token); err != nil {
+		return UserProfile{}, fmt.Errorf("oidc: decode token response: %w", err)
+	}
+	if token.Error != "" {
+		return UserProfile{}, fmt.Errorf("oidc: token exchange failed: %s", coalesce(token.ErrorDescription, token.Error))
+	}
+	if strings.TrimSpace(token.IDToken) == "" {
+		return UserProfile{}, errors.New("oidc: token response missing id_token")
+	}
+
+	claims, err := c.verifyIDToken(ctx, token.IDToken, nonce, doc)
+	if err != nil {
+		return UserProfile{}, err
+	}
+	userInfo := map[string]any{}
+	if doc.UserinfoEndpoint != "" && strings.TrimSpace(token.AccessToken) != "" {
+		userInfo, _ = c.fetchUserInfo(ctx, doc.UserinfoEndpoint, token.AccessToken)
+	}
+	if err := validateUserInfoSubject(claims, userInfo); err != nil {
+		return UserProfile{}, err
+	}
+	profile := profileFromClaims(c.cfg, claims, userInfo, doc.Issuer)
+	if err := validateProfile(c.cfg, profile); err != nil {
+		return UserProfile{}, err
+	}
+	return profile, nil
+}
+
+func (c *httpClient) tokenAuthMethod(doc discoveryDocument) string {
+	if c.cfg.TokenAuthMethod != "" {
+		return c.cfg.TokenAuthMethod
+	}
+	if contains(doc.TokenAuthMethods, "client_secret_post") {
+		return "client_secret_post"
+	}
+	return "client_secret_basic"
+}
+
+type tokenResponse struct {
+	AccessToken      string `json:"access_token"`
+	IDToken          string `json:"id_token"`
+	TokenType        string `json:"token_type"`
+	Scope            string `json:"scope"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+func (c *httpClient) discoveryDocument(ctx context.Context) (discoveryDocument, error) {
+	c.mu.RLock()
+	doc := c.discovery
+	fresh := time.Since(c.refreshed) < c.refreshTTL
+	c.mu.RUnlock()
+	if doc.TokenEndpoint != "" && fresh {
+		return doc, nil
+	}
+	discoveryURL := c.cfg.IssuerURL + "/.well-known/openid-configuration"
+	if err := getJSON(ctx, c.http, discoveryURL, &doc); err != nil {
+		return discoveryDocument{}, fmt.Errorf("oidc: fetch discovery for %q: %w", c.cfg.ID, err)
+	}
+	if strings.TrimSpace(doc.Issuer) == "" {
+		doc.Issuer = c.cfg.IssuerURL
+	}
+	if strings.TrimSpace(doc.AuthorizationEndpoint) == "" ||
+		strings.TrimSpace(doc.TokenEndpoint) == "" ||
+		strings.TrimSpace(doc.JWKSURI) == "" {
+		return discoveryDocument{}, fmt.Errorf("oidc: discovery for %q missing required endpoints", c.cfg.ID)
+	}
+	c.mu.Lock()
+	c.discovery = doc
+	c.refreshed = time.Now()
+	c.mu.Unlock()
+	return doc, nil
+}
+
+func (c *httpClient) verifyIDToken(ctx context.Context, raw, nonce string, doc discoveryDocument) (map[string]any, error) {
+	claims := jwt.MapClaims{}
+	keyfunc := func(token *jwt.Token) (any, error) {
+		alg, _ := token.Header["alg"].(string)
+		if !acceptedAlg(alg, doc.IDTokenAlgs) {
+			return nil, fmt.Errorf("oidc: unsupported signing method %q", alg)
+		}
+		kid, _ := token.Header["kid"].(string)
+		return c.keyForToken(ctx, doc.JWKSURI, kid, alg)
+	}
+	token, err := jwt.ParseWithClaims(raw, claims, keyfunc,
+		jwt.WithIssuer(doc.Issuer),
+		jwt.WithAudience(c.cfg.ClientID),
+		jwt.WithExpirationRequired(),
+		jwt.WithValidMethods(acceptedAlgs(doc.IDTokenAlgs)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: verify id_token: %w", err)
+	}
+	if !token.Valid {
+		return nil, errors.New("oidc: invalid id_token")
+	}
+	if nonce != "" {
+		got, _ := claims["nonce"].(string)
+		if got != nonce {
+			return nil, errors.New("oidc: nonce mismatch")
+		}
+	}
+	return map[string]any(claims), nil
+}
+
+func (c *httpClient) keyForToken(ctx context.Context, jwksURI, kid, alg string) (any, error) {
+	kid = strings.TrimSpace(kid)
+	if kid == "" {
+		return nil, errors.New("oidc: token missing kid header")
+	}
+	c.mu.RLock()
+	key, ok := c.keys[kid]
+	fresh := time.Since(c.refreshed) < c.refreshTTL
+	c.mu.RUnlock()
+	if ok && fresh {
+		return key, nil
+	}
+	if err := c.refreshKeys(ctx, jwksURI); err != nil {
+		if ok {
+			return key, nil
+		}
+		return nil, err
+	}
+	c.mu.RLock()
+	key, ok = c.keys[kid]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("oidc: no signing key for kid %q", kid)
+	}
+	if strings.HasPrefix(alg, "RS") {
+		if _, ok := key.(*rsa.PublicKey); !ok {
+			return nil, fmt.Errorf("oidc: kid %q is not an RSA key", kid)
+		}
+	}
+	if strings.HasPrefix(alg, "ES") {
+		if _, ok := key.(*ecdsa.PublicKey); !ok {
+			return nil, fmt.Errorf("oidc: kid %q is not an ECDSA key", kid)
+		}
+	}
+	return key, nil
+}
+
+func (c *httpClient) refreshKeys(ctx context.Context, jwksURI string) error {
+	var set struct {
+		Keys []jwk `json:"keys"`
+	}
+	if err := getJSON(ctx, c.http, jwksURI, &set); err != nil {
+		return fmt.Errorf("oidc: fetch jwks: %w", err)
+	}
+	keys := map[string]any{}
+	for _, k := range set.Keys {
+		if strings.TrimSpace(k.Kid) == "" {
+			continue
+		}
+		switch strings.ToUpper(k.Kty) {
+		case "RSA":
+			pub, err := jwkToRSA(k)
+			if err == nil {
+				keys[k.Kid] = pub
+			}
+		case "EC":
+			pub, err := jwkToECDSA(k)
+			if err == nil {
+				keys[k.Kid] = pub
+			}
+		}
+	}
+	if len(keys) == 0 {
+		return errors.New("oidc: jwks carried no usable keys")
+	}
+	c.mu.Lock()
+	c.keys = keys
+	c.refreshed = time.Now()
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *httpClient) fetchUserInfo(ctx context.Context, endpoint, accessToken string) (map[string]any, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: fetch userinfo: %w", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("oidc: userinfo endpoint returned %d", resp.StatusCode)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("oidc: decode userinfo: %w", err)
+	}
+	return out, nil
+}
+
+type jwk struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+	Crv string `json:"crv"`
+	X   string `json:"x"`
+	Y   string `json:"y"`
+}
+
+func jwkToRSA(k jwk) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(k.N, "="))
+	if err != nil {
+		return nil, fmt.Errorf("decode modulus: %w", err)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(k.E, "="))
+	if err != nil {
+		return nil, fmt.Errorf("decode exponent: %w", err)
+	}
+	if len(eBytes) == 0 {
+		return nil, errors.New("empty exponent")
+	}
+	var e uint64
+	if len(eBytes) < 8 {
+		padded := make([]byte, 8)
+		copy(padded[8-len(eBytes):], eBytes)
+		e = binary.BigEndian.Uint64(padded)
+	} else {
+		e = binary.BigEndian.Uint64(eBytes[len(eBytes)-8:])
+	}
+	if e == 0 || e > uint64(^uint(0)>>1) {
+		return nil, fmt.Errorf("invalid exponent %d", e)
+	}
+	return &rsa.PublicKey{N: new(big.Int).SetBytes(nBytes), E: int(e)}, nil
+}
+
+func jwkToECDSA(k jwk) (*ecdsa.PublicKey, error) {
+	if k.Crv != "P-256" {
+		return nil, fmt.Errorf("unsupported ec curve %q", k.Crv)
+	}
+	xBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(k.X, "="))
+	if err != nil {
+		return nil, fmt.Errorf("decode x: %w", err)
+	}
+	yBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(k.Y, "="))
+	if err != nil {
+		return nil, fmt.Errorf("decode y: %w", err)
+	}
+	curve := elliptic.P256()
+	x := new(big.Int).SetBytes(xBytes)
+	y := new(big.Int).SetBytes(yBytes)
+	if !curve.IsOnCurve(x, y) {
+		return nil, errors.New("ec point is not on P-256")
+	}
+	return &ecdsa.PublicKey{
+		Curve: curve,
+		X:     x,
+		Y:     y,
+	}, nil
+}
+
+func validateUserInfoSubject(claims, userInfo map[string]any) error {
+	if len(userInfo) == 0 {
+		return nil
+	}
+	infoSub, _ := userInfo["sub"].(string)
+	if strings.TrimSpace(infoSub) == "" {
+		return nil
+	}
+	claimSub, _ := claims["sub"].(string)
+	if infoSub != claimSub {
+		return errors.New("oidc: userinfo sub does not match id_token sub")
+	}
+	return nil
+}
+
+func profileFromClaims(cfg ProviderConfig, claims, userInfo map[string]any, issuer string) UserProfile {
+	merged := make(map[string]any, len(claims)+len(userInfo))
+	for k, v := range claims {
+		merged[k] = v
+	}
+	for k, v := range userInfo {
+		if _, exists := merged[k]; !exists {
+			merged[k] = v
+		}
+	}
+	sub, _ := merged["sub"].(string)
+	email, _ := merged["email"].(string)
+	name, _ := merged["name"].(string)
+	if name == "" {
+		name, _ = merged["preferred_username"].(string)
+	}
+	if name == "" {
+		name, _ = merged["given_name"].(string)
+	}
+	avatar, _ := merged["picture"].(string)
+	return UserProfile{
+		Provider:   "oidc:" + cfg.ID,
+		ProviderID: cfg.ID,
+		Subject:    sub,
+		Email:      strings.TrimSpace(email),
+		Name:       strings.TrimSpace(name),
+		AvatarURL:  strings.TrimSpace(avatar),
+		Issuer:     issuer,
+		Claims:     claims,
+		UserInfo:   userInfo,
+	}
+}
+
+func validateProfile(cfg ProviderConfig, profile UserProfile) error {
+	if strings.TrimSpace(profile.Subject) == "" {
+		return errors.New("oidc: id_token missing sub claim")
+	}
+	if strings.TrimSpace(profile.Email) == "" {
+		return errors.New("oidc: profile missing email claim")
+	}
+	if cfg.RequireVerifiedEmail {
+		verified, ok := boolClaim(profile.Claims["email_verified"])
+		if !ok && len(profile.UserInfo) > 0 {
+			verified, ok = boolClaim(profile.UserInfo["email_verified"])
+		}
+		if !ok || !verified {
+			return errors.New("oidc: email is not verified")
+		}
+	}
+	if len(cfg.AllowedDomains) > 0 {
+		at := strings.LastIndex(profile.Email, "@")
+		if at <= 0 || !contains(cfg.AllowedDomains, strings.ToLower(profile.Email[at+1:])) {
+			return errors.New("oidc: email domain is not allowed")
+		}
+	}
+	return nil
+}
+
+func boolClaim(v any) (bool, bool) {
+	switch t := v.(type) {
+	case bool:
+		return t, true
+	case string:
+		switch strings.ToLower(strings.TrimSpace(t)) {
+		case "true":
+			return true, true
+		case "false":
+			return false, true
+		}
+	}
+	return false, false
+}
+
+func acceptedAlgs(discovered []string) []string {
+	allowed := []string{"RS256", "RS384", "RS512", "ES256"}
+	if len(discovered) == 0 {
+		return allowed
+	}
+	out := make([]string, 0, len(discovered))
+	for _, alg := range discovered {
+		for _, a := range allowed {
+			if alg == a {
+				out = append(out, alg)
+				break
+			}
+		}
+	}
+	if len(out) == 0 {
+		return allowed
+	}
+	return out
+}
+
+func acceptedAlg(alg string, discovered []string) bool {
+	return contains(acceptedAlgs(discovered), alg)
+}
+
+func getJSON(ctx context.Context, hc *http.Client, u string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/server/internal/auth/oidc/client_test.go
+++ b/server/internal/auth/oidc/client_test.go
@@ -1,0 +1,313 @@
+package oidc
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestLoadProviderStatusesMultipleProviders(t *testing.T) {
+	env := map[string]string{
+		EnvProviders:                              "google,company-sso",
+		"PARSAR_AUTH_OIDC_GOOGLE_LABEL":           "Google",
+		"PARSAR_AUTH_OIDC_GOOGLE_ISSUER_URL":      "https://accounts.google.com",
+		"PARSAR_AUTH_OIDC_GOOGLE_CLIENT_ID":       "google-client",
+		"PARSAR_AUTH_OIDC_GOOGLE_CLIENT_SECRET":   "google-secret",
+		"PARSAR_AUTH_OIDC_COMPANY_SSO_LABEL":      "Company SSO",
+		"PARSAR_AUTH_OIDC_COMPANY_SSO_ISSUER_URL": "https://idp.example.com",
+	}
+	statuses, err := LoadProviderStatuses(func(k string) string { return env[k] }, "https://parsar.example")
+	if err != nil {
+		t.Fatalf("LoadProviderStatuses: %v", err)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("status count = %d, want 2", len(statuses))
+	}
+	if statuses[0].Config.ID != "google" || statuses[0].Config.RedirectURI != "https://parsar.example/api/v1/auth/oidc/google/callback" {
+		t.Fatalf("google status = %+v", statuses[0])
+	}
+	if len(statuses[1].MissingEnv) == 0 {
+		t.Fatalf("company status should report missing client env: %+v", statuses[1])
+	}
+}
+
+func TestOIDCExchangeVerifiesIDTokenAndBuildsProfile(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	var issuer string
+	var tokenEndpointSeen url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			writeTestJSON(t, w, map[string]any{
+				"issuer":                                issuer,
+				"authorization_endpoint":                issuer + "/authorize",
+				"token_endpoint":                        issuer + "/token",
+				"userinfo_endpoint":                     issuer + "/userinfo",
+				"jwks_uri":                              issuer + "/jwks",
+				"id_token_signing_alg_values_supported": []string{"RS256"},
+				"token_endpoint_auth_methods_supported": []string{"client_secret_post"},
+			})
+		case "/jwks":
+			writeTestJSON(t, w, map[string]any{
+				"keys": []map[string]any{rsaJWK("test-kid", &key.PublicKey)},
+			})
+		case "/token":
+			if err := r.ParseForm(); err != nil {
+				t.Fatalf("ParseForm: %v", err)
+			}
+			tokenEndpointSeen = r.Form
+			idToken := signTestIDToken(t, key, issuer, "client-1", "nonce-1")
+			writeTestJSON(t, w, map[string]any{
+				"access_token": "access-1",
+				"id_token":     idToken,
+				"token_type":   "Bearer",
+			})
+		case "/userinfo":
+			if got := r.Header.Get("Authorization"); got != "Bearer access-1" {
+				t.Fatalf("Authorization = %q, want bearer", got)
+			}
+			writeTestJSON(t, w, map[string]any{
+				"picture": "https://idp.example/avatar.png",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	issuer = srv.URL
+
+	client, err := NewClient(ProviderConfig{
+		ID:                   "company",
+		Label:                "Company",
+		IssuerURL:            issuer,
+		ClientID:             "client-1",
+		ClientSecret:         "secret-1",
+		RedirectURI:          "https://parsar.example/api/v1/auth/oidc/company/callback",
+		Scopes:               []string{"openid", "email", "profile"},
+		AllowedDomains:       []string{"example.com"},
+		RequireVerifiedEmail: true,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	authURL, err := client.AuthorizeURL(t.Context(), "state-1", "nonce-1")
+	if err != nil {
+		t.Fatalf("AuthorizeURL: %v", err)
+	}
+	if !strings.HasPrefix(authURL, issuer+"/authorize?") {
+		t.Fatalf("authorize URL = %q, want discovered endpoint", authURL)
+	}
+	profile, err := client.ExchangeCode(t.Context(), "code-1", "nonce-1")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if tokenEndpointSeen.Get("client_secret") != "secret-1" || tokenEndpointSeen.Get("code") != "code-1" {
+		t.Fatalf("token form = %v", tokenEndpointSeen)
+	}
+	if profile.Provider != "oidc:company" || profile.Subject != "sub-1" || profile.Email != "admin@example.com" {
+		t.Fatalf("profile = %+v", profile)
+	}
+	if profile.AvatarURL != "https://idp.example/avatar.png" {
+		t.Fatalf("avatar = %q", profile.AvatarURL)
+	}
+}
+
+func TestOIDCExchangeSupportsClientSecretBasic(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	var issuer string
+	var sawBasicUser, sawBasicPass string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			writeTestJSON(t, w, map[string]any{
+				"issuer":                                issuer,
+				"authorization_endpoint":                issuer + "/authorize",
+				"token_endpoint":                        issuer + "/token",
+				"jwks_uri":                              issuer + "/jwks",
+				"id_token_signing_alg_values_supported": []string{"RS256"},
+				"token_endpoint_auth_methods_supported": []string{"client_secret_basic"},
+			})
+		case "/jwks":
+			writeTestJSON(t, w, map[string]any{"keys": []map[string]any{rsaJWK("test-kid", &key.PublicKey)}})
+		case "/token":
+			sawBasicUser, sawBasicPass, _ = r.BasicAuth()
+			writeTestJSON(t, w, map[string]any{
+				"id_token": signTestIDToken(t, key, issuer, "client-1", "nonce-1"),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	issuer = srv.URL
+	client, err := NewClient(ProviderConfig{
+		ID:                   "company",
+		Label:                "Company",
+		IssuerURL:            issuer,
+		ClientID:             "client-1",
+		ClientSecret:         "secret-1",
+		RedirectURI:          "https://parsar.example/api/v1/auth/oidc/company/callback",
+		Scopes:               []string{"openid", "email"},
+		RequireVerifiedEmail: true,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if _, err := client.ExchangeCode(t.Context(), "code-1", "nonce-1"); err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if sawBasicUser != "client-1" || sawBasicPass != "secret-1" {
+		t.Fatalf("basic auth = %q/%q, want client credentials", sawBasicUser, sawBasicPass)
+	}
+}
+
+func TestOIDCExchangeRejectsUserInfoSubjectMismatch(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	var issuer string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			writeTestJSON(t, w, map[string]any{
+				"issuer":                 issuer,
+				"authorization_endpoint": issuer + "/authorize",
+				"token_endpoint":         issuer + "/token",
+				"userinfo_endpoint":      issuer + "/userinfo",
+				"jwks_uri":               issuer + "/jwks",
+			})
+		case "/jwks":
+			writeTestJSON(t, w, map[string]any{"keys": []map[string]any{rsaJWK("test-kid", &key.PublicKey)}})
+		case "/token":
+			writeTestJSON(t, w, map[string]any{
+				"access_token": "access-1",
+				"id_token":     signTestIDToken(t, key, issuer, "client-1", "nonce-1"),
+			})
+		case "/userinfo":
+			writeTestJSON(t, w, map[string]any{"sub": "different-sub"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	issuer = srv.URL
+	client, err := NewClient(ProviderConfig{
+		ID:                   "company",
+		Label:                "Company",
+		IssuerURL:            issuer,
+		ClientID:             "client-1",
+		ClientSecret:         "secret-1",
+		RedirectURI:          "https://parsar.example/api/v1/auth/oidc/company/callback",
+		Scopes:               []string{"openid", "email"},
+		RequireVerifiedEmail: true,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	_, err = client.ExchangeCode(t.Context(), "code-1", "nonce-1")
+	if err == nil || !strings.Contains(err.Error(), "userinfo sub") {
+		t.Fatalf("ExchangeCode err = %v, want userinfo sub mismatch", err)
+	}
+}
+
+func TestOIDCExchangeRejectsNonceMismatch(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	var issuer string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			writeTestJSON(t, w, map[string]any{
+				"issuer":                 issuer,
+				"authorization_endpoint": issuer + "/authorize",
+				"token_endpoint":         issuer + "/token",
+				"jwks_uri":               issuer + "/jwks",
+			})
+		case "/jwks":
+			writeTestJSON(t, w, map[string]any{"keys": []map[string]any{rsaJWK("test-kid", &key.PublicKey)}})
+		case "/token":
+			writeTestJSON(t, w, map[string]any{
+				"id_token": signTestIDToken(t, key, issuer, "client-1", "nonce-from-idp"),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	issuer = srv.URL
+	client, err := NewClient(ProviderConfig{
+		ID:                   "company",
+		Label:                "Company",
+		IssuerURL:            issuer,
+		ClientID:             "client-1",
+		ClientSecret:         "secret-1",
+		RedirectURI:          "https://parsar.example/api/v1/auth/oidc/company/callback",
+		Scopes:               []string{"openid", "email"},
+		RequireVerifiedEmail: true,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	_, err = client.ExchangeCode(t.Context(), "code-1", "expected-nonce")
+	if err == nil || !strings.Contains(err.Error(), "nonce mismatch") {
+		t.Fatalf("ExchangeCode err = %v, want nonce mismatch", err)
+	}
+}
+
+func signTestIDToken(t *testing.T, key *rsa.PrivateKey, issuer, audience, nonce string) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"iss":            issuer,
+		"aud":            audience,
+		"sub":            "sub-1",
+		"email":          "admin@example.com",
+		"email_verified": true,
+		"name":           "Admin User",
+		"nonce":          nonce,
+		"exp":            time.Now().Add(time.Hour).Unix(),
+		"iat":            time.Now().Add(-time.Minute).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-kid"
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+	return signed
+}
+
+func rsaJWK(kid string, key *rsa.PublicKey) map[string]any {
+	return map[string]any{
+		"kty": "RSA",
+		"kid": kid,
+		"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+	}
+}
+
+func writeTestJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+}

--- a/server/internal/auth/oidc/config.go
+++ b/server/internal/auth/oidc/config.go
@@ -1,0 +1,239 @@
+package oidc
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+const (
+	EnvProviders = "PARSAR_AUTH_OIDC_PROVIDERS"
+
+	envPrefix = "PARSAR_AUTH_OIDC_"
+)
+
+var providerIDPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,62}$`)
+
+type EnvFunc func(string) string
+
+type ProviderConfig struct {
+	ID                   string
+	Label                string
+	IssuerURL            string
+	ClientID             string
+	ClientSecret         string
+	RedirectURI          string
+	Scopes               []string
+	AllowedDomains       []string
+	TokenAuthMethod      string
+	RequireVerifiedEmail bool
+}
+
+type ProviderEnvStatus struct {
+	Config      ProviderConfig
+	RequiredEnv []string
+	MissingEnv  []string
+}
+
+func LoadProviderStatuses(env EnvFunc, publicURL string) ([]ProviderEnvStatus, error) {
+	if env == nil {
+		return nil, errors.New("oidc: env func is nil")
+	}
+	ids := splitCSV(env(EnvProviders))
+	out := make([]ProviderEnvStatus, 0, len(ids))
+	seen := map[string]bool{}
+	for _, id := range ids {
+		id = strings.ToLower(strings.TrimSpace(id))
+		if id == "" {
+			continue
+		}
+		if !providerIDPattern.MatchString(id) {
+			return nil, fmt.Errorf("oidc: invalid provider id %q", id)
+		}
+		if seen[id] {
+			return nil, fmt.Errorf("oidc: duplicate provider id %q", id)
+		}
+		seen[id] = true
+
+		key := envKey(id)
+		required := []string{
+			envPrefix + key + "_ISSUER_URL",
+			envPrefix + key + "_CLIENT_ID",
+			envPrefix + key + "_CLIENT_SECRET",
+		}
+		missing := missingEnv(env, required)
+		redirectEnv := envPrefix + key + "_REDIRECT_URI"
+		redirectURI := strings.TrimSpace(env(redirectEnv))
+		if redirectURI == "" {
+			redirectURI = defaultRedirectURI(publicURL, id)
+		}
+		if redirectURI == "" {
+			missing = append(missing, redirectEnv)
+		}
+
+		cfg := ProviderConfig{
+			ID:                   id,
+			Label:                coalesce(strings.TrimSpace(env(envPrefix+key+"_LABEL")), id),
+			IssuerURL:            strings.TrimRight(strings.TrimSpace(env(envPrefix+key+"_ISSUER_URL")), "/"),
+			ClientID:             strings.TrimSpace(env(envPrefix + key + "_CLIENT_ID")),
+			ClientSecret:         strings.TrimSpace(env(envPrefix + key + "_CLIENT_SECRET")),
+			RedirectURI:          redirectURI,
+			Scopes:               splitSpaceList(coalesce(strings.TrimSpace(env(envPrefix+key+"_SCOPES")), "openid email profile")),
+			AllowedDomains:       lowerList(splitCSV(env(envPrefix + key + "_ALLOWED_DOMAINS"))),
+			TokenAuthMethod:      strings.TrimSpace(env(envPrefix + key + "_TOKEN_AUTH_METHOD")),
+			RequireVerifiedEmail: !isExplicitFalse(env(envPrefix + key + "_REQUIRE_VERIFIED_EMAIL")),
+		}
+		out = append(out, ProviderEnvStatus{
+			Config:      cfg,
+			RequiredEnv: append(required, redirectEnv),
+			MissingEnv:  missing,
+		})
+	}
+	return out, nil
+}
+
+func NewClientsFromEnv(env EnvFunc, publicURL string) (map[string]Client, []ProviderEnvStatus, error) {
+	statuses, err := LoadProviderStatuses(env, publicURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	clients := make(map[string]Client, len(statuses))
+	for _, status := range statuses {
+		if len(status.MissingEnv) > 0 {
+			continue
+		}
+		client, err := NewClient(status.Config)
+		if err != nil {
+			return nil, statuses, err
+		}
+		clients[status.Config.ID] = client
+	}
+	return clients, statuses, nil
+}
+
+func defaultRedirectURI(publicURL, id string) string {
+	base := strings.TrimRight(strings.TrimSpace(publicURL), "/")
+	if base == "" {
+		return ""
+	}
+	return base + "/api/v1/auth/oidc/" + id + "/callback"
+}
+
+func envKey(id string) string {
+	var b strings.Builder
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r - 'a' + 'A')
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+func missingEnv(env EnvFunc, names []string) []string {
+	missing := make([]string, 0, len(names))
+	for _, name := range names {
+		if strings.TrimSpace(env(name)) == "" {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+func splitCSV(v string) []string {
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func splitSpaceList(v string) []string {
+	fields := strings.Fields(v)
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if strings.TrimSpace(f) != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func lowerList(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		v = strings.ToLower(strings.TrimSpace(v))
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func isExplicitFalse(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "0", "false", "no", "off":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateConfig(cfg ProviderConfig) error {
+	if !providerIDPattern.MatchString(cfg.ID) {
+		return fmt.Errorf("oidc: invalid provider id %q", cfg.ID)
+	}
+	for name, raw := range map[string]string{
+		"issuer_url":    cfg.IssuerURL,
+		"client_id":     cfg.ClientID,
+		"client_secret": cfg.ClientSecret,
+		"redirect_uri":  cfg.RedirectURI,
+	} {
+		if strings.TrimSpace(raw) == "" {
+			return fmt.Errorf("oidc: %s is required for provider %q", name, cfg.ID)
+		}
+	}
+	if _, err := url.ParseRequestURI(cfg.RedirectURI); err != nil {
+		return fmt.Errorf("oidc: invalid redirect_uri for provider %q: %w", cfg.ID, err)
+	}
+	if u, err := url.Parse(cfg.IssuerURL); err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("oidc: invalid issuer_url for provider %q", cfg.ID)
+	}
+	if !contains(cfg.Scopes, "openid") {
+		return fmt.Errorf("oidc: scopes for provider %q must include openid", cfg.ID)
+	}
+	if cfg.TokenAuthMethod != "" &&
+		cfg.TokenAuthMethod != "client_secret_post" &&
+		cfg.TokenAuthMethod != "client_secret_basic" {
+		return fmt.Errorf("oidc: unsupported token auth method %q for provider %q", cfg.TokenAuthMethod, cfg.ID)
+	}
+	return nil
+}
+
+func contains(values []string, want string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func coalesce(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}

--- a/server/internal/dev/oauth_handlers.go
+++ b/server/internal/dev/oauth_handlers.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/feishu"
+	authoidc "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/oidc"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
 )
 
 // OAuthRuntimeStore is the narrow surface the OAuth callback uses, so
@@ -26,6 +28,9 @@ type OAuthRuntimeStore interface {
 // CookieStateName is the short-lived CSRF cookie name.
 const CookieStateName = "parsar_oauth_state"
 
+// CookieNonceName is the short-lived OIDC nonce cookie name.
+const CookieNonceName = "parsar_oidc_nonce"
+
 // stateCookieTTL is the wall time the state cookie is valid for —
 // generous because the user may pause on the Feishu consent page.
 const stateCookieTTL = 10 * time.Minute
@@ -36,6 +41,7 @@ const stateRandBytes = 16
 // OAuthHandlerDeps wires the three deps the Feishu callback needs.
 type OAuthHandlerDeps struct {
 	Feishu   feishu.Client
+	OIDC     map[string]authoidc.Client
 	Sessions auth.SessionStore
 	Store    OAuthRuntimeStore
 
@@ -46,6 +52,14 @@ type OAuthHandlerDeps struct {
 	// Feishu callback. Defaults to "/" (server-served SPA). In dev set
 	// to the Vite origin so the post-login bounce lands on the dev frontend.
 	LoginRedirectURL string
+}
+
+type oauthProfile struct {
+	Provider string
+	Subject  string
+	Email    string
+	Name     string
+	Metadata map[string]any
 }
 
 // loginRedirectURL returns the configured success redirect, falling back
@@ -94,6 +108,66 @@ func feishuStartHandler(deps OAuthHandlerDeps) http.HandlerFunc {
 			MaxAge:   int(stateCookieTTL.Seconds()),
 		})
 		http.Redirect(w, r, deps.Feishu.AuthorizeURL(state), http.StatusFound)
+	}
+}
+
+// oidcStartHandler is GET /api/v1/auth/oidc/{providerID}/start. It mints
+// CSRF state plus an OIDC nonce, then redirects to the configured provider.
+//
+//	@Summary		Start generic OIDC login
+//	@Description	Mints CSRF and nonce cookies and redirects the browser to the configured OIDC provider authorize URL.
+//	@Tags			auth
+//	@ID				startOIDCOAuth
+//	@Produce		json
+//	@Param			providerID	path	string	true	"OIDC provider ID"
+//	@Success		302	"Redirect to OIDC authorize URL"
+//	@Failure		404	{object}	map[string]string	"OIDC provider is not configured"
+//	@Failure		500	{object}	map[string]string	"State minting or discovery failed"
+//	@Router			/api/v1/auth/oidc/{providerID}/start [get]
+func oidcStartHandler(deps OAuthHandlerDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		providerID := strings.TrimSpace(chi.URLParam(r, "providerID"))
+		client := deps.OIDC[providerID]
+		if client == nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "OIDC provider not configured"})
+			return
+		}
+		state, err := newOAuthState()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to mint CSRF state"})
+			return
+		}
+		nonce, err := newOAuthState()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to mint OIDC nonce"})
+			return
+		}
+		loginURL, err := client.AuthorizeURL(r.Context(), state, nonce)
+		if err != nil {
+			log.Bg().Warn("OIDC discovery failed", "provider", providerID, "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("OIDC discovery failed: %v", err)})
+			return
+		}
+		cookiePath := oidcCookiePath(providerID)
+		http.SetCookie(w, &http.Cookie{
+			Name:     CookieStateName,
+			Value:    state,
+			Path:     cookiePath,
+			HttpOnly: true,
+			Secure:   deps.CookieSecure,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   int(stateCookieTTL.Seconds()),
+		})
+		http.SetCookie(w, &http.Cookie{
+			Name:     CookieNonceName,
+			Value:    nonce,
+			Path:     cookiePath,
+			HttpOnly: true,
+			Secure:   deps.CookieSecure,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   int(stateCookieTTL.Seconds()),
+		})
+		http.Redirect(w, r, loginURL, http.StatusFound)
 	}
 }
 
@@ -153,8 +227,7 @@ func feishuCallbackHandler(deps OAuthHandlerDeps) http.HandlerFunc {
 			return
 		}
 
-		now := time.Now().UTC()
-		upsert, err := deps.Store.UpsertOAuthUser(r.Context(), store.UpsertOAuthUserInput{
+		loginProfile := oauthProfile{
 			Provider: "feishu",
 			Subject:  profile.UnionID,
 			Email:    profile.Email,
@@ -165,31 +238,133 @@ func feishuCallbackHandler(deps OAuthHandlerDeps) http.HandlerFunc {
 				"avatar_url": profile.AvatarURL,
 				"mock":       deps.Feishu.IsMock(),
 			},
-			Now: now,
-		})
-		if err != nil {
-			log.Bg().Error("feishu OIDC user upsert failed", "error", err, "email", profile.Email)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to persist user identity"})
-			return
 		}
-
-		sessionID, err := deps.Sessions.Create(r.Context(), auth.CreateSessionInput{
-			UserID:    upsert.UserID,
-			UserAgent: r.UserAgent(),
-			IP:        clientIP(r),
-		})
-		if err != nil {
-			log.Bg().Error("session create failed after OIDC upsert", "error", err, "user_id", upsert.UserID)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create session"})
-			return
-		}
-		auth.IssueCookie(w, sessionID, 0, deps.CookieSecure)
-		log.Bg().Info("feishu OIDC login success",
-			"user_id", upsert.UserID, "email", upsert.Email,
-			"created", upsert.Created, "mock", deps.Feishu.IsMock())
-
-		http.Redirect(w, r, deps.loginRedirectURL(), http.StatusFound)
+		completeOAuthLogin(w, r, deps, loginProfile)
 	}
+}
+
+// oidcCallbackHandler is GET /api/v1/auth/oidc/{providerID}/callback. It
+// verifies state and nonce, exchanges the code, upserts the identity, and
+// issues a Parsar session cookie.
+//
+//	@Summary		Handle generic OIDC callback
+//	@Description	Verifies CSRF state and OIDC nonce, exchanges the authorization code, upserts the user identity, creates a session cookie, and redirects to the login-success URL.
+//	@Tags			auth
+//	@ID				callbackOIDCOAuth
+//	@Produce		json
+//	@Param			providerID	path	string	true	"OIDC provider ID"
+//	@Param			state		query	string	true	"CSRF state minted at /start"
+//	@Param			code		query	string	true	"OAuth authorization code returned by the OIDC provider"
+//	@Success		302		"Redirect to login-success URL"
+//	@Failure		400		{object}	map[string]string	"Missing state/code or state/nonce mismatch"
+//	@Failure		404		{object}	map[string]string	"OIDC provider is not configured"
+//	@Failure		500		{object}	map[string]string	"User upsert or session creation failed"
+//	@Failure		502		{object}	map[string]string	"OIDC exchange failed"
+//	@Router			/api/v1/auth/oidc/{providerID}/callback [get]
+func oidcCallbackHandler(deps OAuthHandlerDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if deps.Sessions == nil || deps.Store == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+				"error": "OIDC login not configured (missing session store / user store dep)",
+			})
+			return
+		}
+		providerID := strings.TrimSpace(chi.URLParam(r, "providerID"))
+		client := deps.OIDC[providerID]
+		if client == nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "OIDC provider not configured"})
+			return
+		}
+		urlState := strings.TrimSpace(r.URL.Query().Get("state"))
+		code := strings.TrimSpace(r.URL.Query().Get("code"))
+		if urlState == "" || code == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing state or code"})
+			return
+		}
+		cookiePath := oidcCookiePath(providerID)
+		stateCookie, err := r.Cookie(CookieStateName)
+		if err != nil || stateCookie.Value != urlState {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "CSRF state mismatch — re-start the login flow"})
+			return
+		}
+		nonceCookie, err := r.Cookie(CookieNonceName)
+		if err != nil || strings.TrimSpace(nonceCookie.Value) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "OIDC nonce missing — re-start the login flow"})
+			return
+		}
+		clearOAuthCookie(w, CookieStateName, cookiePath, deps.CookieSecure)
+		clearOAuthCookie(w, CookieNonceName, cookiePath, deps.CookieSecure)
+
+		profile, err := client.ExchangeCode(r.Context(), code, nonceCookie.Value)
+		if err != nil {
+			log.Bg().Warn("OIDC exchange failed", "provider", providerID, "error", err)
+			writeJSON(w, http.StatusBadGateway, map[string]string{
+				"error": fmt.Sprintf("OIDC exchange failed: %v", err),
+			})
+			return
+		}
+		completeOAuthLogin(w, r, deps, oauthProfile{
+			Provider: profile.Provider,
+			Subject:  profile.Subject,
+			Email:    profile.Email,
+			Name:     profile.Name,
+			Metadata: map[string]any{
+				"issuer":      profile.Issuer,
+				"name":        profile.Name,
+				"avatar_url":  profile.AvatarURL,
+				"provider_id": profile.ProviderID,
+				"claims":      profile.Claims,
+				"userinfo":    profile.UserInfo,
+			},
+		})
+	}
+}
+
+func completeOAuthLogin(w http.ResponseWriter, r *http.Request, deps OAuthHandlerDeps, profile oauthProfile) {
+	now := time.Now().UTC()
+	upsert, err := deps.Store.UpsertOAuthUser(r.Context(), store.UpsertOAuthUserInput{
+		Provider: profile.Provider,
+		Subject:  profile.Subject,
+		Email:    profile.Email,
+		Name:     profile.Name,
+		Metadata: profile.Metadata,
+		Now:      now,
+	})
+	if err != nil {
+		log.Bg().Error("OAuth user upsert failed", "error", err, "provider", profile.Provider, "email", profile.Email)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to persist user identity"})
+		return
+	}
+	sessionID, err := deps.Sessions.Create(r.Context(), auth.CreateSessionInput{
+		UserID:    upsert.UserID,
+		UserAgent: r.UserAgent(),
+		IP:        clientIP(r),
+	})
+	if err != nil {
+		log.Bg().Error("session create failed after OAuth upsert", "error", err, "user_id", upsert.UserID)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create session"})
+		return
+	}
+	auth.IssueCookie(w, sessionID, 0, deps.CookieSecure)
+	log.Bg().Info("OAuth login success",
+		"provider", profile.Provider, "user_id", upsert.UserID, "email", upsert.Email, "created", upsert.Created)
+	http.Redirect(w, r, deps.loginRedirectURL(), http.StatusFound)
+}
+
+func clearOAuthCookie(w http.ResponseWriter, name, path string, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     path,
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+}
+
+func oidcCookiePath(providerID string) string {
+	return "/api/v1/auth/oidc/" + strings.TrimSpace(providerID)
 }
 
 // authLogoutHandler is POST /api/v1/auth/logout. Revokes the session and

--- a/server/internal/dev/oauth_handlers_test.go
+++ b/server/internal/dev/oauth_handlers_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/feishu"
+	authoidc "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/oidc"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 )
 
@@ -89,9 +90,35 @@ func buildOAuthRouter(t *testing.T, deps OAuthHandlerDeps) http.Handler {
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Get("/auth/feishu/start", feishuStartHandler(deps))
 		r.Get("/auth/feishu/callback", feishuCallbackHandler(deps))
+		r.Get("/auth/oidc/{providerID}/start", oidcStartHandler(deps))
+		r.Get("/auth/oidc/{providerID}/callback", oidcCallbackHandler(deps))
 		r.Post("/auth/logout", authLogoutHandler(deps))
 	})
 	return r
+}
+
+type stubOIDCClient struct {
+	authURL string
+	profile authoidc.UserProfile
+	seen    struct {
+		state string
+		nonce string
+		code  string
+	}
+}
+
+func (c *stubOIDCClient) ID() string          { return c.profile.ProviderID }
+func (c *stubOIDCClient) Label() string       { return "Stub OIDC" }
+func (c *stubOIDCClient) RedirectURI() string { return "/api/v1/auth/oidc/stub/callback" }
+func (c *stubOIDCClient) AuthorizeURL(_ context.Context, state, nonce string) (string, error) {
+	c.seen.state = state
+	c.seen.nonce = nonce
+	return c.authURL + "?state=" + state + "&nonce=" + nonce, nil
+}
+func (c *stubOIDCClient) ExchangeCode(_ context.Context, code, nonce string) (authoidc.UserProfile, error) {
+	c.seen.code = code
+	c.seen.nonce = nonce
+	return c.profile, nil
 }
 
 func TestFeishuStartRedirectsAndSetsStateCookie(t *testing.T) {
@@ -115,6 +142,36 @@ func TestFeishuStartRedirectsAndSetsStateCookie(t *testing.T) {
 	setCookie := rec.Header().Get("Set-Cookie")
 	if !strings.HasPrefix(setCookie, CookieStateName+"=") || !strings.Contains(setCookie, "HttpOnly") {
 		t.Fatalf("state cookie missing or unsafe: %q", setCookie)
+	}
+}
+
+func TestOIDCStartRedirectsAndSetsStateAndNonceCookies(t *testing.T) {
+	client := &stubOIDCClient{
+		authURL: "https://idp.example/authorize",
+		profile: authoidc.UserProfile{
+			ProviderID: "company",
+		},
+	}
+	r := buildOAuthRouter(t, OAuthHandlerDeps{
+		OIDC:     map[string]authoidc.Client{"company": client},
+		Sessions: newStubSessions(),
+		Store:    &stubOAuthStore{},
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/company/start", nil)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); !strings.HasPrefix(loc, "https://idp.example/authorize?") {
+		t.Fatalf("Location = %q, want OIDC authorize URL", loc)
+	}
+	cookies := rec.Header().Values("Set-Cookie")
+	if len(cookies) != 2 {
+		t.Fatalf("cookies = %v, want state and nonce cookies", cookies)
+	}
+	if client.seen.state == "" || client.seen.nonce == "" {
+		t.Fatalf("state/nonce not passed to client: %+v", client.seen)
 	}
 }
 
@@ -174,6 +231,66 @@ func TestFeishuCallbackHappyPath(t *testing.T) {
 	}
 	if st.lastIn.Provider != "feishu" || st.lastIn.Email != "admin@example.com" {
 		t.Fatalf("upsert input wrong: %+v", st.lastIn)
+	}
+}
+
+func TestOIDCCallbackHappyPath(t *testing.T) {
+	client := &stubOIDCClient{
+		authURL: "https://idp.example/authorize",
+		profile: authoidc.UserProfile{
+			Provider:   "oidc:company",
+			ProviderID: "company",
+			Subject:    "sub-123",
+			Email:      "admin@example.com",
+			Name:       "Admin User",
+			AvatarURL:  "https://idp.example/avatar.png",
+			Issuer:     "https://idp.example",
+			Claims: map[string]any{
+				"sub":            "sub-123",
+				"email":          "admin@example.com",
+				"email_verified": true,
+			},
+		},
+	}
+	sessions := newStubSessions()
+	st := &stubOAuthStore{userID: "00000000-0000-0000-0000-0000deadbeef"}
+	r := buildOAuthRouter(t, OAuthHandlerDeps{
+		OIDC:     map[string]authoidc.Client{"company": client},
+		Sessions: sessions,
+		Store:    st,
+	})
+
+	rec1 := httptest.NewRecorder()
+	r.ServeHTTP(rec1, httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/company/start", nil))
+	var state, nonce string
+	for _, rawCookie := range rec1.Header().Values("Set-Cookie") {
+		if strings.HasPrefix(rawCookie, CookieStateName+"=") {
+			state = strings.SplitN(strings.TrimPrefix(rawCookie, CookieStateName+"="), ";", 2)[0]
+		}
+		if strings.HasPrefix(rawCookie, CookieNonceName+"=") {
+			nonce = strings.SplitN(strings.TrimPrefix(rawCookie, CookieNonceName+"="), ";", 2)[0]
+		}
+	}
+	if state == "" || nonce == "" {
+		t.Fatalf("missing start cookies: %v", rec1.Header().Values("Set-Cookie"))
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/company/callback?code=oidc-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: CookieStateName, Value: state})
+	req.AddCookie(&http.Cookie{Name: CookieNonceName, Value: nonce})
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302 redirect to /", rec.Code)
+	}
+	if client.seen.code != "oidc-code" || client.seen.nonce != nonce {
+		t.Fatalf("exchange input = %+v, want code and nonce", client.seen)
+	}
+	if st.lastIn.Provider != "oidc:company" || st.lastIn.Subject != "sub-123" || st.lastIn.Email != "admin@example.com" {
+		t.Fatalf("upsert input wrong: %+v", st.lastIn)
+	}
+	if got := st.lastIn.Metadata["issuer"]; got != "https://idp.example" {
+		t.Fatalf("metadata issuer = %#v", got)
 	}
 }
 
@@ -300,5 +417,3 @@ func TestLogoutIdempotentWithoutCookie(t *testing.T) {
 		t.Fatalf("status = %d, want 204 (idempotent)", rec.Code)
 	}
 }
-
-

--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -542,6 +542,8 @@ func RegisterRoutesWithStore(r chi.Router, runtimeStore RuntimeStore, opts ...Ro
 				// session cookie; logout → revoke + clear cookie.
 				r.Get("/auth/feishu/start", feishuStartHandler(*cfg.oauthDeps))
 				r.Get("/auth/feishu/callback", feishuCallbackHandler(*cfg.oauthDeps))
+				r.Get("/auth/oidc/{providerID}/start", oidcStartHandler(*cfg.oauthDeps))
+				r.Get("/auth/oidc/{providerID}/callback", oidcCallbackHandler(*cfg.oauthDeps))
 				r.Post("/auth/logout", authLogoutHandler(*cfg.oauthDeps))
 			}
 			r.Get("/auth/providers", listAuthProviders(cfg.authProviders))


### PR DESCRIPTION
## Summary
- add env-driven multi-provider OIDC SSO support under `/api/v1/auth/oidc/{providerID}`
- register configured OIDC providers in existing auth provider discovery so the login page renders SSO buttons without frontend changes
- validate OIDC discovery, ID token signature, issuer/audience/expiration, nonce, verified email, allowed domains, and userinfo subject consistency
- document OIDC env configuration and regenerate OpenAPI

## Verification
- `go test ./server/internal/auth/... ./server/internal/dev ./server/cmd/server`
- `make openapi`
- `make check`
