### PR TITLE
feat: add OIDC SSO via standard libraries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,27 @@ PARSAR_FEISHU_VERIFICATION_TOKEN=
 PARSAR_FEISHU_ENCRYPT_KEY=
 
 # -----------------------------------------------------------------------------
+# Auth — generic OIDC SSO (optional)
+# -----------------------------------------------------------------------------
+# Supports multiple OpenID Connect identity providers such as Google,
+# Microsoft Entra ID, Okta, Auth0, Keycloak, or an internal corporate IdP.
+# Full guide: docs/deploy/oidc-sso.md
+# Provider ids must match: ^[a-z][a-z0-9_-]{0,62}$
+#
+# Example:
+#   PARSAR_AUTH_OIDC_PROVIDERS=google,company
+#   PARSAR_AUTH_OIDC_GOOGLE_LABEL=Google
+#   PARSAR_AUTH_OIDC_GOOGLE_ISSUER_URL=https://accounts.google.com
+#   PARSAR_AUTH_OIDC_GOOGLE_CLIENT_ID=
+#   PARSAR_AUTH_OIDC_GOOGLE_CLIENT_SECRET=
+#   PARSAR_AUTH_OIDC_GOOGLE_SCOPES=openid email profile
+#   PARSAR_AUTH_OIDC_GOOGLE_ALLOWED_DOMAINS=example.com
+#
+# If PARSAR_AUTH_OIDC_<ID>_REDIRECT_URI is omitted, Parsar derives:
+#   ${PARSAR_PUBLIC_URL}/api/v1/auth/oidc/<id>/callback
+PARSAR_AUTH_OIDC_PROVIDERS=
+
+# -----------------------------------------------------------------------------
 # Database
 # -----------------------------------------------------------------------------
 # `make dev` starts a Postgres container and exports this URL for you.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,40 @@ description and keep ownership on the side listed here.
   are committed artifacts, but never the source of truth. Change annotations
   or SQL first, then regenerate.
 
+### Auth provider configuration
+
+- Email/password login is always available after bootstrap.
+- Feishu login remains the Feishu-specific adapter because its token exchange
+  needs a Feishu app access token and is not a generic OAuth/OIDC exchange.
+- Generic third-party SSO uses env-driven OIDC providers backed by
+  `github.com/coreos/go-oidc/v3/oidc` and `golang.org/x/oauth2`; do not
+  hand-roll discovery, JWKS parsing, or ID token verification.
+- List provider ids with `PARSAR_AUTH_OIDC_PROVIDERS`, for example
+  `PARSAR_AUTH_OIDC_PROVIDERS=google,company`.
+- Provider ids must match `^[a-z][a-z0-9_-]{0,62}$`. The id becomes part of
+  the login routes and identity key:
+  `/api/v1/auth/oidc/{providerID}/start`,
+  `/api/v1/auth/oidc/{providerID}/callback`, and
+  `auth_identities.provider = "oidc:{providerID}"`.
+- Per-provider env names use the uppercased provider id with non-alphanumeric
+  characters converted to `_`: `company-sso` uses
+  `PARSAR_AUTH_OIDC_COMPANY_SSO_*`.
+- Required per-provider env:
+  `PARSAR_AUTH_OIDC_<ID>_ISSUER_URL`,
+  `PARSAR_AUTH_OIDC_<ID>_CLIENT_ID`,
+  `PARSAR_AUTH_OIDC_<ID>_CLIENT_SECRET`.
+- Optional per-provider env:
+  `PARSAR_AUTH_OIDC_<ID>_LABEL`,
+  `PARSAR_AUTH_OIDC_<ID>_REDIRECT_URI`,
+  `PARSAR_AUTH_OIDC_<ID>_SCOPES`,
+  `PARSAR_AUTH_OIDC_<ID>_ALLOWED_DOMAINS`,
+  `PARSAR_AUTH_OIDC_<ID>_REQUIRE_VERIFIED_EMAIL`.
+- If `REDIRECT_URI` is omitted, Parsar derives it from `PARSAR_PUBLIC_URL` as
+  `{public_url}/api/v1/auth/oidc/{providerID}/callback` (or the dev loopback
+  public URL when running in dev profile).
+- Parsar-owned OIDC logic is limited to state/nonce cookies, verified email,
+  allowed-domain policy, local user/session creation, and provider id mapping.
+
 ## Code quality & architecture
 
 Parsar favors small, single-purpose files and reused helpers over growing

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -88,6 +88,25 @@ PARSAR_FEISHU_AUTHORIZE_BASE=
 PARSAR_FEISHU_API_BASE=
 
 # -----------------------------------------------------------------------------
+# Generic OIDC SSO (optional)
+# -----------------------------------------------------------------------------
+# Multiple providers can be enabled without DB/admin configuration. Examples:
+# Google, Microsoft Entra ID, Okta, Auth0, Keycloak, or an internal IdP.
+# Full guide: ../../docs/deploy/oidc-sso.md
+#
+# Register this callback in each provider:
+#   https://<your-parsar-host>/api/v1/auth/oidc/<provider-id>/callback
+#
+# Example:
+#   PARSAR_AUTH_OIDC_PROVIDERS=google,company
+#   PARSAR_AUTH_OIDC_GOOGLE_LABEL=Google
+#   PARSAR_AUTH_OIDC_GOOGLE_ISSUER_URL=https://accounts.google.com
+#   PARSAR_AUTH_OIDC_GOOGLE_CLIENT_ID=
+#   PARSAR_AUTH_OIDC_GOOGLE_CLIENT_SECRET=
+#   PARSAR_AUTH_OIDC_GOOGLE_ALLOWED_DOMAINS=example.com
+PARSAR_AUTH_OIDC_PROVIDERS=
+
+# -----------------------------------------------------------------------------
 # GitHub personal account connection (OAuth App)
 # -----------------------------------------------------------------------------
 # Creates/rotates the signed-in user's github_pat credential after OAuth.

--- a/deploy/compose/compose.selfhost.yml
+++ b/deploy/compose/compose.selfhost.yml
@@ -92,6 +92,11 @@ services:
       # reverse proxy (nginx / caddy / ingress) terminate
       # TLS there and forward to 127.0.0.1:8080 on the host.
       - "127.0.0.1:${PARSAR_HOST_PORT}:8080"
+    # Pass through dynamic env prefixes such as PARSAR_AUTH_OIDC_<ID>_*.
+    # Explicit environment entries below still document the required and
+    # commonly-used values.
+    env_file:
+      - .env
     environment:
       # ---------- Required ----------
       # Postgres connection. Use the service name `postgres` when

--- a/docs/deploy/deploy-runbook.md
+++ b/docs/deploy/deploy-runbook.md
@@ -10,6 +10,7 @@ Audience: any self-hosted open-source deployment — every deployment profile
 
 > **Related documents**
 > - [feishu-prod.md](./feishu-prod.md) — Feishu OIDC + event-subscription production config.
+> - [oidc-sso.md](./oidc-sso.md) — generic OIDC SSO for Google, Microsoft Entra ID, Okta, Auth0, Keycloak, or internal IdPs.
 > - [feishu-bot-per-agent.md](./feishu-bot-per-agent.md) — expose a single Agent as a Feishu bot (one per Feishu-connected Agent).
 > - [health-and-smoke.md](./health-and-smoke.md) — `/healthz`, `/readyz`, `smoke.sh` checks.
 > - [config.example.yaml](./config.example.yaml) — the fully-commented YAML template.
@@ -245,7 +246,8 @@ layer**. To make a deployment truly production-ready you still need:
 | Sandbox runner (E2B) | Phase 4 in progress | Another session |
 | Admin UI (installer step-by-step) | Phase 4 follow-up | Another session |
 | Real auth (Feishu OIDC production config) | Landed; see `feishu-prod.md` | — |
-| Real auth (other OAuth providers: GitHub / Google / email magic link) | Not implemented | Later phase |
+| Real auth (generic OIDC: Google / Entra / Okta / Auth0 / Keycloak / internal IdP) | Landed; see `oidc-sso.md` | — |
+| Real auth (GitHub login / email magic link) | Not implemented | Later phase |
 | Smoke — post-deploy liveness (/healthz, /readyz, /api/v1/health) | Landed; see the lite mode in `health-and-smoke.md` | — |
 | Smoke — bootstrap path (status / dev_auth shim / provision / idempotency) | Landed; see the core mode in `health-and-smoke.md` | — |
 | Smoke — end-to-end AgentRun / audit / usage | Missing `/api/v1/workspaces/{wid}/{agent-runs,audit-records,usage}` and other cookie-session entry points; smoke-core marks this SKIP/TODO | Later phase |

