### PR TITLE
fix: limit capabilities to MCP and Skill

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -745,7 +745,7 @@
       },
       "add": {
         "title": "{{name}} — add version",
-        "description": "A new version does not affect Agents already using older versions; they switch manually from Agent detail.",
+        "description": "Saving assigns the next version automatically. Agents using older versions are unaffected until they switch from Agent detail.",
         "prefillFromLatest": "Prefilled from the previous version ({{version}}). Edits become the new version on submit.",
         "inlineSecretLostWarning": "Inline secret(s) from the previous version ({{keys}}) are hidden. Re-enter the plaintext to keep them, or switch to a managed credential."
       },

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -745,7 +745,7 @@
       },
       "add": {
         "title": "{{name}} — 添加新版本",
-        "description": "新版本不会影响已启用旧版本的 Agent；他们需要在 Agent 详情手动切换。",
+        "description": "保存时会自动生成下一个版本。已启用旧版本的 Agent 不受影响，需在 Agent 详情中手动切换。",
         "prefillFromLatest": "已用上一版（{{version}}）的内容预填。修改后会作为新版本提交。",
         "inlineSecretLostWarning": "上一版的 inline secret（{{keys}}）已隐藏。如需保留，请重新输入明文；或改成已托管的凭据。"
       },

--- a/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
@@ -4,7 +4,7 @@
  *   - Name + description fields ARE editable here (PATCH'd before the version
  *     commit). The standalone "edit metadata only" dialog was removed in
  *     favor of this single surface.
- *   - Version field is REQUIRED to differ from the current latest version.
+ *   - The server assigns the next version automatically on save.
  *   - When the previous version was imported, prefill rawText + format so the
  *     user can tweak. inline_secret plaintexts CANNOT carry forward (server
  *     only stores ciphertext).
