### PR TITLE
Allow editing model endpoint base URLs

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -190,6 +190,10 @@
         "baseURL": "Base URL",
         "customHeaders": "Custom HTTP headers"
       },
+      "endpointBaseURLs": {
+        "title": "Endpoint base URLs",
+        "description": "Final per-protocol base URL saved for runtime calls and model tests."
+      },
       "credentialBinding": {
         "boundSecret": "Bound Secret",
         "boundSecretNone": "(no Secret bound — model is unusable)",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -190,6 +190,10 @@
         "baseURL": "服务地址",
         "customHeaders": "自定义 HTTP Headers"
       },
+      "endpointBaseURLs": {
+        "title": "接口服务地址",
+        "description": "按协议保存的最终 Base URL，用于运行时请求和模型测试。"
+      },
       "credentialBinding": {
         "boundSecret": "当前绑定的 Secret",
         "boundSecretNone": "(没有绑 Secret — 当前不可用)",

--- a/apps/web/src/lib/model-endpoint-base-urls.ts
+++ b/apps/web/src/lib/model-endpoint-base-urls.ts
@@ -1,0 +1,108 @@
+import type { Model } from "./api-types"
+import {
+  endpointBaseURLsForProvider,
+  endpointTypeForProtocol,
+  type ProviderTypeOption,
+} from "./model-provider-options"
+import { modelSupportedEndpointTypes, type SupportedEndpointType } from "./model-protocol"
+
+export type EditableEndpointType = "anthropic" | "openai" | "openai-response"
+
+const EDITABLE_ENDPOINT_TYPES: EditableEndpointType[] = [
+  "anthropic",
+  "openai",
+  "openai-response",
+]
+
+export interface EndpointBaseURLRow {
+  endpointType: EditableEndpointType
+  baseURL: string
+}
+
+export function endpointTypeDisplayLabel(endpointType: string): string {
+  switch (endpointType) {
+    case "anthropic":
+      return "Anthropic Messages"
+    case "openai":
+      return "OpenAI Chat Completions"
+    case "openai-response":
+      return "OpenAI Responses"
+    default:
+      return endpointType
+  }
+}
+
+export function editableEndpointTypesForModel(
+  model: Pick<Model, "config" | "adapter">,
+  provider: ProviderTypeOption | undefined,
+): EditableEndpointType[] {
+  const supported = modelSupportedEndpointTypes(model)
+  const fromSupported = supported.filter(isEditableEndpointType)
+  if (fromSupported.length > 0) return uniqueEndpointTypes(fromSupported)
+
+  const fromProvider = (provider?.protocols ?? [])
+    .map((protocol) => endpointTypeForProtocol(protocol.id))
+    .filter(isEditableEndpointType)
+  if (fromProvider.length > 0) {
+    const out = uniqueEndpointTypes(fromProvider)
+    if (out.includes("openai") && !out.includes("openai-response")) {
+      out.push("openai-response")
+    }
+    return out
+  }
+
+  if (model.adapter.includes("anthropic")) return ["anthropic"]
+  if (model.adapter.includes("openai")) return ["openai", "openai-response"]
+  return []
+}
+
+export function endpointBaseURLRowsForModel(
+  model: Pick<Model, "config" | "base_url" | "adapter">,
+  provider: ProviderTypeOption | undefined,
+): EndpointBaseURLRow[] {
+  const endpointTypes = editableEndpointTypesForModel(model, provider)
+  const saved = endpointBaseURLsFromConfig(model.config)
+  const inferred = endpointBaseURLsForProvider(provider, model.base_url)
+  return endpointTypes.map((endpointType) => ({
+    endpointType,
+    baseURL: saved[endpointType] ?? inferred[endpointType] ?? model.base_url,
+  }))
+}
+
+export function endpointBaseURLsFromRows(
+  rows: EndpointBaseURLRow[],
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const row of rows) {
+    const baseURL = row.baseURL.trim()
+    if (baseURL) out[row.endpointType] = baseURL
+  }
+  return out
+}
+
+function endpointBaseURLsFromConfig(config: Record<string, unknown> | undefined): Record<string, string> {
+  const raw = config?.endpoint_base_urls
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {}
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(raw)) {
+    if (typeof value !== "string" || value.trim() === "") continue
+    if (!isEditableEndpointType(key)) continue
+    out[key] = value.trim()
+  }
+  return out
+}
+
+function isEditableEndpointType(value: string | null): value is EditableEndpointType {
+  return !!value && EDITABLE_ENDPOINT_TYPES.includes(value as EditableEndpointType)
+}
+
+function uniqueEndpointTypes(values: SupportedEndpointType[]): EditableEndpointType[] {
+  const out: EditableEndpointType[] = []
+  const seen = new Set<string>()
+  for (const value of values) {
+    if (!isEditableEndpointType(value) || seen.has(value)) continue
+    seen.add(value)
+    out.push(value)
+  }
+  return out
+}

--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -29,10 +29,16 @@ import { Input } from "../../components/ui/input"
 import { CredentialKindCombobox } from "./capabilities/CredentialKindCombobox"
 import { ModelKeyCombobox } from "./ModelKeyCombobox"
 import { ProviderTypeCombobox } from "./ProviderTypeCombobox"