--- a/docs/deploy/oidc-sso.md
+++ b/docs/deploy/oidc-sso.md
@@ -1,0 +1,237 @@
+# Generic OIDC SSO deployment guide
+
+This guide configures third-party login through standard OpenID Connect
+providers such as Google, Microsoft Entra ID, Okta, Auth0, Keycloak, or an
+internal corporate IdP.
+
+Feishu stays on its own guide because its token exchange is Feishu-specific:
+see [feishu-prod.md](./feishu-prod.md). GitHub login is not part of this guide
+because GitHub OAuth Apps are OAuth2, not generic OIDC.
+
+## 1. What Parsar supports
+
+Parsar can load one or more OIDC providers from environment variables:
+
+```bash
+PARSAR_AUTH_OIDC_PROVIDERS=google,company
+```
+
+Each provider gets its own login routes:
+
+```text
+GET /api/v1/auth/oidc/google/start
+GET /api/v1/auth/oidc/google/callback
+
+GET /api/v1/auth/oidc/company/start
+GET /api/v1/auth/oidc/company/callback
+```
+
+The login page discovers enabled providers through
+`GET /api/v1/auth/providers`, so no frontend configuration is required.
+
+The local identity binding uses the provider id:
+
+```text
+auth_identities.provider = "oidc:google"
+auth_identities.subject  = "<id_token.sub>"
+```
+
+Do not reuse the same provider id for different issuers.
+
+## 2. Create an OIDC application in your IdP
+
+In your identity provider console, create an OIDC / OAuth client with:
+
+| Field | Value |
+|---|---|
+| Application type | Web application / confidential client |
+| Flow | Authorization code |
+| Redirect URI | `https://<your-parsar-host>/api/v1/auth/oidc/<provider-id>/callback` |
+| Scopes | `openid email profile` |
+
+Record:
+
+- Issuer URL, for example `https://accounts.google.com` or
+  `https://login.microsoftonline.com/<tenant-id>/v2.0`
+- Client ID
+- Client Secret
+
+The issuer URL must be the issuer root that exposes:
+
+```text
+<issuer>/.well-known/openid-configuration
+```
+
+## 3. Configure Parsar
+
+Provider ids must match:
+
+```text
+^[a-z][a-z0-9_-]{0,62}$
+```
+
+The env prefix is the uppercased provider id, with non-alphanumeric characters
+converted to `_`. For example, provider id `company-sso` uses
+`PARSAR_AUTH_OIDC_COMPANY_SSO_*`.
+
+### 3.1 Google example
+
+Register this redirect URI in Google Cloud Console:
+
+```text
+https://parsar.example.com/api/v1/auth/oidc/google/callback
+```
+
+Set:
+
+```bash
+PARSAR_PUBLIC_URL=https://parsar.example.com
+
+PARSAR_AUTH_OIDC_PROVIDERS=google
+PARSAR_AUTH_OIDC_GOOGLE_LABEL=Google
+PARSAR_AUTH_OIDC_GOOGLE_ISSUER_URL=https://accounts.google.com
+PARSAR_AUTH_OIDC_GOOGLE_CLIENT_ID=<google-oauth-client-id>
+PARSAR_AUTH_OIDC_GOOGLE_CLIENT_SECRET=<google-oauth-client-secret>
+PARSAR_AUTH_OIDC_GOOGLE_SCOPES="openid email profile"
+
+# Optional: restrict logins to organization email domains.
+PARSAR_AUTH_OIDC_GOOGLE_ALLOWED_DOMAINS=example.com
+```
+
+### 3.2 Microsoft Entra ID example
+
+Use your tenant-specific issuer, not `common`, when you want one organization:
+
+```bash
+PARSAR_PUBLIC_URL=https://parsar.example.com
+
+PARSAR_AUTH_OIDC_PROVIDERS=entra
+PARSAR_AUTH_OIDC_ENTRA_LABEL="Microsoft Entra ID"
+PARSAR_AUTH_OIDC_ENTRA_ISSUER_URL=https://login.microsoftonline.com/<tenant-id>/v2.0
+PARSAR_AUTH_OIDC_ENTRA_CLIENT_ID=<application-client-id>
+PARSAR_AUTH_OIDC_ENTRA_CLIENT_SECRET=<client-secret-value>
+PARSAR_AUTH_OIDC_ENTRA_SCOPES="openid email profile"
+PARSAR_AUTH_OIDC_ENTRA_ALLOWED_DOMAINS=example.com
+```
+
+### 3.3 Keycloak example
+
+For a realm named `engineering`:
+
+```bash
+PARSAR_PUBLIC_URL=https://parsar.example.com
+
+PARSAR_AUTH_OIDC_PROVIDERS=keycloak
+PARSAR_AUTH_OIDC_KEYCLOAK_LABEL=Keycloak
+PARSAR_AUTH_OIDC_KEYCLOAK_ISSUER_URL=https://keycloak.example.com/realms/engineering
+PARSAR_AUTH_OIDC_KEYCLOAK_CLIENT_ID=parsar
+PARSAR_AUTH_OIDC_KEYCLOAK_CLIENT_SECRET=<keycloak-client-secret>
+PARSAR_AUTH_OIDC_KEYCLOAK_SCOPES="openid email profile"
+```
+
+## 4. Multiple providers
+
+Separate provider ids with commas:
+
+```bash
+PARSAR_AUTH_OIDC_PROVIDERS=google,company
+
+PARSAR_AUTH_OIDC_GOOGLE_LABEL=Google
+PARSAR_AUTH_OIDC_GOOGLE_ISSUER_URL=https://accounts.google.com
+PARSAR_AUTH_OIDC_GOOGLE_CLIENT_ID=<id>
+PARSAR_AUTH_OIDC_GOOGLE_CLIENT_SECRET=<secret>
+PARSAR_AUTH_OIDC_GOOGLE_ALLOWED_DOMAINS=example.com
+
+PARSAR_AUTH_OIDC_COMPANY_LABEL="Company SSO"
+PARSAR_AUTH_OIDC_COMPANY_ISSUER_URL=https://idp.company.example
+PARSAR_AUTH_OIDC_COMPANY_CLIENT_ID=<id>
+PARSAR_AUTH_OIDC_COMPANY_CLIENT_SECRET=<secret>
+PARSAR_AUTH_OIDC_COMPANY_ALLOWED_DOMAINS=company.example
+```
+
+The login page will show one button per enabled provider.
+
+## 5. Optional settings
+
+```bash
+# Defaults to the provider id.
+PARSAR_AUTH_OIDC_<ID>_LABEL="Company SSO"
+
+# Defaults to:
+# ${PARSAR_PUBLIC_URL}/api/v1/auth/oidc/<id>/callback
+PARSAR_AUTH_OIDC_<ID>_REDIRECT_URI=https://parsar.example.com/api/v1/auth/oidc/<id>/callback
+
+# Defaults to: openid email profile
+PARSAR_AUTH_OIDC_<ID>_SCOPES="openid email profile"
+
+# Comma-separated domain allowlist. Empty means any verified email domain.
+PARSAR_AUTH_OIDC_<ID>_ALLOWED_DOMAINS=example.com,example.org
+
+# Defaults to true. Only set false for an IdP that cannot emit email_verified
+# and is otherwise trusted by your organization.
+PARSAR_AUTH_OIDC_<ID>_REQUIRE_VERIFIED_EMAIL=false
+```
+
+## 6. Docker Compose self-hosting
+
+When using `deploy/compose/compose.selfhost.yml`, put the OIDC variables in
+the same `.env` file used by compose:
+
+```bash
+cd deploy/compose
+cp .env.example .env
+$EDITOR .env
+docker compose -f compose.selfhost.yml --env-file .env up -d
+```
+
+The compose service reads `.env` as a container `env_file`, so dynamic
+provider-specific variables such as `PARSAR_AUTH_OIDC_COMPANY_CLIENT_ID` are
+available inside `parsar-server`.
+
+## 7. Verify the deployment
+
+Check the public provider list:
+
+```bash
+curl -fsS https://parsar.example.com/api/v1/auth/providers
+```
+
+Expected shape:
+
+```json
+{
+  "providers": [
+    {
+      "id": "password",
+      "type": "password",
+      "label": "Email password",
+      "enabled": true,
+      "login_url": "/login"
+    },
+    {
+      "id": "oidc:google",
+      "type": "oidc",
+      "label": "Google",
+      "enabled": true,
+      "login_url": "/api/v1/auth/oidc/google/start"
+    }
+  ]
+}
+```
+
+Then open the Parsar login page and click the new provider button.
+
+Workspace owners/admins can also open Settings -> Authentication to see
+callback URL and missing-env diagnostics.
+
+## 8. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Provider does not appear on login page | Missing required env | Check Settings -> Authentication or `/api/v1/workspaces/{id}/auth/providers` |
+| Callback returns `OIDC exchange failed` | Redirect URI mismatch or bad client secret | Make the IdP redirect URI exactly match Parsar's callback URL |
+| Callback returns `nonce mismatch` | Stale callback or cookies blocked | Restart login from the Parsar login page; ensure browser accepts first-party cookies |
+| Callback returns `email is not verified` | IdP did not emit `email_verified=true` | Enable email/profile claims in the IdP, or explicitly set `REQUIRE_VERIFIED_EMAIL=false` only for trusted IdPs |
+| Callback returns `email domain is not allowed` | Email domain not in allowlist | Update `PARSAR_AUTH_OIDC_<ID>_ALLOWED_DOMAINS` |
+| Discovery fails | Wrong issuer URL | Open `<issuer>/.well-known/openid-configuration` in a browser or with curl |
+

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2694,6 +2694,91 @@ paths:
       summary: Log out the current session
       tags:
       - auth
