### PR TITLE
Run imported model health checks asynchronously

### DIFF
--- a/apps/web/src/lib/api-models.ts
+++ b/apps/web/src/lib/api-models.ts
@@ -483,8 +483,19 @@ export interface ModelConnectivityResult {
   success: boolean
   latency_ms: number
   http_status?: number
+  endpoint_type?: string
   error?: string
   sample?: string
+}
+
+async function testModelRequest(
+  workspaceID: string,
+  modelID: string,
+): Promise<ModelConnectivityResult> {
+  return apiRequest<ModelConnectivityResult>(
+    `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/models/${encodeURIComponent(modelID)}/test`,
+    { method: "POST" },
+  )
 }
 
 export function useTestModel(workspaceID: string | null) {
@@ -499,12 +510,44 @@ export function useTestModel(workspaceID: string | null) {
           unreachable: false,
         })
       }
-      return apiRequest<ModelConnectivityResult>(
-        `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/models/${encodeURIComponent(modelID)}/test`,
-        { method: "POST" }
-      )
+      return testModelRequest(workspaceID, modelID)
     },
     onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: KEY_MODELS(workspaceID ?? "_none") })
+    },
+  })
+}
+
+export function useBackgroundTestModels(workspaceID: string | null) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: async (modelIDs: string[]) => {
+      if (!workspaceID) {
+        throw new ApiError({
+          status: 0,
+          code: "no_workspace",
+          message: "no workspace selected — pick a workspace first",
+          unreachable: false,
+        })
+      }
+      const ws = workspaceID
+      const ids = Array.from(new Set(modelIDs.filter(Boolean)))
+      const results: PromiseSettledResult<ModelConnectivityResult>[] = []
+      let next = 0
+      async function worker() {
+        for (;;) {
+          const index = next
+          next += 1
+          const modelID = ids[index]
+          if (!modelID) return
+          const result = await Promise.allSettled([testModelRequest(ws, modelID)])
+          results[index] = result[0]
+        }
+      }
+      await Promise.all(Array.from({ length: Math.min(3, ids.length) }, () => worker()))
+      return results
+    },
+    onSettled: () => {
       void qc.invalidateQueries({ queryKey: KEY_MODELS(workspaceID ?? "_none") })
     },
   })

--- a/apps/web/src/pages/admin/BulkImportModelsDialog.tsx
+++ b/apps/web/src/pages/admin/BulkImportModelsDialog.tsx
@@ -13,7 +13,7 @@ import {
 } from "../../components/ui/dialog"
 import { Input } from "../../components/ui/input"
 import { ApiError } from "../../lib/api-client"
