### PR TITLE
feat: add bulk model import

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -14,6 +14,7 @@
     },
     "actions": {
       "addModel": "Add model",
+      "importModels": "Import models",
       "test": "Test",
       "edit": "Edit",
       "copy": "Duplicate",
@@ -122,6 +123,18 @@
         }
       },
       "submit": "Create model"
+    },
+    "bulkImport": {
+      "title": "Import models from /v1/models",
+      "description": "Discover model ids from the provider endpoint, select the ones to add, then import them into the shared catalog.",
+      "apiKeyHintInline": "Used to discover models and stored as one shared Secret for all imported models unless you reuse an existing Secret.",
+      "apiKeyHintPersonal": "Used only to discover models. Imported models will use the selected personal credential kind.",
+      "discover": "Discover models",
+      "search": "Search discovered models…",
+      "exists": "Already added",
+      "selectedCount": "{{count}} selected",
+      "importSelected": "Import selected",
+      "resultSummary": "{{created}} created, {{skipped}} skipped, {{failed}} failed"
     },
     "editModel": {
       "title": "Edit \"{{name}}\"",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -14,6 +14,7 @@
     },
     "actions": {
       "addModel": "新建模型",
+      "importModels": "导入模型",
       "test": "测试连接",
       "edit": "编辑",
       "copy": "复制为新模型",
@@ -122,6 +123,18 @@
         }
       },
       "submit": "创建模型"
+    },
+    "bulkImport": {
+      "title": "从 /v1/models 导入模型",
+      "description": "从供应商接口发现模型 id，选择要添加的模型后批量导入共享 catalog。",
+      "apiKeyHintInline": "用于发现模型；如果不复用已有 Secret，导入时会存成一条共享 Secret 并给所有导入模型共用。",
+      "apiKeyHintPersonal": "仅用于发现模型。导入后的模型会使用所选个人凭据类型。",
+      "discover": "发现模型",
+      "search": "搜索已发现模型…",
+      "exists": "已添加",
+      "selectedCount": "已选 {{count}} 个",
+      "importSelected": "导入所选",
+      "resultSummary": "已创建 {{created}} 个，已跳过 {{skipped}} 个，失败 {{failed}} 个"
     },
     "editModel": {
       "title": "编辑「{{name}}」",

--- a/apps/web/src/lib/api-models.ts
+++ b/apps/web/src/lib/api-models.ts
@@ -141,6 +141,25 @@ export interface InlineCreateModelInput {
   config?: Record<string, unknown>
 }
 
+function createModelBodyFromInput(
+  input: InlineCreateModelInput,
+  credential: { secretID?: string; credentialKindCode?: string },
+): CreateModelRequest {
+  return {
+    name: input.name,
+    provider_type: input.provider_type,
+    adapter: input.adapter,
+    base_url: input.base_url,
+    model_key: input.model_key,
+    credential_mode: input.credential_mode,
+    secret_id: credential.secretID,
+    credential_kind_code: credential.credentialKindCode,
+    capabilities: input.capabilities,
+    limits: input.limits,
+    config: input.config,
+  }
+}
+
 export function useCreateModel(workspaceID: string | null) {
   const qc = useQueryClient()
   return useMutation({
@@ -190,19 +209,7 @@ export function useCreateModel(workspaceID: string | null) {
         }
       }
 
-      const body: CreateModelRequest = {
-        name: input.name,
-        provider_type: input.provider_type,
-        adapter: input.adapter,
-        base_url: input.base_url,
-        model_key: input.model_key,
-        credential_mode: input.credential_mode,
-        secret_id: secretID,
-        credential_kind_code: credentialKindCode,
-        capabilities: input.capabilities,
-        limits: input.limits,
-        config: input.config,
-      }
+      const body = createModelBodyFromInput(input, { secretID, credentialKindCode })
 
       return apiRequest<Model>(
         `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/models`,
@@ -212,6 +219,65 @@ export function useCreateModel(workspaceID: string | null) {
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: KEY_MODELS(workspaceID ?? "_none") })
       void qc.invalidateQueries({ queryKey: KEY_SECRETS(workspaceID ?? "_none") })
+    },
+  })
+}
+
+export interface ImportProviderModelsInput {
+  provider_type: string
+  adapter: string
+  base_url: string
+  credential_mode: "inline_secret" | "credential_ref"
+  api_key?: string
+  secret_id?: string
+  credential_kind_code?: string
+  model_ids?: string[]
+  dry_run?: boolean
+  skip_existing?: boolean
+  capabilities?: Record<string, unknown>
+  limits?: Record<string, unknown>
+  config?: Record<string, unknown>
+}
+
+export interface ImportProviderModelPreview {
+  id: string
+  exists: boolean
+}
+
+export interface ImportProviderModelFailure {
+  model_key: string
+  error: string
+}
+
+export interface ImportProviderModelsResponse {
+  models: ImportProviderModelPreview[]
+  created: Model[]
+  skipped: string[]
+  failed: ImportProviderModelFailure[]
+}
+
+export function useImportProviderModels(workspaceID: string | null) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (input: ImportProviderModelsInput): Promise<ImportProviderModelsResponse> => {
+      if (!workspaceID) {
+        throw new ApiError({
+          status: 0,
+          code: "no_workspace",
+          message: "no workspace selected — pick a workspace first",
+          unreachable: false,
+        })
+      }
+      return apiRequest<ImportProviderModelsResponse>(
+        `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/models/import`,
+        { method: "POST", body: input },
+      )
+    },
+    onSuccess: (_data, variables) => {
+      if (!variables.dry_run) {
+        void qc.invalidateQueries({ queryKey: KEY_MODELS(workspaceID ?? "_none") })
+        void qc.invalidateQueries({ queryKey: KEY_SECRETS(workspaceID ?? "_none") })
+      }
     },
   })
 }

--- a/apps/web/src/lib/api-models.ts
+++ b/apps/web/src/lib/api-models.ts
@@ -242,6 +242,7 @@ export interface ImportProviderModelsInput {
 export interface ImportProviderModelPreview {
   id: string
   exists: boolean
+  supported_endpoint_types?: string[]
 }
 
 export interface ImportProviderModelFailure {
@@ -278,6 +279,45 @@ export function useImportProviderModels(workspaceID: string | null) {
         void qc.invalidateQueries({ queryKey: KEY_MODELS(workspaceID ?? "_none") })
         void qc.invalidateQueries({ queryKey: KEY_SECRETS(workspaceID ?? "_none") })
       }
+    },
+  })
+}
+
+export interface DetectModelEndpointsInput {
+  base_url: string
+  model_key: string
+  api_key?: string
+  secret_id?: string
+  credential_kind_code?: string
+  config?: Record<string, unknown>
+}
+
+export interface DetectModelEndpointsResponse {
+  supported_endpoint_types: string[]
+}
+
+async function detectModelEndpointsRequest(
+  workspaceID: string,
+  body: DetectModelEndpointsInput,
+): Promise<DetectModelEndpointsResponse> {
+  return apiRequest<DetectModelEndpointsResponse>(
+    `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/models/detect-endpoints`,
+    { method: "POST", body },
+  )
+}
+
+export function useDetectModelEndpoints(workspaceID: string | null) {
+  return useMutation({
+    mutationFn: async (input: DetectModelEndpointsInput): Promise<DetectModelEndpointsResponse> => {
+      if (!workspaceID) {
+        throw new ApiError({
+          status: 0,
+          code: "no_workspace",
+          message: "no workspace selected — pick a workspace first",
+          unreachable: false,
+        })
+      }
+      return detectModelEndpointsRequest(workspaceID, input)
     },
   })
 }

--- a/apps/web/src/lib/model-protocol.ts
+++ b/apps/web/src/lib/model-protocol.ts
@@ -1,13 +1,90 @@
 import type { Model } from "./api-types"
 
 export type WireProtocol = "anthropic" | "openai" | "google"
+export type SupportedEndpointType =
+  | "anthropic"
+  | "openai"
+  | "openai-response"
+  | "google_generative_ai"
+
+function normalizeEndpointType(raw: string): SupportedEndpointType | null {
+  const value = raw.trim().toLowerCase().replace(/[-./]/g, "_")
+  switch (value) {
+    case "message":
+    case "messages":
+    case "anthropic":
+    case "anthropic_message":
+    case "anthropic_messages":
+      return "anthropic"
+    case "openai":
+    case "chat":
+    case "chat_completion":
+    case "chat_completions":
+    case "openai_chat":
+    case "openai_chat_completions":
+      return "openai"
+    case "openai_response":
+    case "openai_responses":
+    case "response":
+    case "responses":
+      return "openai-response"
+    case "google":
+    case "gemini":
+    case "google_generative_ai":
+      return "google_generative_ai"
+    default:
+      return null
+  }
+}
+
+export function modelSupportedEndpointTypes(
+  model: Pick<Model, "config">,
+): SupportedEndpointType[] {
+  const raw = model.config?.supported_endpoint_types
+  if (!Array.isArray(raw)) return []
+  const out: SupportedEndpointType[] = []
+  const seen = new Set<SupportedEndpointType>()
+  for (const item of raw) {
+    if (typeof item !== "string") continue
+    const normalized = normalizeEndpointType(item)
+    if (!normalized || seen.has(normalized)) continue
+    seen.add(normalized)
+    out.push(normalized)
+  }
+  return out
+}
+
+export function modelProtocols(model: Pick<Model, "provider_type" | "adapter" | "config">): WireProtocol[] {
+  const endpointTypes = modelSupportedEndpointTypes(model)
+  const protocols: WireProtocol[] = []
+  const seen = new Set<WireProtocol>()
+  function add(protocol: WireProtocol) {
+    if (seen.has(protocol)) return
+    seen.add(protocol)
+    protocols.push(protocol)
+  }
+  for (const endpointType of endpointTypes) {
+    if (endpointType === "anthropic") add("anthropic")
+    else if (endpointType === "openai" || endpointType === "openai-response") add("openai")
+    else if (endpointType === "google_generative_ai") add("google")
+  }
+  if (protocols.length === 0) {
+    const legacy = legacyModelProtocol(model)
+    if (legacy) add(legacy)
+  }
+  return protocols
+}
 
 /** Classify a model's wire protocol from its provider_type / adapter.
  * Mirrors the allow-lists in
  * server/internal/connector/agentdaemon/model_injection.go
  * (isAnthropicRuntime / isOpenAICompatibleRuntime / piAPIProtocol) — keep the
  * case values in sync so the UI filter matches what the daemon will accept. */