+  /api/v1/auth/oidc/{providerID}/callback:
+    get:
+      description: Verifies CSRF state and OIDC nonce, exchanges the authorization
+        code, upserts the user identity, creates a session cookie, and redirects to
+        the login-success URL.
+      operationId: callbackOIDCOAuth
+      parameters:
+      - description: OIDC provider ID
+        in: path
+        name: providerID
+        required: true
+        type: string
+      - description: CSRF state minted at /start
+        in: query
+        name: state
+        required: true
+        type: string
+      - description: OAuth authorization code returned by the OIDC provider
+        in: query
+        name: code
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "302":
+          description: Redirect to login-success URL
+        "400":
+          description: Missing state/code or state/nonce mismatch
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: OIDC provider is not configured
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: User upsert or session creation failed
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "502":
+          description: OIDC exchange failed
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Handle generic OIDC callback
+      tags:
+      - auth
+  /api/v1/auth/oidc/{providerID}/start:
+    get:
+      description: Mints CSRF and nonce cookies and redirects the browser to the configured
+        OIDC provider authorize URL.
+      operationId: startOIDCOAuth
+      parameters:
+      - description: OIDC provider ID
+        in: path
+        name: providerID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "302":
+          description: Redirect to OIDC authorize URL
+        "404":
+          description: OIDC provider is not configured
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: State minting or discovery failed
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Start generic OIDC login
+      tags:
+      - auth
   /api/v1/auth/providers:
     get:
       description: Returns the login providers the public login page may render. Sensitive

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/aliyun/alibabacloud-oss-go-sdk-v2 v1.5.2
 	github.com/bwmarrin/discordgo v0.29.0
