### PR TITLE
Allow Codex agents to select OpenAI chat models

### DIFF
--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -95,7 +95,7 @@ function engineSupportsModel(engine: AgentEngine, model: Model): boolean {
       case "claude_code":
         return endpointTypes.includes("anthropic")
       case "codex":
-        return endpointTypes.includes("openai-response")
+        return endpointTypes.includes("openai") || endpointTypes.includes("openai-response")
       case "pi":
         return (
           endpointTypes.includes("anthropic") ||


### PR DESCRIPTION
## Summary
- allow Codex agent model filtering to accept models that advertise the OpenAI chat/completions endpoint type
- keep OpenAI Responses models selectable for Codex

## Checks
- make typecheck-web
- make check