### PR TITLE
Allow Codex runtime to use OpenAI endpoint models

### DIFF
--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -370,7 +370,11 @@ func injectOpenCodeManagedModel(opts map[string]any, modelID string, mr store.Mo
 //	  query_params      — flattened from mr.ProviderConfig.query_params
 //	                      (Azure uses api-version=...)
 //
-// Provider gating: codex-rs only speaks OpenAI's Responses API.
+// Provider gating: codex-rs speaks OpenAI-compatible providers through
+// its Responses wire API. Catalog rows may advertise either
+// "openai-response" or the broader "openai" endpoint type depending on the
+// provider's /v1/models metadata; accept both and prefer the responses-specific
+// base URL when present.
 // ProviderType must be "openai" / "openai-compatible" / "azure-openai"
 // or carry an @ai-sdk/openai* adapter slug. Anything else surfaces
 // ErrManagedModelUnsupported so the caller emits a credential-form
@@ -380,7 +384,7 @@ func injectCodexManagedModel(opts map[string]any, modelID string, mr store.Model
 		return fmt.Errorf("%w: model_id=%s provider_type=%q adapter=%q",
 			ErrManagedModelUnsupported, modelID, mr.ProviderType, mr.Adapter)
 	}
-	codexBaseURL := modelEndpointBaseURL(mr, "openai-response")
+	codexBaseURL := modelEndpointBaseURL(mr, codexEndpointBaseURLType(mr))
 	if codexBaseURL == "" {
 		// Without a base_url the only sensible target is api.openai.com;
 		// codex's builtin "openai" provider already covers that. But the
@@ -442,7 +446,8 @@ func flattenStringMap(providerConfig map[string]any, key string) map[string]stri
 // codex_provider TOML block but a future change might split it out.
 func isOpenAICompatibleRuntime(mr store.ModelRuntime) bool {
 	if modelConfigHasEndpointTypes(mr.ProviderConfig) {
-		return modelConfigSupportsEndpointType(mr.ProviderConfig, "openai-response")
+		return modelConfigSupportsEndpointType(mr.ProviderConfig, "openai-response") ||
+			modelConfigSupportsEndpointType(mr.ProviderConfig, "openai")
 	}
 	for _, v := range []string{mr.ProviderType, mr.Adapter} {
 		switch strings.ToLower(strings.TrimSpace(v)) {
@@ -453,6 +458,18 @@ func isOpenAICompatibleRuntime(mr store.ModelRuntime) bool {
 		}
 	}
 	return false
+}
+
+func codexEndpointBaseURLType(mr store.ModelRuntime) string {
+	if modelConfigHasEndpointTypes(mr.ProviderConfig) {
+		if modelConfigSupportsEndpointType(mr.ProviderConfig, "openai-response") {
+			return "openai-response"
+		}
+		if modelConfigSupportsEndpointType(mr.ProviderConfig, "openai") {
+			return "openai"
+		}
+	}
+	return "openai-response"
 }
 
 // piAPIKeyEnv is the env var the daemon sets to the decrypted secret and

--- a/server/internal/connector/agentdaemon/model_injection_test.go
+++ b/server/internal/connector/agentdaemon/model_injection_test.go
@@ -854,7 +854,7 @@ func TestIsOpenAICompatibleRuntime(t *testing.T) {
 		{"azure-openai provider", store.ModelRuntime{ProviderType: "azure-openai"}, true},
 		{"@ai-sdk/openai adapter only", store.ModelRuntime{Adapter: "@ai-sdk/openai"}, true},
 		{"@ai-sdk/azure adapter only", store.ModelRuntime{Adapter: "@ai-sdk/azure"}, true},
-		{"endpoint types openai chat only", store.ModelRuntime{ProviderConfig: map[string]any{"supported_endpoint_types": []any{"openai"}}}, false},
+		{"endpoint types openai chat only", store.ModelRuntime{ProviderConfig: map[string]any{"supported_endpoint_types": []any{"openai"}}}, true},
 		{"endpoint types openai response", store.ModelRuntime{ProviderConfig: map[string]any{"supported_endpoint_types": []any{"openai-response"}}}, true},
 		{"whitespace + case-insensitive", store.ModelRuntime{ProviderType: " Openai "}, true},
 		{"anthropic provider rejected", store.ModelRuntime{ProviderType: "anthropic", Adapter: "@ai-sdk/anthropic"}, false},
@@ -901,6 +901,30 @@ func TestInjectCodexManagedModel_UsesResponsesEndpointBaseURL(t *testing.T) {
 	provider := opts["codex_provider"].(map[string]any)
 	if got := provider["base_url"]; got != "https://api.minimaxi.com/v1" {
 		t.Fatalf("codex_provider.base_url = %v, want /v1 base for /v1/responses", got)
+	}
+}
+
+func TestInjectCodexManagedModel_UsesOpenAIEndpointBaseURLFallback(t *testing.T) {
+	opts := map[string]any{}
+	mr := store.ModelRuntime{
+		ModelID:      "model-openai-only",
+		ModelKey:     "gpt-5.6",
+		ProviderType: "openai-compatible",
+		Adapter:      "@ai-sdk/openai-compatible",
+		BaseURL:      "https://api.example.com/chat",
+		ProviderConfig: map[string]any{
+			"supported_endpoint_types": []any{"openai"},
+			"endpoint_base_urls": map[string]any{
+				"openai": "https://api.example.com/v1",
+			},
+		},
+	}
+	if err := injectCodexManagedModel(opts, mr.ModelID, mr, "sk-platform"); err != nil {
+		t.Fatalf("injectCodexManagedModel: %v", err)
+	}
+	provider := opts["codex_provider"].(map[string]any)
+	if got := provider["base_url"]; got != "https://api.example.com/v1" {
+		t.Fatalf("codex_provider.base_url = %v, want openai endpoint base URL fallback", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow Codex model injection to accept models that advertise the broader OpenAI endpoint type
- prefer openai-response endpoint base URLs when present, and fall back to openai endpoint base URLs otherwise
- add regression coverage for OpenAI-only endpoint metadata

## Checks
- go test ./server/internal/connector/agentdaemon
- make check