+import { ModelEndpointBaseURLsEditor } from "./ModelEndpointBaseURLsEditor"
 import {
   getProviderCatalogSnapshot,
   loadProviderCatalog,
 } from "../../lib/model-presets"
+import {
+  endpointBaseURLRowsForModel,
+  endpointBaseURLsFromRows,
+  type EndpointBaseURLRow,
+} from "../../lib/model-endpoint-base-urls"
 import {
   FALLBACK_PROVIDER_TYPES,
   defaultModelFor,
@@ -774,6 +780,7 @@ export function EditModelDialog({
   const [modelKey, setModelKey] = useState("")
   const [baseURL, setBaseURL] = useState("")
   const [headers, setHeaders] = useState<Record<string, string>>({})
+  const [endpointBaseURLRows, setEndpointBaseURLRows] = useState<EndpointBaseURLRow[]>([])
   const [newAPIKey, setNewAPIKey] = useState("")
   const [secretID, setSecretID] = useState<string>("")
   const [credentialKindCode, setCredentialKindCode] = useState<string>("")
@@ -784,10 +791,11 @@ export function EditModelDialog({
     setModelKey(model.model_key)
     setBaseURL(model.base_url)
     setHeaders((model.config as { headers?: Record<string, string> })?.headers ?? {})
+    setEndpointBaseURLRows(endpointBaseURLRowsForModel(model, providerTypeMeta))
     setNewAPIKey("")
     setSecretID(model.secret_id ?? "")
     setCredentialKindCode(model.credential_kind_code ?? "")
-  }, [open, model])
+  }, [open, model, providerTypeMeta])
 
   if (!model) return null
   const errMsg = extractErrorMessage(error)
@@ -816,6 +824,14 @@ export function EditModelDialog({
       config = Object.keys(headers).length > 0 ? { ...rest, headers } : rest
     } else {
       config = model.config as Record<string, unknown>
+    }
+    const endpointBaseURLs = endpointBaseURLsFromRows(endpointBaseURLRows)
+    if (Object.keys(endpointBaseURLs).length > 0) {
+      config = { ...config, endpoint_base_urls: endpointBaseURLs }
+    } else {
+      const { endpoint_base_urls: _endpointBaseURLs, ...rest } = config
+      void _endpointBaseURLs
+      config = rest
     }
 
     const values: InlineUpdateModelInput = {
@@ -894,6 +910,13 @@ export function EditModelDialog({
             value={baseURL}
             onChange={setBaseURL}
             mono
+          />
+
+          <ModelEndpointBaseURLsEditor
+            rows={endpointBaseURLRows}
+            onChange={setEndpointBaseURLRows}
+            title={t("models.editModel.endpointBaseURLs.title")}
+            description={t("models.editModel.endpointBaseURLs.description")}
           />
 
           {supportsCustomHeaders && (

--- a/apps/web/src/pages/admin/ModelEndpointBaseURLsEditor.tsx
+++ b/apps/web/src/pages/admin/ModelEndpointBaseURLsEditor.tsx
@@ -1,0 +1,53 @@
+import { Input } from "../../components/ui/input"
+import type { EndpointBaseURLRow } from "../../lib/model-endpoint-base-urls"
+import { endpointTypeDisplayLabel } from "../../lib/model-endpoint-base-urls"
+
+interface ModelEndpointBaseURLsEditorProps {
+  rows: EndpointBaseURLRow[]
+  title: string
+  description: string
+  onChange: (rows: EndpointBaseURLRow[]) => void
+}
+
+export function ModelEndpointBaseURLsEditor({
+  rows,
+  title,
+  description,
+  onChange,
+}: ModelEndpointBaseURLsEditorProps) {
+  if (rows.length === 0) return null
+
+  function updateRow(endpointType: string, baseURL: string) {
+    onChange(rows.map((row) => (
+      row.endpointType === endpointType ? { ...row, baseURL } : row
+    )))
+  }
+
+  return (
+    <section className="grid gap-2 rounded-md border border-line bg-surface-subtle/40 p-3">
+      <div className="space-y-0.5">
+        <div className="text-sm font-medium text-fg-muted">{title}</div>
+        <div className="text-xs text-fg-faint">{description}</div>
+      </div>
+      <div className="grid gap-2">
+        {rows.map((row) => (
+          <div key={row.endpointType} className="grid gap-1.5">
+            <label
+              className="text-xs font-medium text-fg-muted"
+              htmlFor={`endpoint-base-url-${row.endpointType}`}
+            >
+              {endpointTypeDisplayLabel(row.endpointType)}
+            </label>
+            <Input
+              id={`endpoint-base-url-${row.endpointType}`}
+              value={row.baseURL}
+              onChange={(event) => updateRow(row.endpointType, event.target.value)}
+              placeholder="https://api.example.com/v1"
+              className="font-mono text-sm"
+            />
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- expose per-endpoint base URLs in the model edit dialog
- seed rows from saved config.endpoint_base_urls, then provider/default inference, then the legacy model base_url
- save edited endpoint URLs back into config.endpoint_base_urls while preserving other model config keys
- split endpoint URL config parsing/rendering into small frontend helpers/components

## Checks
- make typecheck-web
- make check