### PR TITLE
fix: route model endpoint base urls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,6 +190,11 @@ description and keep ownership on the side listed here.
 - Frontend API shape mirrors must live in `apps/web/src/lib/` next to the API
   client/hook that owns them. Page components should receive typed values, not
   parse runtime/provider/config JSON themselves.
+- Multi-endpoint model rows keep the default/legacy `models.base_url`, but
+  protocol-specific runtime URLs belong in `models.config.endpoint_base_urls`
+  keyed by `supported_endpoint_types` values such as `anthropic`, `openai`, and
+  `openai-response`. Runtime injectors must consult the endpoint map before
+  falling back to `models.base_url`.
 - Generated files (`docs/openapi/openapi.yaml`, `server/internal/db/sqlc/*`)
   are committed artifacts, but never the source of truth. Change annotations
   or SQL first, then regenerate.

--- a/apps/web/src/lib/model-provider-options.ts
+++ b/apps/web/src/lib/model-provider-options.ts
@@ -113,6 +113,29 @@ export function endpointTypeForProtocol(id: string): string | null {
   }
 }
 
+export function endpointBaseURLsForProvider(
+  provider: ProviderTypeOption | undefined,
+  fallbackBaseURL: string,
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const protocol of provider?.protocols ?? []) {
+    const endpointType = endpointTypeForProtocol(protocol.id)
+    const baseURL = protocol.baseURL.trim()
+    if (!endpointType || !baseURL) continue
+    out[endpointType] = baseURL
+    if (endpointType === "openai") {
+      out["openai-response"] = baseURL
+    }
+  }
+  if (Object.keys(out).length > 0) return out
+  const trimmed = fallbackBaseURL.trim()
+  if (!trimmed) return out
+  for (const endpointType of ["anthropic", "openai", "openai-response"]) {
+    out[endpointType] = trimmed
+  }
+  return out
+}
+
 export function findProviderModel(
   provider: ProviderTypeOption | undefined,
   modelKey: string,

--- a/apps/web/src/pages/admin/BulkImportModelsDialog.tsx
+++ b/apps/web/src/pages/admin/BulkImportModelsDialog.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../lib/api-models"
 import {
   FALLBACK_PROVIDER_TYPES,
+  endpointBaseURLsForProvider,
   isKnownProviderURL,
   providerTypesFromCatalog,
 } from "../../lib/model-provider-options"
@@ -156,6 +157,10 @@ export function BulkImportModelsDialog({
     const config: Record<string, unknown> = {}
     if (cfg?.authSchemeSelector) {
       config.auth_scheme = "api-key"
+    }
+    const endpointBaseURLs = endpointBaseURLsForProvider(cfg, baseURL)
+    if (Object.keys(endpointBaseURLs).length > 0) {
+      config.endpoint_base_urls = endpointBaseURLs
     }
     const body: ImportProviderModelsInput = {
       provider_type: providerType,

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -17,7 +17,12 @@ import {
 import { Input } from "../../components/ui/input"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
-import { modelProtocols, protocolListLabel, type WireProtocol } from "../../lib/model-protocol"
+import {
+  modelProtocols,
+  modelSupportedEndpointTypes,
+  protocolListLabel,
+  type WireProtocol,
+} from "../../lib/model-protocol"
 import { useCapabilitiesQuery, aggregateRequiredCredentials, aggregateRequiredCredentialsByID, useCapabilityVersionsQuery, useAgentCapabilitiesQuery, useEnableAgentCapabilityMutation } from "../../lib/api-capabilities"
 import { CredentialCheckPanel } from "../../components/admin/CredentialCheckPanel"
 import { useSecrets } from "../../lib/api-secrets"
@@ -84,6 +89,23 @@ function engineSupportsProtocol(engine: AgentEngine, protocol: WireProtocol | nu
 }
 
 function engineSupportsModel(engine: AgentEngine, model: Model): boolean {
+  const endpointTypes = modelSupportedEndpointTypes(model)
+  if (endpointTypes.length > 0) {
+    switch (engine) {
+      case "claude_code":
+        return endpointTypes.includes("anthropic")
+      case "codex":
+        return endpointTypes.includes("openai-response")
+      case "pi":
+        return (
+          endpointTypes.includes("anthropic") ||
+          endpointTypes.includes("openai") ||
+          endpointTypes.includes("google_generative_ai")
+        )
+      case "opencode":
+        return true
+    }
+  }
   return modelProtocols(model).some((protocol) => engineSupportsProtocol(engine, protocol))
 }
 

--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -36,6 +36,7 @@ import {
 import {
   FALLBACK_PROVIDER_TYPES,
   defaultModelFor,
+  endpointBaseURLsForProvider,
   endpointTypeForProtocol,
   findProviderModel,
   isKnownProviderURL,
@@ -464,6 +465,10 @@ export function CreateModelDialog({
     }
     if (showAuthSchemeSelector) {
       config.auth_scheme = authScheme
+    }
+    const endpointBaseURLs = endpointBaseURLsForProvider(cfg, baseURL)
+    if (Object.keys(endpointBaseURLs).length > 0) {
+      config.endpoint_base_urls = endpointBaseURLs
     }
     config.supported_endpoint_types = await detectedEndpointTypes(config)
 

--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -313,7 +313,7 @@ func injectClaudeManagedModel(opts map[string]any, modelID string, mr store.Mode
 		env["ANTHROPIC_API_KEY"] = apiKey
 	}
 	if strings.TrimSpace(mr.BaseURL) != "" {
-		env["ANTHROPIC_BASE_URL"] = strings.TrimSpace(mr.BaseURL)
+		env["ANTHROPIC_BASE_URL"] = modelEndpointBaseURL(mr, "anthropic")
 	}
 	if customHeaders := anthropicCustomHeaders(mr.ProviderConfig); customHeaders != "" {
 		env["ANTHROPIC_CUSTOM_HEADERS"] = customHeaders
@@ -380,7 +380,8 @@ func injectCodexManagedModel(opts map[string]any, modelID string, mr store.Model
 		return fmt.Errorf("%w: model_id=%s provider_type=%q adapter=%q",
 			ErrManagedModelUnsupported, modelID, mr.ProviderType, mr.Adapter)
 	}
-	if strings.TrimSpace(mr.BaseURL) == "" {
+	codexBaseURL := modelEndpointBaseURL(mr, "openai-response")
+	if codexBaseURL == "" {
 		// Without a base_url the only sensible target is api.openai.com;
 		// codex's builtin "openai" provider already covers that. But the
 		// daemon's TOML path needs an explicit base_url to write into
@@ -392,7 +393,7 @@ func injectCodexManagedModel(opts map[string]any, modelID string, mr store.Model
 	opts["model"] = mr.ModelKey
 
 	provider := map[string]any{
-		"base_url":     strings.TrimSpace(mr.BaseURL),
+		"base_url":     codexBaseURL,
 		"bearer_token": apiKey,
 		"wire_api":     "responses",
 	}
@@ -440,8 +441,8 @@ func flattenStringMap(providerConfig map[string]any, key string) map[string]stri
 // hosts as a first-class provider — we route that through the same
 // codex_provider TOML block but a future change might split it out.
 func isOpenAICompatibleRuntime(mr store.ModelRuntime) bool {
-	if modelConfigSupportsEndpointType(mr.ProviderConfig, "openai") || modelConfigSupportsEndpointType(mr.ProviderConfig, "openai-response") {
-		return true
+	if modelConfigHasEndpointTypes(mr.ProviderConfig) {
+		return modelConfigSupportsEndpointType(mr.ProviderConfig, "openai-response")
 	}
 	for _, v := range []string{mr.ProviderType, mr.Adapter} {
 		switch strings.ToLower(strings.TrimSpace(v)) {
@@ -508,7 +509,7 @@ func injectPiManagedModel(opts map[string]any, modelID string, mr store.ModelRun
 		return fmt.Errorf("%w: model_id=%s pi requires a model_key",
 			ErrManagedModelConfigInvalid, modelID)
 	}
-	baseURL := strings.TrimSpace(mr.BaseURL)
+	baseURL := modelEndpointBaseURL(mr, piAPIEndpointType(mr))
 	if baseURL == "" {
 		return fmt.Errorf("%w: model_id=%s base_url is required for pi provider injection",
 			ErrManagedModelConfigInvalid, modelID)
@@ -546,11 +547,14 @@ func piAPIProtocol(mr store.ModelRuntime) string {
 	if modelConfigSupportsEndpointType(mr.ProviderConfig, "anthropic") {
 		return "anthropic-messages"
 	}
-	if modelConfigSupportsEndpointType(mr.ProviderConfig, "openai") || modelConfigSupportsEndpointType(mr.ProviderConfig, "openai-response") {
+	if modelConfigSupportsEndpointType(mr.ProviderConfig, "openai") {
 		return "openai-completions"
 	}
 	if modelConfigSupportsEndpointType(mr.ProviderConfig, "google_generative_ai") {
 		return "google-generative-ai"
+	}
+	if modelConfigHasEndpointTypes(mr.ProviderConfig) {
+		return ""
 	}
 	for _, v := range []string{mr.ProviderType, mr.Adapter} {
 		switch strings.ToLower(strings.TrimSpace(v)) {
@@ -564,6 +568,19 @@ func piAPIProtocol(mr store.ModelRuntime) string {
 		}
 	}
 	return ""
+}
+
+func piAPIEndpointType(mr store.ModelRuntime) string {
+	switch piAPIProtocol(mr) {
+	case "anthropic-messages":
+		return "anthropic"
+	case "openai-completions":
+		return "openai"
+	case "google-generative-ai":
+		return "google_generative_ai"
+	default:
+		return ""
+	}
 }
 
 // applySpecMemoryInjection appends the SessionStart spec/memory bundle
@@ -671,8 +688,8 @@ func resolveModelID(in connector.PromptInput) string {
 }
 
 func isAnthropicRuntime(mr store.ModelRuntime) bool {
-	if modelConfigSupportsEndpointType(mr.ProviderConfig, "anthropic") {
-		return true
+	if modelConfigHasEndpointTypes(mr.ProviderConfig) {
+		return modelConfigSupportsEndpointType(mr.ProviderConfig, "anthropic")
 	}
 	for _, v := range []string{mr.ProviderType, mr.Adapter} {
 		n := strings.ToLower(strings.TrimSpace(v))
@@ -684,11 +701,72 @@ func isAnthropicRuntime(mr store.ModelRuntime) bool {
 	return false
 }
 
+func modelConfigHasEndpointTypes(config map[string]any) bool {
+	return len(modelConfigEndpointTypes(config)) > 0
+}
+
+func modelConfigEndpointTypes(config map[string]any) []string {
+	switch values := config["supported_endpoint_types"].(type) {
+	case []any:
+		out := make([]string, 0, len(values))
+		for _, value := range values {
+			if s, ok := value.(string); ok && strings.TrimSpace(s) != "" {
+				out = append(out, normalizeModelEndpointType(s))
+			}
+		}
+		return out
+	case []string:
+		out := make([]string, 0, len(values))
+		for _, s := range values {
+			if strings.TrimSpace(s) != "" {
+				out = append(out, normalizeModelEndpointType(s))
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+func modelEndpointBaseURL(mr store.ModelRuntime, endpointType string) string {
+	want := normalizeModelEndpointType(endpointType)
+	switch raw := mr.ProviderConfig["endpoint_base_urls"].(type) {
+	case map[string]any:
+		for k, v := range raw {
+			if normalizeModelEndpointType(k) != want {
+				continue
+			}
+			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		}
+	case map[string]string:
+		for k, s := range raw {
+			if normalizeModelEndpointType(k) == want && strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		}
+	}
+	return inferModelEndpointBaseURL(want, mr.BaseURL)
+}
+
+func inferModelEndpointBaseURL(endpointType, fallback string) string {
+	base := strings.TrimRight(strings.TrimSpace(fallback), "/")
+	if endpointType == "openai" || endpointType == "openai-response" {
+		if strings.HasSuffix(base, "/anthropic/v1") {
+			return strings.TrimSuffix(base, "/anthropic/v1") + "/v1"
+		}
+		if strings.HasSuffix(base, "/anthropic") {
+			return strings.TrimSuffix(base, "/anthropic") + "/v1"
+		}
+	}
+	return base
+}
+
 func modelConfigSupportsEndpointType(config map[string]any, endpointType string) bool {
 	want := normalizeModelEndpointType(endpointType)
-	values, _ := config["supported_endpoint_types"].([]any)
-	for _, value := range values {
-		if s, ok := value.(string); ok && normalizeModelEndpointType(s) == want {
+	for _, got := range modelConfigEndpointTypes(config) {
+		if got == want {
 			return true
 		}
 	}
@@ -735,7 +813,6 @@ func anthropicCustomHeaders(providerConfig map[string]any) string {
 	}
 	return strings.Join(lines, "\n")
 }
-
 func copyStringAnyMap(v any) map[string]any {
 	out := map[string]any{}
 	if m, ok := v.(map[string]any); ok {

--- a/server/internal/connector/agentdaemon/model_injection_test.go
+++ b/server/internal/connector/agentdaemon/model_injection_test.go
@@ -854,7 +854,7 @@ func TestIsOpenAICompatibleRuntime(t *testing.T) {
 		{"azure-openai provider", store.ModelRuntime{ProviderType: "azure-openai"}, true},
 		{"@ai-sdk/openai adapter only", store.ModelRuntime{Adapter: "@ai-sdk/openai"}, true},
 		{"@ai-sdk/azure adapter only", store.ModelRuntime{Adapter: "@ai-sdk/azure"}, true},
-		{"endpoint types openai", store.ModelRuntime{ProviderConfig: map[string]any{"supported_endpoint_types": []any{"openai"}}}, true},
+		{"endpoint types openai chat only", store.ModelRuntime{ProviderConfig: map[string]any{"supported_endpoint_types": []any{"openai"}}}, false},
 		{"endpoint types openai response", store.ModelRuntime{ProviderConfig: map[string]any{"supported_endpoint_types": []any{"openai-response"}}}, true},
 		{"whitespace + case-insensitive", store.ModelRuntime{ProviderType: " Openai "}, true},
 		{"anthropic provider rejected", store.ModelRuntime{ProviderType: "anthropic", Adapter: "@ai-sdk/anthropic"}, false},
@@ -876,6 +876,52 @@ func TestIsAnthropicRuntimeSupportsEndpointTypes(t *testing.T) {
 		ProviderConfig: map[string]any{"supported_endpoint_types": []any{"anthropic", "openai"}},
 	}) {
 		t.Fatalf("expected supported_endpoint_types to allow anthropic runtime")
+	}
+}
+
+func TestInjectCodexManagedModel_UsesResponsesEndpointBaseURL(t *testing.T) {
+	opts := map[string]any{}
+	mr := store.ModelRuntime{
+		ModelID:      "model-multi",
+		ModelKey:     "MiniMax-M3",
+		ProviderType: "minimax-cn",
+		Adapter:      "@ai-sdk/anthropic",
+		BaseURL:      "https://api.minimaxi.com/anthropic",
+		ProviderConfig: map[string]any{
+			"supported_endpoint_types": []any{"anthropic", "openai-response"},
+			"endpoint_base_urls": map[string]any{
+				"anthropic":       "https://api.minimaxi.com/anthropic",
+				"openai-response": "https://api.minimaxi.com/v1",
+			},
+		},
+	}
+	if err := injectCodexManagedModel(opts, mr.ModelID, mr, "sk-platform"); err != nil {
+		t.Fatalf("injectCodexManagedModel: %v", err)
+	}
+	provider := opts["codex_provider"].(map[string]any)
+	if got := provider["base_url"]; got != "https://api.minimaxi.com/v1" {
+		t.Fatalf("codex_provider.base_url = %v, want /v1 base for /v1/responses", got)
+	}
+}
+
+func TestInjectCodexManagedModel_InfersResponsesBaseURLForLegacyAnthropicRows(t *testing.T) {
+	opts := map[string]any{}
+	mr := store.ModelRuntime{
+		ModelID:      "model-legacy-multi",
+		ModelKey:     "MiniMax-M3",
+		ProviderType: "minimax-cn",
+		Adapter:      "@ai-sdk/anthropic",
+		BaseURL:      "https://api.minimaxi.com/anthropic",
+		ProviderConfig: map[string]any{
+			"supported_endpoint_types": []any{"anthropic", "openai-response"},
+		},
+	}
+	if err := injectCodexManagedModel(opts, mr.ModelID, mr, "sk-platform"); err != nil {
+		t.Fatalf("injectCodexManagedModel: %v", err)
+	}
+	provider := opts["codex_provider"].(map[string]any)
+	if got := provider["base_url"]; got != "https://api.minimaxi.com/v1" {
+		t.Fatalf("codex_provider.base_url = %v, want inferred /v1 base for /v1/responses", got)
 	}
 }
 
@@ -1117,6 +1163,7 @@ func TestInjectPiManagedModel_ProviderMapping(t *testing.T) {
 	}{
 		{"openai", store.ModelRuntime{ModelKey: "gpt-4o", ProviderType: "openai", BaseURL: "https://x/v1"}, "openai-completions"},
 		{"openai-compatible adapter", store.ModelRuntime{ModelKey: "gpt-4o-mini", Adapter: "@ai-sdk/openai", BaseURL: "https://x/v1"}, "openai-completions"},
+		{"endpoint mapped openai", store.ModelRuntime{ModelKey: "gpt-4o-mini", BaseURL: "https://x/anthropic", ProviderConfig: map[string]any{"supported_endpoint_types": []any{"openai"}, "endpoint_base_urls": map[string]any{"openai": "https://x/v1"}}}, "openai-completions"},
 		{"anthropic", store.ModelRuntime{ModelKey: "claude-sonnet-4-5", ProviderType: "anthropic", BaseURL: "https://x"}, "anthropic-messages"},
 		{"google", store.ModelRuntime{ModelKey: "gemini-2.5-pro", ProviderType: "google", BaseURL: "https://x"}, "google-generative-ai"},
 		{"gemini alias", store.ModelRuntime{ModelKey: "gemini-2.5-flash", ProviderType: "gemini", BaseURL: "https://x"}, "google-generative-ai"},
@@ -1138,6 +1185,23 @@ func TestInjectPiManagedModel_ProviderMapping(t *testing.T) {
 				t.Fatalf("pi_provider.api = %v, want %v", got, tc.wantAPI)
 			}
 		})
+	}
+}
+
+func TestInjectPiManagedModel_RejectsResponsesOnlyEndpointType(t *testing.T) {
+	opts := map[string]any{}
+	mr := store.ModelRuntime{
+		ModelID:      "model-responses",
+		ModelKey:     "gpt-5",
+		ProviderType: "openai",
+		BaseURL:      "https://x/v1",
+		ProviderConfig: map[string]any{
+			"supported_endpoint_types": []any{"openai-response"},
+		},
+	}
+	err := injectPiManagedModel(opts, mr.ModelID, mr, "sk-x")
+	if !errors.Is(err, ErrManagedModelUnsupported) {
+		t.Fatalf("expected responses-only model to be unsupported by pi openai-completions, got %v", err)
 	}
 }
 

--- a/server/internal/dev/routes_models.go
+++ b/server/internal/dev/routes_models.go
@@ -245,6 +245,41 @@ func modelSupportsEndpointType(config map[string]any, endpointType string) bool 
 	return false
 }
 
+func endpointBaseURLFromConfig(config map[string]any, endpointType, fallback string) string {
+	want := normalizeEndpointType(endpointType)
+	switch raw := config["endpoint_base_urls"].(type) {
+	case map[string]any:
+		for k, v := range raw {
+			if normalizeEndpointType(k) != want {
+				continue
+			}
+			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		}
+	case map[string]string:
+		for k, s := range raw {
+			if normalizeEndpointType(k) == want && strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		}
+	}
+	return inferredEndpointBaseURL(want, fallback)
+}
+
+func inferredEndpointBaseURL(endpointType, fallback string) string {
+	base := strings.TrimRight(strings.TrimSpace(fallback), "/")
+	if endpointType == "openai" || endpointType == "openai-response" {
+		if strings.HasSuffix(base, "/anthropic/v1") {
+			return strings.TrimSuffix(base, "/anthropic/v1") + "/v1"
+		}
+		if strings.HasSuffix(base, "/anthropic") {
+			return strings.TrimSuffix(base, "/anthropic") + "/v1"
+		}
+	}
+	return base
+}
+
 func providerModelsURL(baseURL string) string {
 	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	if strings.HasSuffix(base, "/v1") {
@@ -601,21 +636,21 @@ func endpointProbeRequest(ctx context.Context, baseURL, modelKey, apiKey, endpoi
 	url := ""
 	switch normalizeEndpointType(endpointType) {
 	case "anthropic":
-		url = anthropicMessagesURL(baseURL)
+		url = anthropicMessagesURL(endpointBaseURLFromConfig(config, "anthropic", baseURL))
 		body = map[string]any{
 			"model":      modelKey,
 			"messages":   []map[string]any{{"role": "user", "content": "ping"}},
 			"max_tokens": 1,
 		}
 	case "openai":
-		url = strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/chat/completions"
+		url = strings.TrimRight(endpointBaseURLFromConfig(config, "openai", baseURL), "/") + "/chat/completions"
 		body = map[string]any{
 			"model":      modelKey,
 			"messages":   []map[string]any{{"role": "user", "content": "ping"}},
 			"max_tokens": 1,
 		}
 	case "openai-response":
-		url = strings.TrimRight(strings.TrimSpace(baseURL), "/") + "/responses"
+		url = strings.TrimRight(endpointBaseURLFromConfig(config, "openai-response", baseURL), "/") + "/responses"
 		body = map[string]any{
 			"model": modelKey,
 			"input": "ping",
@@ -936,7 +971,9 @@ func testModelConnectivity(runtimeStore RuntimeStore) http.HandlerFunc {
 			return
 		}
 
-		isOpenAICompatible := isOpenAIChatCompletionsAdapter(mr.Adapter) || modelSupportsEndpointType(mr.ProviderConfig, "openai") || modelSupportsEndpointType(mr.ProviderConfig, "openai-response")
+		isOpenAIChatCompatible := isOpenAIChatCompletionsAdapter(mr.Adapter) || modelSupportsEndpointType(mr.ProviderConfig, "openai")
+		isOpenAIResponsesCompatible := modelSupportsEndpointType(mr.ProviderConfig, "openai-response")
+		isOpenAICompatible := isOpenAIChatCompatible || isOpenAIResponsesCompatible
 		isAnthropicCompatible := isAnthropicMessagesAdapter(mr.Adapter) || modelSupportsEndpointType(mr.ProviderConfig, "anthropic")
 
 		if !isOpenAICompatible && !isAnthropicCompatible {
@@ -1011,14 +1048,20 @@ func testModelConnectivity(runtimeStore RuntimeStore) http.HandlerFunc {
 		url := ""
 		body := map[string]any{}
 		if isAnthropicCompatible {
-			url = anthropicMessagesURL(mr.BaseURL)
+			url = anthropicMessagesURL(endpointBaseURLFromConfig(mr.ProviderConfig, "anthropic", mr.BaseURL))
 			body = map[string]any{
 				"model":      mr.ModelKey,
 				"messages":   []map[string]any{{"role": "user", "content": "ping"}},
 				"max_tokens": 16,
 			}
+		} else if isOpenAIResponsesCompatible {
+			url = strings.TrimRight(endpointBaseURLFromConfig(mr.ProviderConfig, "openai-response", mr.BaseURL), "/") + "/responses"
+			body = map[string]any{
+				"model": mr.ModelKey,
+				"input": "ping",
+			}
 		} else {
-			url = strings.TrimRight(mr.BaseURL, "/") + "/chat/completions"
+			url = strings.TrimRight(endpointBaseURLFromConfig(mr.ProviderConfig, "openai", mr.BaseURL), "/") + "/chat/completions"
 			body = map[string]any{
 				"model":      mr.ModelKey,
 				"messages":   []map[string]any{{"role": "user", "content": "ping"}},
@@ -1115,6 +1158,8 @@ func testModelConnectivity(runtimeStore RuntimeStore) http.HandlerFunc {
 					}
 				}
 			}
+		} else if output, ok := parsed["output_text"].(string); ok {
+			sample = strings.TrimSpace(output)
 		}
 		if len(sample) > 200 {
 			sample = sample[:200] + "…"

--- a/server/internal/dev/routes_test.go
+++ b/server/internal/dev/routes_test.go
@@ -626,8 +626,9 @@ func TestImportProviderModelsCreatesSelectedModelsWithOneSecret(t *testing.T) {
 		"base_url":%q,
 		"credential_mode":"inline_secret",
 		"api_key":"sk-import",
-		"model_ids":["gpt-5.4","gpt-5.5","gpt-5.6"]
-	}`, upstream.URL+"/v1")
+		"model_ids":["gpt-5.4","gpt-5.5","gpt-5.6"],
+		"config":{"endpoint_base_urls":{"anthropic":%q,"openai-response":%q}}
+	}`, upstream.URL+"/v1", upstream.URL+"/anthropic", upstream.URL+"/v1")
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/00000000-0000-0000-0000-000000000002/models/import", strings.NewReader(body))
 	res := httptest.NewRecorder()
 	r.ServeHTTP(res, req)
@@ -643,6 +644,10 @@ func TestImportProviderModelsCreatesSelectedModelsWithOneSecret(t *testing.T) {
 	}
 	if got := fmt.Sprint(store.createdModels[0].Config["supported_endpoint_types"]); got != "[anthropic openai-response]" {
 		t.Fatalf("expected endpoint types stored for gpt-5.5, got %s", got)
+	}
+	baseURLs, _ := store.createdModels[0].Config["endpoint_base_urls"].(map[string]any)
+	if got := baseURLs["openai-response"]; got != upstream.URL+"/v1" {
+		t.Fatalf("expected openai-response endpoint base URL to survive import config, got %v", got)
 	}
 	if got := fmt.Sprint(store.createdModels[1].Config["supported_endpoint_types"]); got != "[openai]" {
 		t.Fatalf("expected chat_completions alias normalized for gpt-5.6, got %s", got)
@@ -690,8 +695,9 @@ func TestDetectProviderModelEndpointsFindsSharedBaseURLFamilies(t *testing.T) {
 	body := fmt.Sprintf(`{
 		"base_url":%q,
 		"model_key":"shared-model",
-		"api_key":"sk-detect"
-	}`, upstream.URL+"/v1")
+		"api_key":"sk-detect",
+		"config":{"endpoint_base_urls":{"anthropic":%q,"openai":%q,"openai-response":%q}}
+	}`, upstream.URL+"/anthropic", upstream.URL, upstream.URL+"/v1", upstream.URL+"/v1")
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/00000000-0000-0000-0000-000000000002/models/detect-endpoints", strings.NewReader(body))
 	res := httptest.NewRecorder()
 	r.ServeHTTP(res, req)


### PR DESCRIPTION
## Summary
- persist `config.endpoint_base_urls` from provider catalog protocols during manual create and bulk import
- route Claude/Codex/Pi injections through the endpoint-specific base URL before falling back to `models.base_url`
- keep a fallback for legacy rows saved with `/anthropic` by inferring `/v1` for OpenAI/Responses endpoints
- make Codex require `openai-response` when `supported_endpoint_types` is present, and avoid sending responses-only models through Pi chat-completions
- document the model endpoint URL contract in `CONTRIBUTING.md`

## Tests
- `go test ./server/internal/dev ./server/internal/connector/agentdaemon`
- `pnpm --filter @parsar/web typecheck`
- `make check`