@@ -72,7 +72,6 @@ export function AddCapabilityVersionDialog({
 
   const [name, setName] = useState(capability.name)
   const [description, setDescription] = useState(capability.description ?? "")
-  const [version, setVersion] = useState("")
   const [spec, setSpec] = useState<CanonicalSpec | null>(null)
   const [inlineSecrets, setInlineSecrets] = useState<ImportInlineSecretInput[]>([])
   const [rawText, setRawText] = useState("")
@@ -106,7 +105,6 @@ export function AddCapabilityVersionDialog({
     if (!open) return
     setName(capability.name)
     setDescription(capability.description ?? "")
-    setVersion("")
     setSpec(null)
     setInlineSecrets([])
     setRawText(prefill.rawText)
@@ -130,26 +128,12 @@ export function AddCapabilityVersionDialog({
           : null
 
   const trimmedName = name.trim()
-  const trimmedVersion = version.trim()
-  // Version-uniqueness guard: the user is always required to bump the version
-  // even when only name/description changed (see plan: "always require a new version").
-  const versionConflict =
-    !!trimmedVersion && !!latestVersion && trimmedVersion === latestVersion.version
   const nameError =
     !trimmedName
       ? t("capabilities.errors.nameRequired")
       : trimmedName.length > 50
         ? t("capabilities.errors.nameTooLong")
         : null
-  const versionError = !trimmedVersion
-    ? t("capabilities.errors.versionRequired", { defaultValue: "Please enter a new version" })
-    : versionConflict
-      ? t("capabilities.errors.versionMustBump", {
-          version: latestVersion?.version ?? "",
-          defaultValue: "The new version must differ from the current latest ({{version}}).",
-        })
-      : null
-
   // For plugin / skill-zip kinds we accept "no new upload" and let the server
   // reuse the previous OSS blob. So the canSubmit guard relaxes when an
   // inherited blob exists.
@@ -172,7 +156,6 @@ export function AddCapabilityVersionDialog({
     !updateMut.isPending &&
     !!workspaceID &&
     !nameError &&
-    !versionError &&
     pluginHasUsableArtifact &&
     skillSpecReady &&
     mcpSpecReady
@@ -223,7 +206,6 @@ export function AddCapabilityVersionDialog({
           : undefined
 
     const payload: ImportCapabilityVersionCommitRequest = {
-      version: trimmedVersion,
       canonical_spec: fallbackSpec,
       inline_secrets: kind === "plugin" || inlineSecrets.length === 0 ? undefined : inlineSecrets,
       source_payload: rawText
@@ -301,20 +283,6 @@ export function AddCapabilityVersionDialog({
               placeholder={t("capabilities.fields.name.placeholder")}
             />
           </Field>
-          <Field label={t("capabilities.fields.version.label")} required>
-            <Input
-              value={version}
-              onChange={(e) => setVersion(e.target.value)}
-              placeholder={
-                latestVersion?.version
-                  ? t("capabilities.fields.version.placeholderBump", {
-                      version: latestVersion.version,
-                      defaultValue: "> {{version}}",
-                    })
-                  : "1.0.3"
-              }
-            />
-          </Field>
           <Field label={t("capabilities.fields.description.label")}>
             <Input
               value={description}
@@ -324,12 +292,12 @@ export function AddCapabilityVersionDialog({
           </Field>
         </div>
 
-        {(nameError || versionError) && (
+        {nameError && (
           <div
             role="alert"
             className="mt-2 rounded-md border border-danger-border bg-danger-subtle px-3 py-2 text-sm text-danger-emphasis"
           >
-            {nameError ?? versionError}
+            {nameError}
           </div>
         )}
 

--- a/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
@@ -1,7 +1,6 @@
 /**
- * Top-level dialog shell. Per-kind subforms (ImportMCPForm /
- * ImportSkillForm / ImportPluginForm) are controlled children; this
- * dialog owns the draft and POSTs /import/commit.
+ * Top-level dialog shell. ImportMCPForm and ImportSkillForm are controlled
+ * children; this dialog owns the draft and POSTs /import/commit.
  *
  * Contract: the Name input is NEVER auto-overwritten by re-parses.
  * suggested_name applies only while nameTouched is false.
@@ -26,13 +25,8 @@ import { ApiError } from "../../../lib/api-client"
 import { useImportCommitMutation } from "./api"
 import { ImportMCPForm } from "./ImportMCPForm"
 import { ImportSkillForm } from "./ImportSkillForm"
-import { ImportPluginForm, type PluginUploadState } from "./ImportPluginForm"
-import { ImportSystemPromptForm, type SystemPromptDraft } from "./ImportSystemPromptForm"
 import { isImportSpecReady } from "./importValidation"
-import { systemPromptCapabilityPayload } from "../../../lib/api-capabilities"
-import { useCreateCapability } from "../../../lib/api-capabilities"
 import type {
-  CanonicalKind,
   CanonicalSpec,
   ImportCommitRequest,
   ImportInlineSecretInput,
@@ -48,6 +42,8 @@ interface Props {
   onCreated?: (capabilityID: string) => void
 }
 
+type AddCapabilityKind = "mcp" | "skill"
+
 export function ImportCapabilityDialog({
   workspaceID,
   open,
@@ -56,35 +52,20 @@ export function ImportCapabilityDialog({
 }: Props) {
   const { t } = useTranslation("admin")
   const commitMut = useImportCommitMutation(workspaceID)
-  const createMut = useCreateCapability(workspaceID)
 
   // Draft is preserved across tab flips, but the spec itself is dropped
   // on kind change (an MCP spec is meaningless as a Skill spec).
-  const [kind, setKind] = useState<CanonicalKind>("mcp")
+  const [kind, setKind] = useState<AddCapabilityKind>("mcp")
   const [name, setName] = useState("")
   const [description, setDescription] = useState("")
   const [spec, setSpec] = useState<CanonicalSpec | null>(null)
   const [inlineSecrets, setInlineSecrets] = useState<ImportInlineSecretInput[]>([])
   const [rawText, setRawText] = useState("")
   const [sourceFormat, setSourceFormat] = useState<SourceFormat>("json")
-  /** Plugin-only: ossKey + validation result. Tracked separately
-   *  because plugin's commit payload differs from mcp/skill — it
-   *  needs to reference an OSS object rather than carry a spec body. */
-  const [pluginUpload, setPluginUpload] = useState<PluginUploadState>({
-    ossKey: null,
-    uploadSource: null,
-    validation: null,
-  })
   /** Skill-only: ossKey of an uploaded zip (null when paste mode or
    *  when the user hasn't picked a zip yet). Threaded into the commit
    *  payload so the server can re-fetch + re-parse the same bytes. */
   const [skillOssKey, setSkillOssKey] = useState<string | null>(null)
-  /** system_prompt-only: prompt body + append/override + version label. */
-  const [systemPromptDraft, setSystemPromptDraft] = useState<SystemPromptDraft>({
-    prompt: "",
-    mode: "append",
-    version: "1.0.0",
-  })
 
   /** Tracks whether the user typed in the Name input. Once true we stop
    *  letting the preview's suggested_name overwrite their value.
@@ -103,18 +84,15 @@ export function ImportCapabilityDialog({
     setInlineSecrets([])
     setRawText("")
     setSourceFormat("json")
-    setPluginUpload({ ossKey: null, uploadSource: null, validation: null })
     setSkillOssKey(null)
-    setSystemPromptDraft({ prompt: "", mode: "append", version: "1.0.0" })
     nameTouched.current = false
     commitMut.reset()
-    createMut.reset()
     // intentionally only on the open transition
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
   const onTabChange = (next: string) => {
-    const nextKind = next as CanonicalKind
+    const nextKind = next as AddCapabilityKind
     if (nextKind === kind) return
     setKind(nextKind)
     // Cross-kind drafts don't make sense — drop the parsed spec and
@@ -122,12 +100,10 @@ export function ImportCapabilityDialog({
     setSpec(null)
     setInlineSecrets([])
     setRawText("")
-    setPluginUpload({ ossKey: null, uploadSource: null, validation: null })
     setSkillOssKey(null)
-    setSystemPromptDraft({ prompt: "", mode: "append", version: "1.0.0" })
     setSourceFormat(nextKind === "skill" ? "markdown" : "json")
     // For Skill, frontmatter is the source of truth — reset name/desc
-    // on a fresh tab. MCP/Plugin keep user input across tab flips.
+    // on a fresh tab. MCP keeps user input across tab flips.
     if (nextKind === "skill") {
       nameTouched.current = false
       setName("")
@@ -137,8 +113,8 @@ export function ImportCapabilityDialog({
   }
 
   const onSuggestedName = (suggested: string) => {
-    // Skill always overrides (frontmatter is the truth). MCP/Plugin
-    // only fill on first preview to avoid clobbering user edits.
+    // Skill always overrides (frontmatter is the truth). MCP only fills on
+    // first preview to avoid clobbering user edits.
     if (kind !== "skill" && nameTouched.current) return
     if (!suggested) return
     setName(suggested)
@@ -156,70 +132,31 @@ export function ImportCapabilityDialog({
     ? commitMut.error.envelope.message
     : commitMut.error instanceof Error
       ? commitMut.error.message
-      : createMut.error instanceof ApiError
-        ? createMut.error.envelope.message
-        : createMut.error instanceof Error
-          ? createMut.error.message
-          : null
+      : null
 
   const canSubmit =
     !commitMut.isPending &&
-    !createMut.isPending &&
     !!workspaceID &&
     name.trim().length > 0 &&
-    (kind === "system_prompt"
-      ? systemPromptDraft.prompt.trim().length > 0 && systemPromptDraft.version.trim().length > 0
-      : !!spec &&
-        (kind === "plugin"
-          ? !!pluginUpload.ossKey && (pluginUpload.validation?.valid ?? false)
-          : isImportSpecReady(kind, spec, inlineSecrets)))
+    !!spec &&
+    isImportSpecReady(kind, spec, inlineSecrets)
 
   const submit = () => {
     if (!canSubmit) return
-    if (kind === "system_prompt") {
-      createMut.mutate(
-        systemPromptCapabilityPayload({
-          name: name.trim(),
-          description: description.trim(),
-          version: systemPromptDraft.version.trim(),
-          prompt: systemPromptDraft.prompt,
-          mode: systemPromptDraft.mode,
-        }),
-        {
-          onSuccess: (cap) => {
-            onOpenChange(false)
-            onCreated?.(cap.id)
-          },
-        },
-      )
-      return
-    }
     if (!spec) return
     const payload: ImportCommitRequest = {
       kind,
       name: name.trim(),
       description: description.trim() || undefined,
       canonical_spec: spec,
-      inline_secrets: kind === "plugin" || inlineSecrets.length === 0 ? undefined : inlineSecrets,
+      inline_secrets: inlineSecrets.length === 0 ? undefined : inlineSecrets,
       source_payload: rawText
         ? { raw_text: rawText, source_format: sourceFormat }
         : undefined,
-      // Plugin commits: server rebuilds canonical_spec from oss_key +
-      // upload_source, ignoring the client spec body.
       // Skill zip commits: server uses oss_key to re-fetch the zip and
       // re-parse files[] into canonical_spec.skill.files.
-      oss_key:
-        kind === "plugin"
-          ? pluginUpload.ossKey ?? undefined
-          : kind === "skill"
-            ? skillOssKey ?? undefined
-            : undefined,
-      upload_source:
-        kind === "plugin"
-          ? pluginUpload.uploadSource ?? undefined
-          : kind === "skill" && skillOssKey
-            ? "zip"
-            : undefined,
+      oss_key: kind === "skill" ? skillOssKey ?? undefined : undefined,
+      upload_source: kind === "skill" && skillOssKey ? "zip" : undefined,
     }
     commitMut.mutate(payload, {
       onSuccess: (res) => {
@@ -235,7 +172,7 @@ export function ImportCapabilityDialog({
         className="max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-6xl overflow-x-hidden overflow-y-auto"
         // Keep typing in the textareas from triggering submit on Enter etc.
         onInteractOutside={(e) => {
-          if (commitMut.isPending || createMut.isPending) e.preventDefault()
+          if (commitMut.isPending) e.preventDefault()
         }}
       >
         <DialogHeader>
@@ -248,20 +185,10 @@ export function ImportCapabilityDialog({
                   "capabilities.import.dialog.descriptionSkill",
                   "Paste a SKILL.md or upload a zip. The Skill name and description come from the frontmatter; the body is injected into the model as the instruction.",
                 )
-              : kind === "plugin"
-                ? t(
-                    "capabilities.import.dialog.descriptionPlugin",
-                    "Upload a .claude-plugin zip. The server validates the manifest and parses it.",
-                  )
-                : kind === "system_prompt"
-                  ? t(
-                      "capabilities.import.dialog.descriptionSystemPrompt",
-                      "Register a system prompt as a reusable capability. Append prepends to the user system prompt; Override replaces it entirely.",
-                    )
-                  : t(
-                      "capabilities.import.dialog.description",
-                      "Paste a third-party MCP config (JSON / TOML); we parse and preview it. Plain env values are imported as-is; only env values starting with $ trigger the credential prompt.",
-                    )}
+              : t(
+                  "capabilities.import.dialog.description",
+                  "Paste a third-party MCP config (JSON / TOML); we parse and preview it. Plain env values are imported as-is; only env values starting with $ trigger the credential prompt.",
+                )}
           </DialogDescription>
         </DialogHeader>
 
@@ -273,15 +200,9 @@ export function ImportCapabilityDialog({
             <TabsTrigger value="skill">
               {t("capabilities.import.tab.skill", "Skill")}
             </TabsTrigger>
-            <TabsTrigger value="plugin">
-              {t("capabilities.import.tab.plugin", "Plugin")}
-            </TabsTrigger>
-            <TabsTrigger value="system_prompt">
-              {t("capabilities.import.tab.systemPrompt", "System Prompt")}
-            </TabsTrigger>
           </TabsList>
 
-          {/* ---- shared meta fields (MCP/Plugin only) ----------------
+          {/* ---- shared meta fields (MCP only) -----------------------
               Skill imports derive name + description from frontmatter;
               showing manual inputs would let the form value drift from
               the source-of-truth markdown and silently overwrite it. */}
@@ -351,24 +272,6 @@ export function ImportCapabilityDialog({
               />
             )}
           </TabsContent>
-          <TabsContent value="plugin" className="mt-3">
-            {kind === "plugin" && (
-              <ImportPluginForm
-                workspaceID={workspaceID}
-                onChange={setSpec}
-                onUploadStateChange={setPluginUpload}
-                onSuggestedName={onSuggestedName}
-              />
-            )}
-          </TabsContent>
-          <TabsContent value="system_prompt" className="mt-3">
-            {kind === "system_prompt" && (
-              <ImportSystemPromptForm
-                value={systemPromptDraft}
-                onChange={setSystemPromptDraft}
-              />
-            )}
-          </TabsContent>
         </Tabs>
 
         {errMsg && (
@@ -384,13 +287,13 @@ export function ImportCapabilityDialog({
           <Button
             variant="outline"
             size="sm"
-            disabled={commitMut.isPending || createMut.isPending}
+            disabled={commitMut.isPending}
             onClick={() => onOpenChange(false)}
           >
             {t("capabilities.actions.cancel", "Cancel")}
           </Button>
           <Button size="sm" disabled={!canSubmit} onClick={submit}>
-            {(commitMut.isPending || createMut.isPending) && (
+            {commitMut.isPending && (
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
             )}
             {t("capabilities.import.dialog.submit", "Import")}

--- a/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
@@ -1,14 +1,12 @@
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { ArrowLeft, ArrowRight, PackageCheck, Search } from "lucide-react"
+import { ArrowLeft, ArrowRight, PackageCheck } from "lucide-react"
 
 import { Badge } from "../../../components/ui/badge"
 import { Button } from "../../../components/ui/button"
 import { EmptyState } from "../../../components/ui/empty-state"
 import { ErrorState } from "../../../components/ui/error-state"
-import { Input } from "../../../components/ui/input"
 import { Skeleton } from "../../../components/ui/skeleton"
-import { Tabs, TabsList, TabsTrigger } from "../../../components/ui/tabs"
 import { useMarketplaceList, type MarketplaceCapability, marketplaceSourceName } from "../../../lib/api-marketplace"
 import { useWorkspaceId } from "../../../lib/workspace"
 import { requiredCredentialsLabel } from "../capability-ui"
@@ -16,18 +14,16 @@ import type { Capability } from "../../../lib/api-types"
 
 interface MarketplaceTabProps {
   itemID: string | null
+  query: string
+  typeFilter: "all" | "mcp" | "skill"
   onSelectItem: (id: string | null) => void
   onInstall: (capability: MarketplaceCapability) => void
 }
 
-type TypeFilter = "all" | "mcp" | "skill" | "plugin" | "system_prompt"
-
-export function MarketplaceTab({ itemID, onSelectItem, onInstall }: MarketplaceTabProps) {
+export function MarketplaceTab({ itemID, query, typeFilter, onSelectItem, onInstall }: MarketplaceTabProps) {
   const { t, i18n } = useTranslation("admin")
   const workspaceID = useWorkspaceId()
   const marketplaceQ = useMarketplaceList(workspaceID)
-  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all")
-  const [query, setQuery] = useState("")
   const [hideInstalled, setHideInstalled] = useState(true)
 
   const items = useMemo(() => marketplaceQ.data ?? [], [marketplaceQ.data])
@@ -57,16 +53,7 @@ export function MarketplaceTab({ itemID, onSelectItem, onInstall }: MarketplaceT
 
   return (
     <div className="space-y-3">
-      <div className="flex flex-wrap items-center gap-3">
-        <Tabs value={typeFilter} onValueChange={(value) => setTypeFilter(value as TypeFilter)}>
-          <TabsList>
-            <TabsTrigger value="all">{t("capabilities.marketplace.filters.all")}</TabsTrigger>
-            <TabsTrigger value="mcp">MCP</TabsTrigger>
-            <TabsTrigger value="skill">Skill</TabsTrigger>
-            <TabsTrigger value="plugin">Plugin</TabsTrigger>
-            <TabsTrigger value="system_prompt">System Prompt</TabsTrigger>
-          </TabsList>
-        </Tabs>
+      <div className="flex justify-end">
         <label className="inline-flex select-none items-center gap-1.5 text-sm text-fg-muted">
           <input
             type="checkbox"
@@ -76,15 +63,6 @@ export function MarketplaceTab({ itemID, onSelectItem, onInstall }: MarketplaceT
           />
           {t("capabilities.marketplace.filters.hideInstalled")}
         </label>
-        <div className="relative ml-auto w-full max-w-[280px]">
-          <Search className="pointer-events-none absolute left-2.5 top-2.5 h-3.5 w-3.5 text-fg-faint" />
-          <Input
-            className="pl-8"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder={t("capabilities.marketplace.filters.search")}
-          />
-        </div>
       </div>
 
       {marketplaceQ.isLoading ? (

--- a/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
@@ -15,7 +15,7 @@ import type { Capability } from "../../../lib/api-types"
 interface MarketplaceTabProps {
   itemID: string | null
   query: string
-  typeFilter: "all" | "mcp" | "skill"
+  typeFilter: "mcp" | "skill"
   onSelectItem: (id: string | null) => void
   onInstall: (capability: MarketplaceCapability) => void
 }
@@ -31,7 +31,7 @@ export function MarketplaceTab({ itemID, query, typeFilter, onSelectItem, onInst
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase()
     return items.filter((item) => {
-      if (typeFilter !== "all" && item.type !== typeFilter) return false
+      if (item.type !== typeFilter) return false
       // "Hide what's already in this workspace" — both rows you published
       // and rows you installed from elsewhere are available locally.
       if (hideInstalled && (item.installed || item.self_published)) return false

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -84,7 +84,7 @@ interface AgentInstallation {
   latest: boolean
 }
 
-type CapabilityTypeFilter = "all" | "mcp" | "skill" | "plugin" | "system_prompt"
+type CapabilityTypeFilter = "all" | "mcp" | "skill"
 type PageTab = "workspace" | "marketplace"
 
 export function CapabilitiesPage() {
@@ -258,7 +258,16 @@ export function CapabilitiesPage() {
       {toast && <ToastBanner message={toast} />}
       {marketClientError && <ErrorBanner message={marketClientError} />}
 
-      <Tabs value={pageTab} onValueChange={(value) => setPageTab(value as PageTab)} className="mb-4">
+      {!marketplaceItem && (
+        <CapabilitiesFilterBar
+          query={query}
+          onQueryChange={setQuery}
+          typeFilter={typeFilter}
+          onTypeFilterChange={setTypeFilter}
+        />
+      )}
+
+      <Tabs value={pageTab} onValueChange={(value) => setPageTab(value as PageTab)} className="mb-4 mt-3">
         <TabsList>
           <TabsTrigger value="workspace">{t("capabilities.tabs.workspace")}</TabsTrigger>
           <TabsTrigger value="marketplace">{t("capabilities.tabs.marketplace")}</TabsTrigger>
@@ -268,6 +277,8 @@ export function CapabilitiesPage() {
       {pageTab === "marketplace" ? (
         <MarketplaceTab
           itemID={marketplaceItem}
+          query={query}
+          typeFilter={typeFilter}
           onSelectItem={(item) => navigate("capabilities", { tab: "marketplace", item })}
           onInstall={goToAgentsForCapability}
         />
@@ -288,13 +299,6 @@ export function CapabilitiesPage() {
       ) : (
         <Tooltip.Provider delayDuration={150}>
           <div className="space-y-3">
-            <CapabilitiesFilterBar
-              query={query}
-              onQueryChange={setQuery}
-              typeFilter={typeFilter}
-              onTypeFilterChange={setTypeFilter}
-            />
-
             {capsQ.isLoading ? (
               <CapabilitiesLoading />
             ) : allCapabilities.length === 0 ? (
@@ -526,8 +530,6 @@ function CapabilitiesFilterBar({
           <TabsTrigger value="all">{t("capabilities.filters.all")}</TabsTrigger>
           <TabsTrigger value="mcp">MCP</TabsTrigger>
           <TabsTrigger value="skill">Skill</TabsTrigger>
-          <TabsTrigger value="plugin">Plugin</TabsTrigger>
-          <TabsTrigger value="system_prompt">{t("capabilities.filters.systemPrompt", "System Prompt")}</TabsTrigger>
         </TabsList>
       </Tabs>
       <div className="relative ml-auto w-full max-w-[280px]">

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -84,7 +84,7 @@ interface AgentInstallation {
   latest: boolean
 }
 
-type CapabilityTypeFilter = "all" | "mcp" | "skill"
+type CapabilityTypeFilter = "mcp" | "skill"
 type PageTab = "workspace" | "marketplace"
 
 export function CapabilitiesPage() {
@@ -92,11 +92,11 @@ export function CapabilitiesPage() {
   const wid = useWorkspaceId()
   const { navigate } = useAdminView()
   const [query, setQuery] = useState("")
-  const [typeFilter, setTypeFilter] = useState<CapabilityTypeFilter>("all")
+  const [typeFilter, setTypeFilter] = useState<CapabilityTypeFilter>("mcp")
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(20)
   const debouncedQuery = useDebouncedValue(query, 250)
-  const typeParam = typeFilter === "all" ? "" : typeFilter
+  const typeParam = typeFilter
   // Reset to page 1 whenever the user changes filters / page size.
   useEffect(() => {
     setPage(1)
@@ -174,7 +174,7 @@ export function CapabilitiesPage() {
   const visibleTotal = usingServerPage
     ? capsQ.data?.total ?? 0
     : ownCapabilities.length + allInstalls.length
-  const filtersActive = !!debouncedQuery.trim() || typeFilter !== "all"
+  const filtersActive = !!debouncedQuery.trim()
   const versionSummary = useCapabilityVersionSummary(wid, ownCapabilities)
   const latestVersions = versionSummary.latest
   const selectedLatestVersion = addVersionCapability ? latestVersions.get(addVersionCapability.id) : undefined
@@ -313,7 +313,6 @@ export function CapabilitiesPage() {
                       variant="outline"
                       onClick={() => {
                         setQuery("")
-                        setTypeFilter("all")
                       }}
                     >
                       {t("capabilities.emptyFiltered.reset")}
@@ -527,7 +526,6 @@ function CapabilitiesFilterBar({
     <div className="flex flex-wrap items-center gap-3">
       <Tabs value={typeFilter} onValueChange={(value) => onTypeFilterChange(value as CapabilityTypeFilter)}>
         <TabsList>
-          <TabsTrigger value="all">{t("capabilities.filters.all")}</TabsTrigger>
           <TabsTrigger value="mcp">MCP</TabsTrigger>
           <TabsTrigger value="skill">Skill</TabsTrigger>
         </TabsList>

--- a/apps/web/src/pages/admin/capabilities/types.ts
+++ b/apps/web/src/pages/admin/capabilities/types.ts
@@ -219,7 +219,7 @@ export interface ImportCommitResponse {
  * we lock kind in the UI but the server enforces it as a 422 anyway.
  */
 export interface ImportCapabilityVersionCommitRequest {
-  /** Defaults server-side to "1.0.0" when empty. */
+  /** Optional compatibility override; omitted values advance from the latest version. */
   version?: string
   /** Opaque blob the server writes verbatim to capability_version.source_payload. */
   source_payload?: unknown

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -716,7 +716,7 @@ definitions:
       github_repo:
         type: string
       kind:
-        description: '"mcp" | "skill" | "plugin"'
+        description: '"mcp" | "skill"'
         type: string
       oss_key:
         description: |-
@@ -2938,9 +2938,9 @@ paths:
       - bootstrap
   /api/v1/capabilities/marketplace:
     get:
-      description: Lists public capabilities offered on the marketplace, filtered
-        to items visible to the caller's workspace. Workspace is taken from ?workspace_id
-        or the X-Parsar-Workspace-ID header.
+      description: Lists public MCP and Skill capabilities offered on the marketplace,
+        filtered to items visible to the caller's workspace. Workspace is taken from
+        ?workspace_id or the X-Parsar-Workspace-ID header.
       operationId: listDevMarketplaceCapabilities
       parameters:
       - description: Workspace UUID (falls back to X-Parsar-Workspace-ID header)
@@ -5343,9 +5343,9 @@ paths:
       - auth
   /api/v1/workspaces/{workspaceID}/capabilities:
     get:
-      description: Returns the workspace's own capabilities plus its marketplace installs
-        and available marketplace items. Optional pagination via page + page_size
-        opts into a paged shape.
+      description: Returns MCP and Skill capabilities from the workspace plus its
+        marketplace installs and available marketplace items. Optional pagination
+        via page + page_size opts into a paged shape.
       operationId: listDevWorkspaceCapabilities
       parameters:
       - description: Workspace UUID
@@ -5361,7 +5361,7 @@ paths:
         in: query
         name: scope
         type: string
-      - description: Filter by capability type (mcp/skill/plugin/system_prompt)
+      - description: Filter by capability type (mcp/skill)
         in: query
         name: type
         type: string
@@ -5409,8 +5409,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Creates a capability in the workspace. Owner/admin only. When body.version
-        is set, an initial capability_version is created in the same call.
+      description: Creates an MCP or Skill capability in the workspace. Owner/admin
+        only. When body.version is set, an initial capability_version is created in
+        the same call.
       operationId: createDevWorkspaceCapability
       parameters:
       - description: Workspace UUID
@@ -6103,10 +6104,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Encrypts inline_secrets then runs the whole import (capability
-        + capability_version + secrets) in a single transaction. For kind=plugin (and
-        skill zip) the canonical_spec is rebuilt from OSS bytes; the client-supplied
-        spec is discarded. Owner/admin only.
+      description: Encrypts inline_secrets then runs the whole MCP or Skill import
+        (capability + capability_version + secrets) in a single transaction. For Skill
+        zip imports the canonical_spec is rebuilt from OSS bytes. Owner/admin only.
       operationId: commitDevCapabilityImport
       parameters:
       - description: Workspace UUID
@@ -6166,9 +6166,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Pure parse for mcp/skill (no DB writes). For plugin (and skill
-        zip) the just-uploaded zip is downloaded from OSS and validated. Owner/admin
-        only.
+      description: Pure parse for MCP or Skill imports. Skill zip uploads are downloaded
+        from object storage and validated. Owner/admin only.
       operationId: previewDevCapabilityImport
       parameters:
       - description: Workspace UUID

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -6031,7 +6031,8 @@ paths:
       consumes:
       - application/json
       description: Adds a new version to an existing capability, sharing the parse/rebuild
-        pipeline with capability import commit. Spec.kind must match capability.type.
+        pipeline with capability import commit. When version is omitted, the server
+        advances the latest version automatically. Spec.kind must match capability.type.
         When oss_key is omitted for plugin or skill-zip kinds, the previous version's
         bytes are reused. Owner/admin only.
       operationId: commitDevCapabilityVersionImport

--- a/server/internal/dev/capability_import_routes.go
+++ b/server/internal/dev/capability_import_routes.go
@@ -575,7 +575,7 @@ func rebuildSkillSpecFromOSS(ctx context.Context, workspaceID, ossKey string, bl
 // capability.type or the store returns ErrCapabilityKindMismatch.
 //
 //	@Summary		Commit a new version of an existing capability
-//	@Description	Adds a new version to an existing capability, sharing the parse/rebuild pipeline with capability import commit. Spec.kind must match capability.type. When oss_key is omitted for plugin or skill-zip kinds, the previous version's bytes are reused. Owner/admin only.
+//	@Description	Adds a new version to an existing capability, sharing the parse/rebuild pipeline with capability import commit. When version is omitted, the server advances the latest version automatically. Spec.kind must match capability.type. When oss_key is omitted for plugin or skill-zip kinds, the previous version's bytes are reused. Owner/admin only.
 //	@Tags			capabilities
 //	@ID				commitDevCapabilityVersionImport
 //	@Accept			json

--- a/server/internal/dev/capability_import_routes.go
+++ b/server/internal/dev/capability_import_routes.go
@@ -31,7 +31,7 @@ import (
 // For plugins the zip is already in OSS (PUT via presign-upload), so callers
 // pass OssKey instead of RawText.
 type previewCapabilityImportBody struct {
-	Kind         string `json:"kind"`          // "mcp" | "skill" | "plugin"
+	Kind         string `json:"kind"`          // "mcp" | "skill"
 	RawText      string `json:"raw_text"`      // user paste (mcp / skill)
 	SourceFormat string `json:"source_format"` // matches parser.SourceFormat (mcp / skill)
 
@@ -68,12 +68,12 @@ type commitInlineSecretBody struct {
 // may have empty SecretID (server fills them); credential_ref entries must
 // already have a valid credential_kind_code.
 type commitCapabilityImportBody struct {
-	Kind          string                   `json:"kind"`        // "mcp" | "skill" | "plugin"
+	Kind          string                   `json:"kind"`        // "mcp" | "skill"
 	Name          string                   `json:"name"`        // capability display name
 	Description   string                   `json:"description"` // optional
 	Visibility    string                   `json:"visibility"`  // "private" | "public" | …
 	Version       string                   `json:"version"`     // capability_version.version; "1.0.0" default
-	Type          string                   `json:"type"`        // capability.type column ("mcp" | "skill" | "plugin")
+	Type          string                   `json:"type"`        // capability.type column ("mcp" | "skill")
 	SourcePayload json.RawMessage          `json:"source_payload,omitempty"`
 	CanonicalSpec canonical.Spec           `json:"canonical_spec"`
 	InlineSecrets []commitInlineSecretBody `json:"inline_secrets,omitempty"`
@@ -96,12 +96,10 @@ type commitCapabilityImportResponse struct {
 }
 
 // previewCapabilityImport handles POST .../capabilities/import/preview.
-// Pure parse for mcp/skill (no DB writes). The plugin branch downloads
-// the just-uploaded zip from OSS so ValidatePluginZip can run against
-// the actual bytes.
+// Pure parse for mcp/skill (no DB writes).
 //
 //	@Summary		Preview a capability import
-//	@Description	Pure parse for mcp/skill (no DB writes). For plugin (and skill zip) the just-uploaded zip is downloaded from OSS and validated. Owner/admin only.
+//	@Description	Pure parse for MCP or Skill imports. Skill zip uploads are downloaded from object storage and validated. Owner/admin only.
 //	@Tags			capabilities
 //	@ID				previewDevCapabilityImport
 //	@Accept			json
@@ -127,7 +125,7 @@ func previewCapabilityImport(runtimeStore RuntimeStore, blobStore blob.Store) ht
 		}
 		kind := strings.ToLower(strings.TrimSpace(body.Kind))
 		if kind == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "kind is required (mcp|skill|plugin)"})
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "kind is required (mcp|skill)"})
 			return
 		}
 		switch kind {
@@ -135,10 +133,8 @@ func previewCapabilityImport(runtimeStore RuntimeStore, blobStore blob.Store) ht
 			previewMCPOrSkillImport(w, body, parseAsMCP)
 		case "skill":
 			previewSkillImport(r.Context(), w, workspaceID, body, blobStore)
-		case "plugin":
-			previewPluginImport(r.Context(), w, workspaceID, body, blobStore)
 		default:
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("unknown kind %q (want mcp|skill|plugin)", kind)})
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("unknown kind %q (want mcp|skill)", kind)})
 		}
 	}
 }
@@ -328,7 +324,7 @@ func previewPluginImport(ctx context.Context, w http.ResponseWriter, workspaceID
 // is rebuilt from OSS bytes (the on-disk zip is authoritative).
 //
 //	@Summary		Commit a capability import
-//	@Description	Encrypts inline_secrets then runs the whole import (capability + capability_version + secrets) in a single transaction. For kind=plugin (and skill zip) the canonical_spec is rebuilt from OSS bytes; the client-supplied spec is discarded. Owner/admin only.
+//	@Description	Encrypts inline_secrets then runs the whole MCP or Skill import (capability + capability_version + secrets) in a single transaction. For Skill zip imports the canonical_spec is rebuilt from OSS bytes. Owner/admin only.
 //	@Tags			capabilities
 //	@ID				commitDevCapabilityImport
 //	@Accept			json
@@ -365,14 +361,14 @@ func commitCapabilityImport(runtimeStore RuntimeStore, blobStore blob.Store) htt
 		if kind == "" {
 			kind = string(body.CanonicalSpec.Kind)
 		}
-		if kind != string(canonical.KindMCP) && kind != string(canonical.KindSkill) && kind != string(canonical.KindPlugin) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("unknown kind %q (want mcp|skill|plugin)", kind)})
+		if kind != string(canonical.KindMCP) && kind != string(canonical.KindSkill) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("unknown kind %q (want mcp|skill)", kind)})
 			return
 		}
 
-		// Plugin and Skill-zip imports rebuild canonical_spec server-side
-		// from the OSS zip; the client-supplied spec is discarded so a
-		// forged files/oss_key/sha256 cannot reach the DB.
+		// Skill-zip imports rebuild canonical_spec server-side from the OSS
+		// zip; the client-supplied spec is discarded so forged file metadata
+		// cannot reach the DB.
 		//
 		// Gate ordering: skill is matched first so kind=skill + OssKey +
 		// UploadSource (confused client) doesn't accidentally satisfy the
@@ -380,8 +376,6 @@ func commitCapabilityImport(runtimeStore RuntimeStore, blobStore blob.Store) htt
 		spec := body.CanonicalSpec
 		var skillSHA256 string
 		skillZipShaped := kind == string(canonical.KindSkill) && strings.TrimSpace(body.OssKey) != ""
-		pluginShaped := kind == string(canonical.KindPlugin) ||
-			(strings.TrimSpace(body.OssKey) != "" && strings.TrimSpace(body.UploadSource) != "")
 		switch {
 		case skillZipShaped:
 			rebuilt, sum, httpErr := rebuildSkillSpecFromOSS(r.Context(), workspaceID, body.OssKey, blobStore)
@@ -391,24 +385,14 @@ func commitCapabilityImport(runtimeStore RuntimeStore, blobStore blob.Store) htt
 			}
 			spec = rebuilt
 			skillSHA256 = sum
-		case pluginShaped:
-			// Lock kind to plugin so any later read sees the real shape.
-			kind = string(canonical.KindPlugin)
-			rebuilt, httpErr := rebuildPluginSpecFromOSS(r.Context(), workspaceID, body, blobStore)
-			if httpErr != nil {
-				writeJSON(w, httpErr.status, map[string]string{"error": httpErr.message})
-				return
-			}
-			spec = rebuilt
 		default:
-			if strings.TrimSpace(body.UploadSource) != "" {
-				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "upload_source / github_* fields are only allowed for kind=plugin"})
+			if strings.TrimSpace(body.OssKey) != "" || strings.TrimSpace(body.UploadSource) != "" {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "oss_key and upload_source are only allowed for Skill zip imports"})
 				return
 			}
 		}
 
-		// inline_secrets only make sense for mcp (skill / plugin have
-		// no env map).
+		// inline_secrets only make sense for mcp (skill has no env map).
 		if kind != string(canonical.KindMCP) && len(body.InlineSecrets) > 0 {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("inline_secrets is only allowed for kind=mcp (got kind=%q)", kind)})
 			return

--- a/server/internal/dev/capability_import_routes_test.go
+++ b/server/internal/dev/capability_import_routes_test.go
@@ -36,9 +36,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // TestCapabilityImportPreview_DefaultsEnvToLiteral pins Decision #8:
@@ -474,6 +474,41 @@ func TestCapabilityVersionImportCommit_HappyPath(t *testing.T) {
 	}
 	if capIDFromVersion != capabilityID {
 		t.Fatalf("version's capability_id = %q, want %q", capIDFromVersion, capabilityID)
+	}
+}
+
+func TestCapabilityVersionImportCommit_AssignsNextVersionWhenOmitted(t *testing.T) {
+	r, _ := capabilityTestRouter(t, map[string]string{store.DefaultDevFixtureIDs().UserID: "admin"}, nil)
+	ids := store.DefaultDevFixtureIDs()
+	capabilityID := bootstrapMCPCapabilityForVersionTest(t, r, ids, "Automatic Version", "automatic", "AUTOMATIC_TOKEN")
+
+	spec := canonical.Spec{
+		SchemaVersion: canonical.SchemaVersionCurrent,
+		Kind:          canonical.KindMCP,
+		MCP: &canonical.MCPSpec{
+			Servers: []canonical.MCPServer{{
+				Name:    "automatic",
+				Command: "echo",
+				Env:     map[string]canonical.EnvValue{},
+			}},
+		},
+	}
+	body := mustJSON(t, map[string]any{"canonical_spec": spec})
+	res := serveCapabilityRoute(t, r, http.MethodPost,
+		"/api/v1/workspaces/"+ids.WorkspaceID+"/capabilities/"+capabilityID+"/versions/import/commit",
+		body, ids.UserID)
+	if res.Code != http.StatusCreated {
+		t.Fatalf("automatic version import expected 201, got %d: %s", res.Code, res.Body.String())
+	}
+
+	var response struct {
+		CapabilityVersion store.CapabilityVersionRead `json:"capability_version"`
+	}
+	if err := json.Unmarshal(res.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.CapabilityVersion.Version != "1.0.1" {
+		t.Fatalf("automatic version = %q, want 1.0.1", response.CapabilityVersion.Version)
 	}
 }
 

--- a/server/internal/dev/capability_routes.go
+++ b/server/internal/dev/capability_routes.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
 )
 
 type capabilityBody struct {
@@ -145,14 +145,14 @@ var plaintextSecretPatterns = []struct {
 // and available marketplace items for the workspace.
 //
 //	@Summary		List workspace capabilities
-//	@Description	Returns the workspace's own capabilities plus its marketplace installs and available marketplace items. Optional pagination via page + page_size opts into a paged shape.
+//	@Description	Returns MCP and Skill capabilities from the workspace plus its marketplace installs and available marketplace items. Optional pagination via page + page_size opts into a paged shape.
 //	@Tags			capabilities
 //	@ID				listDevWorkspaceCapabilities
 //	@Produce		json
 //	@Param			workspaceID	path	string	true	"Workspace UUID"
 //	@Param			visibility	query	string	false	"Filter by capability visibility (private/public)"
 //	@Param			scope		query	string	false	"Alias of visibility (legacy)"
-//	@Param			type		query	string	false	"Filter by capability type (mcp/skill/plugin/system_prompt)"
+//	@Param			type		query	string	false	"Filter by capability type (mcp/skill)"
 //	@Param			name		query	string	false	"Case-insensitive substring match on name/description"
 //	@Param			page		query	int		false	"1-based page number (opts into paged shape)"
 //	@Param			page_size	query	int		false	"Page size, 1..100 (defaults to 20)"
@@ -171,13 +171,24 @@ func listWorkspaceCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 		if visibility == "" {
 			visibility = r.URL.Query().Get("scope")
 		}
-		typeFilter := strings.TrimSpace(r.URL.Query().Get("type"))
+		typeFilter := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("type")))
+		if typeFilter != "" && !isListedCapabilityType(typeFilter) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "type must be mcp or skill"})
+			return
+		}
 		nameFilter := strings.TrimSpace(r.URL.Query().Get("name"))
 		caps, err := runtimeStore.ListCapabilities(r.Context(), workspaceID, store.ListCapabilityFilter{Type: typeFilter, Visibility: visibility, Name: nameFilter})
 		if err != nil {
 			writeCapabilityError(w, err, "failed to list capabilities")
 			return
 		}
+		filteredCaps := caps[:0]
+		for _, item := range caps {
+			if isListedCapabilityType(item.Type) {
+				filteredCaps = append(filteredCaps, item)
+			}
+		}
+		caps = filteredCaps
 		marketplaceInstalls, err := runtimeStore.ListWorkspaceMarketplaceInstalls(r.Context(), workspaceID)
 		if err != nil {
 			writeCapabilityError(w, err, "failed to list marketplace installs")
@@ -193,6 +204,9 @@ func listWorkspaceCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 		nameNeedle := strings.ToLower(nameFilter)
 		filteredInstalls := marketplaceInstalls[:0]
 		for _, item := range marketplaceInstalls {
+			if !isListedCapabilityType(item.Type) {
+				continue
+			}
 			if typeFilter != "" && item.Type != typeFilter {
 				continue
 			}
@@ -206,6 +220,9 @@ func listWorkspaceCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 		// already-installed so they don't double up with the workspace section.
 		filteredAvailable := marketplaceAvailable[:0]
 		for _, item := range marketplaceAvailable {
+			if !isListedCapabilityType(item.Type) {
+				continue
+			}
 			if item.Installed || item.SelfPublished {
 				continue
 			}
@@ -246,11 +263,11 @@ func listWorkspaceCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 		}
 
 		type mergedRow struct {
-			OwnIndex     int // -1 when this row is a marketplace install
-			MarketIndex  int // -1 when this row is an own capability
-			Name         string
-			CreatedAt    time.Time
-			IsInstall    bool
+			OwnIndex    int // -1 when this row is a marketplace install
+			MarketIndex int // -1 when this row is an own capability
+			Name        string
+			CreatedAt   time.Time
+			IsInstall   bool
 		}
 		merged := make([]mergedRow, 0, len(caps)+len(marketplaceInstalls))
 		for i, c := range caps {
@@ -304,7 +321,7 @@ func listWorkspaceCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 // marketplace, filtered to items the caller's workspace can install.
 //
 //	@Summary		List marketplace capabilities
-//	@Description	Lists public capabilities offered on the marketplace, filtered to items visible to the caller's workspace. Workspace is taken from ?workspace_id or the X-Parsar-Workspace-ID header.
+//	@Description	Lists public MCP and Skill capabilities offered on the marketplace, filtered to items visible to the caller's workspace. Workspace is taken from ?workspace_id or the X-Parsar-Workspace-ID header.
 //	@Tags			capabilities
 //	@ID				listDevMarketplaceCapabilities
 //	@Produce		json
@@ -337,7 +354,22 @@ func listMarketplaceCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeCapabilityError(w, err, "failed to list marketplace capabilities")
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]any{"workspace_id": workspaceID, "capabilities": capabilities})
+		filtered := capabilities[:0]
+		for _, capability := range capabilities {
+			if isListedCapabilityType(capability.Type) {
+				filtered = append(filtered, capability)
+			}
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"workspace_id": workspaceID, "capabilities": filtered})
+	}
+}
+
+func isListedCapabilityType(capabilityType string) bool {
+	switch strings.ToLower(strings.TrimSpace(capabilityType)) {
+	case "mcp", "skill":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -440,7 +472,7 @@ func listMarketplaceEnabledAgents(runtimeStore RuntimeStore) http.HandlerFunc {
 // version) in the given workspace. Owner/admin only.
 //
 //	@Summary		Create a workspace capability
-//	@Description	Creates a capability in the workspace. Owner/admin only. When body.version is set, an initial capability_version is created in the same call.
+//	@Description	Creates an MCP or Skill capability in the workspace. Owner/admin only. When body.version is set, an initial capability_version is created in the same call.
 //	@Tags			capabilities
 //	@ID				createDevWorkspaceCapability
 //	@Accept			json
@@ -469,6 +501,11 @@ func createWorkspaceCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 		}
 		if strings.TrimSpace(body.Name) == "" || strings.TrimSpace(body.Type) == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name and type are required"})
+			return
+		}
+		body.Type = strings.ToLower(strings.TrimSpace(body.Type))
+		if !isListedCapabilityType(body.Type) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "type must be mcp or skill"})
 			return
 		}
 		input := store.CreateCapabilityInput{WorkspaceID: workspaceID, Type: body.Type, Name: body.Name, Description: body.Description, Visibility: capabilityVisibility(body.Visibility, body.Scope), CreatorID: actorID}

--- a/server/internal/dev/routes_capability_test.go
+++ b/server/internal/dev/routes_capability_test.go
@@ -9,11 +9,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 const (
@@ -34,6 +34,32 @@ func TestCapabilityAdminCreatesCapabilityAndVersion(t *testing.T) {
 	}
 }
 
+func TestCapabilityCreationRejectsHiddenTypes(t *testing.T) {
+	r, _ := capabilityTestRouter(t, map[string]string{store.DefaultDevFixtureIDs().UserID: "admin"}, nil)
+	wid := store.DefaultDevFixtureIDs().WorkspaceID
+	uid := store.DefaultDevFixtureIDs().UserID
+
+	for _, capabilityType := range []string{"plugin", "system_prompt"} {
+		t.Run("create "+capabilityType, func(t *testing.T) {
+			body := `{"type":"` + capabilityType + `","name":"Hidden capability"}`
+			res := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+wid+"/capabilities", body, uid)
+			if res.Code != http.StatusBadRequest || !strings.Contains(res.Body.String(), "type must be mcp or skill") {
+				t.Fatalf("hidden create expected 400, got %d: %s", res.Code, res.Body.String())
+			}
+		})
+	}
+
+	for _, endpoint := range []string{"preview", "commit"} {
+		t.Run("import plugin "+endpoint, func(t *testing.T) {
+			body := `{"kind":"plugin","name":"Hidden plugin"}`
+			res := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+wid+"/capabilities/import/"+endpoint, body, uid)
+			if res.Code != http.StatusBadRequest || !strings.Contains(res.Body.String(), "want mcp|skill") {
+				t.Fatalf("hidden import expected 400, got %d: %s", res.Code, res.Body.String())
+			}
+		})
+	}
+}
+
 func TestCapabilityRejectsUnknownCredentialKind(t *testing.T) {
 	r, _ := capabilityTestRouter(t, map[string]string{store.DefaultDevFixtureIDs().UserID: "admin"}, nil)
 	res := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/capabilities", `{"type":"mcp","name":"Unknown Credential","required_credentials":[{"kind":"github_token","required":true}],"version":"v1.0.0","content":{"mcpServers":{"github":{"command":"npx"}}}}`, store.DefaultDevFixtureIDs().UserID)
@@ -51,10 +77,9 @@ func TestCapabilityCreateRequiresWorkspaceAdmin(t *testing.T) {
 }
 
 // TestCapabilityListFiltersByTypeAndName exercises the ?type and ?name query
-// params plumbed from the frontend "All / MCP / Skill / Plugin" tabs and the
-// search box. Backend filter logic lives in store.ListCapabilities; this test
-// guards the HTTP layer wiring so a future refactor doesn't silently drop the
-// query parameter parsing.
+// params plumbed from the frontend "All / MCP / Skill" tabs and the search
+// box. Plugin and system-prompt rows remain stored but are intentionally not
+// exposed by this product surface.
 func TestCapabilityListFiltersByTypeAndName(t *testing.T) {
 	r, db := capabilityTestRouter(t, map[string]string{store.DefaultDevFixtureIDs().UserID: "admin"}, nil)
 	wid := store.DefaultDevFixtureIDs().WorkspaceID
@@ -62,6 +87,7 @@ func TestCapabilityListFiltersByTypeAndName(t *testing.T) {
 	insertCapabilityOfType(t, db, wid, uid, "mcp", "GitHub MCP filter")
 	insertCapabilityOfType(t, db, wid, uid, "skill", "Codereview Skill filter")
 	insertCapabilityOfType(t, db, wid, uid, "plugin", "Browser Plugin filter")
+	insertCapabilityOfType(t, db, wid, uid, "system_prompt", "Review System Prompt filter")
 	base := "/api/v1/workspaces/" + wid + "/capabilities"
 	cases := []struct {
 		name     string
@@ -69,12 +95,11 @@ func TestCapabilityListFiltersByTypeAndName(t *testing.T) {
 		mustHave []string
 		mustMiss []string
 	}{
-		{"no filter returns all", "", []string{"GitHub MCP filter", "Codereview Skill filter", "Browser Plugin filter"}, nil},
-		{"type=mcp", "?type=mcp", []string{"GitHub MCP filter"}, []string{"Codereview Skill filter", "Browser Plugin filter"}},
-		{"type=skill", "?type=skill", []string{"Codereview Skill filter"}, []string{"GitHub MCP filter", "Browser Plugin filter"}},
-		{"type=plugin", "?type=plugin", []string{"Browser Plugin filter"}, []string{"GitHub MCP filter", "Codereview Skill filter"}},
-		{"name substring case-insensitive", "?name=codereview", []string{"Codereview Skill filter"}, []string{"GitHub MCP filter", "Browser Plugin filter"}},
-		{"type and name combined", "?type=mcp&name=github", []string{"GitHub MCP filter"}, []string{"Codereview Skill filter", "Browser Plugin filter"}},
+		{"no filter returns listed types", "", []string{"GitHub MCP filter", "Codereview Skill filter"}, []string{"Browser Plugin filter", "Review System Prompt filter"}},
+		{"type=mcp", "?type=mcp", []string{"GitHub MCP filter"}, []string{"Codereview Skill filter", "Browser Plugin filter", "Review System Prompt filter"}},
+		{"type=skill", "?type=skill", []string{"Codereview Skill filter"}, []string{"GitHub MCP filter", "Browser Plugin filter", "Review System Prompt filter"}},
+		{"name substring case-insensitive", "?name=codereview", []string{"Codereview Skill filter"}, []string{"GitHub MCP filter", "Browser Plugin filter", "Review System Prompt filter"}},
+		{"type and name combined", "?type=mcp&name=github", []string{"GitHub MCP filter"}, []string{"Codereview Skill filter", "Browser Plugin filter", "Review System Prompt filter"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -92,6 +117,15 @@ func TestCapabilityListFiltersByTypeAndName(t *testing.T) {
 				if strings.Contains(body, miss) {
 					t.Fatalf("%s: expected response NOT to contain %q, got: %s", tc.name, miss, body)
 				}
+			}
+		})
+	}
+
+	for _, hiddenType := range []string{"plugin", "system_prompt"} {
+		t.Run("reject type="+hiddenType, func(t *testing.T) {
+			res := serveCapabilityRoute(t, r, http.MethodGet, base+"?type="+hiddenType, "", uid)
+			if res.Code != http.StatusBadRequest || !strings.Contains(res.Body.String(), "type must be mcp or skill") {
+				t.Fatalf("hidden type expected 400, got %d: %s", res.Code, res.Body.String())
 			}
 		})
 	}
@@ -204,6 +238,11 @@ func TestCapabilityMarketplaceCrossWorkspaceEnableUpgradeUninstallAndReverseQuer
 	insertForeignWorkspace(t, db, foreignWorkspaceID)
 	capID, v1, v2 := insertCapabilityVersions(t, db, foreignWorkspaceID, "Foreign Public MCP")
 	publishForeignCapability(t, db, capID)
+	hiddenPluginID, _, _ := insertCapabilityVersions(t, db, foreignWorkspaceID, "Foreign Public Plugin")
+	if _, err := db.Exec(context.Background(), `update capability set type = 'plugin' where id = $1`, hiddenPluginID); err != nil {
+		t.Fatal(err)
+	}
+	publishForeignCapability(t, db, hiddenPluginID)
 	agentA := insertAgentForOwner(t, db, testUserAID, "market-agent-a")
 	agentB := insertAgentForOwner(t, db, testUserAID, "market-agent-b")
 
@@ -220,7 +259,7 @@ func TestCapabilityMarketplaceCrossWorkspaceEnableUpgradeUninstallAndReverseQuer
 		t.Fatalf("reverse marketplace list expected count=2, got %d: %s", list.Code, list.Body.String())
 	}
 	market := serveCapabilityRoute(t, r, http.MethodGet, "/api/v1/capabilities/marketplace?workspace_id="+store.DefaultDevFixtureIDs().WorkspaceID, ``, testUserAID)
-	if market.Code != http.StatusOK || !strings.Contains(market.Body.String(), `"installed":true`) || strings.Contains(market.Body.String(), foreignWorkspaceID) {
+	if market.Code != http.StatusOK || !strings.Contains(market.Body.String(), `"installed":true`) || strings.Contains(market.Body.String(), foreignWorkspaceID) || strings.Contains(market.Body.String(), "Foreign Public Plugin") {
 		t.Fatalf("marketplace list expected installed without source workspace id leak, got %d: %s", market.Code, market.Body.String())
 	}
 	upgraded := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/agents/"+agentA+"/capabilities/"+capID+"/upgrade", `{"new_version_id":"`+v2+`"}`, testUserAID)

--- a/server/internal/store/capability_import.go
+++ b/server/internal/store/capability_import.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -340,6 +341,17 @@ func (s *Store) ImportCapabilityVersion(ctx context.Context, input ImportCapabil
 	if !capabilityKindMatchesType(input.Spec.Kind, existing.Type) {
 		return ImportCapabilityResult{}, fmt.Errorf("%w: spec kind %q vs capability type %q", ErrCapabilityKindMismatch, input.Spec.Kind, existing.Type)
 	}
+	if strings.TrimSpace(input.Version) == "" {
+		versions, listErr := s.ListCapabilityVersions(ctx, input.CapabilityID)
+		if listErr != nil {
+			return ImportCapabilityResult{}, fmt.Errorf("import_capability_version: list versions: %w", listErr)
+		}
+		latest := ""
+		if len(versions) > 0 {
+			latest = versions[0].Version
+		}
+		input.Version = nextAutomaticCapabilityVersion(latest)
+	}
 
 	credentialKinds, err := s.collectAndValidateCredentialRefs(ctx, input.Spec)
 	if err != nil {
@@ -383,6 +395,36 @@ func (s *Store) ImportCapabilityVersion(ctx context.Context, input ImportCapabil
 		CapabilityVersion: versionRead,
 		CreatedSecretIDs:  createdSecretIDs,
 	}, nil
+}
+
+func nextAutomaticCapabilityVersion(current string) string {
+	current = strings.TrimSpace(current)
+	if current == "" {
+		return "1.0.0"
+	}
+
+	digitStart := len(current)
+	for digitStart > 0 {
+		char := current[digitStart-1]
+		if char < '0' || char > '9' {
+			break
+		}
+		digitStart--
+	}
+	if digitStart == len(current) {
+		return current + ".1"
+	}
+
+	suffix := current[digitStart:]
+	number, err := strconv.ParseUint(suffix, 10, 64)
+	if err != nil || number == ^uint64(0) {
+		return current + ".1"
+	}
+	next := strconv.FormatUint(number+1, 10)
+	if len(next) < len(suffix) {
+		next = strings.Repeat("0", len(suffix)-len(next)) + next
+	}
+	return current[:digitStart] + next
 }
 
 // commitVersionParams bundles inputs for commitCapabilityVersionInTx. Spec is

--- a/server/internal/store/capability_import_test.go
+++ b/server/internal/store/capability_import_test.go
@@ -7,6 +7,22 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
 )
 
+func TestNextAutomaticCapabilityVersion(t *testing.T) {
+	tests := map[string]string{
+		"":           "1.0.0",
+		"1.0.0":      "1.0.1",
+		"v1.2.9":     "v1.2.10",
+		"2026.07.20": "2026.07.21",
+		"release":    "release.1",
+		"build.009":  "build.010",
+	}
+	for current, want := range tests {
+		if got := nextAutomaticCapabilityVersion(current); got != want {
+			t.Errorf("nextAutomaticCapabilityVersion(%q) = %q, want %q", current, got, want)
+		}
+	}
+}
+
 func TestPatchInlineSecretID_HappyPath(t *testing.T) {
 	spec := canonical.Spec{
 		Kind: canonical.KindMCP,


### PR DESCRIPTION
## What & why

Limit the Capabilities management surface to MCP and Skill, and remove manual version bookkeeping from the edit flow. Workspace and marketplace views now expose the same supported types, while every save creates the next capability version automatically.

## How

- share the MCP/Skill and search state across workspace and marketplace views
- remove the All, Plugin, and System Prompt choices from capability management
- remove the manual version field from the edit/new-version dialog
- assign `1.0.0` to the first version and advance the trailing numeric segment for later saves
- retain explicit API version values as a compatibility override
- enforce MCP/Skill-only listing, creation, import preview, and import commit on the server
- keep historical Plugin/System Prompt records and existing runtime bindings intact
- regenerate OpenAPI output and add automatic-version regression coverage

## Verification

- [x] `make check`
- [x] `go test ./server/internal/store ./server/internal/dev`
- [x] `pnpm --filter @parsar/web typecheck`
- [x] Relevant E2E target: not applicable

## Notes for reviewers

This restricts only management/list and new-creation surfaces. It does not migrate or delete existing Plugin/System Prompt data. Existing API clients may still send an explicit version; the web UI now lets the server assign it automatically.