### PR TITLE
Normalize OpenAI runtime endpoint base URLs

### DIFF
--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -754,13 +754,13 @@ func modelEndpointBaseURL(mr store.ModelRuntime, endpointType string) string {
 				continue
 			}
 			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
-				return strings.TrimSpace(s)
+				return inferModelEndpointBaseURL(want, s)
 			}
 		}
 	case map[string]string:
 		for k, s := range raw {
 			if normalizeModelEndpointType(k) == want && strings.TrimSpace(s) != "" {
-				return strings.TrimSpace(s)
+				return inferModelEndpointBaseURL(want, s)
 			}
 		}
 	}
@@ -769,13 +769,26 @@ func modelEndpointBaseURL(mr store.ModelRuntime, endpointType string) string {
 
 func inferModelEndpointBaseURL(endpointType, fallback string) string {
 	base := strings.TrimRight(strings.TrimSpace(fallback), "/")
+	if base == "" {
+		return ""
+	}
 	if endpointType == "openai" || endpointType == "openai-response" {
+		if strings.HasSuffix(base, "/chat/completions") {
+			base = strings.TrimSuffix(base, "/chat/completions")
+		}
+		if strings.HasSuffix(base, "/responses") {
+			base = strings.TrimSuffix(base, "/responses")
+		}
 		if strings.HasSuffix(base, "/anthropic/v1") {
 			return strings.TrimSuffix(base, "/anthropic/v1") + "/v1"
 		}
 		if strings.HasSuffix(base, "/anthropic") {
 			return strings.TrimSuffix(base, "/anthropic") + "/v1"
 		}
+		if strings.HasSuffix(base, "/v1") {
+			return base
+		}
+		return base + "/v1"
 	}
 	return base
 }

--- a/server/internal/connector/agentdaemon/model_injection_test.go
+++ b/server/internal/connector/agentdaemon/model_injection_test.go
@@ -928,6 +928,51 @@ func TestInjectCodexManagedModel_UsesOpenAIEndpointBaseURLFallback(t *testing.T)
 	}
 }
 
+func TestInjectCodexManagedModel_NormalizesOpenAIEndpointRootBaseURL(t *testing.T) {
+	opts := map[string]any{}
+	mr := store.ModelRuntime{
+		ModelID:      "model-openai-root",
+		ModelKey:     "glm-5.2",
+		ProviderType: "openai-compatible",
+		Adapter:      "@ai-sdk/openai-compatible",
+		BaseURL:      "https://api.appintheloop.com",
+		ProviderConfig: map[string]any{
+			"supported_endpoint_types": []any{"openai"},
+			"endpoint_base_urls": map[string]any{
+				"openai": "https://api.appintheloop.com",
+			},
+		},
+	}
+	if err := injectCodexManagedModel(opts, mr.ModelID, mr, "sk-platform"); err != nil {
+		t.Fatalf("injectCodexManagedModel: %v", err)
+	}
+	provider := opts["codex_provider"].(map[string]any)
+	if got := provider["base_url"]; got != "https://api.appintheloop.com/v1" {
+		t.Fatalf("codex_provider.base_url = %v, want normalized /v1 base URL", got)
+	}
+}
+
+func TestInjectCodexManagedModel_NormalizesOpenAIModelRootBaseURL(t *testing.T) {
+	opts := map[string]any{}
+	mr := store.ModelRuntime{
+		ModelID:      "model-openai-root-fallback",
+		ModelKey:     "glm-5.2",
+		ProviderType: "openai-compatible",
+		Adapter:      "@ai-sdk/openai-compatible",
+		BaseURL:      "https://api.appintheloop.com",
+		ProviderConfig: map[string]any{
+			"supported_endpoint_types": []any{"openai"},
+		},
+	}
+	if err := injectCodexManagedModel(opts, mr.ModelID, mr, "sk-platform"); err != nil {
+		t.Fatalf("injectCodexManagedModel: %v", err)
+	}
+	provider := opts["codex_provider"].(map[string]any)
+	if got := provider["base_url"]; got != "https://api.appintheloop.com/v1" {
+		t.Fatalf("codex_provider.base_url = %v, want normalized /v1 fallback base URL", got)
+	}
+}
+
 func TestInjectCodexManagedModel_InfersResponsesBaseURLForLegacyAnthropicRows(t *testing.T) {
 	opts := map[string]any{}
 	mr := store.ModelRuntime{


### PR DESCRIPTION
## Summary
- normalize explicit runtime endpoint_base_urls for OpenAI-compatible endpoints before injecting them into agent daemon options
- align agent daemon runtime URL inference with the admin probe path so root OpenAI-compatible base URLs become /v1
- add regressions for Codex using root OpenAI endpoint URLs from model config and model base_url fallback

## Checks
- go test ./server/internal/connector/agentdaemon
- make check