### PR TITLE
Fix model test OpenAI base URL inference

### DIFF
--- a/server/internal/dev/routes_models.go
+++ b/server/internal/dev/routes_models.go
@@ -256,13 +256,13 @@ func endpointBaseURLFromConfig(config map[string]any, endpointType, fallback str
 				continue
 			}
 			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
-				return strings.TrimSpace(s)
+				return inferredEndpointBaseURL(want, s)
 			}
 		}
 	case map[string]string:
 		for k, s := range raw {
 			if normalizeEndpointType(k) == want && strings.TrimSpace(s) != "" {
-				return strings.TrimSpace(s)
+				return inferredEndpointBaseURL(want, s)
 			}
 		}
 	}
@@ -272,12 +272,22 @@ func endpointBaseURLFromConfig(config map[string]any, endpointType, fallback str
 func inferredEndpointBaseURL(endpointType, fallback string) string {
 	base := strings.TrimRight(strings.TrimSpace(fallback), "/")
 	if endpointType == "openai" || endpointType == "openai-response" {
+		if strings.HasSuffix(base, "/chat/completions") {
+			base = strings.TrimSuffix(base, "/chat/completions")
+		}
+		if strings.HasSuffix(base, "/responses") {
+			base = strings.TrimSuffix(base, "/responses")
+		}
 		if strings.HasSuffix(base, "/anthropic/v1") {
 			return strings.TrimSuffix(base, "/anthropic/v1") + "/v1"
 		}
 		if strings.HasSuffix(base, "/anthropic") {
 			return strings.TrimSuffix(base, "/anthropic") + "/v1"
 		}
+		if strings.HasSuffix(base, "/v1") {
+			return base
+		}
+		return base + "/v1"
 	}
 	return base
 }

--- a/server/internal/dev/routes_test.go
+++ b/server/internal/dev/routes_test.go
@@ -1309,6 +1309,73 @@ func TestModelConnectivityTestsAllSupportedEndpointTypes(t *testing.T) {
 	}
 }
 
+func TestModelConnectivityInfersOpenAIV1BaseURL(t *testing.T) {
+	const masterKey = "test-master-key"
+	t.Setenv("PARSAR_MASTER_KEY", masterKey)
+	svc, err := secrets.New(masterKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc, err := svc.Encrypt(map[string]any{"api_key": "sk-test-12345"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seenPaths := map[string]bool{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		seenPaths[req.URL.Path] = true
+		w.Header().Set("Content-Type", "application/json")
+		switch req.URL.Path {
+		case "/v1/chat/completions":
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"pong chat"}}]}`))
+		case "/v1/responses":
+			_, _ = w.Write([]byte(`{"output_text":"pong responses"}`))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`404 page not found`))
+		}
+	}))
+	defer upstream.Close()
+
+	store := connectivityStubStore{
+		runtime: store.ModelRuntime{
+			ModelID:  "00000000-0000-0000-0000-000000000702",
+			ModelKey: "grok-4.3",
+			Adapter:  "@ai-sdk/openai-compatible",
+			BaseURL:  upstream.URL,
+			SecretID: "00000000-0000-0000-0000-000000000601",
+			ProviderConfig: map[string]any{
+				"supported_endpoint_types": []any{"openai", "openai-response"},
+			},
+		},
+		payload: store.SecretPayload{EncryptedPayload: enc},
+	}
+	r := chi.NewRouter()
+	RegisterRoutesWithStore(r, store)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/workspaces/00000000-0000-0000-0000-000000000002/models/00000000-0000-0000-0000-000000000702/test", nil)
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+	requireStatus(t, res, http.StatusOK)
+
+	var result connectivityTestResponse
+	if err := json.Unmarshal(res.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode connectivity result: %v; body=%s", err, res.Body.String())
+	}
+	if !result.Success || result.HealthyCount != 2 || result.TotalCount != 2 {
+		t.Fatalf("expected both OpenAI endpoints healthy, got %+v", result)
+	}
+	for _, path := range []string{"/v1/chat/completions", "/v1/responses"} {
+		if !seenPaths[path] {
+			t.Fatalf("expected upstream path %s to be tested; seen=%+v", path, seenPaths)
+		}
+	}
+	for _, endpoint := range result.Results {
+		if !strings.Contains(endpoint.Request.URL, "/v1/") {
+			t.Fatalf("expected request URL to include /v1, got %s", endpoint.Request.URL)
+		}
+	}
+}
+
 func TestModelConnectivityPersistsHealth(t *testing.T) {
 	const masterKey = "test-master-key"
 	t.Setenv("PARSAR_MASTER_KEY", masterKey)


### PR DESCRIPTION
## Summary
- normalize OpenAI endpoint base URLs through the shared inference helper even when they come from endpoint_base_urls
- infer /v1 for OpenAI chat-completions and responses when the saved base_url is a bare provider host
- add a regression test covering bare host + openai/openai-response model tests

## Checks
- go test ./server/internal/dev -run 'TestModelConnectivity'
- make check