-import type { ModelCredentialMode, Secret } from "../../lib/api-types"
+import type { Model, ModelCredentialMode, Secret } from "../../lib/api-types"
 import {
   useImportProviderModels,
   type ImportProviderModelPreview,
@@ -58,6 +58,7 @@ interface BulkImportModelsDialogProps {
   onOpenChange: (open: boolean) => void
   secrets: Secret[]
   workspaceID: string | null
+  onImported?: (models: Model[]) => void
 }
 
 export function BulkImportModelsDialog({
@@ -65,6 +66,7 @@ export function BulkImportModelsDialog({
   onOpenChange,
   secrets,
   workspaceID,
+  onImported,
 }: BulkImportModelsDialogProps) {
   const { t } = useTranslation("admin")
   const { t: tc } = useTranslation("common")
@@ -201,6 +203,10 @@ export function BulkImportModelsDialog({
         setImportResult(data)
         setPreviewModels(data.models ?? [])
         setSelected(new Set())
+        if ((data.created?.length ?? 0) > 0) {
+          onImported?.(data.created)
+          onOpenChange(false)
+        }
       },
     })
   }

--- a/apps/web/src/pages/admin/ModelsPage.tsx
+++ b/apps/web/src/pages/admin/ModelsPage.tsx
@@ -39,6 +39,7 @@ import {
 } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
 import {
+  useBackgroundTestModels,
   useBulkDeleteModels,
   useCreateModel,
   useDeleteModel,
@@ -215,6 +216,7 @@ export function ModelsPage() {
   const deleteMut = useDeleteModel(wsId)
   const bulkDeleteMut = useBulkDeleteModels(wsId)
   const testMut = useTestModel(wsId)
+  const backgroundTestMut = useBackgroundTestModels(wsId)
 
   const [createOpen, setCreateOpen] = useState(false)
   const [bulkImportOpen, setBulkImportOpen] = useState(false)
@@ -226,6 +228,7 @@ export function ModelsPage() {
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false)
   const [selectedModelIDs, setSelectedModelIDs] = useState<Set<string>>(() => new Set())
   const [bulkDeleteResult, setBulkDeleteResult] = useState<BulkDeleteModelsResponse | null>(null)
+  const [backgroundTestingIDs, setBackgroundTestingIDs] = useState<Set<string>>(() => new Set())
   const [testResult, setTestResult] = useState<{
     modelID: string
     data: ModelConnectivityResult
@@ -257,6 +260,13 @@ export function ModelsPage() {
 
   const err = modelsQ.error
   const isUnreachable = err instanceof ApiError && err.envelope.unreachable
+  const testingModelIDs = useMemo(() => {
+    const ids = new Set(backgroundTestingIDs)
+    if (testMut.isPending && typeof testMut.variables === "string") {
+      ids.add(testMut.variables)
+    }
+    return ids
+  }, [backgroundTestingIDs, testMut.isPending, testMut.variables])
 
   function performTest(m: Model) {
     testMut.mutate(m.id, {
@@ -273,6 +283,15 @@ export function ModelsPage() {
           },
         })
       },
+    })
+  }
+
+  function startBackgroundTests(models: Model[]) {
+    const ids = models.map((model) => model.id).filter(Boolean)
+    if (ids.length === 0) return
+    setBackgroundTestingIDs(new Set(ids))
+    backgroundTestMut.mutate(ids, {
+      onSettled: () => setBackgroundTestingIDs(new Set()),
     })
   }
 
@@ -499,7 +518,7 @@ export function ModelsPage() {
           <ModelsTable
             data={filteredModels}
             selectedIDs={selectedModelIDs}
-            testingModelID={testMut.isPending ? (testMut.variables as string) : null}
+            testingModelIDs={testingModelIDs}
             currentUserID={currentUserID}
             isAdmin={isAdmin}
             onToggleModel={toggleModelSelection}
@@ -543,6 +562,7 @@ export function ModelsPage() {
         secrets={secrets}
         workspaceID={wsId}
         onOpenChange={setBulkImportOpen}
+        onImported={startBackgroundTests}
       />
 
       <EditModelDialog

--- a/apps/web/src/pages/admin/ModelsTable.tsx
+++ b/apps/web/src/pages/admin/ModelsTable.tsx
@@ -127,7 +127,7 @@ function ModelProtocolCell({ model }: { model: Model }) {
 export function ModelsTable({
   data,
   selectedIDs,
-  testingModelID,
+  testingModelIDs,
   onToggleModel,
   onToggleAllVisible,
   onRequestEdit,
@@ -139,7 +139,7 @@ export function ModelsTable({
 }: {
   data: Model[]
   selectedIDs: Set<string>
-  testingModelID: string | null
+  testingModelIDs: Set<string>
   onToggleModel: (modelID: string, selected: boolean) => void
   onToggleAllVisible: (selected: boolean) => void
   onRequestEdit: (m: Model) => void
@@ -202,7 +202,7 @@ export function ModelsTable({
         <TableBody>
           {data.map((m) => {
             const canEdit = isAdmin || (currentUserID && m.created_by === currentUserID)
-            const isTesting = testingModelID === m.id
+            const isTesting = testingModelIDs.has(m.id)
             const canTest = !isTesting && m.status === "active"
             const health = modelHealth(m)
             return (

--- a/server/internal/dev/routes_models.go
+++ b/server/internal/dev/routes_models.go
@@ -613,7 +613,6 @@ func importProviderModels(runtimeStore RuntimeStore) http.HandlerFunc {
 				})
 				continue
 			}
-			model = persistModelHealth(r.Context(), runtimeStore, workspaceID, model, actorIDFromRequest(r))
 			response.Created = append(response.Created, model)
 			existingKeys[modelKey] = true
 		}


### PR DESCRIPTION
## Summary
- stop running model health probes inside the import API request loop
- close the bulk import dialog immediately after models are created
- kick off bounded-concurrency background health checks from the Models page and show imported rows as Checking while they run

## Verification
- go test ./server/internal/dev ./server/internal/store
- make typecheck-web
- make check