+	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/httprate v0.16.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -18,11 +19,13 @@ require (
 	github.com/slack-go/slack v0.27.0
 	go.opentelemetry.io/proto/otlp v1.10.0
 	golang.org/x/crypto v0.54.0
+	golang.org/x/oauth2 v0.36.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+Eg
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coreos/go-oidc/v3 v3.20.0 h1:EtE0WIBHk03N+DqGkY4+UONzzZHk7amKt6IyNd7OsZE=
+github.com/coreos/go-oidc/v3 v3.20.0/go.mod h1:DYCf24+ncYi+XkIH97GY1+dqoRlbaSI26KVTCI9SrY4=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -16,6 +18,8 @@ github.com/go-chi/chi/v5 v5.3.1 h1:3j4HZLGZQ3JpMCrPJF/Jl3mYJfWLKBfNJ6quurUGCf8=
 github.com/go-chi/chi/v5 v5.3.1/go.mod h1:R+tYY2hNuVUUjxoPtqUdgBqevM9s9njzkTLutVsOCto=
 github.com/go-chi/httprate v0.16.0 h1:8V5DH9j6pSK6UQoBsTpvMyFxycqaKEIToyPKzHJjUa8=
 github.com/go-chi/httprate v0.16.0/go.mod h1:A8lo+qRhk+s9LiuP5saS7XCGDXRXMcrueq0NfIuCa/I=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -118,6 +122,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
 golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/feishu"
 	authgithub "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/github"
+	authoidc "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/oidc"
 	authpassword "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/password"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/bootstrap"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/config"
@@ -346,10 +347,15 @@ func main() {
 	// must publish into the same broker the UI /stream is subscribing
 	// to, otherwise events land in a per-call broker and the UI hangs.
 	runStreamBroker := runstream.NewBroker(runstream.DefaultBufferSize)
+	oidcPublicURL := strings.TrimRight(cfg.BuildPublicURL("/"), "/")
+	oidcClients, oidcStatuses, oidcErr := authoidc.NewClientsFromEnv(authoidc.EnvFunc(envLookup), oidcPublicURL)
+	if oidcErr != nil {
+		log.Bg().Warn("OIDC auth providers disabled", "error", oidcErr)
+	}
 	opts := []dev.RouterOption{
 		dev.WithDispatchContext(serverRootCtx),
 		dev.WithRunStreamBroker(runStreamBroker),
-		dev.WithAuthProviders(buildAuthProviderRegistry(envLookup, cfg, feishuDecision)),
+		dev.WithAuthProviders(buildAuthProviderRegistry(envLookup, cfg, feishuDecision, oidcStatuses)),
 	}
 	if shouldRegisterFeishuAppProvisioning(cfg) {
 		if regClient, err := gatewaypkg.NewFeishuAppRegistrationClient(gatewaypkg.FeishuAppRegistrationClientOptions{
@@ -635,27 +641,32 @@ func main() {
 			CookieSecure: cfg.Auth.Cookie.Secure,
 		}))
 
-		if feishuDecision.RegisterOAuthHandlers {
+		if feishuDecision.RegisterOAuthHandlers || len(oidcClients) > 0 {
+			loginRedirect := strings.TrimSpace(cfg.Gateway.Feishu.LoginRedirectURL)
+			cookieSecure := cfg.Auth.Cookie.Secure
+			deps := dev.OAuthHandlerDeps{
+				OIDC:             oidcClients,
+				Sessions:         sessionStore,
+				Store:            dbStore,
+				CookieSecure:     cookieSecure,
+				LoginRedirectURL: loginRedirect,
+			}
 			feishuClient, err := feishu.NewClientFromEnv(envLookup)
-			if err != nil {
+			if feishuDecision.RegisterOAuthHandlers && err != nil {
 				log.Bg().Warn("feishu OIDC client not registered", "error", err)
-			} else {
-				// CookieSecure driven by Config.Auth.Cookie.Secure; we
-				// do not sniff request scheme because proxies lie.
-				cookieSecure := cfg.Auth.Cookie.Secure
-				// loginRedirect: default "/" for prod / single-origin
-				// where the server serves the SPA; `make dev` points
-				// at the Vite origin (e.g. http://127.0.0.1:5173/).
-				loginRedirect := strings.TrimSpace(cfg.Gateway.Feishu.LoginRedirectURL)
-				opts = append(opts, dev.WithOAuthHandlers(dev.OAuthHandlerDeps{
-					Feishu:           feishuClient,
-					Sessions:         sessionStore,
-					Store:            dbStore,
-					CookieSecure:     cookieSecure,
-					LoginRedirectURL: loginRedirect,
-				}))
+			}
+			if err == nil {
+				deps.Feishu = feishuClient
+			}
+			opts = append(opts, dev.WithOAuthHandlers(deps))
+			if deps.Feishu != nil {
 				log.Bg().Info("feishu OIDC handlers registered",
 					"mode", feishuDecision.Mode, "mock", feishuClient.IsMock(), "cookie_secure", cookieSecure,
+					"login_redirect", loginRedirect)
+			}
+			if len(oidcClients) > 0 {
+				log.Bg().Info("OIDC auth handlers registered",
+					"providers", len(oidcClients), "cookie_secure", cookieSecure,
 					"login_redirect", loginRedirect)
 			}
 		}
@@ -1062,7 +1073,7 @@ func decideFeishuStartup(env func(string) string) feishuStartupDecision {
 	}
 }
 
-func buildAuthProviderRegistry(env func(string) string, cfg config.Config, feishuDecision feishuStartupDecision) dev.AuthProviderRegistry {
+func buildAuthProviderRegistry(env func(string) string, cfg config.Config, feishuDecision feishuStartupDecision, oidcStatuses []authoidc.ProviderEnvStatus) dev.AuthProviderRegistry {
 	if env == nil {
 		env = os.Getenv
 	}
@@ -1105,6 +1116,26 @@ func buildAuthProviderRegistry(env func(string) string, cfg config.Config, feish
 		feishuProvider.LoginURL = "/api/v1/auth/feishu/start"
 	}
 	providers = append(providers, feishuProvider)
+
+	for _, status := range oidcStatuses {
+		providerID := status.Config.ID
+		enabled := len(status.MissingEnv) == 0
+		provider := dev.AuthProvider{
+			ID:          "oidc:" + providerID,
+			Type:        dev.AuthProviderTypeOIDC,
+			Label:       status.Config.Label,
+			Enabled:     enabled,
+			Configured:  enabled,
+			CallbackURL: status.Config.RedirectURI,
+			RequiredEnv: status.RequiredEnv,
+			MissingEnv:  status.MissingEnv,
+			DocsURL:     "docs/deploy/oidc-sso.md",
+		}
+		if provider.Enabled {
+			provider.LoginURL = "/api/v1/auth/oidc/" + providerID + "/start"
+		}
+		providers = append(providers, provider)
+	}
 
 	return dev.AuthProviderRegistry{Providers: providers}
 }

--- a/server/cmd/server/main_test.go
+++ b/server/cmd/server/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/feishu"
+	authoidc "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/oidc"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/config"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 )
@@ -74,6 +75,7 @@ func TestBuildAuthProviderRegistry(t *testing.T) {
 		env              map[string]string
 		wantFeishuEnable bool
 		wantMissing      []string
+		wantProviderIDs  []string
 	}{
 		{
 			name: "default password only and feishu diagnostic disabled",
@@ -83,6 +85,7 @@ func TestBuildAuthProviderRegistry(t *testing.T) {
 				feishu.EnvAppSecret,
 				feishu.EnvRedirectURI,
 			},
+			wantProviderIDs: []string{"password", "feishu"},
 		},
 		{
 			name: "feishu oauth configured",
@@ -92,6 +95,7 @@ func TestBuildAuthProviderRegistry(t *testing.T) {
 				feishu.EnvRedirectURI: "https://parsar.example/api/v1/auth/feishu/callback",
 			},
 			wantFeishuEnable: true,
+			wantProviderIDs:  []string{"password", "feishu"},
 		},
 		{
 			name: "mock feishu configured",
@@ -99,14 +103,45 @@ func TestBuildAuthProviderRegistry(t *testing.T) {
 				feishu.EnvMock: "true",
 			},
 			wantFeishuEnable: true,
+			wantProviderIDs:  []string{"password", "feishu"},
+		},
+		{
+			name: "multiple oidc providers",
+			env: map[string]string{
+				authoidc.EnvProviders:                      "google,company",
+				"PARSAR_AUTH_OIDC_GOOGLE_LABEL":            "Google",
+				"PARSAR_AUTH_OIDC_GOOGLE_ISSUER_URL":       "https://accounts.google.com",
+				"PARSAR_AUTH_OIDC_GOOGLE_CLIENT_ID":        "google-client",
+				"PARSAR_AUTH_OIDC_GOOGLE_CLIENT_SECRET":    "google-secret",
+				"PARSAR_AUTH_OIDC_COMPANY_LABEL":           "Company SSO",
+				"PARSAR_AUTH_OIDC_COMPANY_ISSUER_URL":      "https://idp.example.com",
+				"PARSAR_AUTH_OIDC_COMPANY_CLIENT_ID":       "company-client",
+				"PARSAR_AUTH_OIDC_COMPANY_CLIENT_SECRET":   "company-secret",
+				"PARSAR_AUTH_OIDC_COMPANY_ALLOWED_DOMAINS": "example.com",
+			},
+			wantMissing: []string{
+				feishu.EnvAppID,
+				feishu.EnvAppSecret,
+				feishu.EnvRedirectURI,
+			},
+			wantProviderIDs: []string{"password", "feishu", "oidc:google", "oidc:company"},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			env := func(k string) string { return tc.env[k] }
-			registry := buildAuthProviderRegistry(env, cfg, decideFeishuStartup(env))
-			if len(registry.Providers) != 2 {
-				t.Fatalf("provider count = %d, want 2", len(registry.Providers))
+			oidcStatuses, err := authoidc.LoadProviderStatuses(authoidc.EnvFunc(env), cfg.Server.PublicURL)
+			if err != nil {
+				t.Fatalf("LoadProviderStatuses: %v", err)
+			}
+			registry := buildAuthProviderRegistry(env, cfg, decideFeishuStartup(env), oidcStatuses)
+			if len(registry.Providers) != len(tc.wantProviderIDs) {
+				t.Fatalf("provider count = %d, want %d", len(registry.Providers), len(tc.wantProviderIDs))
+			}
+			for i, wantID := range tc.wantProviderIDs {
+				if registry.Providers[i].ID != wantID {
+					t.Fatalf("provider[%d] id = %q, want %q", i, registry.Providers[i].ID, wantID)
+				}
 			}
 			if registry.Providers[0].ID != "password" || !registry.Providers[0].Enabled {
 				t.Fatalf("password provider = %+v, want enabled password", registry.Providers[0])

--- a/server/internal/auth/oidc/client.go
+++ b/server/internal/auth/oidc/client.go
@@ -1,0 +1,198 @@
+package oidc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	gooidc "github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+)
+
+type Client interface {
+	AuthorizeURL(ctx context.Context, state, nonce string) (string, error)
+	ExchangeCode(ctx context.Context, code, nonce string) (UserProfile, error)
+}
+
+type UserProfile struct {
+	Provider   string
+	ProviderID string
+	Subject    string
+	Email      string
+	Name       string
+	AvatarURL  string
+	Issuer     string
+	Claims     map[string]any
+	UserInfo   map[string]any
+}
+
+type httpClient struct {
+	cfg ProviderConfig
+
+	mu       sync.RWMutex
+	provider *gooidc.Provider
+}
+
+func NewClient(cfg ProviderConfig) (Client, error) {
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+	return &httpClient{cfg: cfg}, nil
+}
+
+func (c *httpClient) AuthorizeURL(ctx context.Context, state, nonce string) (string, error) {
+	provider, err := c.providerFor(ctx)
+	if err != nil {
+		return "", err
+	}
+	oauth2Config := c.oauth2Config(provider)
+	return oauth2Config.AuthCodeURL(state, gooidc.Nonce(nonce)), nil
+}
+
+func (c *httpClient) ExchangeCode(ctx context.Context, code, nonce string) (UserProfile, error) {
+	provider, err := c.providerFor(ctx)
+	if err != nil {
+		return UserProfile{}, err
+	}
+	oauth2Config := c.oauth2Config(provider)
+	token, err := oauth2Config.Exchange(ctx, strings.TrimSpace(code))
+	if err != nil {
+		return UserProfile{}, fmt.Errorf("oidc: exchange code for provider %q: %w", c.cfg.ID, err)
+	}
+	rawIDToken, ok := token.Extra("id_token").(string)
+	if !ok || strings.TrimSpace(rawIDToken) == "" {
+		return UserProfile{}, errors.New("oidc: token response missing id_token")
+	}
+
+	verifier := provider.Verifier(&gooidc.Config{ClientID: c.cfg.ClientID})
+	idToken, err := verifier.Verify(ctx, rawIDToken)
+	if err != nil {
+		return UserProfile{}, fmt.Errorf("oidc: verify id_token for provider %q: %w", c.cfg.ID, err)
+	}
+	if idToken.Nonce != nonce {
+		return UserProfile{}, errors.New("oidc: nonce mismatch")
+	}
+
+	claims := map[string]any{}
+	if err := idToken.Claims(&claims); err != nil {
+		return UserProfile{}, fmt.Errorf("oidc: decode id_token claims: %w", err)
+	}
+	userInfo := map[string]any{}
+	if token.AccessToken != "" && provider.UserInfoEndpoint() != "" {
+		info, err := provider.UserInfo(ctx, oauth2.StaticTokenSource(token))
+		if err == nil {
+			if err := info.Claims(&userInfo); err != nil {
+				return UserProfile{}, fmt.Errorf("oidc: decode userinfo claims: %w", err)
+			}
+			if info.Subject != "" && info.Subject != idToken.Subject {
+				return UserProfile{}, errors.New("oidc: userinfo sub does not match id_token sub")
+			}
+		}
+	}
+	profile := profileFromClaims(c.cfg, idToken, claims, userInfo)
+	if err := validateProfile(c.cfg, profile); err != nil {
+		return UserProfile{}, err
+	}
+	return profile, nil
+}
+
+func (c *httpClient) providerFor(ctx context.Context) (*gooidc.Provider, error) {
+	c.mu.RLock()
+	provider := c.provider
+	c.mu.RUnlock()
+	if provider != nil {
+		return provider, nil
+	}
+	provider, err := gooidc.NewProvider(ctx, c.cfg.IssuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: discover provider %q: %w", c.cfg.ID, err)
+	}
+	c.mu.Lock()
+	c.provider = provider
+	c.mu.Unlock()
+	return provider, nil
+}
+
+func (c *httpClient) oauth2Config(provider *gooidc.Provider) oauth2.Config {
+	return oauth2.Config{
+		ClientID:     c.cfg.ClientID,
+		ClientSecret: c.cfg.ClientSecret,
+		RedirectURL:  c.cfg.RedirectURI,
+		Endpoint:     provider.Endpoint(),
+		Scopes:       c.cfg.Scopes,
+	}
+}
+
+func profileFromClaims(cfg ProviderConfig, idToken *gooidc.IDToken, claims, userInfo map[string]any) UserProfile {
+	merged := make(map[string]any, len(claims)+len(userInfo))
+	for k, v := range claims {
+		merged[k] = v
+	}
+	for k, v := range userInfo {
+		if _, ok := merged[k]; !ok {
+			merged[k] = v
+		}
+	}
+	email, _ := merged["email"].(string)
+	name, _ := merged["name"].(string)
+	if name == "" {
+		name, _ = merged["preferred_username"].(string)
+	}
+	if name == "" {
+		name, _ = merged["given_name"].(string)
+	}
+	avatar, _ := merged["picture"].(string)
+	return UserProfile{
+		Provider:   "oidc:" + cfg.ID,
+		ProviderID: cfg.ID,
+		Subject:    idToken.Subject,
+		Email:      strings.TrimSpace(email),
+		Name:       strings.TrimSpace(name),
+		AvatarURL:  strings.TrimSpace(avatar),
+		Issuer:     idToken.Issuer,
+		Claims:     claims,
+		UserInfo:   userInfo,
+	}
+}
+
+func validateProfile(cfg ProviderConfig, profile UserProfile) error {
+	if strings.TrimSpace(profile.Subject) == "" {
+		return errors.New("oidc: id_token missing sub claim")
+	}
+	if strings.TrimSpace(profile.Email) == "" {
+		return errors.New("oidc: profile missing email claim")
+	}
+	if cfg.RequireVerifiedEmail {
+		verified, ok := boolClaim(profile.Claims["email_verified"])
+		if !ok && len(profile.UserInfo) > 0 {
+			verified, ok = boolClaim(profile.UserInfo["email_verified"])
+		}
+		if !ok || !verified {
+			return errors.New("oidc: email is not verified")
+		}
+	}
+	if len(cfg.AllowedDomains) > 0 {
+		at := strings.LastIndex(profile.Email, "@")
+		if at <= 0 || !contains(cfg.AllowedDomains, strings.ToLower(profile.Email[at+1:])) {
+			return errors.New("oidc: email domain is not allowed")
+		}
+	}
+	return nil
+}
+
+func boolClaim(v any) (bool, bool) {
+	switch t := v.(type) {
+	case bool:
+		return t, true
+	case string:
+		switch strings.ToLower(strings.TrimSpace(t)) {
+		case "true":
+			return true, true
+		case "false":
+			return false, true
+		}
+	}
+	return false, false
+}

--- a/server/internal/auth/oidc/client_test.go
+++ b/server/internal/auth/oidc/client_test.go
@@ -1,0 +1,170 @@
+package oidc
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestLoadProviderStatusesMultipleProviders(t *testing.T) {
+	env := map[string]string{
+		EnvProviders:                              "google,company-sso",
+		"PARSAR_AUTH_OIDC_GOOGLE_LABEL":           "Google",
+		"PARSAR_AUTH_OIDC_GOOGLE_ISSUER_URL":      "https://accounts.google.com",
+		"PARSAR_AUTH_OIDC_GOOGLE_CLIENT_ID":       "google-client",
+		"PARSAR_AUTH_OIDC_GOOGLE_CLIENT_SECRET":   "google-secret",
+		"PARSAR_AUTH_OIDC_COMPANY_SSO_LABEL":      "Company SSO",
+		"PARSAR_AUTH_OIDC_COMPANY_SSO_ISSUER_URL": "https://idp.example.com",
+	}
+	statuses, err := LoadProviderStatuses(func(k string) string { return env[k] }, "https://parsar.example")
+	if err != nil {
+		t.Fatalf("LoadProviderStatuses: %v", err)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("status count = %d, want 2", len(statuses))
+	}
+	if statuses[0].Config.ID != "google" || statuses[0].Config.RedirectURI != "https://parsar.example/api/v1/auth/oidc/google/callback" {
+		t.Fatalf("google status = %+v", statuses[0])
+	}
+	if len(statuses[1].MissingEnv) == 0 {
+		t.Fatalf("company status should report missing client env: %+v", statuses[1])
+	}
+}
+
+func TestClientExchangeUsesOIDCLibraryAndBuildsProfile(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	var issuer string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			writeTestJSON(t, w, map[string]any{
+				"issuer":                                issuer,
+				"authorization_endpoint":                issuer + "/authorize",
+				"token_endpoint":                        issuer + "/token",
+				"userinfo_endpoint":                     issuer + "/userinfo",
+				"jwks_uri":                              issuer + "/jwks",
+				"id_token_signing_alg_values_supported": []string{"RS256"},
+			})
+		case "/jwks":
+			writeTestJSON(t, w, map[string]any{
+				"keys": []map[string]any{rsaJWK("test-kid", &key.PublicKey)},
+			})
+		case "/token":
+			user, pass, _ := r.BasicAuth()
+			if user != "client-1" || pass != "secret-1" {
+				t.Fatalf("basic auth = %q/%q, want client credentials", user, pass)
+			}
+			writeTestJSON(t, w, map[string]any{
+				"access_token": "access-1",
+				"id_token":     signTestIDToken(t, key, issuer, "client-1", "nonce-1"),
+				"token_type":   "Bearer",
+			})
+		case "/userinfo":
+			writeTestJSON(t, w, map[string]any{
+				"sub":     "sub-1",
+				"picture": "https://idp.example/avatar.png",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	issuer = srv.URL
+
+	client, err := NewClient(ProviderConfig{
+		ID:                   "company",
+		Label:                "Company",
+		IssuerURL:            issuer,
+		ClientID:             "client-1",
+		ClientSecret:         "secret-1",
+		RedirectURI:          "https://parsar.example/api/v1/auth/oidc/company/callback",
+		Scopes:               []string{"openid", "email", "profile"},
+		AllowedDomains:       []string{"example.com"},
+		RequireVerifiedEmail: true,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	authURL, err := client.AuthorizeURL(t.Context(), "state-1", "nonce-1")
+	if err != nil {
+		t.Fatalf("AuthorizeURL: %v", err)
+	}
+	if !strings.HasPrefix(authURL, issuer+"/authorize?") {
+		t.Fatalf("authorize URL = %q, want discovered endpoint", authURL)
+	}
+	profile, err := client.ExchangeCode(t.Context(), "code-1", "nonce-1")
+	if err != nil {
+		t.Fatalf("ExchangeCode: %v", err)
+	}
+	if profile.Provider != "oidc:company" || profile.Subject != "sub-1" || profile.Email != "admin@example.com" {
+		t.Fatalf("profile = %+v", profile)
+	}
+	if profile.AvatarURL != "https://idp.example/avatar.png" {
+		t.Fatalf("avatar = %q", profile.AvatarURL)
+	}
+}
+
+func TestClientExchangeRejectsDomainPolicy(t *testing.T) {
+	err := validateProfile(ProviderConfig{
+		AllowedDomains:       []string{"example.com"},
+		RequireVerifiedEmail: true,
+	}, UserProfile{
+		Subject: "sub-1",
+		Email:   "admin@other.com",
+		Claims:  map[string]any{"email_verified": true},
+	})
+	if err == nil || !strings.Contains(err.Error(), "email domain") {
+		t.Fatalf("validateProfile err = %v, want domain rejection", err)
+	}
+}
+
+func signTestIDToken(t *testing.T, key *rsa.PrivateKey, issuer, audience, nonce string) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"iss":            issuer,
+		"aud":            audience,
+		"sub":            "sub-1",
+		"email":          "admin@example.com",
+		"email_verified": true,
+		"name":           "Admin User",
+		"nonce":          nonce,
+		"exp":            time.Now().Add(time.Hour).Unix(),
+		"iat":            time.Now().Add(-time.Minute).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-kid"
+	signed, err := token.SignedString(key)
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+	return signed
+}
+
+func rsaJWK(kid string, key *rsa.PublicKey) map[string]any {
+	return map[string]any{
+		"kty": "RSA",
+		"kid": kid,
+		"n":   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+		"e":   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+	}
+}
+
+func writeTestJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+}

--- a/server/internal/auth/oidc/config.go
+++ b/server/internal/auth/oidc/config.go
@@ -1,0 +1,232 @@
+package oidc
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+const (
+	EnvProviders = "PARSAR_AUTH_OIDC_PROVIDERS"
+
+	envPrefix = "PARSAR_AUTH_OIDC_"
+)
+
+var providerIDPattern = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,62}$`)
+
+type EnvFunc func(string) string
+
+type ProviderConfig struct {
+	ID                   string
+	Label                string
+	IssuerURL            string
+	ClientID             string
+	ClientSecret         string
+	RedirectURI          string
+	Scopes               []string
+	AllowedDomains       []string
+	RequireVerifiedEmail bool
+}
+
+type ProviderEnvStatus struct {
+	Config      ProviderConfig
+	RequiredEnv []string
+	MissingEnv  []string
+}
+
+func LoadProviderStatuses(env EnvFunc, publicURL string) ([]ProviderEnvStatus, error) {
+	if env == nil {
+		return nil, errors.New("oidc: env func is nil")
+	}
+	ids := splitCSV(env(EnvProviders))
+	out := make([]ProviderEnvStatus, 0, len(ids))
+	seen := map[string]bool{}
+	for _, id := range ids {
+		id = strings.ToLower(strings.TrimSpace(id))
+		if id == "" {
+			continue
+		}
+		if !providerIDPattern.MatchString(id) {
+			return nil, fmt.Errorf("oidc: invalid provider id %q", id)
+		}
+		if seen[id] {
+			return nil, fmt.Errorf("oidc: duplicate provider id %q", id)
+		}
+		seen[id] = true
+
+		key := envKey(id)
+		required := []string{
+			envPrefix + key + "_ISSUER_URL",
+			envPrefix + key + "_CLIENT_ID",
+			envPrefix + key + "_CLIENT_SECRET",
+		}
+		missing := missingEnv(env, required)
+		redirectEnv := envPrefix + key + "_REDIRECT_URI"
+		redirectURI := strings.TrimSpace(env(redirectEnv))
+		if redirectURI == "" {
+			redirectURI = defaultRedirectURI(publicURL, id)
+		}
+		if redirectURI == "" {
+			missing = append(missing, redirectEnv)
+		}
+
+		cfg := ProviderConfig{
+			ID:                   id,
+			Label:                coalesce(strings.TrimSpace(env(envPrefix+key+"_LABEL")), id),
+			IssuerURL:            strings.TrimRight(strings.TrimSpace(env(envPrefix+key+"_ISSUER_URL")), "/"),
+			ClientID:             strings.TrimSpace(env(envPrefix + key + "_CLIENT_ID")),
+			ClientSecret:         strings.TrimSpace(env(envPrefix + key + "_CLIENT_SECRET")),
+			RedirectURI:          redirectURI,
+			Scopes:               splitSpaceList(coalesce(strings.TrimSpace(env(envPrefix+key+"_SCOPES")), "openid email profile")),
+			AllowedDomains:       lowerList(splitCSV(env(envPrefix + key + "_ALLOWED_DOMAINS"))),
+			RequireVerifiedEmail: !isExplicitFalse(env(envPrefix + key + "_REQUIRE_VERIFIED_EMAIL")),
+		}
+		out = append(out, ProviderEnvStatus{
+			Config:      cfg,
+			RequiredEnv: append(required, redirectEnv),
+			MissingEnv:  missing,
+		})
+	}
+	return out, nil
+}
+
+func NewClientsFromEnv(env EnvFunc, publicURL string) (map[string]Client, []ProviderEnvStatus, error) {
+	statuses, err := LoadProviderStatuses(env, publicURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	clients := make(map[string]Client, len(statuses))
+	for _, status := range statuses {
+		if len(status.MissingEnv) > 0 {
+			continue
+		}
+		client, err := NewClient(status.Config)
+		if err != nil {
+			return nil, statuses, err
+		}
+		clients[status.Config.ID] = client
+	}
+	return clients, statuses, nil
+}
+
+func defaultRedirectURI(publicURL, id string) string {
+	base := strings.TrimRight(strings.TrimSpace(publicURL), "/")
+	if base == "" {
+		return ""
+	}
+	return base + "/api/v1/auth/oidc/" + id + "/callback"
+}
+
+func envKey(id string) string {
+	var b strings.Builder
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r - 'a' + 'A')
+		case r >= 'A' && r <= 'Z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+func missingEnv(env EnvFunc, names []string) []string {
+	missing := make([]string, 0, len(names))
+	for _, name := range names {
+		if strings.TrimSpace(env(name)) == "" {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+func splitCSV(v string) []string {
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func splitSpaceList(v string) []string {
+	fields := strings.Fields(v)
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f != "" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func lowerList(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		v = strings.ToLower(strings.TrimSpace(v))
+		if v != "" {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+func isExplicitFalse(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "0", "false", "no", "off":
+		return true
+	default:
+		return false
+	}
+}
+
+func validateConfig(cfg ProviderConfig) error {
+	if !providerIDPattern.MatchString(cfg.ID) {
+		return fmt.Errorf("oidc: invalid provider id %q", cfg.ID)
+	}
+	for name, raw := range map[string]string{
+		"issuer_url":    cfg.IssuerURL,
+		"client_id":     cfg.ClientID,
+		"client_secret": cfg.ClientSecret,
+		"redirect_uri":  cfg.RedirectURI,
+	} {
+		if strings.TrimSpace(raw) == "" {
+			return fmt.Errorf("oidc: %s is required for provider %q", name, cfg.ID)
+		}
+	}
+	if _, err := url.ParseRequestURI(cfg.RedirectURI); err != nil {
+		return fmt.Errorf("oidc: invalid redirect_uri for provider %q: %w", cfg.ID, err)
+	}
+	if u, err := url.Parse(cfg.IssuerURL); err != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("oidc: invalid issuer_url for provider %q", cfg.ID)
+	}
+	if !contains(cfg.Scopes, "openid") {
+		return fmt.Errorf("oidc: scopes for provider %q must include openid", cfg.ID)
+	}
+	return nil
+}
+
+func contains(values []string, want string) bool {
+	for _, v := range values {
+		if strings.EqualFold(v, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func coalesce(v, fallback string) string {
+	if v == "" {
+		return fallback
+	}
+	return v
+}

--- a/server/internal/dev/oauth_handlers.go
+++ b/server/internal/dev/oauth_handlers.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/feishu"
+	authoidc "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/oidc"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
 )
 
 // OAuthRuntimeStore is the narrow surface the OAuth callback uses, so
@@ -26,6 +28,9 @@ type OAuthRuntimeStore interface {
 // CookieStateName is the short-lived CSRF cookie name.
 const CookieStateName = "parsar_oauth_state"
 
+// CookieNonceName is the short-lived OIDC nonce cookie name.
+const CookieNonceName = "parsar_oidc_nonce"
+
 // stateCookieTTL is the wall time the state cookie is valid for —
 // generous because the user may pause on the Feishu consent page.
 const stateCookieTTL = 10 * time.Minute
@@ -36,6 +41,7 @@ const stateRandBytes = 16
 // OAuthHandlerDeps wires the three deps the Feishu callback needs.
 type OAuthHandlerDeps struct {
 	Feishu   feishu.Client
+	OIDC     map[string]authoidc.Client
 	Sessions auth.SessionStore
 	Store    OAuthRuntimeStore
 
@@ -46,6 +52,14 @@ type OAuthHandlerDeps struct {
 	// Feishu callback. Defaults to "/" (server-served SPA). In dev set
 	// to the Vite origin so the post-login bounce lands on the dev frontend.
 	LoginRedirectURL string
+}
+
+type oauthProfile struct {
+	Provider string
+	Subject  string
+	Email    string
+	Name     string
+	Metadata map[string]any
 }
 
 // loginRedirectURL returns the configured success redirect, falling back
@@ -94,6 +108,49 @@ func feishuStartHandler(deps OAuthHandlerDeps) http.HandlerFunc {
 			MaxAge:   int(stateCookieTTL.Seconds()),
 		})
 		http.Redirect(w, r, deps.Feishu.AuthorizeURL(state), http.StatusFound)
+	}
+}
+
+// oidcStartHandler is GET /api/v1/auth/oidc/{providerID}/start.
+//
+//	@Summary		Start generic OIDC login
+//	@Description	Mints CSRF and nonce cookies and redirects the browser to the configured OIDC provider authorize URL.
+//	@Tags			auth
+//	@ID				startOIDCOAuth
+//	@Produce		json
+//	@Param			providerID	path	string	true	"OIDC provider ID"
+//	@Success		302	"Redirect to OIDC authorize URL"
+//	@Failure		404	{object}	map[string]string	"OIDC provider is not configured"
+//	@Failure		500	{object}	map[string]string	"State minting or discovery failed"
+//	@Router			/api/v1/auth/oidc/{providerID}/start [get]
+func oidcStartHandler(deps OAuthHandlerDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		providerID := strings.TrimSpace(chi.URLParam(r, "providerID"))
+		client := deps.OIDC[providerID]
+		if client == nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "OIDC provider not configured"})
+			return
+		}
+		state, err := newOAuthState()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to mint CSRF state"})
+			return
+		}
+		nonce, err := newOAuthState()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to mint OIDC nonce"})
+			return
+		}
+		loginURL, err := client.AuthorizeURL(r.Context(), state, nonce)
+		if err != nil {
+			log.Bg().Warn("OIDC discovery failed", "provider", providerID, "error", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": fmt.Sprintf("OIDC discovery failed: %v", err)})
+			return
+		}
+		cookiePath := oidcCookiePath(providerID)
+		setOAuthCookie(w, CookieStateName, state, cookiePath, deps.CookieSecure)
+		setOAuthCookie(w, CookieNonceName, nonce, cookiePath, deps.CookieSecure)
+		http.Redirect(w, r, loginURL, http.StatusFound)
 	}
 }
 
@@ -153,8 +210,7 @@ func feishuCallbackHandler(deps OAuthHandlerDeps) http.HandlerFunc {
 			return
 		}
 
-		now := time.Now().UTC()
-		upsert, err := deps.Store.UpsertOAuthUser(r.Context(), store.UpsertOAuthUserInput{
+		completeOAuthLogin(w, r, deps, oauthProfile{
 			Provider: "feishu",
 			Subject:  profile.UnionID,
 			Email:    profile.Email,
@@ -165,31 +221,141 @@ func feishuCallbackHandler(deps OAuthHandlerDeps) http.HandlerFunc {
 				"avatar_url": profile.AvatarURL,
 				"mock":       deps.Feishu.IsMock(),
 			},
-			Now: now,
 		})
-		if err != nil {
-			log.Bg().Error("feishu OIDC user upsert failed", "error", err, "email", profile.Email)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to persist user identity"})
-			return
-		}
-
-		sessionID, err := deps.Sessions.Create(r.Context(), auth.CreateSessionInput{
-			UserID:    upsert.UserID,
-			UserAgent: r.UserAgent(),
-			IP:        clientIP(r),
-		})
-		if err != nil {
-			log.Bg().Error("session create failed after OIDC upsert", "error", err, "user_id", upsert.UserID)
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create session"})
-			return
-		}
-		auth.IssueCookie(w, sessionID, 0, deps.CookieSecure)
-		log.Bg().Info("feishu OIDC login success",
-			"user_id", upsert.UserID, "email", upsert.Email,
-			"created", upsert.Created, "mock", deps.Feishu.IsMock())
-
-		http.Redirect(w, r, deps.loginRedirectURL(), http.StatusFound)
 	}
+}
+
+// oidcCallbackHandler is GET /api/v1/auth/oidc/{providerID}/callback.
+//
+//	@Summary		Handle generic OIDC callback
+//	@Description	Verifies CSRF state and OIDC nonce, exchanges the authorization code, upserts the user identity, creates a session cookie, and redirects to the login-success URL.
+//	@Tags			auth
+//	@ID				callbackOIDCOAuth
+//	@Produce		json
+//	@Param			providerID	path	string	true	"OIDC provider ID"
+//	@Param			state		query	string	true	"CSRF state minted at /start"
+//	@Param			code		query	string	true	"OAuth authorization code returned by the OIDC provider"
+//	@Success		302		"Redirect to login-success URL"
+//	@Failure		400		{object}	map[string]string	"Missing state/code or state/nonce mismatch"
+//	@Failure		404		{object}	map[string]string	"OIDC provider is not configured"
+//	@Failure		500		{object}	map[string]string	"User upsert or session creation failed"
+//	@Failure		502		{object}	map[string]string	"OIDC exchange failed"
+//	@Router			/api/v1/auth/oidc/{providerID}/callback [get]
+func oidcCallbackHandler(deps OAuthHandlerDeps) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if deps.Sessions == nil || deps.Store == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+				"error": "OIDC login not configured (missing session store / user store dep)",
+			})
+			return
+		}
+		providerID := strings.TrimSpace(chi.URLParam(r, "providerID"))
+		client := deps.OIDC[providerID]
+		if client == nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "OIDC provider not configured"})
+			return
+		}
+		urlState := strings.TrimSpace(r.URL.Query().Get("state"))
+		code := strings.TrimSpace(r.URL.Query().Get("code"))
+		if urlState == "" || code == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "missing state or code"})
+			return
+		}
+		cookiePath := oidcCookiePath(providerID)
+		stateCookie, err := r.Cookie(CookieStateName)
+		if err != nil || stateCookie.Value != urlState {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "CSRF state mismatch — re-start the login flow"})
+			return
+		}
+		nonceCookie, err := r.Cookie(CookieNonceName)
+		if err != nil || strings.TrimSpace(nonceCookie.Value) == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "OIDC nonce missing — re-start the login flow"})
+			return
+		}
+		clearOAuthCookie(w, CookieStateName, cookiePath, deps.CookieSecure)
+		clearOAuthCookie(w, CookieNonceName, cookiePath, deps.CookieSecure)
+
+		profile, err := client.ExchangeCode(r.Context(), code, nonceCookie.Value)
+		if err != nil {
+			log.Bg().Warn("OIDC exchange failed", "provider", providerID, "error", err)
+			writeJSON(w, http.StatusBadGateway, map[string]string{
+				"error": fmt.Sprintf("OIDC exchange failed: %v", err),
+			})
+			return
+		}
+		completeOAuthLogin(w, r, deps, oauthProfile{
+			Provider: profile.Provider,
+			Subject:  profile.Subject,
+			Email:    profile.Email,
+			Name:     profile.Name,
+			Metadata: map[string]any{
+				"issuer":      profile.Issuer,
+				"name":        profile.Name,
+				"avatar_url":  profile.AvatarURL,
+				"provider_id": profile.ProviderID,
+				"claims":      profile.Claims,
+				"userinfo":    profile.UserInfo,
+			},
+		})
+	}
+}
+
+func completeOAuthLogin(w http.ResponseWriter, r *http.Request, deps OAuthHandlerDeps, profile oauthProfile) {
+	upsert, err := deps.Store.UpsertOAuthUser(r.Context(), store.UpsertOAuthUserInput{
+		Provider: profile.Provider,
+		Subject:  profile.Subject,
+		Email:    profile.Email,
+		Name:     profile.Name,
+		Metadata: profile.Metadata,
+		Now:      time.Now().UTC(),
+	})
+	if err != nil {
+		log.Bg().Error("OAuth user upsert failed", "error", err, "provider", profile.Provider, "email", profile.Email)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to persist user identity"})
+		return
+	}
+	sessionID, err := deps.Sessions.Create(r.Context(), auth.CreateSessionInput{
+		UserID:    upsert.UserID,
+		UserAgent: r.UserAgent(),
+		IP:        clientIP(r),
+	})
+	if err != nil {
+		log.Bg().Error("session create failed after OAuth upsert", "error", err, "user_id", upsert.UserID)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create session"})
+		return
+	}
+	auth.IssueCookie(w, sessionID, 0, deps.CookieSecure)
+	log.Bg().Info("OAuth login success",
+		"provider", profile.Provider, "user_id", upsert.UserID, "email", upsert.Email, "created", upsert.Created)
+	http.Redirect(w, r, deps.loginRedirectURL(), http.StatusFound)
+}
+
+func setOAuthCookie(w http.ResponseWriter, name, value, path string, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     path,
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(stateCookieTTL.Seconds()),
+	})
+}
+
+func clearOAuthCookie(w http.ResponseWriter, name, path string, secure bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     path,
+		HttpOnly: true,
+		Secure:   secure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+}
+
+func oidcCookiePath(providerID string) string {
+	return "/api/v1/auth/oidc/" + strings.TrimSpace(providerID)
 }
 
 // authLogoutHandler is POST /api/v1/auth/logout. Revokes the session and

--- a/server/internal/dev/oauth_handlers_test.go
+++ b/server/internal/dev/oauth_handlers_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/feishu"
+	authoidc "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/oidc"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 )
 
@@ -89,9 +90,33 @@ func buildOAuthRouter(t *testing.T, deps OAuthHandlerDeps) http.Handler {
 	r.Route("/api/v1", func(r chi.Router) {
 		r.Get("/auth/feishu/start", feishuStartHandler(deps))
 		r.Get("/auth/feishu/callback", feishuCallbackHandler(deps))
+		r.Get("/auth/oidc/{providerID}/start", oidcStartHandler(deps))
+		r.Get("/auth/oidc/{providerID}/callback", oidcCallbackHandler(deps))
 		r.Post("/auth/logout", authLogoutHandler(deps))
 	})
 	return r
+}
+
+type stubOIDCClient struct {
+	authURL string
+	profile authoidc.UserProfile
+	seen    struct {
+		state string
+		nonce string
+		code  string
+	}
+}
+
+func (c *stubOIDCClient) AuthorizeURL(_ context.Context, state, nonce string) (string, error) {
+	c.seen.state = state
+	c.seen.nonce = nonce
+	return c.authURL + "?state=" + state + "&nonce=" + nonce, nil
+}
+
+func (c *stubOIDCClient) ExchangeCode(_ context.Context, code, nonce string) (authoidc.UserProfile, error) {
+	c.seen.code = code
+	c.seen.nonce = nonce
+	return c.profile, nil
 }
 
 func TestFeishuStartRedirectsAndSetsStateCookie(t *testing.T) {
@@ -115,6 +140,31 @@ func TestFeishuStartRedirectsAndSetsStateCookie(t *testing.T) {
 	setCookie := rec.Header().Get("Set-Cookie")
 	if !strings.HasPrefix(setCookie, CookieStateName+"=") || !strings.Contains(setCookie, "HttpOnly") {
 		t.Fatalf("state cookie missing or unsafe: %q", setCookie)
+	}
+}
+
+func TestOIDCStartRedirectsAndSetsStateAndNonceCookies(t *testing.T) {
+	client := &stubOIDCClient{authURL: "https://idp.example/authorize"}
+	r := buildOAuthRouter(t, OAuthHandlerDeps{
+		OIDC:     map[string]authoidc.Client{"company": client},
+		Sessions: newStubSessions(),
+		Store:    &stubOAuthStore{},
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/company/start", nil)
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); !strings.HasPrefix(loc, "https://idp.example/authorize?") {
+		t.Fatalf("Location = %q, want OIDC authorize URL", loc)
+	}
+	cookies := rec.Header().Values("Set-Cookie")
+	if len(cookies) != 2 {
+		t.Fatalf("cookies = %v, want state and nonce cookies", cookies)
+	}
+	if client.seen.state == "" || client.seen.nonce == "" {
+		t.Fatalf("state/nonce not passed to client: %+v", client.seen)
 	}
 }
 
@@ -174,6 +224,66 @@ func TestFeishuCallbackHappyPath(t *testing.T) {
 	}
 	if st.lastIn.Provider != "feishu" || st.lastIn.Email != "admin@example.com" {
 		t.Fatalf("upsert input wrong: %+v", st.lastIn)
+	}
+}
+
+func TestOIDCCallbackHappyPath(t *testing.T) {
+	client := &stubOIDCClient{
+		authURL: "https://idp.example/authorize",
+		profile: authoidc.UserProfile{
+			Provider:   "oidc:company",
+			ProviderID: "company",
+			Subject:    "sub-123",
+			Email:      "admin@example.com",
+			Name:       "Admin User",
+			AvatarURL:  "https://idp.example/avatar.png",
+			Issuer:     "https://idp.example",
+			Claims: map[string]any{
+				"sub":            "sub-123",
+				"email":          "admin@example.com",
+				"email_verified": true,
+			},
+		},
+	}
+	sessions := newStubSessions()
+	st := &stubOAuthStore{userID: "00000000-0000-0000-0000-0000deadbeef"}
+	r := buildOAuthRouter(t, OAuthHandlerDeps{
+		OIDC:     map[string]authoidc.Client{"company": client},
+		Sessions: sessions,
+		Store:    st,
+	})
+
+	rec1 := httptest.NewRecorder()
+	r.ServeHTTP(rec1, httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/company/start", nil))
+	var state, nonce string
+	for _, rawCookie := range rec1.Header().Values("Set-Cookie") {
+		if strings.HasPrefix(rawCookie, CookieStateName+"=") {
+			state = strings.SplitN(strings.TrimPrefix(rawCookie, CookieStateName+"="), ";", 2)[0]
+		}
+		if strings.HasPrefix(rawCookie, CookieNonceName+"=") {
+			nonce = strings.SplitN(strings.TrimPrefix(rawCookie, CookieNonceName+"="), ";", 2)[0]
+		}
+	}
+	if state == "" || nonce == "" {
+		t.Fatalf("missing start cookies: %v", rec1.Header().Values("Set-Cookie"))
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/company/callback?code=oidc-code&state="+state, nil)
+	req.AddCookie(&http.Cookie{Name: CookieStateName, Value: state})
+	req.AddCookie(&http.Cookie{Name: CookieNonceName, Value: nonce})
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302 redirect to /", rec.Code)
+	}
+	if client.seen.code != "oidc-code" || client.seen.nonce != nonce {
+		t.Fatalf("exchange input = %+v, want code and nonce", client.seen)
+	}
+	if st.lastIn.Provider != "oidc:company" || st.lastIn.Subject != "sub-123" || st.lastIn.Email != "admin@example.com" {
+		t.Fatalf("upsert input wrong: %+v", st.lastIn)
+	}
+	if got := st.lastIn.Metadata["issuer"]; got != "https://idp.example" {
+		t.Fatalf("metadata issuer = %#v", got)
 	}
 }
 
@@ -300,5 +410,3 @@ func TestLogoutIdempotentWithoutCookie(t *testing.T) {
 		t.Fatalf("status = %d, want 204 (idempotent)", rec.Code)
 	}
 }
-
-

--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -542,6 +542,8 @@ func RegisterRoutesWithStore(r chi.Router, runtimeStore RuntimeStore, opts ...Ro
 				// session cookie; logout → revoke + clear cookie.
 				r.Get("/auth/feishu/start", feishuStartHandler(*cfg.oauthDeps))
 				r.Get("/auth/feishu/callback", feishuCallbackHandler(*cfg.oauthDeps))
+				r.Get("/auth/oidc/{providerID}/start", oidcStartHandler(*cfg.oauthDeps))
+				r.Get("/auth/oidc/{providerID}/callback", oidcCallbackHandler(*cfg.oauthDeps))
 				r.Post("/auth/logout", authLogoutHandler(*cfg.oauthDeps))
 			}
 			r.Get("/auth/providers", listAuthProviders(cfg.authProviders))


### PR DESCRIPTION
## Summary
- replace the previous hand-written OIDC/JWKS approach with a smaller implementation backed by `github.com/coreos/go-oidc/v3/oidc` and `golang.org/x/oauth2`
- add env-driven multi-provider OIDC SSO under `/api/v1/auth/oidc/{providerID}`
- register configured OIDC providers in existing auth provider discovery so the login page renders SSO buttons without frontend changes
- keep Parsar-owned logic limited to state/nonce cookies, email verification, allowed-domain policy, local identity upsert, and session creation
- document OIDC env configuration and regenerate OpenAPI

Old PR #195 was closed because it hand-rolled too much OIDC/JWKS/token verification code for a first SSO change.

## Verification
- `go test ./server/internal/auth/oidc`
- `go test ./server/internal/auth/... ./server/internal/dev ./server/cmd/server`
- `make openapi`
- `make check`
