### PR TITLE
Expose model test diagnostics

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -93,8 +93,24 @@
     },
     "test": {
       "success": "Reached upstream in {{ms}}ms",
+      "successWithEndpoints": "{{healthy}}/{{total}} endpoints reached upstream in {{ms}}ms",
       "failure": "Upstream rejected the test call",
-      "unsupported": "Connectivity test only supports OpenAI / Anthropic-compatible providers"
+      "failureWithEndpoints": "{{healthy}}/{{total}} endpoints passed",
+      "unsupported": "Connectivity test only supports OpenAI / Anthropic-compatible providers",
+      "details": {
+        "title": "Model test diagnostics",
+        "open": "Details",
+        "summary": "{{healthy}}/{{total}} endpoints healthy",
+        "primaryEndpoint": "Primary result: {{endpoint}} · {{ms}}ms",
+        "noEndpoint": "No endpoint was tested",
+        "unknownEndpoint": "unknown",
+        "latency": "{{ms}}ms",
+        "httpStatus": "HTTP {{status}}",
+        "request": "Request",
+        "response": "Response",
+        "noResponse": "No response",
+        "copy": "Copy"
+      }
     },
     "createProvider": {
       "fields": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -93,8 +93,24 @@
     },
     "test": {
       "success": "{{ms}}ms 内联通上游",
+      "successWithEndpoints": "{{healthy}}/{{total}} 个接口在 {{ms}}ms 内联通上游",
       "failure": "上游拒绝了测试请求",
-      "unsupported": "暂不支持 (仅 OpenAI / Anthropic 协议)"
+      "failureWithEndpoints": "{{healthy}}/{{total}} 个接口通过测试",
+      "unsupported": "暂不支持 (仅 OpenAI / Anthropic 协议)",
+      "details": {
+        "title": "模型测试诊断",
+        "open": "详情",
+        "summary": "{{healthy}}/{{total}} 个接口健康",
+        "primaryEndpoint": "主结果：{{endpoint}} · {{ms}}ms",
+        "noEndpoint": "没有测试任何接口",
+        "unknownEndpoint": "未知接口",
+        "latency": "{{ms}}ms",
+        "httpStatus": "HTTP {{status}}",
+        "request": "请求",
+        "response": "响应",
+        "noResponse": "无响应",
+        "copy": "复制"
+      }
     },
     "createProvider": {
       "fields": {

--- a/apps/web/src/lib/api-models.ts
+++ b/apps/web/src/lib/api-models.ts
@@ -486,6 +486,37 @@ export interface ModelConnectivityResult {
   endpoint_type?: string
   error?: string
   sample?: string
+  healthy_count?: number
+  total_count?: number
+  results?: ModelConnectivityEndpointResult[]
+}
+
+export interface ModelConnectivityEndpointResult {
+  endpoint_type: string
+  supported: boolean
+  success: boolean
+  latency_ms: number
+  http_status?: number
+  failure_stage?: string
+  error?: string
+  sample?: string
+  request?: ModelConnectivityHTTPRequest
+  response?: ModelConnectivityHTTPResponse
+}
+
+export interface ModelConnectivityHTTPRequest {
+  method: string
+  url: string
+  headers?: Record<string, string>
+  body?: Record<string, unknown>
+}
+
+export interface ModelConnectivityHTTPResponse {
+  status: number
+  headers?: Record<string, string>
+  body?: unknown
+  raw_body?: string
+  truncated?: boolean
 }
 
 async function testModelRequest(

--- a/apps/web/src/pages/admin/ModelTestDiagnosticsDialog.tsx
+++ b/apps/web/src/pages/admin/ModelTestDiagnosticsDialog.tsx
@@ -1,0 +1,204 @@
+import { AlertCircle, CheckCircle2, Copy } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "../../components/ui/badge"
+import { Button } from "../../components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../../components/ui/dialog"
+import type {
+  ModelConnectivityEndpointResult,
+  ModelConnectivityResult,
+} from "../../lib/api-models"
+
+interface ModelTestDiagnosticsDialogProps {
+  open: boolean
+  result: { modelID: string; data: ModelConnectivityResult } | null
+  onOpenChange: (open: boolean) => void
+}
+
+export function ModelTestDiagnosticsDialog({
+  open,
+  result,
+  onOpenChange,
+}: ModelTestDiagnosticsDialogProps) {
+  const { t } = useTranslation("admin")
+  const data = result?.data
+  const endpoints = data?.results?.length
+    ? data.results
+    : data
+      ? [resultFromTopLevel(data)]
+      : []
+  const healthyCount = data?.healthy_count ?? endpoints.filter((item) => item.success).length
+  const totalCount = data?.total_count ?? endpoints.length
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[calc(100vh-2rem)] max-w-4xl gap-0 overflow-hidden p-0">
+        <DialogHeader className="border-b border-line px-5 py-4">
+          <div className="flex flex-wrap items-center gap-2 pr-8">
+            <DialogTitle className="text-sm">
+              {t("models.test.details.title")}
+            </DialogTitle>
+            {data && (
+              <Badge variant={data.success ? "success" : "destructive"} dot>
+                {t("models.test.details.summary", {
+                  healthy: healthyCount,
+                  total: totalCount,
+                })}
+              </Badge>
+            )}
+          </div>
+          <DialogDescription className="text-xs">
+            {data?.endpoint_type
+              ? t("models.test.details.primaryEndpoint", {
+                  endpoint: data.endpoint_type,
+                  ms: data.latency_ms,
+                })
+              : t("models.test.details.noEndpoint")}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[calc(100vh-9rem)] space-y-3 overflow-y-auto px-5 py-4">
+          {endpoints.map((endpoint, index) => (
+            <EndpointDiagnostics
+              key={`${endpoint.endpoint_type}-${index}`}
+              endpoint={endpoint}
+            />
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function EndpointDiagnostics({ endpoint }: { endpoint: ModelConnectivityEndpointResult }) {
+  const { t } = useTranslation("admin")
+  const requestJSON = prettyJSON({
+    headers: endpoint.request?.headers,
+    body: endpoint.request?.body,
+  })
+  const responseJSON = prettyJSON({
+    headers: endpoint.response?.headers,
+    body: endpoint.response?.body ?? endpoint.response?.raw_body,
+    truncated: endpoint.response?.truncated || undefined,
+  })
+
+  return (
+    <section className="rounded-md border border-line bg-surface">
+      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-line px-4 py-3">
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-xs font-semibold text-fg">
+              {endpoint.endpoint_type || t("models.test.details.unknownEndpoint")}
+            </span>
+            <Badge variant={endpoint.success ? "success" : endpoint.supported ? "destructive" : "neutral"} dot>
+              {endpoint.success
+                ? t("models.health.healthy")
+                : endpoint.supported
+                  ? t("models.health.failed")
+                  : t("models.health.unsupported")}
+            </Badge>
+            {endpoint.failure_stage && (
+              <Badge variant="warning">{endpoint.failure_stage}</Badge>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-fg-muted">
+            <span>{t("models.test.details.latency", { ms: endpoint.latency_ms })}</span>
+            {endpoint.http_status && (
+              <span>{t("models.test.details.httpStatus", { status: endpoint.http_status })}</span>
+            )}
+          </div>
+        </div>
+        {endpoint.success ? (
+          <CheckCircle2 className="h-4 w-4 text-success" />
+        ) : (
+          <AlertCircle className="h-4 w-4 text-danger-emphasis" />
+        )}
+      </div>
+
+      {endpoint.error && (
+        <div className="border-b border-line bg-danger-subtle/50 px-4 py-2 text-xs text-danger-emphasis">
+          {endpoint.error}
+        </div>
+      )}
+      {endpoint.sample && (
+        <div className="border-b border-line bg-success-subtle/50 px-4 py-2 text-xs text-success-emphasis">
+          {endpoint.sample}
+        </div>
+      )}
+
+      <div className="grid gap-3 p-4 lg:grid-cols-2">
+        <DiagnosticsBlock
+          title={t("models.test.details.request")}
+          meta={`${endpoint.request?.method ?? "POST"} ${endpoint.request?.url ?? ""}`}
+          value={requestJSON}
+        />
+        <DiagnosticsBlock
+          title={t("models.test.details.response")}
+          meta={endpoint.response?.status ? String(endpoint.response.status) : t("models.test.details.noResponse")}
+          value={responseJSON}
+        />
+      </div>
+    </section>
+  )
+}
+
+function DiagnosticsBlock({
+  title,
+  meta,
+  value,
+}: {
+  title: string
+  meta: string
+  value: string
+}) {
+  const { t } = useTranslation("admin")
+  async function copyValue() {
+    await navigator.clipboard?.writeText(value)
+  }
+
+  return (
+    <div className="min-w-0 rounded-md border border-line-muted bg-surface-subtle">
+      <div className="flex min-h-10 items-center justify-between gap-2 border-b border-line-muted px-3 py-2">
+        <div className="min-w-0">
+          <div className="text-xs font-medium text-fg">{title}</div>
+          <div className="truncate font-mono text-xs text-fg-muted">{meta}</div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          title={t("models.test.details.copy")}
+          onClick={copyValue}
+        >
+          <Copy className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-xs leading-relaxed text-fg-muted">
+        {value}
+      </pre>
+    </div>
+  )
+}
+
+function resultFromTopLevel(data: ModelConnectivityResult): ModelConnectivityEndpointResult {
+  return {
+    endpoint_type: data.endpoint_type ?? "",
+    supported: data.supported,
+    success: data.success,
+    latency_ms: data.latency_ms,
+    http_status: data.http_status,
+    error: data.error,
+    sample: data.sample,
+  }
+}
+
+function prettyJSON(value: unknown): string {
+  return JSON.stringify(value ?? {}, null, 2)
+}

--- a/apps/web/src/pages/admin/ModelsPage.tsx
+++ b/apps/web/src/pages/admin/ModelsPage.tsx
@@ -54,6 +54,7 @@ import type {
 } from "../../lib/api-models"
 import { CreateModelDialog, EditModelDialog } from "./ModelCrudDialogs"
 import { BulkImportModelsDialog } from "./BulkImportModelsDialog"
+import { ModelTestDiagnosticsDialog } from "./ModelTestDiagnosticsDialog"
 import { ModelsTable } from "./ModelsTable"
 import type { Model } from "../../lib/api-types"
 import { useWorkspaceId } from "../../lib/workspace"
@@ -126,15 +127,19 @@ function ConfirmDialog({
 
 function TestResultBanner({
   result,
+  onDetails,
   onClose,
 }: {
   result: { modelID: string; data: ModelConnectivityResult } | null
+  onDetails: () => void
   onClose: () => void
 }) {
   const { t } = useTranslation("admin")
   if (!result) return null
   const { data } = result
   const ok = data.success
+  const healthyCount = data.healthy_count ?? data.results?.filter((item) => item.success).length
+  const totalCount = data.total_count ?? data.results?.length
   return (
     <div className={`fixed bottom-4 right-4 z-50 max-w-md rounded-md border shadow-md ${
       ok ? "border-success-border bg-success-subtle" : "border-danger-border bg-danger-subtle"
@@ -149,7 +154,13 @@ function TestResultBanner({
           {ok ? (
             <>
               <div className="font-medium text-success-emphasis">
-                {t("models.test.success", { ms: data.latency_ms })}
+                {totalCount
+                  ? t("models.test.successWithEndpoints", {
+                      healthy: healthyCount ?? 0,
+                      total: totalCount,
+                      ms: data.latency_ms,
+                    })
+                  : t("models.test.success", { ms: data.latency_ms })}
               </div>
               {data.sample && (
                 <div className="mt-1 text-xs text-success-emphasis/80 line-clamp-2">
@@ -160,7 +171,14 @@ function TestResultBanner({
           ) : (
             <>
               <div className="font-medium text-danger-emphasis">
-                {data.supported ? t("models.test.failure") : t("models.test.unsupported")}
+                {totalCount
+                  ? t("models.test.failureWithEndpoints", {
+                      healthy: healthyCount ?? 0,
+                      total: totalCount,
+                    })
+                  : data.supported
+                    ? t("models.test.failure")
+                    : t("models.test.unsupported")}
               </div>
               {data.error && (
                 <div className="mt-1 text-xs text-danger-emphasis/80 line-clamp-3">
@@ -169,6 +187,15 @@ function TestResultBanner({
               )}
             </>
           )}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="mt-2 h-7 px-2"
+            onClick={onDetails}
+          >
+            {t("models.test.details.open")}
+          </Button>
         </div>
         <button
           type="button"
@@ -233,6 +260,7 @@ export function ModelsPage() {
     modelID: string
     data: ModelConnectivityResult
   } | null>(null)
+  const [testDiagnosticsOpen, setTestDiagnosticsOpen] = useState(false)
   const [ownership, setOwnership] = useState<OwnershipFilter>("all")
 
   const refreshing = modelsQ.isFetching || secretsQ.isFetching || kindsQ.isFetching
@@ -270,7 +298,10 @@ export function ModelsPage() {
 
   function performTest(m: Model) {
     testMut.mutate(m.id, {
-      onSuccess: (data) => setTestResult({ modelID: m.id, data }),
+      onSuccess: (data) => {
+        setTestResult({ modelID: m.id, data })
+        setTestDiagnosticsOpen(true)
+      },
       onError: (e) => {
         const message = e instanceof Error ? e.message : String(e)
         setTestResult({
@@ -282,6 +313,7 @@ export function ModelsPage() {
             error: message,
           },
         })
+        setTestDiagnosticsOpen(true)
       },
     })
   }
@@ -619,10 +651,17 @@ export function ModelsPage() {
 
       <TestResultBanner
         result={testResult}
+        onDetails={() => setTestDiagnosticsOpen(true)}
         onClose={() => {
           setTestResult(null)
           testMut.reset()
         }}
+      />
+
+      <ModelTestDiagnosticsDialog
+        open={testDiagnosticsOpen && !!testResult}
+        result={testResult}
+        onOpenChange={setTestDiagnosticsOpen}
       />
 
       {bulkDeleteResult && (

--- a/server/internal/dev/routes_model_health.go
+++ b/server/internal/dev/routes_model_health.go
@@ -51,14 +51,47 @@ func anthropicMessagesURL(baseURL string) string {
 }
 
 type connectivityTestResponse struct {
-	Supported    bool   `json:"supported"`
-	Success      bool   `json:"success"`
-	LatencyMS    int64  `json:"latency_ms"`
-	Status       int    `json:"http_status,omitempty"`
-	EndpointType string `json:"endpoint_type,omitempty"`
-	Error        string `json:"error,omitempty"`
-	Sample       string `json:"sample,omitempty"`
+	Supported    bool                       `json:"supported"`
+	Success      bool                       `json:"success"`
+	LatencyMS    int64                      `json:"latency_ms"`
+	Status       int                        `json:"http_status,omitempty"`
+	EndpointType string                     `json:"endpoint_type,omitempty"`
+	Error        string                     `json:"error,omitempty"`
+	Sample       string                     `json:"sample,omitempty"`
+	HealthyCount int                        `json:"healthy_count"`
+	TotalCount   int                        `json:"total_count"`
+	Results      []connectivityEndpointTest `json:"results"`
 }
+
+type connectivityEndpointTest struct {
+	EndpointType string                   `json:"endpoint_type"`
+	Supported    bool                     `json:"supported"`
+	Success      bool                     `json:"success"`
+	LatencyMS    int64                    `json:"latency_ms"`
+	Status       int                      `json:"http_status,omitempty"`
+	FailureStage string                   `json:"failure_stage,omitempty"`
+	Error        string                   `json:"error,omitempty"`
+	Sample       string                   `json:"sample,omitempty"`
+	Request      connectivityHTTPRequest  `json:"request"`
+	Response     connectivityHTTPResponse `json:"response,omitempty"`
+}
+
+type connectivityHTTPRequest struct {
+	Method  string            `json:"method"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
+	Body    map[string]any    `json:"body,omitempty"`
+}
+
+type connectivityHTTPResponse struct {
+	Status    int               `json:"status"`
+	Headers   map[string]string `json:"headers,omitempty"`
+	Body      any               `json:"body,omitempty"`
+	RawBody   string            `json:"raw_body,omitempty"`
+	Truncated bool              `json:"truncated,omitempty"`
+}
+
+const connectivityResponseBodyLimit = 8 * 1024
 
 // testModelConnectivity sends a minimal request to the upstream provider so the
 // admin can verify base_url + api_key + custom headers + model_key without
@@ -128,10 +161,12 @@ func modelHealthFromProbe(result connectivityTestResponse) map[string]any {
 		status = "unsupported"
 	}
 	health := map[string]any{
-		"status":     status,
-		"checked_at": time.Now().UTC().Format(time.RFC3339),
-		"latency_ms": result.LatencyMS,
-		"supported":  result.Supported,
+		"status":        status,
+		"checked_at":    time.Now().UTC().Format(time.RFC3339),
+		"latency_ms":    result.LatencyMS,
+		"supported":     result.Supported,
+		"healthy_count": result.HealthyCount,
+		"total_count":   result.TotalCount,
 	}
 	if result.Status != 0 {
 		health["http_status"] = result.Status
@@ -145,6 +180,28 @@ func modelHealthFromProbe(result connectivityTestResponse) map[string]any {
 	if result.Sample != "" {
 		health["sample"] = result.Sample
 	}
+	if len(result.Results) > 0 {
+		summaries := make([]map[string]any, 0, len(result.Results))
+		for _, item := range result.Results {
+			summary := map[string]any{
+				"endpoint_type": item.EndpointType,
+				"supported":     item.Supported,
+				"success":       item.Success,
+				"latency_ms":    item.LatencyMS,
+			}
+			if item.Status != 0 {
+				summary["http_status"] = item.Status
+			}
+			if item.FailureStage != "" {
+				summary["failure_stage"] = item.FailureStage
+			}
+			if item.Error != "" {
+				summary["error"] = item.Error
+			}
+			summaries = append(summaries, summary)
+		}
+		health["results_summary"] = summaries
+	}
 	return health
 }
 
@@ -152,7 +209,12 @@ func probeModelConnectivity(ctx context.Context, runtimeStore RuntimeStore, work
 	mr, err := runtimeStore.ResolveModelRuntimeForUser(ctx, modelID, callerUserID)
 	if err != nil {
 		if errors.Is(err, store.ErrModelDisabled) {
-			return connectivityTestResponse{Supported: true, Success: false, Error: err.Error()}, nil
+			return aggregateConnectivityResults([]connectivityEndpointTest{{
+				Supported:    true,
+				Success:      false,
+				FailureStage: "credential",
+				Error:        err.Error(),
+			}}), nil
 		}
 		if errors.Is(err, store.ErrUnknownModel) {
 			return connectivityTestResponse{}, err
@@ -160,14 +222,14 @@ func probeModelConnectivity(ctx context.Context, runtimeStore RuntimeStore, work
 		return connectivityTestResponse{}, errors.New("failed to resolve model")
 	}
 
-	isOpenAIChatCompatible := isOpenAIChatCompletionsAdapter(mr.Adapter) || modelSupportsEndpointType(mr.ProviderConfig, "openai")
-	isOpenAIResponsesCompatible := modelSupportsEndpointType(mr.ProviderConfig, "openai-response")
-	isAnthropicCompatible := isAnthropicMessagesAdapter(mr.Adapter) || modelSupportsEndpointType(mr.ProviderConfig, "anthropic")
-	if !isOpenAIChatCompatible && !isOpenAIResponsesCompatible && !isAnthropicCompatible {
-		return connectivityTestResponse{
-			Supported: false,
-			Error:     "connectivity test only supports OpenAI chat-completions, OpenAI responses, and Anthropic messages compatible providers",
-		}, nil
+	endpointTypes := modelProbeEndpointTypes(mr)
+	if len(endpointTypes) == 0 {
+		return aggregateConnectivityResults([]connectivityEndpointTest{{
+			Supported:    false,
+			Success:      false,
+			FailureStage: "unsupported",
+			Error:        "connectivity test only supports OpenAI chat-completions, OpenAI responses, and Anthropic messages compatible providers",
+		}}), nil
 	}
 
 	var encryptedPayload []byte
@@ -175,11 +237,11 @@ func probeModelConnectivity(ctx context.Context, runtimeStore RuntimeStore, work
 		encryptedPayload = mr.EncryptedPayload
 	} else {
 		if mr.SecretID == "" {
-			return connectivityTestResponse{Supported: true, Success: false, Error: "no API key bound to this model"}, nil
+			return aggregateCredentialFailure(endpointTypes, "no API key bound to this model"), nil
 		}
 		sp, err := runtimeStore.GetSecretPayload(ctx, workspaceID, mr.SecretID)
 		if err != nil {
-			return connectivityTestResponse{Supported: true, Success: false, Error: fmt.Sprintf("failed to fetch secret: %v", err)}, nil
+			return aggregateCredentialFailure(endpointTypes, fmt.Sprintf("failed to fetch secret: %v", err)), nil
 		}
 		encryptedPayload = sp.EncryptedPayload
 	}
@@ -190,7 +252,7 @@ func probeModelConnectivity(ctx context.Context, runtimeStore RuntimeStore, work
 	}
 	payload, err := secretService.Decrypt(encryptedPayload)
 	if err != nil {
-		return connectivityTestResponse{Supported: true, Success: false, Error: "failed to decrypt credential: " + err.Error()}, nil
+		return aggregateCredentialFailure(endpointTypes, "failed to decrypt credential: "+err.Error()), nil
 	}
 	apiKey, _ := payload["api_key"].(string)
 	if strings.TrimSpace(apiKey) == "" {
@@ -199,39 +261,103 @@ func probeModelConnectivity(ctx context.Context, runtimeStore RuntimeStore, work
 		}
 	}
 	if strings.TrimSpace(apiKey) == "" {
-		return connectivityTestResponse{Supported: true, Success: false, Error: "credential payload missing api_key / value field"}, nil
+		return aggregateCredentialFailure(endpointTypes, "credential payload missing api_key / value field"), nil
 	}
 
-	endpointType := "openai"
-	url := ""
-	body := map[string]any{}
-	if isAnthropicCompatible {
-		endpointType = "anthropic"
-		url = anthropicMessagesURL(endpointBaseURLFromConfig(mr.ProviderConfig, "anthropic", mr.BaseURL))
-		body = map[string]any{
-			"model":      mr.ModelKey,
-			"messages":   []map[string]any{{"role": "user", "content": "ping"}},
-			"max_tokens": 16,
+	results := make([]connectivityEndpointTest, 0, len(endpointTypes))
+	for _, endpointType := range endpointTypes {
+		results = append(results, probeModelEndpoint(ctx, mr, endpointType, apiKey))
+	}
+	return aggregateConnectivityResults(results), nil
+}
+
+func modelProbeEndpointTypes(mr store.ModelRuntime) []string {
+	raw := endpointTypesFromAny(mr.ProviderConfig["supported_endpoint_types"])
+	if len(raw) == 0 {
+		switch {
+		case isAnthropicMessagesAdapter(mr.Adapter):
+			raw = []string{"anthropic"}
+		case isOpenAIChatCompletionsAdapter(mr.Adapter):
+			raw = []string{"openai"}
 		}
-	} else if isOpenAIResponsesCompatible {
-		endpointType = "openai-response"
-		url = strings.TrimRight(endpointBaseURLFromConfig(mr.ProviderConfig, "openai-response", mr.BaseURL), "/") + "/responses"
-		body = map[string]any{
-			"model": mr.ModelKey,
-			"input": "ping",
+	}
+	out := make([]string, 0, len(raw))
+	seen := map[string]bool{}
+	for _, endpointType := range raw {
+		normalized := normalizeEndpointType(endpointType)
+		switch normalized {
+		case "openai", "openai-response", "anthropic":
+			if !seen[normalized] {
+				seen[normalized] = true
+				out = append(out, normalized)
+			}
 		}
-	} else {
-		url = strings.TrimRight(endpointBaseURLFromConfig(mr.ProviderConfig, "openai", mr.BaseURL), "/") + "/chat/completions"
-		body = map[string]any{
-			"model":      mr.ModelKey,
-			"messages":   []map[string]any{{"role": "user", "content": "ping"}},
-			"max_tokens": 16,
+	}
+	return out
+}
+
+func aggregateCredentialFailure(endpointTypes []string, msg string) connectivityTestResponse {
+	results := make([]connectivityEndpointTest, 0, len(endpointTypes))
+	for _, endpointType := range endpointTypes {
+		results = append(results, connectivityEndpointTest{
+			EndpointType: endpointType,
+			Supported:    true,
+			Success:      false,
+			FailureStage: "credential",
+			Error:        msg,
+		})
+	}
+	return aggregateConnectivityResults(results)
+}
+
+func aggregateConnectivityResults(results []connectivityEndpointTest) connectivityTestResponse {
+	out := connectivityTestResponse{Results: results, TotalCount: len(results)}
+	for _, result := range results {
+		out.LatencyMS += result.LatencyMS
+		if result.Supported {
+			out.Supported = true
 		}
+		if result.Success {
+			out.Success = true
+			out.HealthyCount++
+			if out.EndpointType == "" {
+				out.EndpointType = result.EndpointType
+				out.Status = result.Status
+				out.Sample = result.Sample
+			}
+			continue
+		}
+		if out.Error == "" && result.Error != "" {
+			out.EndpointType = result.EndpointType
+			out.Status = result.Status
+			out.Error = result.Error
+		}
+	}
+	if out.Error == "" && !out.Success && len(results) > 0 {
+		out.Error = results[0].Error
+		out.EndpointType = results[0].EndpointType
+		out.Status = results[0].Status
+	}
+	return out
+}
+
+func probeModelEndpoint(ctx context.Context, mr store.ModelRuntime, endpointType, apiKey string) connectivityEndpointTest {
+	url, body := modelProbeRequestSpec(mr, endpointType)
+	result := connectivityEndpointTest{
+		EndpointType: endpointType,
+		Supported:    true,
+		Request: connectivityHTTPRequest{
+			Method: http.MethodPost,
+			URL:    url,
+			Body:   body,
+		},
 	}
 	bodyBytes, _ := json.Marshal(body)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(bodyBytes)))
 	if err != nil {
-		return connectivityTestResponse{Supported: true, Success: false, EndpointType: endpointType, Error: "failed to build request: " + err.Error()}, nil
+		result.FailureStage = "request_build"
+		result.Error = "failed to build request: " + err.Error()
+		return result
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if endpointType == "anthropic" {
@@ -247,33 +373,149 @@ func probeModelConnectivity(ctx context.Context, runtimeStore RuntimeStore, work
 			}
 		}
 	}
+	result.Request.Headers = maskedHeaderMap(req.Header)
 
 	start := time.Now()
 	resp, err := testModelHTTPClient.Do(req)
-	latency := time.Since(start).Milliseconds()
+	result.LatencyMS = time.Since(start).Milliseconds()
 	if err != nil {
-		return connectivityTestResponse{Supported: true, Success: false, LatencyMS: latency, EndpointType: endpointType, Error: "request failed: " + err.Error()}, nil
+		result.FailureStage = "network"
+		result.Error = "request failed: " + err.Error()
+		return result
 	}
 	defer resp.Body.Close()
-	respBytes, _ := io.ReadAll(resp.Body)
 
-	var parsed map[string]any
-	_ = json.Unmarshal(respBytes, &parsed)
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 || parsed["error"] != nil {
-		msg := strings.TrimSpace(string(respBytes))
-		if eo, ok := parsed["error"].(map[string]any); ok {
-			if m, ok := eo["message"].(string); ok {
-				msg = m
-			}
-		}
-		if len(msg) > 500 {
-			msg = msg[:500] + "…"
-		}
-		return connectivityTestResponse{Supported: true, Success: false, LatencyMS: latency, Status: resp.StatusCode, EndpointType: endpointType, Error: msg}, nil
+	respBytes, truncated := readLimitedResponseBody(resp.Body)
+	parsed, parsedOK := parseJSONBody(respBytes)
+	result.Status = resp.StatusCode
+	result.Response = connectivityHTTPResponse{
+		Status:    resp.StatusCode,
+		Headers:   selectedResponseHeaders(resp.Header),
+		RawBody:   string(respBytes),
+		Truncated: truncated,
+	}
+	if parsedOK {
+		result.Response.Body = parsed
 	}
 
-	sample := modelProbeSample(parsed, endpointType)
-	return connectivityTestResponse{Supported: true, Success: true, LatencyMS: latency, Status: resp.StatusCode, EndpointType: endpointType, Sample: sample}, nil
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 || parsed["error"] != nil {
+		msg := responseErrorMessage(respBytes, parsed)
+		if truncated {
+			msg += "…"
+		}
+		result.FailureStage = "upstream_http"
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			result.FailureStage = "upstream_body"
+		}
+		result.Error = msg
+		return result
+	}
+
+	result.Success = true
+	result.Sample = modelProbeSample(parsed, endpointType)
+	return result
+}
+
+func modelProbeRequestSpec(mr store.ModelRuntime, endpointType string) (string, map[string]any) {
+	switch endpointType {
+	case "anthropic":
+		return anthropicMessagesURL(endpointBaseURLFromConfig(mr.ProviderConfig, "anthropic", mr.BaseURL)), map[string]any{
+			"model":      mr.ModelKey,
+			"messages":   []map[string]any{{"role": "user", "content": "ping"}},
+			"max_tokens": 16,
+		}
+	case "openai-response":
+		return strings.TrimRight(endpointBaseURLFromConfig(mr.ProviderConfig, "openai-response", mr.BaseURL), "/") + "/responses", map[string]any{
+			"model": mr.ModelKey,
+			"input": "ping",
+		}
+	default:
+		return strings.TrimRight(endpointBaseURLFromConfig(mr.ProviderConfig, "openai", mr.BaseURL), "/") + "/chat/completions", map[string]any{
+			"model":      mr.ModelKey,
+			"messages":   []map[string]any{{"role": "user", "content": "ping"}},
+			"max_tokens": 16,
+		}
+	}
+}
+
+func readLimitedResponseBody(body io.Reader) ([]byte, bool) {
+	respBytes, _ := io.ReadAll(io.LimitReader(body, connectivityResponseBodyLimit+1))
+	if len(respBytes) > connectivityResponseBodyLimit {
+		return respBytes[:connectivityResponseBodyLimit], true
+	}
+	return respBytes, false
+}
+
+func parseJSONBody(body []byte) (map[string]any, bool) {
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return map[string]any{}, false
+	}
+	return parsed, true
+}
+
+func responseErrorMessage(respBytes []byte, parsed map[string]any) string {
+	msg := strings.TrimSpace(string(respBytes))
+	if eo, ok := parsed["error"].(map[string]any); ok {
+		if m, ok := eo["message"].(string); ok {
+			msg = m
+		}
+	}
+	if msg == "" {
+		msg = "upstream returned an empty response body"
+	}
+	if len(msg) > 500 {
+		msg = msg[:500] + "…"
+	}
+	return msg
+}
+
+func maskedHeaderMap(headers http.Header) map[string]string {
+	out := map[string]string{}
+	for key, values := range headers {
+		if len(values) == 0 {
+			continue
+		}
+		if isSensitiveHeader(key) {
+			out[key] = maskSecret(values[0])
+			continue
+		}
+		out[key] = values[0]
+	}
+	return out
+}
+
+func selectedResponseHeaders(headers http.Header) map[string]string {
+	out := map[string]string{}
+	for _, key := range []string{"Content-Type", "X-Request-Id", "Request-Id"} {
+		if value := headers.Get(key); value != "" {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func isSensitiveHeader(key string) bool {
+	k := strings.ToLower(key)
+	return strings.Contains(k, "authorization") ||
+		strings.Contains(k, "api-key") ||
+		strings.Contains(k, "token") ||
+		strings.Contains(k, "secret") ||
+		k == "x-api-key"
+}
+
+func maskSecret(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if strings.HasPrefix(strings.ToLower(value), "bearer ") {
+		return "Bearer " + maskSecret(strings.TrimSpace(value[7:]))
+	}
+	if len(value) <= 8 {
+		return "****"
+	}
+	return value[:4] + "..." + value[len(value)-4:]
 }
 
 func modelProbeSample(parsed map[string]any, endpointType string) string {

--- a/server/internal/dev/routes_test.go
+++ b/server/internal/dev/routes_test.go
@@ -1212,6 +1212,103 @@ func TestModelConnectivitySuccess(t *testing.T) {
 	}
 }
 
+func TestModelConnectivityTestsAllSupportedEndpointTypes(t *testing.T) {
+	const masterKey = "test-master-key"
+	t.Setenv("PARSAR_MASTER_KEY", masterKey)
+	svc, err := secrets.New(masterKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc, err := svc.Encrypt(map[string]any{"api_key": "sk-test-12345"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seenPaths := map[string]bool{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		seenPaths[req.URL.Path] = true
+		if got := req.Header.Get("Authorization"); got != "" && got != "Bearer sk-test-12345" {
+			t.Fatalf("upstream got wrong Authorization: %q", got)
+		}
+		if got := req.Header.Get("x-api-key"); got != "" && got != "sk-test-12345" {
+			t.Fatalf("upstream got wrong x-api-key: %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Request-Id", "req_test")
+		switch req.URL.Path {
+		case "/openai/v1/chat/completions":
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"pong chat"}}]}`))
+		case "/responses/v1/responses":
+			_, _ = w.Write([]byte(`{"output_text":"pong responses"}`))
+		case "/anthropic/v1/messages":
+			_, _ = w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"pong anthropic"}]}`))
+		default:
+			t.Fatalf("unexpected upstream path %s", req.URL.Path)
+		}
+	}))
+	defer upstream.Close()
+
+	store := connectivityStubStore{
+		runtime: store.ModelRuntime{
+			ModelID:  "00000000-0000-0000-0000-000000000702",
+			ModelKey: "gpt-5.5",
+			Adapter:  "@ai-sdk/openai-compatible",
+			BaseURL:  upstream.URL + "/v1",
+			SecretID: "00000000-0000-0000-0000-000000000601",
+			ProviderConfig: map[string]any{
+				"supported_endpoint_types": []any{"openai", "openai-response", "anthropic"},
+				"endpoint_base_urls": map[string]any{
+					"openai":          upstream.URL + "/openai/v1",
+					"openai-response": upstream.URL + "/responses/v1",
+					"anthropic":       upstream.URL + "/anthropic",
+				},
+				"headers": map[string]any{"X-Sub-Module": "model-test"},
+			},
+		},
+		payload:       store.SecretPayload{EncryptedPayload: enc},
+		updatedHealth: map[string]any{},
+	}
+	r := chi.NewRouter()
+	RegisterRoutesWithStore(r, store)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/00000000-0000-0000-0000-000000000002/models/00000000-0000-0000-0000-000000000702/test", nil)
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+	requireStatus(t, res, http.StatusOK)
+
+	var result connectivityTestResponse
+	if err := json.Unmarshal(res.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode connectivity result: %v; body=%s", err, res.Body.String())
+	}
+	if !result.Success || result.HealthyCount != 3 || result.TotalCount != 3 || len(result.Results) != 3 {
+		t.Fatalf("expected all three endpoints healthy, got %+v", result)
+	}
+	for _, path := range []string{"/openai/v1/chat/completions", "/responses/v1/responses", "/anthropic/v1/messages"} {
+		if !seenPaths[path] {
+			t.Fatalf("expected upstream path %s to be tested; seen=%+v", path, seenPaths)
+		}
+	}
+	for _, endpoint := range result.Results {
+		if endpoint.Request.Method != http.MethodPost || endpoint.Request.URL == "" {
+			t.Fatalf("expected request diagnostics for %s, got %+v", endpoint.EndpointType, endpoint.Request)
+		}
+		if strings.Contains(fmt.Sprint(endpoint.Request.Headers), "sk-test-12345") {
+			t.Fatalf("expected sensitive request header masked, got %+v", endpoint.Request.Headers)
+		}
+		if endpoint.Response.Status != http.StatusOK || endpoint.Response.Headers["X-Request-Id"] != "req_test" || endpoint.Response.RawBody == "" {
+			t.Fatalf("expected response diagnostics for %s, got %+v", endpoint.EndpointType, endpoint.Response)
+		}
+	}
+	if store.updatedHealth["healthy_count"] != 3 || store.updatedHealth["total_count"] != 3 {
+		t.Fatalf("expected aggregate health counts, got %+v", store.updatedHealth)
+	}
+	if _, ok := store.updatedHealth["results"]; ok {
+		t.Fatalf("persisted health must not keep full diagnostics: %+v", store.updatedHealth)
+	}
+	if _, ok := store.updatedHealth["results_summary"]; !ok {
+		t.Fatalf("expected persisted health summary, got %+v", store.updatedHealth)
+	}
+}
+
 func TestModelConnectivityPersistsHealth(t *testing.T) {
 	const masterKey = "test-master-key"
 	t.Setenv("PARSAR_MASTER_KEY", masterKey)


### PR DESCRIPTION
## Summary
- test every supported OpenAI chat, OpenAI responses, and Anthropic endpoint for a model instead of selecting only one protocol
- return masked request diagnostics and selected upstream response details from the manual model test API
- add a Models page diagnostics dialog showing endpoint-level request, response, latency, status, and failure stage
- persist only aggregate health and per-endpoint summaries, not raw request/response diagnostics

## Checks
- make check