### PR TITLE
Prevent model dialogs from closing on outside clicks

### DIFF
--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -498,7 +498,11 @@ export function CreateModelDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent
+        className="max-w-2xl"
+        onPointerDownOutside={(event) => event.preventDefault()}
+        onInteractOutside={(event) => event.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>{t("models.createModel.title")}</DialogTitle>
         </DialogHeader>
@@ -857,7 +861,11 @@ export function EditModelDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent
+        className="max-w-2xl"
+        onPointerDownOutside={(event) => event.preventDefault()}
+        onInteractOutside={(event) => event.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>{t("models.editModel.title", { name: model.name })}</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
## What & why

Clicking outside the create or edit model dialog dismisses it immediately and discards the in-progress configuration. This is especially easy to trigger after switching to a personal key and interacting with credential controls.

## How

Prevent outside pointer and interaction events from dismissing the create and edit model dialogs. The explicit Cancel and close controls continue to work normally.

## Verification

- [x] `make check`
- [x] Relevant E2E target: no dedicated target
- [x] Local Playwright smoke: select Personal key, click outside the dialog, and verify the model dialog remains visible