-export function modelProtocol(m: Pick<Model, "provider_type" | "adapter">): WireProtocol | null {
+export function modelProtocol(m: Pick<Model, "provider_type" | "adapter" | "config">): WireProtocol | null {
+  return modelProtocols(m)[0] ?? null
+}
+
+function legacyModelProtocol(m: Pick<Model, "provider_type" | "adapter">): WireProtocol | null {
   for (const v of [m.provider_type, m.adapter]) {
     switch (v.trim().toLowerCase()) {
       case "anthropic":
@@ -48,4 +125,9 @@ export function protocolLabel(protocol: WireProtocol | null): string {
     default:
       return "—"
   }
+}
+
+export function protocolListLabel(protocols: WireProtocol[]): string {
+  if (protocols.length === 0) return "—"
+  return protocols.map((protocol) => protocolLabel(protocol)).join(" + ")
 }

--- a/apps/web/src/lib/model-provider-options.ts
+++ b/apps/web/src/lib/model-provider-options.ts
@@ -1,0 +1,122 @@
+import {
+  PROVIDER_CATALOG,
+  type ModelPreset,
+  type ProtocolPreset,
+  type ProviderPreset,
+} from "./model-presets"
+
+export interface ProviderTypeOption {
+  key: string
+  adapter: string
+  defaultBaseURL: string
+  customHeaders: boolean
+  authSchemeSelector: boolean
+  label?: string
+  labelKey?: string
+  models?: ModelPreset[]
+  protocols: ProtocolPreset[]
+}
+
+export const GATEWAY_PROVIDER_TYPES: ProviderTypeOption[] = [
+  {
+    key: "anthropic-compatible",
+    adapter: "@ai-sdk/anthropic",
+    defaultBaseURL: "",
+    customHeaders: true,
+    authSchemeSelector: true,
+    labelKey: "models.createProvider.providerTypeLabel.anthropicCompatible",
+    protocols: [{ id: "anthropic", adapter: "@ai-sdk/anthropic", baseURL: "" }],
+  },
+  {
+    key: "openai-compatible",
+    adapter: "@ai-sdk/openai-compatible",
+    defaultBaseURL: "",
+    customHeaders: true,
+    authSchemeSelector: false,
+    labelKey: "models.createProvider.providerTypeLabel.openaiCompatible",
+    protocols: [{ id: "openai", adapter: "@ai-sdk/openai-compatible", baseURL: "" }],
+  },
+]
+
+export function providerTypesFromCatalog(catalog: ProviderPreset[]): ProviderTypeOption[] {
+  return [
+    ...catalog.map((p) => ({
+      key: p.key,
+      adapter: p.adapter,
+      defaultBaseURL: p.defaultBaseURL,
+      customHeaders: p.customHeaders,
+      authSchemeSelector: p.authSchemeSelector,
+      label: p.name,
+      models: p.models,
+      protocols: p.protocols,
+    })),
+    ...GATEWAY_PROVIDER_TYPES,
+  ]
+}
+
+export const FALLBACK_PROVIDER_TYPES = providerTypesFromCatalog(PROVIDER_CATALOG)
+
+export function defaultModelFor(provider: ProviderTypeOption | undefined): ModelPreset | undefined {
+  return provider?.models?.[0]
+}
+
+export function resolveProtocol(
+  provider: ProviderTypeOption | undefined,
+  protocolID: string,
+): ProtocolPreset | undefined {
+  if (!provider) return undefined
+  return provider.protocols.find((p) => p.id === protocolID) ?? provider.protocols[0]
+}
+
+export function isKnownProviderURL(provider: ProviderTypeOption | undefined, url: string): boolean {
+  if (!provider) return false
+  return provider.protocols.some((p) => p.baseURL === url)
+}
+
+export function protocolIDForSeed(
+  provider: ProviderTypeOption | undefined,
+  seed: { base_url: string; adapter: string },
+): string {
+  const protocols = provider?.protocols ?? []
+  if (protocols.length === 0) return "openai"
+  const url = seed.base_url.trim()
+  const byURL = protocols.find((p) => p.baseURL === url)
+  if (byURL) return byURL.id
+  const byAdapter = protocols.find((p) => p.adapter === seed.adapter.trim())
+  if (byAdapter) return byAdapter.id
+  return protocols[0].id
+}
+
+export function protocolDisplayLabel(id: string): string {
+  switch (id) {
+    case "anthropic":
+      return "Anthropic"
+    case "openai":
+      return "OpenAI"
+    case "google":
+      return "Google"
+    default:
+      return id
+  }
+}
+
+export function findProviderModel(
+  provider: ProviderTypeOption | undefined,
+  modelKey: string,
+): ModelPreset | undefined {
+  const key = modelKey.trim()
+  if (!key) return undefined
+  return provider?.models?.find((model) => model.id === key)
+}
+
+export function shouldReplaceProviderModelKey(
+  modelKey: string,
+  provider: ProviderTypeOption | undefined,
+): boolean {
+  return modelKey.trim() === "" || !!findProviderModel(provider, modelKey)
+}
+
+export function shouldReplaceModelName(name: string, model: ModelPreset | undefined): boolean {
+  const current = name.trim()
+  return current === "" || (!!model && current === model.name)
+}

--- a/apps/web/src/lib/model-provider-options.ts
+++ b/apps/web/src/lib/model-provider-options.ts
@@ -100,6 +100,19 @@ export function protocolDisplayLabel(id: string): string {
   }
 }
 
+export function endpointTypeForProtocol(id: string): string | null {
+  switch (id) {
+    case "anthropic":
+      return "anthropic"
+    case "openai":
+      return "openai"
+    case "google":
+      return "google_generative_ai"
+    default:
+      return null
+  }
+}
+
 export function findProviderModel(
   provider: ProviderTypeOption | undefined,
   modelKey: string,

--- a/apps/web/src/pages/admin/BulkImportModelsDialog.tsx
+++ b/apps/web/src/pages/admin/BulkImportModelsDialog.tsx
@@ -23,9 +23,7 @@ import {
 import {
   FALLBACK_PROVIDER_TYPES,
   isKnownProviderURL,
-  protocolDisplayLabel,
   providerTypesFromCatalog,
-  resolveProtocol,
 } from "../../lib/model-provider-options"
 import { getProviderCatalogSnapshot, loadProviderCatalog } from "../../lib/model-presets"
 import { ProviderTypeCombobox } from "./ProviderTypeCombobox"
@@ -74,7 +72,6 @@ export function BulkImportModelsDialog({
   const defaultProviderType = providerTypes[0] ?? FALLBACK_PROVIDER_TYPES[0]
 
   const [providerType, setProviderType] = useState(defaultProviderType.key)
-  const [protocolID, setProtocolID] = useState(defaultProviderType.protocols[0].id)
   const [baseURL, setBaseURL] = useState(defaultProviderType.defaultBaseURL)
   const [credentialMode, setCredentialMode] = useState<ModelCredentialMode>("inline_secret")
   const [apiKey, setApiKey] = useState("")
@@ -102,7 +99,6 @@ export function BulkImportModelsDialog({
   useEffect(() => {
     if (open && !wasOpenRef.current) {
       setProviderType(defaultProviderType.key)
-      setProtocolID(defaultProviderType.protocols[0].id)
       setBaseURL(defaultProviderType.defaultBaseURL)
       setCredentialMode("inline_secret")
       setApiKey("")
@@ -119,9 +115,7 @@ export function BulkImportModelsDialog({
   }, [open, defaultProviderType, previewMut, importMut])
 
   const cfg = providerTypes.find((p) => p.key === providerType)
-  const activeProtocol = resolveProtocol(cfg, protocolID)
-  const adapter = activeProtocol?.adapter ?? cfg?.adapter ?? "@ai-sdk/openai-compatible"
-  const protocolChoices = cfg?.protocols ?? []
+  const adapter = cfg?.adapter ?? "@ai-sdk/openai-compatible"
   const activeSecrets = secrets.filter((s) => s.status === "active" && s.kind === "model_provider")
   const pending = previewMut.isPending || importMut.isPending
   const errMsg = errorMessage(previewMut.error) ?? errorMessage(importMut.error)
@@ -149,23 +143,9 @@ export function BulkImportModelsDialog({
     const nextCfg = providerTypes.find((p) => p.key === next)
     if (!nextCfg) return
     const previousCfg = providerTypes.find((p) => p.key === providerType)
-    const nextProtocol = nextCfg.protocols[0]
     setProviderType(next)
-    setProtocolID(nextProtocol.id)
     if (baseURL === "" || isKnownProviderURL(previousCfg, baseURL)) {
-      setBaseURL(nextProtocol.baseURL)
-    }
-    setPreviewModels([])
-    setSelected(new Set())
-    setImportResult(null)
-  }
-
-  function handleProtocolChange(nextID: string) {
-    const nextProtocol = resolveProtocol(cfg, nextID)
-    if (!nextProtocol) return
-    setProtocolID(nextProtocol.id)
-    if (baseURL === "" || isKnownProviderURL(cfg, baseURL)) {
-      setBaseURL(nextProtocol.baseURL)
+      setBaseURL(nextCfg.defaultBaseURL)
     }
     setPreviewModels([])
     setSelected(new Set())
@@ -262,36 +242,6 @@ export function BulkImportModelsDialog({
               />
             </div>
           </div>
-
-          {protocolChoices.length > 0 && (
-            <div className="grid gap-1.5">
-              <span className="text-sm font-medium text-fg-muted">
-                {t("models.createProvider.fields.protocol")}
-              </span>
-              {protocolChoices.length > 1 ? (
-                <div className="inline-flex w-fit gap-0.5 rounded-md border border-line bg-surface-subtle p-0.5">
-                  {protocolChoices.map((p) => (
-                    <button
-                      key={p.id}
-                      type="button"
-                      onClick={() => handleProtocolChange(p.id)}
-                      className={
-                        p.id === protocolID
-                          ? "rounded bg-surface px-2.5 py-1 text-xs font-medium text-fg shadow-sm"
-                          : "rounded px-2.5 py-1 text-xs font-medium text-fg-subtle transition-colors hover:text-fg"
-                      }
-                    >
-                      {protocolDisplayLabel(p.id)}
-                    </button>
-                  ))}
-                </div>
-              ) : (
-                <span className="w-fit rounded border border-line-muted px-2 py-0.5 text-xs text-fg-subtle">
-                  {protocolDisplayLabel(protocolChoices[0].id)}
-                </span>
-              )}
-            </div>
-          )}
 
           <fieldset className="rounded-md border border-line p-3">
             <legend className="px-1 text-sm font-medium text-fg-muted">
@@ -444,6 +394,18 @@ export function BulkImportModelsDialog({
                         <span className="block truncate font-mono text-xs text-fg-faint" title={model.id}>
                           {model.id}
                         </span>
+                        {model.supported_endpoint_types && model.supported_endpoint_types.length > 0 && (
+                          <span className="mt-1 flex flex-wrap gap-1">
+                            {model.supported_endpoint_types.map((endpointType) => (
+                              <span
+                                key={endpointType}
+                                className="rounded border border-line-muted px-1.5 py-0.5 font-mono text-xs text-fg-subtle"
+                              >
+                                {endpointType}
+                              </span>
+                            ))}
+                          </span>
+                        )}
                       </span>
                       {model.exists && (
                         <span className="shrink-0 rounded border border-line-muted px-1.5 py-0.5 text-xs text-fg-subtle">

--- a/apps/web/src/pages/admin/BulkImportModelsDialog.tsx
+++ b/apps/web/src/pages/admin/BulkImportModelsDialog.tsx
@@ -1,0 +1,500 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { CheckCircle2, Loader2, Search } from "lucide-react"
+
+import { Button } from "../../components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../components/ui/dialog"
+import { Input } from "../../components/ui/input"
+import { ApiError } from "../../lib/api-client"
+import type { ModelCredentialMode, Secret } from "../../lib/api-types"
+import {
+  useImportProviderModels,
+  type ImportProviderModelPreview,
+  type ImportProviderModelsInput,
+  type ImportProviderModelsResponse,
+} from "../../lib/api-models"
+import {
+  FALLBACK_PROVIDER_TYPES,
+  isKnownProviderURL,
+  protocolDisplayLabel,
+  providerTypesFromCatalog,
+  resolveProtocol,
+} from "../../lib/model-provider-options"
+import { getProviderCatalogSnapshot, loadProviderCatalog } from "../../lib/model-presets"
+import { ProviderTypeCombobox } from "./ProviderTypeCombobox"
+import { CredentialKindCombobox } from "./capabilities/CredentialKindCombobox"
+
+function errorMessage(err: unknown): string | null {
+  if (!err) return null
+  if (err instanceof ApiError) return err.envelope.message || err.message
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+function modelLabel(id: string): string {
+  return id
+    .split(/[-_:./]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+}
+
+function selectedCount(models: ImportProviderModelPreview[], selected: Set<string>): number {
+  let count = 0
+  for (const model of models) {
+    if (!model.exists && selected.has(model.id)) count += 1
+  }
+  return count
+}
+
+interface BulkImportModelsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  secrets: Secret[]
+  workspaceID: string | null
+}
+
+export function BulkImportModelsDialog({
+  open,
+  onOpenChange,
+  secrets,
+  workspaceID,
+}: BulkImportModelsDialogProps) {
+  const { t } = useTranslation("admin")
+  const { t: tc } = useTranslation("common")
+  const [providerCatalog, setProviderCatalog] = useState(getProviderCatalogSnapshot)
+  const providerTypes = useMemo(() => providerTypesFromCatalog(providerCatalog), [providerCatalog])
+  const defaultProviderType = providerTypes[0] ?? FALLBACK_PROVIDER_TYPES[0]
+
+  const [providerType, setProviderType] = useState(defaultProviderType.key)
+  const [protocolID, setProtocolID] = useState(defaultProviderType.protocols[0].id)
+  const [baseURL, setBaseURL] = useState(defaultProviderType.defaultBaseURL)
+  const [credentialMode, setCredentialMode] = useState<ModelCredentialMode>("inline_secret")
+  const [apiKey, setApiKey] = useState("")
+  const [existingSecretID, setExistingSecretID] = useState("")
+  const [credentialKindCode, setCredentialKindCode] = useState("")
+  const [search, setSearch] = useState("")
+  const [previewModels, setPreviewModels] = useState<ImportProviderModelPreview[]>([])
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [importResult, setImportResult] = useState<ImportProviderModelsResponse | null>(null)
+  const wasOpenRef = useRef(false)
+
+  const previewMut = useImportProviderModels(workspaceID)
+  const importMut = useImportProviderModels(workspaceID)
+
+  useEffect(() => {
+    let cancelled = false
+    loadProviderCatalog().then((catalog) => {
+      if (!cancelled) setProviderCatalog(catalog)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (open && !wasOpenRef.current) {
+      setProviderType(defaultProviderType.key)
+      setProtocolID(defaultProviderType.protocols[0].id)
+      setBaseURL(defaultProviderType.defaultBaseURL)
+      setCredentialMode("inline_secret")
+      setApiKey("")
+      setExistingSecretID("")
+      setCredentialKindCode("")
+      setSearch("")
+      setPreviewModels([])
+      setSelected(new Set())
+      setImportResult(null)
+      previewMut.reset()
+      importMut.reset()
+    }
+    wasOpenRef.current = open
+  }, [open, defaultProviderType, previewMut, importMut])
+
+  const cfg = providerTypes.find((p) => p.key === providerType)
+  const activeProtocol = resolveProtocol(cfg, protocolID)
+  const adapter = activeProtocol?.adapter ?? cfg?.adapter ?? "@ai-sdk/openai-compatible"
+  const protocolChoices = cfg?.protocols ?? []
+  const activeSecrets = secrets.filter((s) => s.status === "active" && s.kind === "model_provider")
+  const pending = previewMut.isPending || importMut.isPending
+  const errMsg = errorMessage(previewMut.error) ?? errorMessage(importMut.error)
+  const count = selectedCount(previewModels, selected)
+
+  const providerChoices = useMemo(
+    () =>
+      providerTypes.map((p) => ({
+        key: p.key,
+        label: p.label ?? (p.labelKey ? t(p.labelKey as never) : p.key),
+        adapter: p.adapter,
+        modelCount: p.models?.length ?? 0,
+        protocols: p.protocols.map((proto) => proto.id),
+      })),
+    [providerTypes, t],
+  )
+
+  const visibleModels = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return previewModels
+    return previewModels.filter((model) => model.id.toLowerCase().includes(q))
+  }, [previewModels, search])
+
+  function handleProviderTypeChange(next: string) {
+    const nextCfg = providerTypes.find((p) => p.key === next)
+    if (!nextCfg) return
+    const previousCfg = providerTypes.find((p) => p.key === providerType)
+    const nextProtocol = nextCfg.protocols[0]
+    setProviderType(next)
+    setProtocolID(nextProtocol.id)
+    if (baseURL === "" || isKnownProviderURL(previousCfg, baseURL)) {
+      setBaseURL(nextProtocol.baseURL)
+    }
+    setPreviewModels([])
+    setSelected(new Set())
+    setImportResult(null)
+  }
+
+  function handleProtocolChange(nextID: string) {
+    const nextProtocol = resolveProtocol(cfg, nextID)
+    if (!nextProtocol) return
+    setProtocolID(nextProtocol.id)
+    if (baseURL === "" || isKnownProviderURL(cfg, baseURL)) {
+      setBaseURL(nextProtocol.baseURL)
+    }
+    setPreviewModels([])
+    setSelected(new Set())
+    setImportResult(null)
+  }
+
+  function payload(dryRun: boolean): ImportProviderModelsInput {
+    const config: Record<string, unknown> = {}
+    if (cfg?.authSchemeSelector) {
+      config.auth_scheme = "api-key"
+    }
+    const body: ImportProviderModelsInput = {
+      provider_type: providerType,
+      adapter,
+      base_url: baseURL.trim(),
+      credential_mode: credentialMode,
+      dry_run: dryRun,
+      skip_existing: true,
+      config: Object.keys(config).length > 0 ? config : undefined,
+    }
+    if (apiKey.trim()) body.api_key = apiKey.trim()
+    if (credentialMode === "inline_secret") {
+      if (existingSecretID) body.secret_id = existingSecretID
+    } else {
+      body.credential_kind_code = credentialKindCode.trim()
+    }
+    if (!dryRun) {
+      body.model_ids = previewModels
+        .filter((model) => !model.exists && selected.has(model.id))
+        .map((model) => model.id)
+    }
+    return body
+  }
+
+  function discover() {
+    previewMut.mutate(payload(true), {
+      onSuccess: (data) => {
+        setPreviewModels(data.models ?? [])
+        setSelected(new Set((data.models ?? []).filter((m) => !m.exists).map((m) => m.id)))
+        setImportResult(null)
+      },
+    })
+  }
+
+  function importSelected() {
+    importMut.mutate(payload(false), {
+      onSuccess: (data) => {
+        setImportResult(data)
+        setPreviewModels(data.models ?? [])
+        setSelected(new Set())
+      },
+    })
+  }
+
+  const canDiscover = !!workspaceID && baseURL.trim() !== "" && providerType !== "" && adapter !== "" && !pending
+  const canImport =
+    count > 0 &&
+    !pending &&
+    (credentialMode === "credential_ref"
+      ? credentialKindCode.trim() !== ""
+      : apiKey.trim() !== "" || existingSecretID !== "")
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>{t("models.bulkImport.title")}</DialogTitle>
+          <DialogDescription>{t("models.bulkImport.description")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="grid gap-1.5 min-w-0">
+              <label className="text-sm font-medium text-fg-muted" htmlFor="bulk-model-provider">
+                {t("models.createProvider.fields.providerType")}
+              </label>
+              <ProviderTypeCombobox
+                id="bulk-model-provider"
+                value={providerType}
+                onChange={handleProviderTypeChange}
+                options={providerChoices}
+              />
+            </div>
+            <div className="grid gap-1.5 min-w-0">
+              <label className="text-sm font-medium text-fg-muted" htmlFor="bulk-model-base-url">
+                {t("models.createProvider.fields.baseURL")}
+              </label>
+              <Input
+                id="bulk-model-base-url"
+                value={baseURL}
+                onChange={(event) => setBaseURL(event.target.value)}
+                placeholder="https://api.example.com/v1"
+                className="font-mono text-sm"
+              />
+            </div>
+          </div>
+
+          {protocolChoices.length > 0 && (
+            <div className="grid gap-1.5">
+              <span className="text-sm font-medium text-fg-muted">
+                {t("models.createProvider.fields.protocol")}
+              </span>
+              {protocolChoices.length > 1 ? (
+                <div className="inline-flex w-fit gap-0.5 rounded-md border border-line bg-surface-subtle p-0.5">
+                  {protocolChoices.map((p) => (
+                    <button
+                      key={p.id}
+                      type="button"
+                      onClick={() => handleProtocolChange(p.id)}
+                      className={
+                        p.id === protocolID
+                          ? "rounded bg-surface px-2.5 py-1 text-xs font-medium text-fg shadow-sm"
+                          : "rounded px-2.5 py-1 text-xs font-medium text-fg-subtle transition-colors hover:text-fg"
+                      }
+                    >
+                      {protocolDisplayLabel(p.id)}
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <span className="w-fit rounded border border-line-muted px-2 py-0.5 text-xs text-fg-subtle">
+                  {protocolDisplayLabel(protocolChoices[0].id)}
+                </span>
+              )}
+            </div>
+          )}
+
+          <fieldset className="rounded-md border border-line p-3">
+            <legend className="px-1 text-sm font-medium text-fg-muted">
+              {t("models.createModel.fields.credentialMode")}
+            </legend>
+            <div className="mt-2 grid gap-2 sm:grid-cols-2">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="bulk-credential-mode"
+                  value="inline_secret"
+                  checked={credentialMode === "inline_secret"}
+                  onChange={() => setCredentialMode("inline_secret")}
+                />
+                <span className="font-medium text-fg-emphasis">
+                  {t("models.createModel.credentialMode.inlineSecret.title")}
+                </span>
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="bulk-credential-mode"
+                  value="credential_ref"
+                  checked={credentialMode === "credential_ref"}
+                  onChange={() => setCredentialMode("credential_ref")}
+                />
+                <span className="font-medium text-fg-emphasis">
+                  {t("models.createModel.credentialMode.credentialRef.title")}
+                </span>
+              </label>
+            </div>
+          </fieldset>
+
+          <div className="grid gap-3 rounded-md bg-surface-subtle/60 p-3">
+            <div className="grid gap-1.5">
+              <label className="text-sm font-medium text-fg-muted" htmlFor="bulk-model-api-key">
+                {t("models.createProvider.fields.apiKey")}
+              </label>
+              <Input
+                id="bulk-model-api-key"
+                type="password"
+                value={apiKey}
+                onChange={(event) => {
+                  setApiKey(event.target.value)
+                  if (event.target.value.trim() !== "") setExistingSecretID("")
+                }}
+                placeholder="sk-..."
+              />
+              <span className="text-xs text-fg-faint">
+                {credentialMode === "inline_secret"
+                  ? t("models.bulkImport.apiKeyHintInline")
+                  : t("models.bulkImport.apiKeyHintPersonal")}
+              </span>
+            </div>
+
+            {credentialMode === "inline_secret" && activeSecrets.length > 0 && (
+              <div className="grid gap-1.5">
+                <label className="text-sm font-medium text-fg-muted" htmlFor="bulk-model-secret">
+                  {t("models.createModel.credentialMode.inlineSecret.reuseSecret")}
+                </label>
+                <select
+                  id="bulk-model-secret"
+                  value={existingSecretID}
+                  onChange={(event) => {
+                    setExistingSecretID(event.target.value)
+                    if (event.target.value !== "") setApiKey("")
+                  }}
+                  className="flex h-9 w-full rounded-md border border-line bg-surface px-3 py-1.5 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong"
+                >
+                  <option value="">
+                    {t("models.createModel.credentialMode.inlineSecret.reuseNone")}
+                  </option>
+                  {activeSecrets.map((secret) => (
+                    <option key={secret.id} value={secret.id}>
+                      {secret.name} ({secret.masked})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+
+            {credentialMode === "credential_ref" && (
+              <div className="grid gap-1.5">
+                <label className="text-sm font-medium text-fg-muted" htmlFor="bulk-model-kind">
+                  {t("models.createModel.credentialMode.credentialRef.kindLabel")}
+                </label>
+                <CredentialKindCombobox
+                  workspaceID={workspaceID}
+                  value={credentialKindCode}
+                  onChange={setCredentialKindCode}
+                  className="w-full"
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between gap-3">
+            <Button type="button" variant="outline" size="sm" onClick={discover} disabled={!canDiscover}>
+              {previewMut.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Search className="h-3.5 w-3.5" />
+              )}
+              {t("models.bulkImport.discover")}
+            </Button>
+            {previewModels.length > 0 && (
+              <span className="text-xs text-fg-faint">
+                {t("models.bulkImport.selectedCount", { count })}
+              </span>
+            )}
+          </div>
+
+          {previewModels.length > 0 && (
+            <div className="rounded-md border border-line">
+              <div className="border-b border-line-muted p-2">
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-fg-faint" />
+                  <Input
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder={t("models.bulkImport.search")}
+                    className="pl-8"
+                  />
+                </div>
+              </div>
+              <div className="max-h-64 overflow-y-auto">
+                {visibleModels.map((model) => {
+                  const checked = selected.has(model.id)
+                  return (
+                    <label
+                      key={model.id}
+                      className="flex min-w-0 items-center gap-3 border-b border-line-muted px-3 py-2 last:border-b-0"
+                    >
+                      <input
+                        type="checkbox"
+                        className="h-3.5 w-3.5"
+                        disabled={model.exists}
+                        checked={!model.exists && checked}
+                        onChange={(event) => {
+                          const next = new Set(selected)
+                          if (event.target.checked) next.add(model.id)
+                          else next.delete(model.id)
+                          setSelected(next)
+                        }}
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium text-fg" title={model.id}>
+                          {modelLabel(model.id)}
+                        </span>
+                        <span className="block truncate font-mono text-xs text-fg-faint" title={model.id}>
+                          {model.id}
+                        </span>
+                      </span>
+                      {model.exists && (
+                        <span className="shrink-0 rounded border border-line-muted px-1.5 py-0.5 text-xs text-fg-subtle">
+                          {t("models.bulkImport.exists")}
+                        </span>
+                      )}
+                    </label>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          {importResult && (
+            <div className="flex items-start gap-2 rounded-md bg-success-subtle px-3 py-2 text-sm text-success-emphasis">
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>
+                {t("models.bulkImport.resultSummary", {
+                  created: importResult.created?.length ?? 0,
+                  skipped: importResult.skipped?.length ?? 0,
+                  failed: importResult.failed?.length ?? 0,
+                })}
+              </span>
+            </div>
+          )}
+          {importResult?.failed?.length ? (
+            <div className="max-h-28 overflow-y-auto rounded-md bg-danger-subtle px-3 py-2 text-xs text-danger-emphasis">
+              {importResult.failed.map((failure) => (
+                <div key={failure.model_key} className="break-all">
+                  {failure.model_key}: {failure.error}
+                </div>
+              ))}
+            </div>
+          ) : null}
+          {errMsg && (
+            <p className="rounded-md bg-danger-subtle px-3 py-2 text-sm text-danger-emphasis break-all">
+              {errMsg}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button type="button" variant="outline" size="sm" onClick={() => onOpenChange(false)} disabled={pending}>
+            {tc("actions.cancel")}
+          </Button>
+          <Button type="button" size="sm" onClick={importSelected} disabled={!canImport}>
+            {importMut.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {t("models.bulkImport.importSelected")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -17,7 +17,7 @@ import {
 import { Input } from "../../components/ui/input"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
-import { modelProtocol, protocolLabel, type WireProtocol } from "../../lib/model-protocol"
+import { modelProtocols, protocolListLabel, type WireProtocol } from "../../lib/model-protocol"
 import { useCapabilitiesQuery, aggregateRequiredCredentials, aggregateRequiredCredentialsByID, useCapabilityVersionsQuery, useAgentCapabilitiesQuery, useEnableAgentCapabilityMutation } from "../../lib/api-capabilities"
 import { CredentialCheckPanel } from "../../components/admin/CredentialCheckPanel"
 import { useSecrets } from "../../lib/api-secrets"
@@ -81,6 +81,10 @@ function engineSupportsProtocol(engine: AgentEngine, protocol: WireProtocol | nu
     case "opencode":
       return true
   }
+}
+
+function engineSupportsModel(engine: AgentEngine, model: Model): boolean {
+  return modelProtocols(model).some((protocol) => engineSupportsProtocol(engine, protocol))
 }
 
 function sandboxSizeFromAgent(a?: Agent | null): SandboxSize {
@@ -285,7 +289,7 @@ export function CreateAgentDialog({
   // fresh create (and any engine switch) never lands on a greyed-out model
   // that the daemon would reject at run time.
   const firstModelID =
-    activeModels.find((m) => engineSupportsProtocol(agentEngine, modelProtocol(m)))?.id ??
+    activeModels.find((m) => engineSupportsModel(agentEngine, m))?.id ??
     activeModels[0]?.id ??
     ""
   const selectedModelID = modelID || (mode === "create" ? firstModelID : "")
@@ -383,7 +387,7 @@ export function CreateAgentDialog({
   const incompatibleModelIDs = useMemo(() => {
     const out = new Set<string>()
     for (const m of activeModels) {
-      if (!engineSupportsProtocol(agentEngine, modelProtocol(m))) out.add(m.id)
+      if (!engineSupportsModel(agentEngine, m)) out.add(m.id)
     }
     return out
   }, [activeModels, agentEngine])
@@ -1201,7 +1205,7 @@ export function CreateAgentDialog({
                                     not) so the user can see each model's wire
                                     protocol at a glance. */}
                                 <span className="text-xs text-fg-faint">
-                                  {protocolLabel(modelProtocol(m))}
+                                  {protocolListLabel(modelProtocols(m))}
                                 </span>
                                 {selected && !incompatible && (
                                   <span className="inline-flex items-center gap-1 text-xs text-fg-subtle">

--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -11,9 +11,12 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ApiError } from "../../lib/api-client"
-import { cn } from "../../lib/utils"
 import type { Model, ModelCredentialMode, Secret } from "../../lib/api-types"
-import type { InlineCreateModelInput, InlineUpdateModelInput } from "../../lib/api-models"
+import {
+  useDetectModelEndpoints,
+  type InlineCreateModelInput,
+  type InlineUpdateModelInput,
+} from "../../lib/api-models"
 import { Button } from "../../components/ui/button"
 import {
   Dialog,
@@ -27,13 +30,19 @@ import { CredentialKindCombobox } from "./capabilities/CredentialKindCombobox"
 import { ModelKeyCombobox } from "./ModelKeyCombobox"
 import { ProviderTypeCombobox } from "./ProviderTypeCombobox"
 import {
-  PROVIDER_CATALOG,
   getProviderCatalogSnapshot,
   loadProviderCatalog,
-  type ModelPreset,
-  type ProviderPreset,
-  type ProtocolPreset,
 } from "../../lib/model-presets"
+import {
+  FALLBACK_PROVIDER_TYPES,
+  defaultModelFor,
+  endpointTypeForProtocol,
+  findProviderModel,
+  isKnownProviderURL,
+  providerTypesFromCatalog,
+  shouldReplaceModelName,
+  shouldReplaceProviderModelKey,
+} from "../../lib/model-provider-options"
 
 function extractErrorMessage(err: unknown): string | null {
   if (!err) return null
@@ -42,152 +51,6 @@ function extractErrorMessage(err: unknown): string | null {
   }
   if (err instanceof Error) return err.message
   return String(err)
-}
-
-/* --- Provider type catalog ----------------------------------------------
- *
- * `adapter` is the npm package opencode loads at runtime (rendered into
- * opencode.json `npm: "<adapter>"`). Short names ("openai") make
- * opencode look for the wrong package and ProviderInitError.
- *
- * `@ai-sdk/openai` targets `/v1/responses`, which third-party
- * OpenAI-compatible gateways (vLLM, Ollama, DeepSeek, internal gateways)
- * typically don't implement — they only expose `/v1/chat/completions`.
- * Use `@ai-sdk/openai-compatible` for those.
- *
- * Branded providers come from lib/model-presets.ts, backed by a small
- * whitelisted JSON catalog. The two generic "custom gateway" entries are kept
- * as fallbacks for endpoints not in the catalog (internal gateways,
- * self-hosted).
- */
-interface ProviderTypeOption {
-  key: string
-  adapter: string
-  defaultBaseURL: string
-  customHeaders: boolean
-  authSchemeSelector: boolean
-  /** Literal brand name (catalog) — takes precedence over labelKey. */
-  label?: string
-  /** i18n key for the generic gateway entries. */
-  labelKey?: string
-  /** Model id suggestions for the model_key datalist (catalog only). */
-  models?: ModelPreset[]
-  /** Wire protocols this provider serves. Length > 1 shows the protocol
-   * toggle; each entry supplies its own adapter + base URL. */
-  protocols: ProtocolPreset[]
-}
-
-const GATEWAY_PROVIDER_TYPES: ProviderTypeOption[] = [
-  {
-    key: "anthropic-compatible",
-    adapter: "@ai-sdk/anthropic",
-    defaultBaseURL: "",
-    customHeaders: true,
-    authSchemeSelector: true,
-    labelKey: "models.createProvider.providerTypeLabel.anthropicCompatible",
-    protocols: [{ id: "anthropic", adapter: "@ai-sdk/anthropic", baseURL: "" }],
-  },
-  {
-    key: "openai-compatible",
-    adapter: "@ai-sdk/openai-compatible",
-    defaultBaseURL: "",
-    customHeaders: true,
-    authSchemeSelector: false,
-    labelKey: "models.createProvider.providerTypeLabel.openaiCompatible",
-    protocols: [{ id: "openai", adapter: "@ai-sdk/openai-compatible", baseURL: "" }],
-  },
-]
-
-function providerTypesFromCatalog(catalog: ProviderPreset[]): ProviderTypeOption[] {
-  return [
-    ...catalog.map((p) => ({
-      key: p.key,
-      adapter: p.adapter,
-      defaultBaseURL: p.defaultBaseURL,
-      customHeaders: p.customHeaders,
-      authSchemeSelector: p.authSchemeSelector,
-      label: p.name,
-      models: p.models,
-      protocols: p.protocols,
-    })),
-    ...GATEWAY_PROVIDER_TYPES,
-  ]
-}
-
-const FALLBACK_PROVIDER_TYPES = providerTypesFromCatalog(PROVIDER_CATALOG)
-
-function defaultModelFor(provider: ProviderTypeOption | undefined): ModelPreset | undefined {
-  return provider?.models?.[0]
-}
-
-/** Resolve the active protocol entry for a provider, falling back to the
- * first protocol when the id is unknown (e.g. after switching providers). */
-function resolveProtocol(
-  provider: ProviderTypeOption | undefined,
-  protocolID: string,
-): ProtocolPreset | undefined {
-  if (!provider) return undefined
-  return provider.protocols.find((p) => p.id === protocolID) ?? provider.protocols[0]
-}
-
-/** True when `url` is one of the provider's known protocol base URLs — i.e.
- * catalog-managed, not a custom endpoint the user hand-typed. Used to decide
- * whether switching provider / protocol may overwrite the base URL. */
-function isKnownProviderURL(provider: ProviderTypeOption | undefined, url: string): boolean {
-  if (!provider) return false
-  return provider.protocols.some((p) => p.baseURL === url)
-}
-
-/** Recover the protocol a duplicated model used, by matching its base URL
- * (then adapter) against the provider's protocols. Falls back to the default
- * protocol so a custom endpoint still lands somewhere sensible. */
-function protocolIDForSeed(
-  provider: ProviderTypeOption | undefined,
-  seed: { base_url: string; adapter: string },
-): string {
-  const protocols = provider?.protocols ?? []
-  if (protocols.length === 0) return "openai"
-  const url = seed.base_url.trim()
-  const byURL = protocols.find((p) => p.baseURL === url)
-  if (byURL) return byURL.id
-  const byAdapter = protocols.find((p) => p.adapter === seed.adapter.trim())
-  if (byAdapter) return byAdapter.id
-  return protocols[0].id
-}
-
-/** Human label for a protocol toggle button. */
-function protocolLabel(id: string): string {
-  switch (id) {
-    case "anthropic":
-      return "Anthropic"
-    case "openai":
-      return "OpenAI"
-    case "google":
-      return "Google"
-    default:
-      return id
-  }
-}
-
-function findProviderModel(
-  provider: ProviderTypeOption | undefined,
-  modelKey: string,
-): ModelPreset | undefined {
-  const key = modelKey.trim()
-  if (!key) return undefined
-  return provider?.models?.find((model) => model.id === key)
-}
-
-function shouldReplaceProviderModelKey(
-  modelKey: string,
-  provider: ProviderTypeOption | undefined,
-): boolean {
-  return modelKey.trim() === "" || !!findProviderModel(provider, modelKey)
-}
-
-function shouldReplaceModelName(name: string, model: ModelPreset | undefined): boolean {
-  const current = name.trim()
-  return current === "" || (!!model && current === model.name)
 }
 
 /* --- HeadersEditor ------------------------------------------------------
@@ -387,7 +250,6 @@ export function CreateModelDialog({
 
   const [name, setName] = useState(() => defaultModel?.name ?? "")
   const [providerType, setProviderType] = useState<string>(() => defaultProviderType.key)
-  const [protocolID, setProtocolID] = useState<string>(() => defaultProviderType.protocols[0].id)
   const [baseURL, setBaseURL] = useState<string>(() => defaultProviderType.defaultBaseURL)
   const [modelKey, setModelKey] = useState(() => defaultModel?.id ?? "")
   const [credentialMode, setCredentialMode] = useState<ModelCredentialMode>("inline_secret")
@@ -404,6 +266,7 @@ export function CreateModelDialog({
   // when the dialog opens fresh ("+ New model" path) so a vanilla create
   // doesn't inherit anything.
   const [baseConfig, setBaseConfig] = useState<Record<string, unknown>>({})
+  const detectEndpointsMut = useDetectModelEndpoints(workspaceID)
 
   const wasOpenRef = useRef(false)
   useEffect(() => {
@@ -417,10 +280,6 @@ export function CreateModelDialog({
         const providerCfg = providerTypes.find((p) => p.key === seed.provider_type)
         setName(seed.name)
         setProviderType(seed.provider_type)
-        // Recover which protocol the duplicated model used by matching its
-        // base URL / adapter against the provider's protocols; fall back to
-        // the default protocol when nothing matches (custom endpoint).
-        setProtocolID(protocolIDForSeed(providerCfg, seed))
         setBaseURL(seed.base_url)
         setModelKey(seed.model_key)
         setCredentialMode(seed.credential_mode)
@@ -453,7 +312,6 @@ export function CreateModelDialog({
         const nextDefaultModel = defaultModelFor(defaultProviderType)
         setName(nextDefaultModel?.name ?? "")
         setProviderType(defaultProviderType.key)
-        setProtocolID(defaultProviderType.protocols[0].id)
         setBaseURL(defaultProviderType.defaultBaseURL)
         setModelKey(nextDefaultModel?.id ?? "")
         setCredentialMode("inline_secret")
@@ -475,16 +333,11 @@ export function CreateModelDialog({
     const previousCfg = providerTypes.find((p) => p.key === providerType)
     const previousModel = findProviderModel(previousCfg, modelKey)
     const nextDefaultModel = defaultModelFor(cfg)
-    // Switching provider resets to that provider's default (first) protocol.
-    const nextProtocol = cfg.protocols[0]
-    setProtocolID(nextProtocol.id)
     // Overwrite the base URL unless the user hand-typed a custom endpoint —
     // i.e. the current value still matches ANY of the previous provider's
-    // protocol URLs (default or the one they toggled to), not just its
-    // default. Checking only the default stranded the URL after a protocol
-    // switch.
+    // known protocol URLs.
     if (baseURL === "" || isKnownProviderURL(previousCfg, baseURL)) {
-      setBaseURL(nextProtocol.baseURL)
+      setBaseURL(cfg.defaultBaseURL)
     }
     if (shouldReplaceProviderModelKey(modelKey, previousCfg)) {
       setModelKey(nextDefaultModel?.id ?? "")
@@ -495,27 +348,9 @@ export function CreateModelDialog({
     setProviderType(next)
   }
 
-  // Switching protocol swaps the endpoint + adapter. Only overwrite the base
-  // URL when the user hasn't hand-edited it (still equals a known protocol
-  // URL for this provider), mirroring handleProviderTypeChange's guard.
-  function handleProtocolChange(nextID: string) {
-    const currentCfg = providerTypes.find((p) => p.key === providerType)
-    const nextProtocol = resolveProtocol(currentCfg, nextID)
-    if (!nextProtocol) return
-    if (baseURL === "" || isKnownProviderURL(currentCfg, baseURL)) {
-      setBaseURL(nextProtocol.baseURL)
-    }
-    setProtocolID(nextProtocol.id)
-  }
-
   const cfg = providerTypes.find((p) => p.key === providerType)
-  const activeProtocol = resolveProtocol(cfg, protocolID)
-  const adapter = activeProtocol?.adapter ?? cfg?.adapter ?? "@ai-sdk/openai-compatible"
-  // Only surface the protocol toggle when the provider actually serves more
-  // than one wire protocol (MiniMax, GLM, DeepSeek, …). Single-protocol
-  // providers and the generic gateways render no toggle.
+  const adapter = cfg?.adapter ?? "@ai-sdk/openai-compatible"
   const protocolChoices = cfg?.protocols ?? []
-  const showProtocolToggle = protocolChoices.length > 1
   const showHeadersEditor = !!cfg?.customHeaders
   const showAuthSchemeSelector = !!cfg?.authSchemeSelector
   const providerModels = cfg?.models ?? []
@@ -575,9 +410,43 @@ export function CreateModelDialog({
     modelKey.trim() !== "" &&
     inlineSecretBranchValid &&
     credentialRefBranchValid &&
-    !pending
+    !pending &&
+    !detectEndpointsMut.isPending
 
-  function handleSubmit(e: React.FormEvent) {
+  function fallbackEndpointTypes(): string[] {
+    const out: string[] = []
+    const seen = new Set<string>()
+    for (const protocol of protocolChoices) {
+      const endpointType = endpointTypeForProtocol(protocol.id)
+      if (!endpointType || seen.has(endpointType)) continue
+      seen.add(endpointType)
+      out.push(endpointType)
+    }
+    return out
+  }
+
+  async function detectedEndpointTypes(config: Record<string, unknown>): Promise<string[]> {
+    if (credentialMode !== "inline_secret") return fallbackEndpointTypes()
+    const secretID = existingSecretID || undefined
+    const key = apiKey.trim()
+    if (!secretID && !key) return fallbackEndpointTypes()
+    try {
+      const result = await detectEndpointsMut.mutateAsync({
+        base_url: baseURL.trim(),
+        model_key: modelKey.trim(),
+        api_key: key || undefined,
+        secret_id: secretID,
+        config,
+      })
+      return result.supported_endpoint_types.length > 0
+        ? result.supported_endpoint_types
+        : fallbackEndpointTypes()
+    } catch {
+      return fallbackEndpointTypes()
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     // Start from baseConfig so duplicate-flow values (capabilities,
     // limits, modalities, …) survive the round-trip. For a vanilla
@@ -596,6 +465,7 @@ export function CreateModelDialog({
     if (showAuthSchemeSelector) {
       config.auth_scheme = authScheme
     }
+    config.supported_endpoint_types = await detectedEndpointTypes(config)
 
     const payload: InlineCreateModelInput = {
       name: name.trim(),
@@ -651,42 +521,6 @@ export function CreateModelDialog({
           </div>
 
           {/* --- Protocol row ---
-              The active protocol drives base URL + adapter, which in turn
-              decides which agent engine (claude_code=Anthropic,
-              codex=OpenAI) the model can attach to. Dual-protocol providers
-              get a clickable toggle; single-protocol ones show a read-only
-              label so "one protocol" is explicit, not a blank gap. */}
-          {protocolChoices.length > 0 && (
-            <div className="grid gap-1.5">
-              <span className="text-sm font-medium text-fg-muted">
-                {t("models.createProvider.fields.protocol", "API protocol")}
-              </span>
-              {showProtocolToggle ? (
-                <div className="inline-flex w-fit gap-0.5 rounded-md border border-line bg-surface-subtle p-0.5">
-                  {protocolChoices.map((p) => (
-                    <button
-                      key={p.id}
-                      type="button"
-                      onClick={() => handleProtocolChange(p.id)}
-                      className={cn(
-                        "rounded px-2.5 py-1 text-xs font-medium transition-colors",
-                        p.id === protocolID
-                          ? "bg-surface text-fg shadow-sm"
-                          : "text-fg-subtle hover:text-fg",
-                      )}
-                    >
-                      {protocolLabel(p.id)}
-                    </button>
-                  ))}
-                </div>
-              ) : (
-                <span className="w-fit rounded border border-line-muted px-2 py-0.5 text-xs text-fg-subtle">
-                  {protocolLabel(protocolChoices[0].id)}
-                </span>
-              )}
-            </div>
-          )}
-
           <Field
             id="model-base-url"
             label={t("models.createProvider.fields.baseURL")}
@@ -877,12 +711,12 @@ export function CreateModelDialog({
               variant="outline"
               size="sm"
               onClick={() => onOpenChange(false)}
-              disabled={pending}
+              disabled={pending || detectEndpointsMut.isPending}
             >
               {tc("actions.cancel")}
             </Button>
             <Button type="submit" size="sm" disabled={!canSubmit}>
-              {pending ? tc("states.loading") : t("models.createModel.submit")}
+              {pending || detectEndpointsMut.isPending ? tc("states.loading") : t("models.createModel.submit")}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/web/src/pages/admin/ModelsPage.tsx
+++ b/apps/web/src/pages/admin/ModelsPage.tsx
@@ -12,6 +12,7 @@ import {
   Copy,
   Cpu,
   Database,
+  Download,
   Globe,
   KeyRound,
   Loader2,
@@ -67,6 +68,7 @@ import type {
   ModelConnectivityResult,
 } from "../../lib/api-models"
 import { CreateModelDialog, EditModelDialog } from "./ModelCrudDialogs"
+import { BulkImportModelsDialog } from "./BulkImportModelsDialog"
 import type { Model } from "../../lib/api-types"
 import { useWorkspaceId } from "../../lib/workspace"
 import { useSecrets } from "../../lib/api-secrets"
@@ -486,6 +488,7 @@ export function ModelsPage() {
   const testMut = useTestModel(wsId)
 
   const [createOpen, setCreateOpen] = useState(false)
+  const [bulkImportOpen, setBulkImportOpen] = useState(false)
   // Pre-filled values from "duplicate"; null = empty Create dialog.
   const [duplicateInitial, setDuplicateInitial] =
     useState<InlineCreateModelInput | null>(null)
@@ -614,9 +617,14 @@ export function ModelsPage() {
           title={t("models.empty.title")}
           description={t("models.empty.description")}
           action={
-            <Button size="sm" shape="pill" onClick={() => setCreateOpen(true)}>
-              <Plus className="h-3.5 w-3.5" /> {t("models.actions.addModel")}
-            </Button>
+            <div className="flex items-center justify-center gap-2">
+              <Button size="sm" shape="pill" onClick={() => setCreateOpen(true)}>
+                <Plus className="h-3.5 w-3.5" /> {t("models.actions.addModel")}
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => setBulkImportOpen(true)}>
+                <Download className="h-3.5 w-3.5" /> {t("models.actions.importModels")}
+              </Button>
+            </div>
           }
         />
       ) : (
@@ -657,6 +665,15 @@ export function ModelsPage() {
                   <RefreshCw className="h-3.5 w-3.5" />
                 )}
                 {tc("actions.refresh")}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setBulkImportOpen(true)}
+                disabled={!wsId}
+              >
+                <Download className="h-3.5 w-3.5" />
+                {t("models.actions.importModels")}
               </Button>
               <Button
                 size="sm"
@@ -706,6 +723,13 @@ export function ModelsPage() {
             },
           })
         }}
+      />
+
+      <BulkImportModelsDialog
+        open={bulkImportOpen}
+        secrets={secrets}
+        workspaceID={wsId}
+        onOpenChange={setBulkImportOpen}
       />
 
       <EditModelDialog

--- a/apps/web/src/pages/admin/ModelsPage.tsx
+++ b/apps/web/src/pages/admin/ModelsPage.tsx
@@ -55,7 +55,7 @@ import {
   TabsTrigger,
 } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
-import { modelProtocol, protocolLabel } from "../../lib/model-protocol"
+import { modelProtocols, protocolListLabel } from "../../lib/model-protocol"
 import {
   useCreateModel,
   useDisableModel,
@@ -158,10 +158,9 @@ function ProviderCompatibilityCell({ type }: { type: string }) {
 
 function ModelProtocolCell({ model }: { model: Model }) {
   const { t } = useTranslation("admin")
-  const protocol = modelProtocol(model)
   return (
     <Badge variant="neutral" title={t("models.createProvider.fields.protocol")}>
-      {protocolLabel(protocol)}
+      {protocolListLabel(modelProtocols(model))}
     </Badge>
   )
 }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -424,6 +424,13 @@ definitions:
       plaintext_value:
         type: string
     type: object
+  dev.discoveredProviderModel:
+    properties:
+      exists:
+        type: boolean
+      id:
+        type: string
+    type: object
   dev.gatewayActor:
     properties:
       email:
@@ -489,6 +496,66 @@ definitions:
         additionalProperties:
           type: string
         type: object
+    type: object
+  dev.importProviderModelFailure:
+    properties:
+      error:
+        type: string
+      model_key:
+        type: string
+    type: object
+  dev.importProviderModelsBody:
+    properties:
+      adapter:
+        type: string
+      api_key:
+        type: string
+      base_url:
+        type: string
+      capabilities:
+        additionalProperties: {}
+        type: object
+      config:
+        additionalProperties: {}
+        type: object
+      credential_kind_code:
+        type: string
+      credential_mode:
+        type: string
+      dry_run:
+        type: boolean
+      limits:
+        additionalProperties: {}
+        type: object
+      model_ids:
+        items:
+          type: string
+        type: array
+      provider_type:
+        type: string
+      secret_id:
+        type: string
+      skip_existing:
+        type: boolean
+    type: object
+  dev.importProviderModelsResponse:
+    properties:
+      created:
+        items:
+          $ref: '#/definitions/store.ModelRead'
+        type: array
+      failed:
+        items:
+          $ref: '#/definitions/dev.importProviderModelFailure'
+        type: array
+      models:
+        items:
+          $ref: '#/definitions/dev.discoveredProviderModel'
+        type: array
+      skipped:
+        items:
+          type: string
+        type: array
     type: object
   dev.listCredentialKindsResponse:
     properties:
@@ -1343,6 +1410,40 @@ definitions:
           Size is the byte count before base64 expansion. Cached so
           observability surfaces don't have to decode.
         type: integer
+    type: object
+  store.ModelRead:
+    properties:
+      adapter:
+        type: string
+      base_url:
+        type: string
+      config:
+        additionalProperties: {}
+        type: object
+      created_at:
+        type: string
+      created_by:
+        type: string
+      credential_kind_code:
+        type: string
+      credential_mode:
+        type: string
+      id:
+        type: string
+      model_key:
+        type: string
+      name:
+        type: string
+      provider_type:
+        type: string
+      secret_id:
+        type: string
+      slug:
+        type: string
+      status:
+        type: string
+      updated_at:
+        type: string
     type: object
   store.RequiredCredential:
     properties:
@@ -6843,6 +6944,47 @@ paths:
               type: string
             type: object
       summary: Test a model's connectivity
+      tags:
+      - models
+  /api/v1/workspaces/{workspaceID}/models/import:
+    post:
+      consumes:
+      - application/json
+      description: Fetches model ids from base_url + /v1/models and batch-creates
+        model rows using the existing model catalog schema. Owner/admin only.
+      operationId: importDevProviderModels
+      parameters:
+      - description: Workspace UUID
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: Model import payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dev.importProviderModelsBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Import preview or result
+          schema:
+            $ref: '#/definitions/dev.importProviderModelsResponse'
+        "400":
+          description: Invalid body, UUID, provider response, or credentials
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Caller is not workspace owner/admin
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Import models from provider /models
       tags:
       - models
   /api/v1/workspaces/{workspaceID}/runtime/credential:

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -424,12 +424,39 @@ definitions:
       plaintext_value:
         type: string
     type: object
+  dev.detectProviderModelEndpointsBody:
+    properties:
+      api_key:
+        type: string
+      base_url:
+        type: string
+      config:
+        additionalProperties: {}
+        type: object
+      credential_kind_code:
+        type: string
+      model_key:
+        type: string
+      secret_id:
+        type: string
+    type: object
+  dev.detectProviderModelEndpointsResponse:
+    properties:
+      supported_endpoint_types:
+        items:
+          type: string
+        type: array
+    type: object
   dev.discoveredProviderModel:
     properties:
       exists:
         type: boolean
       id:
         type: string
+      supported_endpoint_types:
+        items:
+          type: string
+        type: array
     type: object
   dev.gatewayActor:
     properties:
@@ -6944,6 +6971,47 @@ paths:
               type: string
             type: object
       summary: Test a model's connectivity
+      tags:
+      - models
+  /api/v1/workspaces/{workspaceID}/models/detect-endpoints:
+    post:
+      consumes:
+      - application/json
+      description: Probes common OpenAI/Anthropic endpoint families for a base URL
+        and model key. Owner/admin only.
+      operationId: detectDevModelEndpoints
+      parameters:
+      - description: Workspace UUID
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: Endpoint detection payload
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dev.detectProviderModelEndpointsBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Detected endpoint families
+          schema:
+            $ref: '#/definitions/dev.detectProviderModelEndpointsResponse'
+        "400":
+          description: Invalid body, UUID, or credentials
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Caller is not workspace owner/admin
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Detect supported model endpoint types
       tags:
       - models
   /api/v1/workspaces/{workspaceID}/models/import:

--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -440,6 +440,9 @@ func flattenStringMap(providerConfig map[string]any, key string) map[string]stri
 // hosts as a first-class provider — we route that through the same
 // codex_provider TOML block but a future change might split it out.
 func isOpenAICompatibleRuntime(mr store.ModelRuntime) bool {
+	if modelConfigSupportsEndpointType(mr.ProviderConfig, "openai") || modelConfigSupportsEndpointType(mr.ProviderConfig, "openai-response") {
+		return true
+	}
 	for _, v := range []string{mr.ProviderType, mr.Adapter} {
 		switch strings.ToLower(strings.TrimSpace(v)) {
 		case "openai", "openai-compatible", "openai_compatible",
@@ -540,6 +543,15 @@ func injectPiManagedModel(opts map[string]any, modelID string, mr store.ModelRun
 // `api` wire protocol the materialised provider speaks. Empty string means
 // unsupported (rejected upstream as ErrManagedModelUnsupported).
 func piAPIProtocol(mr store.ModelRuntime) string {
+	if modelConfigSupportsEndpointType(mr.ProviderConfig, "anthropic") {
+		return "anthropic-messages"
+	}
+	if modelConfigSupportsEndpointType(mr.ProviderConfig, "openai") || modelConfigSupportsEndpointType(mr.ProviderConfig, "openai-response") {
+		return "openai-completions"
+	}
+	if modelConfigSupportsEndpointType(mr.ProviderConfig, "google_generative_ai") {
+		return "google-generative-ai"
+	}
 	for _, v := range []string{mr.ProviderType, mr.Adapter} {
 		switch strings.ToLower(strings.TrimSpace(v)) {
 		case "anthropic", "anthropic-compatible", "anthropic_compatible", "@ai-sdk/anthropic":
@@ -659,6 +671,9 @@ func resolveModelID(in connector.PromptInput) string {
 }
 
 func isAnthropicRuntime(mr store.ModelRuntime) bool {
+	if modelConfigSupportsEndpointType(mr.ProviderConfig, "anthropic") {
+		return true
+	}
 	for _, v := range []string{mr.ProviderType, mr.Adapter} {
 		n := strings.ToLower(strings.TrimSpace(v))
 		switch n {
@@ -667,6 +682,36 @@ func isAnthropicRuntime(mr store.ModelRuntime) bool {
 		}
 	}
 	return false
+}
+
+func modelConfigSupportsEndpointType(config map[string]any, endpointType string) bool {
+	want := normalizeModelEndpointType(endpointType)
+	values, _ := config["supported_endpoint_types"].([]any)
+	for _, value := range values {
+		if s, ok := value.(string); ok && normalizeModelEndpointType(s) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeModelEndpointType(raw string) string {
+	v := strings.ToLower(strings.TrimSpace(raw))
+	v = strings.ReplaceAll(v, "-", "_")
+	v = strings.ReplaceAll(v, ".", "_")
+	v = strings.ReplaceAll(v, "/", "_")
+	switch v {
+	case "openai", "chat", "chat_completion", "chat_completions", "openai_chat", "openai_chat_completions":
+		return "openai"
+	case "openai_response", "openai_responses", "response", "responses":
+		return "openai-response"
+	case "anthropic", "message", "messages", "anthropic_message", "anthropic_messages":
+		return "anthropic"
+	case "google", "google_generative_ai", "gemini":
+		return "google_generative_ai"
+	default:
+		return v
+	}
 }
 
 func anthropicCustomHeaders(providerConfig map[string]any) string {

--- a/server/internal/connector/agentdaemon/model_injection_test.go
+++ b/server/internal/connector/agentdaemon/model_injection_test.go
@@ -854,6 +854,8 @@ func TestIsOpenAICompatibleRuntime(t *testing.T) {
 		{"azure-openai provider", store.ModelRuntime{ProviderType: "azure-openai"}, true},
 		{"@ai-sdk/openai adapter only", store.ModelRuntime{Adapter: "@ai-sdk/openai"}, true},
 		{"@ai-sdk/azure adapter only", store.ModelRuntime{Adapter: "@ai-sdk/azure"}, true},
+		{"endpoint types openai", store.ModelRuntime{ProviderConfig: map[string]any{"supported_endpoint_types": []any{"openai"}}}, true},
+		{"endpoint types openai response", store.ModelRuntime{ProviderConfig: map[string]any{"supported_endpoint_types": []any{"openai-response"}}}, true},
 		{"whitespace + case-insensitive", store.ModelRuntime{ProviderType: " Openai "}, true},
 		{"anthropic provider rejected", store.ModelRuntime{ProviderType: "anthropic", Adapter: "@ai-sdk/anthropic"}, false},
 		{"empty", store.ModelRuntime{}, false},
@@ -865,6 +867,15 @@ func TestIsOpenAICompatibleRuntime(t *testing.T) {
 				t.Fatalf("isOpenAICompatibleRuntime(%+v) = %v, want %v", tc.mr, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestIsAnthropicRuntimeSupportsEndpointTypes(t *testing.T) {
+	if !isAnthropicRuntime(store.ModelRuntime{
+		Adapter:        "@ai-sdk/openai-compatible",
+		ProviderConfig: map[string]any{"supported_endpoint_types": []any{"anthropic", "openai"}},
+	}) {
+		t.Fatalf("expected supported_endpoint_types to allow anthropic runtime")
 	}
 }
 

--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -645,6 +645,7 @@ func RegisterRoutesWithStore(r chi.Router, runtimeStore RuntimeStore, opts ...Ro
 			r.Get("/workspaces/{workspaceID}/secrets", listSecrets(runtimeStore))
 			r.Post("/workspaces/{workspaceID}/secrets/{secretID}/disable", disableSecret(runtimeStore))
 			r.Post("/workspaces/{workspaceID}/models", createModel(runtimeStore))
+			r.Post("/workspaces/{workspaceID}/models/detect-endpoints", detectProviderModelEndpoints(runtimeStore))
 			r.Post("/workspaces/{workspaceID}/models/import", importProviderModels(runtimeStore))
 			r.Get("/workspaces/{workspaceID}/models", listModels(runtimeStore))
 			r.Post("/workspaces/{workspaceID}/models/{modelID}/disable", disableModel(runtimeStore))

--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -645,6 +645,7 @@ func RegisterRoutesWithStore(r chi.Router, runtimeStore RuntimeStore, opts ...Ro
 			r.Get("/workspaces/{workspaceID}/secrets", listSecrets(runtimeStore))
 			r.Post("/workspaces/{workspaceID}/secrets/{secretID}/disable", disableSecret(runtimeStore))
 			r.Post("/workspaces/{workspaceID}/models", createModel(runtimeStore))
+			r.Post("/workspaces/{workspaceID}/models/import", importProviderModels(runtimeStore))
 			r.Get("/workspaces/{workspaceID}/models", listModels(runtimeStore))
 			r.Post("/workspaces/{workspaceID}/models/{modelID}/disable", disableModel(runtimeStore))
 			r.Patch("/workspaces/{workspaceID}/models/{modelID}", updateModel(runtimeStore))

--- a/server/internal/dev/routes_models.go
+++ b/server/internal/dev/routes_models.go
@@ -1,6 +1,7 @@
 package dev
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -121,6 +122,365 @@ func createModel(runtimeStore RuntimeStore) http.HandlerFunc {
 			return
 		}
 		writeJSON(w, http.StatusCreated, model)
+	}
+}
+
+// importProviderModelsBody is a backend-mediated batch import from an
+// OpenAI-shaped GET {base_url}/v1/models endpoint. Dry-run returns the
+// discovered ids and existing status without creating rows.
+type importProviderModelsBody struct {
+	ProviderType       string         `json:"provider_type"`
+	Adapter            string         `json:"adapter"`
+	BaseURL            string         `json:"base_url"`
+	CredentialMode     string         `json:"credential_mode"`
+	SecretID           string         `json:"secret_id"`
+	CredentialKindCode string         `json:"credential_kind_code"`
+	APIKey             string         `json:"api_key"`
+	ModelIDs           []string       `json:"model_ids"`
+	DryRun             bool           `json:"dry_run"`
+	SkipExisting       *bool          `json:"skip_existing"`
+	Capabilities       map[string]any `json:"capabilities"`
+	Limits             map[string]any `json:"limits"`
+	Config             map[string]any `json:"config"`
+}
+
+type discoveredProviderModel struct {
+	ID     string `json:"id"`
+	Exists bool   `json:"exists"`
+}
+
+type importProviderModelFailure struct {
+	ModelKey string `json:"model_key"`
+	Error    string `json:"error"`
+}
+
+type importProviderModelsResponse struct {
+	Models  []discoveredProviderModel    `json:"models"`
+	Created []store.ModelRead            `json:"created"`
+	Skipped []string                     `json:"skipped"`
+	Failed  []importProviderModelFailure `json:"failed"`
+}
+
+var importProviderModelsHTTPClient = &http.Client{Timeout: 15 * time.Second}
+
+func modelImportSkipExisting(req importProviderModelsBody) bool {
+	return req.SkipExisting == nil || *req.SkipExisting
+}
+
+func providerModelsURL(baseURL string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if strings.HasSuffix(base, "/v1") {
+		return base + "/models"
+	}
+	return base + "/v1/models"
+}
+
+func stringHeaders(raw map[string]any) map[string]string {
+	out := map[string]string{}
+	if hdrs, ok := raw["headers"].(map[string]any); ok {
+		for k, v := range hdrs {
+			if s, ok := v.(string); ok && strings.TrimSpace(k) != "" && s != "" {
+				out[k] = s
+			}
+		}
+	}
+	return out
+}
+
+func modelImportAuthScheme(req importProviderModelsBody) string {
+	if s, ok := req.Config["auth_scheme"].(string); ok && strings.TrimSpace(s) != "" {
+		return strings.TrimSpace(s)
+	}
+	if isAnthropicMessagesAdapter(req.Adapter) {
+		return "api-key"
+	}
+	return "bearer"
+}
+
+func apiKeyFromPayload(payload map[string]any) string {
+	apiKey, _ := payload["api_key"].(string)
+	if strings.TrimSpace(apiKey) == "" {
+		if v, _ := payload["value"].(string); strings.TrimSpace(v) != "" {
+			apiKey = v
+		}
+	}
+	return strings.TrimSpace(apiKey)
+}
+
+func importProviderModelIDs(ctx context.Context, req importProviderModelsBody, apiKey string) ([]string, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, providerModelsURL(req.BaseURL), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build upstream request: %w", err)
+	}
+	httpReq.Header.Set("Accept", "application/json")
+	for k, v := range stringHeaders(req.Config) {
+		httpReq.Header.Set(k, v)
+	}
+	if apiKey != "" {
+		if modelImportAuthScheme(req) == "api-key" {
+			httpReq.Header.Set("x-api-key", apiKey)
+		} else {
+			httpReq.Header.Set("Authorization", "Bearer "+apiKey)
+		}
+	}
+	resp, err := importProviderModelsHTTPClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("upstream /models request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		msg := strings.TrimSpace(string(bodyBytes))
+		if len(msg) > 500 {
+			msg = msg[:500] + "..."
+		}
+		return nil, fmt.Errorf("upstream /models returned %d: %s", resp.StatusCode, msg)
+	}
+	var body struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(bodyBytes, &body); err != nil {
+		return nil, fmt.Errorf("failed to parse upstream /models response: %w", err)
+	}
+	seen := map[string]bool{}
+	ids := make([]string, 0, len(body.Data))
+	for _, item := range body.Data {
+		id := strings.TrimSpace(item.ID)
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func existingModelKeys(models []store.ModelRead) map[string]bool {
+	out := map[string]bool{}
+	for _, model := range models {
+		key := strings.TrimSpace(model.ModelKey)
+		if key != "" {
+			out[key] = true
+		}
+	}
+	return out
+}
+
+func emptyImportProviderModelsResponse(models []discoveredProviderModel) importProviderModelsResponse {
+	return importProviderModelsResponse{
+		Models:  models,
+		Created: []store.ModelRead{},
+		Skipped: []string{},
+		Failed:  []importProviderModelFailure{},
+	}
+}
+
+func selectedImportModelKeys(discovered []string, selected []string) []string {
+	if len(selected) == 0 {
+		return discovered
+	}
+	discoveredSet := map[string]bool{}
+	for _, id := range discovered {
+		discoveredSet[id] = true
+	}
+	out := make([]string, 0, len(selected))
+	seen := map[string]bool{}
+	for _, raw := range selected {
+		id := strings.TrimSpace(raw)
+		if id == "" || seen[id] || !discoveredSet[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	return out
+}
+
+func importSecretID(runtimeStore RuntimeStore, r *http.Request, workspaceID string, req importProviderModelsBody) (string, error) {
+	if strings.TrimSpace(req.SecretID) != "" {
+		return strings.TrimSpace(req.SecretID), nil
+	}
+	apiKey := strings.TrimSpace(req.APIKey)
+	if apiKey == "" {
+		return "", errors.New("api_key or secret_id is required for inline_secret mode")
+	}
+	serverMasterKey := os.Getenv("PARSAR_MASTER_KEY")
+	if serverMasterKey == "" {
+		return "", errors.New("server has no PARSAR_MASTER_KEY configured; refusing to create a secret")
+	}
+	secretService, err := secrets.New(serverMasterKey)
+	if err != nil {
+		return "", err
+	}
+	payload := map[string]any{"api_key": apiKey}
+	encrypted, err := secretService.Encrypt(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to encrypt secret: %w", err)
+	}
+	secret, err := runtimeStore.CreateSecret(r.Context(), store.CreateSecretInput{
+		WorkspaceID: workspaceID,
+		Name:        "model-key-" + time.Now().UTC().Format("20060102150405"),
+		Kind:        "model_provider",
+		Provider:    req.ProviderType,
+		AuthType:    "api_key",
+		Payload:     payload,
+		Masked:      secrets.MaskPayload(payload),
+	}, encrypted)
+	if err != nil {
+		return "", err
+	}
+	return secret.ID, nil
+}
+
+func importDiscoveryAPIKey(runtimeStore RuntimeStore, r *http.Request, workspaceID string, req importProviderModelsBody) (string, error) {
+	if apiKey := strings.TrimSpace(req.APIKey); apiKey != "" {
+		return apiKey, nil
+	}
+	if strings.TrimSpace(req.SecretID) == "" {
+		return "", nil
+	}
+	serverMasterKey := os.Getenv("PARSAR_MASTER_KEY")
+	if serverMasterKey == "" {
+		return "", errors.New("server has no PARSAR_MASTER_KEY configured; refusing to decrypt the selected secret")
+	}
+	secretPayload, err := runtimeStore.GetSecretPayload(r.Context(), workspaceID, strings.TrimSpace(req.SecretID))
+	if err != nil {
+		return "", err
+	}
+	secretService, err := secrets.New(serverMasterKey)
+	if err != nil {
+		return "", err
+	}
+	payload, err := secretService.Decrypt(secretPayload.EncryptedPayload)
+	if err != nil {
+		return "", err
+	}
+	return apiKeyFromPayload(payload), nil
+}
+
+// importProviderModels discovers model ids from an upstream /v1/models endpoint
+// and optionally creates model rows for selected ids.
+//
+//	@Summary		Import models from provider /models
+//	@Description	Fetches model ids from base_url + /v1/models and batch-creates model rows using the existing model catalog schema. Owner/admin only.
+//	@Tags			models
+//	@ID				importDevProviderModels
+//	@Accept			json
+//	@Produce		json
+//	@Param			workspaceID	path	string						true	"Workspace UUID"
+//	@Param			body		body	importProviderModelsBody	true	"Model import payload"
+//	@Success		200 {object} importProviderModelsResponse "Import preview or result"
+//	@Failure		400 {object} map[string]string "Invalid body, UUID, provider response, or credentials"
+//	@Failure		403 {object} map[string]string "Caller is not workspace owner/admin"
+//	@Router			/api/v1/workspaces/{workspaceID}/models/import [post]
+func importProviderModels(runtimeStore RuntimeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if runtimeStore == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed model registry is disabled"})
+			return
+		}
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
+			return
+		}
+		var req importProviderModelsBody
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+			return
+		}
+		req.ProviderType = strings.TrimSpace(req.ProviderType)
+		req.Adapter = strings.TrimSpace(req.Adapter)
+		req.BaseURL = strings.TrimSpace(req.BaseURL)
+		if req.ProviderType == "" || req.Adapter == "" || req.BaseURL == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "provider_type, adapter, and base_url are required"})
+			return
+		}
+		mode := strings.TrimSpace(req.CredentialMode)
+		if mode == "" {
+			mode = "inline_secret"
+		}
+		if mode != "inline_secret" && mode != "credential_ref" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "credential_mode must be inline_secret or credential_ref"})
+			return
+		}
+		req.CredentialMode = mode
+
+		apiKey, err := importDiscoveryAPIKey(runtimeStore, r, workspaceID, req)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		discoveredIDs, err := importProviderModelIDs(r.Context(), req, apiKey)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		existing, err := runtimeStore.ListModels(r.Context(), workspaceID, 1000)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list existing models"})
+			return
+		}
+		existingKeys := existingModelKeys(existing)
+		discovered := make([]discoveredProviderModel, 0, len(discoveredIDs))
+		for _, id := range discoveredIDs {
+			discovered = append(discovered, discoveredProviderModel{ID: id, Exists: existingKeys[id]})
+		}
+		if req.DryRun {
+			writeJSON(w, http.StatusOK, emptyImportProviderModelsResponse(discovered))
+			return
+		}
+
+		response := emptyImportProviderModelsResponse(discovered)
+		modelKeys := make([]string, 0, len(discoveredIDs))
+		for _, modelKey := range selectedImportModelKeys(discoveredIDs, req.ModelIDs) {
+			if modelImportSkipExisting(req) && existingKeys[modelKey] {
+				response.Skipped = append(response.Skipped, modelKey)
+				continue
+			}
+			modelKeys = append(modelKeys, modelKey)
+		}
+		if len(modelKeys) == 0 {
+			writeJSON(w, http.StatusOK, response)
+			return
+		}
+		if mode == "credential_ref" && strings.TrimSpace(req.CredentialKindCode) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "credential_kind_code is required for credential_ref mode"})
+			return
+		}
+		secretID := ""
+		if mode == "inline_secret" {
+			secretID, err = importSecretID(runtimeStore, r, workspaceID, req)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+		}
+		for _, modelKey := range modelKeys {
+			model, err := runtimeStore.CreateModel(r.Context(), store.CreateModelInput{
+				Name:               modelKey,
+				ProviderType:       req.ProviderType,
+				Adapter:            req.Adapter,
+				BaseURL:            req.BaseURL,
+				ModelKey:           modelKey,
+				CredentialMode:     mode,
+				SecretID:           secretID,
+				CredentialKindCode: strings.TrimSpace(req.CredentialKindCode),
+				Config:             foldModelConfig(req.Config, req.Capabilities, req.Limits),
+				CreatedBy:          actorIDFromRequest(r),
+			})
+			if err != nil {
+				response.Failed = append(response.Failed, importProviderModelFailure{
+					ModelKey: modelKey,
+					Error:    err.Error(),
+				})
+				continue
+			}
+			response.Created = append(response.Created, model)
+			existingKeys[modelKey] = true
+		}
+		writeJSON(w, http.StatusOK, response)
 	}
 }
 

--- a/server/internal/dev/routes_models.go
+++ b/server/internal/dev/routes_models.go
@@ -145,8 +145,9 @@ type importProviderModelsBody struct {
 }
 
 type discoveredProviderModel struct {
-	ID     string `json:"id"`
-	Exists bool   `json:"exists"`
+	ID                     string   `json:"id"`
+	Exists                 bool     `json:"exists"`
+	SupportedEndpointTypes []string `json:"supported_endpoint_types"`
 }
 
 type importProviderModelFailure struct {
@@ -163,8 +164,85 @@ type importProviderModelsResponse struct {
 
 var importProviderModelsHTTPClient = &http.Client{Timeout: 15 * time.Second}
 
+type providerModelDiscovery struct {
+	ID                     string
+	SupportedEndpointTypes []string
+}
+
 func modelImportSkipExisting(req importProviderModelsBody) bool {
 	return req.SkipExisting == nil || *req.SkipExisting
+}
+
+func normalizeEndpointType(raw string) string {
+	v := strings.ToLower(strings.TrimSpace(raw))
+	v = strings.ReplaceAll(v, "-", "_")
+	v = strings.ReplaceAll(v, ".", "_")
+	v = strings.ReplaceAll(v, "/", "_")
+	switch v {
+	case "openai", "chat", "chat_completion", "chat_completions", "openai_chat", "openai_chat_completions":
+		return "openai"
+	case "openai_response", "openai_responses", "response", "responses":
+		return "openai-response"
+	case "anthropic", "message", "messages", "anthropic_message", "anthropic_messages":
+		return "anthropic"
+	case "google", "google_generative_ai", "gemini":
+		return "google_generative_ai"
+	default:
+		return v
+	}
+}
+
+func normalizeEndpointTypes(raw []string) []string {
+	out := make([]string, 0, len(raw))
+	seen := map[string]bool{}
+	for _, item := range raw {
+		normalized := normalizeEndpointType(item)
+		if normalized == "" || seen[normalized] {
+			continue
+		}
+		seen[normalized] = true
+		out = append(out, normalized)
+	}
+	return out
+}
+
+func endpointTypesFromAny(value any) []string {
+	switch typed := value.(type) {
+	case []any:
+		raw := make([]string, 0, len(typed))
+		for _, item := range typed {
+			if s, ok := item.(string); ok {
+				raw = append(raw, s)
+			}
+		}
+		return normalizeEndpointTypes(raw)
+	case []string:
+		return normalizeEndpointTypes(typed)
+	default:
+		return nil
+	}
+}
+
+func configWithSupportedEndpointTypes(config map[string]any, endpointTypes []string) map[string]any {
+	merged := map[string]any{}
+	for k, v := range config {
+		merged[k] = v
+	}
+	normalized := normalizeEndpointTypes(endpointTypes)
+	if len(normalized) > 0 {
+		merged["supported_endpoint_types"] = normalized
+	}
+	return merged
+}
+
+func modelSupportsEndpointType(config map[string]any, endpointType string) bool {
+	want := normalizeEndpointType(endpointType)
+	for _, got := range endpointTypesFromAny(config["supported_endpoint_types"]) {
+		if got == want {
+			return true
+		}
+	}
+	return false
 }
 
 func providerModelsURL(baseURL string) string {
@@ -207,7 +285,7 @@ func apiKeyFromPayload(payload map[string]any) string {
 	return strings.TrimSpace(apiKey)
 }
 
-func importProviderModelIDs(ctx context.Context, req importProviderModelsBody, apiKey string) ([]string, error) {
+func importProviderModelIDs(ctx context.Context, req importProviderModelsBody, apiKey string) ([]providerModelDiscovery, error) {
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, providerModelsURL(req.BaseURL), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build upstream request: %w", err)
@@ -238,23 +316,27 @@ func importProviderModelIDs(ctx context.Context, req importProviderModelsBody, a
 	}
 	var body struct {
 		Data []struct {
-			ID string `json:"id"`
+			ID                     string   `json:"id"`
+			SupportedEndpointTypes []string `json:"supported_endpoint_types"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(bodyBytes, &body); err != nil {
 		return nil, fmt.Errorf("failed to parse upstream /models response: %w", err)
 	}
 	seen := map[string]bool{}
-	ids := make([]string, 0, len(body.Data))
+	models := make([]providerModelDiscovery, 0, len(body.Data))
 	for _, item := range body.Data {
 		id := strings.TrimSpace(item.ID)
 		if id == "" || seen[id] {
 			continue
 		}
 		seen[id] = true
-		ids = append(ids, id)
+		models = append(models, providerModelDiscovery{
+			ID:                     id,
+			SupportedEndpointTypes: normalizeEndpointTypes(item.SupportedEndpointTypes),
+		})
 	}
-	return ids, nil
+	return models, nil
 }
 
 func existingModelKeys(models []store.ModelRead) map[string]bool {
@@ -277,13 +359,17 @@ func emptyImportProviderModelsResponse(models []discoveredProviderModel) importP
 	}
 }
 
-func selectedImportModelKeys(discovered []string, selected []string) []string {
+func selectedImportModelKeys(discovered []providerModelDiscovery, selected []string) []string {
 	if len(selected) == 0 {
-		return discovered
+		out := make([]string, 0, len(discovered))
+		for _, model := range discovered {
+			out = append(out, model.ID)
+		}
+		return out
 	}
 	discoveredSet := map[string]bool{}
-	for _, id := range discovered {
-		discoveredSet[id] = true
+	for _, model := range discovered {
+		discoveredSet[model.ID] = true
 	}
 	out := make([]string, 0, len(selected))
 	seen := map[string]bool{}
@@ -294,6 +380,14 @@ func selectedImportModelKeys(discovered []string, selected []string) []string {
 		}
 		seen[id] = true
 		out = append(out, id)
+	}
+	return out
+}
+
+func discoveredEndpointTypesByID(discovered []providerModelDiscovery) map[string][]string {
+	out := map[string][]string{}
+	for _, model := range discovered {
+		out[model.ID] = model.SupportedEndpointTypes
 	}
 	return out
 }
@@ -412,7 +506,7 @@ func importProviderModels(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
 		}
-		discoveredIDs, err := importProviderModelIDs(r.Context(), req, apiKey)
+		discoveredModels, err := importProviderModelIDs(r.Context(), req, apiKey)
 		if err != nil {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			return
@@ -423,9 +517,13 @@ func importProviderModels(runtimeStore RuntimeStore) http.HandlerFunc {
 			return
 		}
 		existingKeys := existingModelKeys(existing)
-		discovered := make([]discoveredProviderModel, 0, len(discoveredIDs))
-		for _, id := range discoveredIDs {
-			discovered = append(discovered, discoveredProviderModel{ID: id, Exists: existingKeys[id]})
+		discovered := make([]discoveredProviderModel, 0, len(discoveredModels))
+		for _, model := range discoveredModels {
+			discovered = append(discovered, discoveredProviderModel{
+				ID:                     model.ID,
+				Exists:                 existingKeys[model.ID],
+				SupportedEndpointTypes: model.SupportedEndpointTypes,
+			})
 		}
 		if req.DryRun {
 			writeJSON(w, http.StatusOK, emptyImportProviderModelsResponse(discovered))
@@ -433,8 +531,9 @@ func importProviderModels(runtimeStore RuntimeStore) http.HandlerFunc {
 		}
 
 		response := emptyImportProviderModelsResponse(discovered)
-		modelKeys := make([]string, 0, len(discoveredIDs))
-		for _, modelKey := range selectedImportModelKeys(discoveredIDs, req.ModelIDs) {
+		endpointTypesByID := discoveredEndpointTypesByID(discoveredModels)
+		modelKeys := make([]string, 0, len(discoveredModels))
+		for _, modelKey := range selectedImportModelKeys(discoveredModels, req.ModelIDs) {
 			if modelImportSkipExisting(req) && existingKeys[modelKey] {
 				response.Skipped = append(response.Skipped, modelKey)
 				continue
@@ -467,7 +566,7 @@ func importProviderModels(runtimeStore RuntimeStore) http.HandlerFunc {
 				CredentialMode:     mode,
 				SecretID:           secretID,
 				CredentialKindCode: strings.TrimSpace(req.CredentialKindCode),
-				Config:             foldModelConfig(req.Config, req.Capabilities, req.Limits),
+				Config:             foldModelConfig(configWithSupportedEndpointTypes(req.Config, endpointTypesByID[modelKey]), req.Capabilities, req.Limits),
 				CreatedBy:          actorIDFromRequest(r),
 			})
 			if err != nil {
@@ -481,6 +580,149 @@ func importProviderModels(runtimeStore RuntimeStore) http.HandlerFunc {
 			existingKeys[modelKey] = true
 		}
 		writeJSON(w, http.StatusOK, response)
+	}
+}
+
+type detectProviderModelEndpointsBody struct {
+	BaseURL            string         `json:"base_url"`
+	ModelKey           string         `json:"model_key"`
+	APIKey             string         `json:"api_key"`
+	SecretID           string         `json:"secret_id"`
+	Config             map[string]any `json:"config"`
+	CredentialKindCode string         `json:"credential_kind_code"`
+}
+
+type detectProviderModelEndpointsResponse struct {
+	SupportedEndpointTypes []string `json:"supported_endpoint_types"`
+}
+
+func endpointProbeRequest(ctx context.Context, baseURL, modelKey, apiKey, endpointType string, config map[string]any) (*http.Request, error) {
+	body := map[string]any{}
+	url := ""
+	switch normalizeEndpointType(endpointType) {
+	case "anthropic":
+		url = anthropicMessagesURL(baseURL)
+		body = map[string]any{
+			"model":      modelKey,
+			"messages":   []map[string]any{{"role": "user", "content": "ping"}},
+			"max_tokens": 1,
+		}
+	case "openai":
+		url = strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/chat/completions"
+		body = map[string]any{
+			"model":      modelKey,
+			"messages":   []map[string]any{{"role": "user", "content": "ping"}},
+			"max_tokens": 1,
+		}
+	case "openai-response":
+		url = strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/responses"
+		body = map[string]any{
+			"model": modelKey,
+			"input": "ping",
+		}
+	default:
+		return nil, fmt.Errorf("unsupported endpoint probe type %q", endpointType)
+	}
+	bodyBytes, _ := json.Marshal(body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if normalizeEndpointType(endpointType) == "anthropic" {
+		req.Header.Set("x-api-key", apiKey)
+		req.Header.Set("anthropic-version", "2023-06-01")
+	} else {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+	for k, v := range stringHeaders(config) {
+		req.Header.Set(k, v)
+	}
+	return req, nil
+}
+
+func probeProviderEndpoint(ctx context.Context, baseURL, modelKey, apiKey, endpointType string, config map[string]any) bool {
+	req, err := endpointProbeRequest(ctx, baseURL, modelKey, apiKey, endpointType, config)
+	if err != nil {
+		return false
+	}
+	resp, err := testModelHTTPClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	var parsed map[string]any
+	_ = json.Unmarshal(bodyBytes, &parsed)
+	return resp.StatusCode >= 200 && resp.StatusCode < 300 && parsed["error"] == nil
+}
+
+func detectEndpointTypes(ctx context.Context, baseURL, modelKey, apiKey string, config map[string]any) []string {
+	if strings.TrimSpace(baseURL) == "" || strings.TrimSpace(modelKey) == "" || strings.TrimSpace(apiKey) == "" {
+		return nil
+	}
+	candidates := []string{"anthropic", "openai", "openai-response"}
+	supported := make([]string, 0, len(candidates))
+	for _, endpointType := range candidates {
+		if probeProviderEndpoint(ctx, baseURL, modelKey, apiKey, endpointType, config) {
+			supported = append(supported, endpointType)
+		}
+	}
+	return supported
+}
+
+// detectProviderModelEndpoints probes common provider endpoint families for a
+// model key so manual model creation can store all supported protocols instead
+// of asking the user to choose one.
+//
+//	@Summary		Detect supported model endpoint types
+//	@Description	Probes common OpenAI/Anthropic endpoint families for a base URL and model key. Owner/admin only.
+//	@Tags			models
+//	@ID				detectDevModelEndpoints
+//	@Accept			json
+//	@Produce		json
+//	@Param			workspaceID	path	string								true	"Workspace UUID"
+//	@Param			body		body	detectProviderModelEndpointsBody	true	"Endpoint detection payload"
+//	@Success		200 {object} detectProviderModelEndpointsResponse "Detected endpoint families"
+//	@Failure		400 {object} map[string]string "Invalid body, UUID, or credentials"
+//	@Failure		403 {object} map[string]string "Caller is not workspace owner/admin"
+//	@Router			/api/v1/workspaces/{workspaceID}/models/detect-endpoints [post]
+func detectProviderModelEndpoints(runtimeStore RuntimeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if runtimeStore == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed model registry is disabled"})
+			return
+		}
+		workspaceID, ok := requireWorkspaceOwnerOrAdminRequest(w, r, runtimeStore)
+		if !ok {
+			return
+		}
+		var req detectProviderModelEndpointsBody
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+			return
+		}
+		req.BaseURL = strings.TrimSpace(req.BaseURL)
+		req.ModelKey = strings.TrimSpace(req.ModelKey)
+		if req.BaseURL == "" || req.ModelKey == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "base_url and model_key are required"})
+			return
+		}
+		apiKey, err := importDiscoveryAPIKey(runtimeStore, r, workspaceID, importProviderModelsBody{
+			APIKey:   req.APIKey,
+			SecretID: req.SecretID,
+		})
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+			return
+		}
+		if strings.TrimSpace(apiKey) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "api_key or secret_id is required to detect endpoint types"})
+			return
+		}
+		writeJSON(w, http.StatusOK, detectProviderModelEndpointsResponse{
+			SupportedEndpointTypes: detectEndpointTypes(r.Context(), req.BaseURL, req.ModelKey, apiKey, req.Config),
+		})
 	}
 }
 
@@ -694,8 +936,8 @@ func testModelConnectivity(runtimeStore RuntimeStore) http.HandlerFunc {
 			return
 		}
 
-		isOpenAICompatible := isOpenAIChatCompletionsAdapter(mr.Adapter)
-		isAnthropicCompatible := isAnthropicMessagesAdapter(mr.Adapter)
+		isOpenAICompatible := isOpenAIChatCompletionsAdapter(mr.Adapter) || modelSupportsEndpointType(mr.ProviderConfig, "openai") || modelSupportsEndpointType(mr.ProviderConfig, "openai-response")
+		isAnthropicCompatible := isAnthropicMessagesAdapter(mr.Adapter) || modelSupportsEndpointType(mr.ProviderConfig, "anthropic")
 
 		if !isOpenAICompatible && !isAnthropicCompatible {
 			writeJSON(w, http.StatusOK, connectivityTestResponse{

--- a/server/internal/dev/routes_test.go
+++ b/server/internal/dev/routes_test.go
@@ -478,6 +478,171 @@ func TestUpdateModelAPIErrors(t *testing.T) {
 	requireStatus(t, res, http.StatusNotFound)
 }
 
+type modelImportStore struct {
+	stubRuntimeStore
+	createdModels  []store.CreateModelInput
+	createdSecrets []store.CreateSecretInput
+}
+
+func (s *modelImportStore) ListModels(ctx context.Context, workspaceID string, limit int32) ([]store.ModelRead, error) {
+	return []store.ModelRead{{
+		ID:             "00000000-0000-0000-0000-000000000702",
+		Slug:           "model-test",
+		Name:           "GPT 5.4",
+		ProviderType:   "openai",
+		Adapter:        "@ai-sdk/openai",
+		BaseURL:        "https://platform-api.example.com/v1",
+		ModelKey:       "gpt-5.4",
+		CredentialMode: "inline_secret",
+		SecretID:       "00000000-0000-0000-0000-000000000601",
+		Status:         "active",
+		Config:         map[string]any{},
+		CreatedAt:      time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:      time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC),
+	}}, nil
+}
+
+func (s *modelImportStore) CreateSecret(ctx context.Context, input store.CreateSecretInput, encryptedPayload []byte) (store.SecretRead, error) {
+	s.createdSecrets = append(s.createdSecrets, input)
+	return store.SecretRead{
+		ID:        "00000000-0000-0000-0000-000000000777",
+		Name:      input.Name,
+		Kind:      input.Kind,
+		Provider:  input.Provider,
+		AuthType:  input.AuthType,
+		Status:    "active",
+		Masked:    input.Masked,
+		CreatedAt: time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+func (s *modelImportStore) CreateModel(ctx context.Context, input store.CreateModelInput) (store.ModelRead, error) {
+	s.createdModels = append(s.createdModels, input)
+	return store.ModelRead{
+		ID:             fmt.Sprintf("created-%d", len(s.createdModels)),
+		Slug:           fmt.Sprintf("created-%d", len(s.createdModels)),
+		Name:           input.Name,
+		ProviderType:   input.ProviderType,
+		Adapter:        input.Adapter,
+		BaseURL:        input.BaseURL,
+		ModelKey:       input.ModelKey,
+		CredentialMode: input.CredentialMode,
+		SecretID:       input.SecretID,
+		Status:         "active",
+		Config:         input.Config,
+		CreatedAt:      time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:      time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC),
+	}, nil
+}
+
+func TestImportProviderModelsDryRunListsDiscoveredIDs(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/models" {
+			t.Fatalf("unexpected upstream request %s %s", r.Method, r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer sk-import" {
+			t.Fatalf("expected bearer auth, got %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{
+			{"id": "gpt-5.4"},
+			{"id": "gpt-5.5"},
+		}})
+	}))
+	defer upstream.Close()
+
+	store := &modelImportStore{}
+	r := chi.NewRouter()
+	RegisterRoutesWithStore(r, store)
+	body := fmt.Sprintf(`{
+		"provider_type":"openai",
+		"adapter":"@ai-sdk/openai",
+		"base_url":%q,
+		"api_key":"sk-import",
+		"dry_run":true
+	}`, upstream.URL+"/v1")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/00000000-0000-0000-0000-000000000002/models/import", strings.NewReader(body))
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+	requireStatus(t, res, http.StatusOK)
+	if !strings.Contains(res.Body.String(), `"id":"gpt-5.4","exists":true`) {
+		t.Fatalf("expected existing model marker, got %s", res.Body.String())
+	}
+	if len(store.createdSecrets) != 0 || len(store.createdModels) != 0 {
+		t.Fatalf("dry run should not create secrets/models, got secrets=%d models=%d", len(store.createdSecrets), len(store.createdModels))
+	}
+}
+
+func TestImportProviderModelsAppendsV1BeforeModels(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/anthropic/v1/models" {
+			t.Fatalf("expected /anthropic/v1/models, got %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{
+			{"id": "MiniMax-M1"},
+		}})
+	}))
+	defer upstream.Close()
+
+	store := &modelImportStore{}
+	r := chi.NewRouter()
+	RegisterRoutesWithStore(r, store)
+	body := fmt.Sprintf(`{
+		"provider_type":"minimax-en",
+		"adapter":"@ai-sdk/anthropic",
+		"base_url":%q,
+		"api_key":"sk-import",
+		"dry_run":true
+	}`, upstream.URL+"/anthropic")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/00000000-0000-0000-0000-000000000002/models/import", strings.NewReader(body))
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+	requireStatus(t, res, http.StatusOK)
+	if !strings.Contains(res.Body.String(), `"id":"MiniMax-M1"`) {
+		t.Fatalf("expected discovered model, got %s", res.Body.String())
+	}
+}
+
+func TestImportProviderModelsCreatesSelectedModelsWithOneSecret(t *testing.T) {
+	t.Setenv("PARSAR_MASTER_KEY", "test-master-key")
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{
+			{"id": "gpt-5.4"},
+			{"id": "gpt-5.5"},
+			{"id": "gpt-5.6"},
+		}})
+	}))
+	defer upstream.Close()
+
+	store := &modelImportStore{}
+	r := chi.NewRouter()
+	RegisterRoutesWithStore(r, store)
+	body := fmt.Sprintf(`{
+		"provider_type":"openai",
+		"adapter":"@ai-sdk/openai",
+		"base_url":%q,
+		"credential_mode":"inline_secret",
+		"api_key":"sk-import",
+		"model_ids":["gpt-5.4","gpt-5.5","gpt-5.6"]
+	}`, upstream.URL+"/v1")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/00000000-0000-0000-0000-000000000002/models/import", strings.NewReader(body))
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+	requireStatus(t, res, http.StatusOK)
+	if len(store.createdSecrets) != 1 {
+		t.Fatalf("expected one shared secret, got %d", len(store.createdSecrets))
+	}
+	if len(store.createdModels) != 2 {
+		t.Fatalf("expected two created models (existing skipped), got %d", len(store.createdModels))
+	}
+	if store.createdModels[0].SecretID != "00000000-0000-0000-0000-000000000777" || store.createdModels[1].SecretID != "00000000-0000-0000-0000-000000000777" {
+		t.Fatalf("expected imported models to reuse created secret, got %+v", store.createdModels)
+	}
+	if !strings.Contains(res.Body.String(), `"skipped":["gpt-5.4"]`) {
+		t.Fatalf("expected existing model to be skipped, got %s", res.Body.String())
+	}
+}
+
 // connectivityStubStore overrides ResolveModelRuntime + GetSecretPayload
 // so the tests can point the connectivity check at a httptest.Server and
 // inject a real encrypted secret.

--- a/server/internal/dev/routes_test.go
+++ b/server/internal/dev/routes_test.go
@@ -544,9 +544,9 @@ func TestImportProviderModelsDryRunListsDiscoveredIDs(t *testing.T) {
 		if got := r.Header.Get("Authorization"); got != "Bearer sk-import" {
 			t.Fatalf("expected bearer auth, got %q", got)
 		}
-		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{
-			{"id": "gpt-5.4"},
-			{"id": "gpt-5.5"},
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{
+			{"id": "gpt-5.4", "supported_endpoint_types": []string{"openai"}},
+			{"id": "gpt-5.5", "supported_endpoint_types": []string{"anthropic", "openai-response"}},
 		}})
 	}))
 	defer upstream.Close()
@@ -567,6 +567,9 @@ func TestImportProviderModelsDryRunListsDiscoveredIDs(t *testing.T) {
 	requireStatus(t, res, http.StatusOK)
 	if !strings.Contains(res.Body.String(), `"id":"gpt-5.4","exists":true`) {
 		t.Fatalf("expected existing model marker, got %s", res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), `"supported_endpoint_types":["anthropic","openai-response"]`) {
+		t.Fatalf("expected supported endpoint types in preview, got %s", res.Body.String())
 	}
 	if len(store.createdSecrets) != 0 || len(store.createdModels) != 0 {
 		t.Fatalf("dry run should not create secrets/models, got secrets=%d models=%d", len(store.createdSecrets), len(store.createdModels))
@@ -606,10 +609,10 @@ func TestImportProviderModelsAppendsV1BeforeModels(t *testing.T) {
 func TestImportProviderModelsCreatesSelectedModelsWithOneSecret(t *testing.T) {
 	t.Setenv("PARSAR_MASTER_KEY", "test-master-key")
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{
-			{"id": "gpt-5.4"},
-			{"id": "gpt-5.5"},
-			{"id": "gpt-5.6"},
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]any{
+			{"id": "gpt-5.4", "supported_endpoint_types": []string{"openai"}},
+			{"id": "gpt-5.5", "supported_endpoint_types": []string{"anthropic", "openai-response"}},
+			{"id": "gpt-5.6", "supported_endpoint_types": []string{"chat_completions"}},
 		}})
 	}))
 	defer upstream.Close()
@@ -638,8 +641,66 @@ func TestImportProviderModelsCreatesSelectedModelsWithOneSecret(t *testing.T) {
 	if store.createdModels[0].SecretID != "00000000-0000-0000-0000-000000000777" || store.createdModels[1].SecretID != "00000000-0000-0000-0000-000000000777" {
 		t.Fatalf("expected imported models to reuse created secret, got %+v", store.createdModels)
 	}
+	if got := fmt.Sprint(store.createdModels[0].Config["supported_endpoint_types"]); got != "[anthropic openai-response]" {
+		t.Fatalf("expected endpoint types stored for gpt-5.5, got %s", got)
+	}
+	if got := fmt.Sprint(store.createdModels[1].Config["supported_endpoint_types"]); got != "[openai]" {
+		t.Fatalf("expected chat_completions alias normalized for gpt-5.6, got %s", got)
+	}
 	if !strings.Contains(res.Body.String(), `"skipped":["gpt-5.4"]`) {
 		t.Fatalf("expected existing model to be skipped, got %s", res.Body.String())
+	}
+}
+
+func TestDetectProviderModelEndpointsFindsSharedBaseURLFamilies(t *testing.T) {
+	var sawAnthropic, sawOpenAI bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		switch r.URL.Path {
+		case "/v1/messages":
+			sawAnthropic = true
+			if got := r.Header.Get("x-api-key"); got != "sk-detect" {
+				t.Fatalf("expected anthropic x-api-key, got %q", got)
+			}
+			if !strings.Contains(string(bodyBytes), `"model":"shared-model"`) {
+				t.Fatalf("expected model in anthropic probe body, got %s", string(bodyBytes))
+			}
+			_, _ = w.Write([]byte(`{"content":[{"type":"text","text":"pong"}]}`))
+		case "/v1/chat/completions":
+			sawOpenAI = true
+			if got := r.Header.Get("Authorization"); got != "Bearer sk-detect" {
+				t.Fatalf("expected bearer auth, got %q", got)
+			}
+			if !strings.Contains(string(bodyBytes), `"model":"shared-model"`) {
+				t.Fatalf("expected model in openai probe body, got %s", string(bodyBytes))
+			}
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"pong"}}]}`))
+		case "/v1/responses":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error":{"message":"not found"}}`))
+		default:
+			t.Fatalf("unexpected probe path %s", r.URL.Path)
+		}
+	}))
+	defer upstream.Close()
+
+	store := &modelImportStore{}
+	r := chi.NewRouter()
+	RegisterRoutesWithStore(r, store)
+	body := fmt.Sprintf(`{
+		"base_url":%q,
+		"model_key":"shared-model",
+		"api_key":"sk-detect"
+	}`, upstream.URL+"/v1")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/00000000-0000-0000-0000-000000000002/models/detect-endpoints", strings.NewReader(body))
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+	requireStatus(t, res, http.StatusOK)
+	if !sawAnthropic || !sawOpenAI {
+		t.Fatalf("expected both anthropic and openai probes, got anthropic=%v openai=%v", sawAnthropic, sawOpenAI)
+	}
+	if got := res.Body.String(); !strings.Contains(got, `"supported_endpoint_types":["anthropic","openai"]`) {
+		t.Fatalf("expected detected endpoint types, got %s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a workspace model import API that discovers OpenAI-shaped `/v1/models` endpoints and creates selected model rows
- add the admin bulk import dialog with provider/protocol selection, dry-run preview, existing-model skipping, and import result feedback
- update OpenAPI and admin i18n copy for the new import route and UI

## Architecture boundary
- Server owns model discovery orchestration and persisted model/secret creation through the existing dev model registry route surface.
- Frontend only sends typed import requests and renders preview/import results; provider option helpers live in `apps/web/src/lib/`.

## Tests
- `make check`