### PR TITLE
Replace agent disable action with delete

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1618,6 +1618,9 @@
       "title": "Delete \"{{name}}\"?",
       "description": "This permanently removes the Agent from the workspace. Historical conversations, runs, and audit records are preserved.",
       "confirmNameLabel": "Type {{name}} to confirm.",
+      "confirmNamePrefix": "Type",
+      "confirmNameSuffix": "to confirm.",
+      "copyName": "Copy Agent name",
       "confirm": "Delete Agent",
       "deletedToast": "Deleted {{name}}"
     },

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1614,6 +1614,13 @@
       "enabledToast": "Enabled {{name}}",
       "clonedToast": "Cloned as \"{{name}}\""
     },
+    "delete": {
+      "title": "Delete \"{{name}}\"?",
+      "description": "This permanently removes the Agent from the workspace. Historical conversations, runs, and audit records are preserved.",
+      "confirmNameLabel": "Type {{name}} to confirm.",
+      "confirm": "Delete Agent",
+      "deletedToast": "Deleted {{name}}"
+    },
     "execution": {
       "sandbox": {
         "title": "Cloud isolation",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1618,6 +1618,9 @@
       "title": "删除「{{name}}」？",
       "description": "这会从当前工作区永久删除该 Agent。历史对话、运行和审计记录会保留。",
       "confirmNameLabel": "输入 {{name}} 以确认删除。",
+      "confirmNamePrefix": "输入",
+      "confirmNameSuffix": "以确认删除。",
+      "copyName": "复制 Agent 名称",
       "confirm": "删除 Agent",
       "deletedToast": "已删除 {{name}}"
     },

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1614,6 +1614,13 @@
       "enabledToast": "已启用 {{name}}",
       "clonedToast": "已复制为「{{name}}」"
     },
+    "delete": {
+      "title": "删除「{{name}}」？",
+      "description": "这会从当前工作区永久删除该 Agent。历史对话、运行和审计记录会保留。",
+      "confirmNameLabel": "输入 {{name}} 以确认删除。",
+      "confirm": "删除 Agent",
+      "deletedToast": "已删除 {{name}}"
+    },
     "execution": {
       "sandbox": {
         "title": "云端隔离",

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -2,7 +2,6 @@ import { type ReactNode, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   Bot,
-  Loader2,
   Plus,
 } from "lucide-react"
 
@@ -14,15 +13,6 @@ import { Button } from "../../components/ui/button"
 import { EmptyState } from "../../components/ui/empty-state"
 import { ErrorState } from "../../components/ui/error-state"
 import { Skeleton } from "../../components/ui/skeleton"
-import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "../../components/ui/alert-dialog"
 import {
   Tabs,
   TabsContent,
@@ -36,7 +26,7 @@ import {
   useCreateAgent,
   useAgentDetail,
   useAgents,
-  useSetAgentStatus,
+  useDeleteAgent,
   useUpdateAgent,
   useUpdateAgentProfile,
 } from "../../lib/api-agents"
@@ -53,6 +43,7 @@ import { AgentDetailActions } from "./agents/AgentDetailActions"
 import { AgentDynamicsTab } from "./agents/AgentDynamicsTab"
 import { AgentsListTable } from "./agents/AgentsListTable"
 import { AgentStatusBadge } from "./agents/AgentStatusBadge"
+import { DeleteAgentDialog } from "./agents/DeleteAgentDialog"
 
 function usePendingCapability(workspaceID: string | null) {
   const id = new URLSearchParams(window.location.search).get("pendingCapability")
@@ -78,7 +69,7 @@ export function AgentsPage() {
   const [createOpen, setCreateOpen] = useState(false)
   const [editAgent, setEditAgent] = useState<Agent | null>(null)
   const [cloneAgent, setCloneAgent] = useState<Agent | null>(null)
-  const [disableTarget, setDisableTarget] = useState<Agent | null>(null)
+  const [deleteTarget, setDeleteTarget] = useState<Agent | null>(null)
   const [toast, setToast] = useState<string | null>(null)
   const [chatPendingID, setChatPendingID] = useState<string | null>(null)
   const fmtAgo = useRelativeTime()
@@ -89,7 +80,7 @@ export function AgentsPage() {
   const modelsQ = useModels(wid)
   const updateMut = useUpdateAgent(wid)
   const updateProfileMut = useUpdateAgentProfile(wid)
-  const statusMut = useSetAgentStatus(wid)
+  const deleteMut = useDeleteAgent(wid)
   const workspacesQ = useMyWorkspaces()
   const agents = useMemo(() => query.data?.agents ?? [], [query.data])
   const models = modelsQ.data?.models ?? []
@@ -182,23 +173,14 @@ export function AgentsPage() {
           models={models}
           keyword={keyword}
           chatPendingID={chatPendingID}
-          statusPending={statusMut.isPending}
+          deletePending={deleteMut.isPending}
           formatRelativeTime={fmtAgo}
           onKeywordChange={setKeyword}
           onOpenAgent={(agent) => navigate("agents", { id: agent.id })}
           onChat={(agent) => void startChatWith(agent)}
           onEdit={setEditAgent}
           onClone={setCloneAgent}
-          onStatusChange={(agent, enabled) => {
-            if (!enabled) {
-              setDisableTarget(agent)
-              return
-            }
-            statusMut.mutate(
-              { agentID: agent.id, enabled: true },
-              { onSuccess: () => setToast(t("agents.listActions.enabledToast", { name: agent.name })) },
-            )
-          }}
+          onDelete={setDeleteTarget}
         />
       )}
 
@@ -295,41 +277,25 @@ export function AgentsPage() {
         }}
       />
 
-      <AlertDialog open={disableTarget !== null} onOpenChange={(open) => {
-        if (!open && !statusMut.isPending) setDisableTarget(null)
-      }}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{t("agents.listActions.disableConfirmTitle", { name: disableTarget?.name ?? "" })}</AlertDialogTitle>
-            <AlertDialogDescription>{t("agents.listActions.disableConfirmDescription")}</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel asChild>
-              <Button variant="outline" size="sm" disabled={statusMut.isPending}>{t("agents.listActions.cancel")}</Button>
-            </AlertDialogCancel>
-            <Button
-              variant="destructive"
-              size="sm"
-              disabled={!disableTarget || statusMut.isPending}
-              onClick={() => {
-                if (!disableTarget) return
-                statusMut.mutate(
-                  { agentID: disableTarget.id, enabled: false },
-                  {
-                    onSuccess: () => {
-                      setToast(t("agents.listActions.disabledToast", { name: disableTarget.name }))
-                      setDisableTarget(null)
-                    },
-                  },
-                )
-              }}
-            >
-              {statusMut.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
-              {t("agents.listActions.disableConfirm")}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <DeleteAgentDialog
+        agent={deleteTarget}
+        pending={deleteMut.isPending}
+        error={deleteMut.error}
+        onCancel={() => {
+          setDeleteTarget(null)
+          deleteMut.reset()
+        }}
+        onConfirm={() => {
+          if (!deleteTarget) return
+          const name = deleteTarget.name
+          deleteMut.mutate(deleteTarget.id, {
+            onSuccess: () => {
+              setDeleteTarget(null)
+              setToast(t("agents.delete.deletedToast", { name }))
+            },
+          })
+        }}
+      />
     </AdminLayout>
   )
 }

--- a/apps/web/src/pages/admin/agents/AgentDetailActions.tsx
+++ b/apps/web/src/pages/admin/agents/AgentDetailActions.tsx
@@ -1,22 +1,14 @@
 import { useState } from "react"
-import { Loader2, MessageSquare, Pencil, Power, PowerOff } from "lucide-react"
+import { Loader2, MessageSquare, Pencil, Trash2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
-import {
-  AlertDialog,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "../../../components/ui/alert-dialog"
 import { Button } from "../../../components/ui/button"
-import { useSetAgentStatus, useUpdateAgent, useUpdateAgentProfile } from "../../../lib/api-agents"
+import { useDeleteAgent, useUpdateAgent, useUpdateAgentProfile } from "../../../lib/api-agents"
 import { createAgentConversation } from "../../../lib/api-conversations"
 import type { Agent, Model, UserWorkspace } from "../../../lib/api-types"
 import { useAdminView } from "../../../lib/admin-router"
 import { CreateAgentDialog } from "../CreateAgentDialog"
+import { DeleteAgentDialog } from "./DeleteAgentDialog"
 
 export function AgentDetailActions({
   agent,
@@ -36,11 +28,11 @@ export function AgentDetailActions({
   const { t, i18n } = useTranslation("admin")
   const { navigate } = useAdminView()
   const [editOpen, setEditOpen] = useState(false)
-  const [disableOpen, setDisableOpen] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
   const [chatPending, setChatPending] = useState(false)
   const updateMut = useUpdateAgent(workspaceID)
   const updateProfileMut = useUpdateAgentProfile(workspaceID)
-  const statusMut = useSetAgentStatus(workspaceID)
+  const deleteMut = useDeleteAgent(workspaceID)
 
   async function startChat() {
     if (!workspaceID || chatPending) return
@@ -75,26 +67,11 @@ export function AgentDetailActions({
       <Button
         variant="outline"
         size="sm"
-        disabled={statusMut.isPending}
-        onClick={() => {
-          if (agent.status === "active") {
-            setDisableOpen(true)
-            return
-          }
-          statusMut.mutate(
-            { agentID: agent.id, enabled: true },
-            {
-              onSuccess: () => onToast(t("agents.listActions.enabledToast", { name: agent.name })),
-            },
-          )
-        }}
+        disabled={deleteMut.isPending}
+        onClick={() => setDeleteOpen(true)}
       >
-        {agent.status === "active" ? (
-          <PowerOff className="h-3.5 w-3.5" />
-        ) : (
-          <Power className="h-3.5 w-3.5" />
-        )}
-        {t(agent.status === "active" ? "agents.actions.disable" : "agents.actions.enable")}
+        {deleteMut.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+        {t("agents.actions.delete")}
       </Button>
 
       <CreateAgentDialog
@@ -129,49 +106,25 @@ export function AgentDetailActions({
         }}
       />
 
-      <AlertDialog
-        open={disableOpen}
-        onOpenChange={(open) => {
-          if (!statusMut.isPending) setDisableOpen(open)
+      <DeleteAgentDialog
+        agent={deleteOpen ? agent : null}
+        pending={deleteMut.isPending}
+        error={deleteMut.error}
+        onCancel={() => {
+          setDeleteOpen(false)
+          deleteMut.reset()
         }}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>
-              {t("agents.listActions.disableConfirmTitle", { name: agent.name })}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {t("agents.listActions.disableConfirmDescription")}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel asChild>
-              <Button variant="outline" size="sm" disabled={statusMut.isPending}>
-                {t("agents.listActions.cancel")}
-              </Button>
-            </AlertDialogCancel>
-            <Button
-              variant="destructive"
-              size="sm"
-              disabled={statusMut.isPending}
-              onClick={() =>
-                statusMut.mutate(
-                  { agentID: agent.id, enabled: false },
-                  {
-                    onSuccess: () => {
-                      setDisableOpen(false)
-                      onToast(t("agents.listActions.disabledToast", { name: agent.name }))
-                    },
-                  },
-                )
-              }
-            >
-              {statusMut.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-              {t("agents.listActions.disableConfirm")}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onConfirm={() => {
+          const name = agent.name
+          deleteMut.mutate(agent.id, {
+            onSuccess: () => {
+              setDeleteOpen(false)
+              onToast(t("agents.delete.deletedToast", { name }))
+              navigate("agents")
+            },
+          })
+        }}
+      />
     </>
   )
 }

--- a/apps/web/src/pages/admin/agents/AgentRowActions.tsx
+++ b/apps/web/src/pages/admin/agents/AgentRowActions.tsx
@@ -1,5 +1,5 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
-import { Copy, Loader2, MessageSquare, MoreHorizontal, Pencil, Power, PowerOff } from "lucide-react"
+import { Copy, Loader2, MessageSquare, MoreHorizontal, Pencil, Trash2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "../../../components/ui/button"
@@ -8,19 +8,19 @@ import type { Agent } from "../../../lib/api-types"
 export function AgentRowActions({
   agent,
   chatPending,
-  statusPending,
+  deletePending,
   onChat,
   onEdit,
   onClone,
-  onStatusChange,
+  onDelete,
 }: {
   agent: Agent
   chatPending: boolean
-  statusPending: boolean
+  deletePending: boolean
   onChat: () => void
   onEdit: () => void
   onClone: () => void
-  onStatusChange: (enabled: boolean) => void
+  onDelete: () => void
 }) {
   const { t } = useTranslation("admin")
   const enabled = agent.status === "active"
@@ -58,11 +58,11 @@ export function AgentRowActions({
             <MenuItem icon={Copy} label={t("agents.actions.clone")} onSelect={onClone} />
             <DropdownMenu.Separator className="my-1 h-px bg-line" />
             <MenuItem
-              icon={enabled ? PowerOff : Power}
-              label={t(enabled ? "agents.actions.disable" : "agents.actions.enable")}
-              tone={enabled ? "danger" : "success"}
-              disabled={statusPending}
-              onSelect={() => onStatusChange(!enabled)}
+              icon={Trash2}
+              label={t("agents.actions.delete")}
+              tone="danger"
+              disabled={deletePending}
+              onSelect={onDelete}
             />
           </DropdownMenu.Content>
         </DropdownMenu.Portal>

--- a/apps/web/src/pages/admin/agents/AgentsListTable.tsx
+++ b/apps/web/src/pages/admin/agents/AgentsListTable.tsx
@@ -27,27 +27,27 @@ export function AgentsListTable({
   models,
   keyword,
   chatPendingID,
-  statusPending,
+  deletePending,
   formatRelativeTime,
   onKeywordChange,
   onOpenAgent,
   onChat,
   onEdit,
   onClone,
-  onStatusChange,
+  onDelete,
 }: {
   agents: Agent[]
   models: Model[]
   keyword: string
   chatPendingID: string | null
-  statusPending: boolean
+  deletePending: boolean
   formatRelativeTime: (value: string) => string
   onKeywordChange: (value: string) => void
   onOpenAgent: (agent: Agent) => void
   onChat: (agent: Agent) => void
   onEdit: (agent: Agent) => void
   onClone: (agent: Agent) => void
-  onStatusChange: (agent: Agent, enabled: boolean) => void
+  onDelete: (agent: Agent) => void
 }) {
   const { t } = useTranslation("admin")
   const filtered = agents.filter((agent) => {
@@ -124,11 +124,11 @@ export function AgentsListTable({
                     <AgentRowActions
                       agent={agent}
                       chatPending={chatPendingID === agent.id}
-                      statusPending={statusPending}
+                      deletePending={deletePending}
                       onChat={() => onChat(agent)}
                       onEdit={() => onEdit(agent)}
                       onClone={() => onClone(agent)}
-                      onStatusChange={(enabled) => onStatusChange(agent, enabled)}
+                      onDelete={() => onDelete(agent)}
                     />
                   </TableCell>
                 </TableRow>

--- a/apps/web/src/pages/admin/agents/DeleteAgentDialog.tsx
+++ b/apps/web/src/pages/admin/agents/DeleteAgentDialog.tsx
@@ -1,4 +1,4 @@
-import { Loader2 } from "lucide-react"
+import { Check, Copy, Loader2 } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -38,13 +38,26 @@ export function DeleteAgentDialog({
 }) {
   const { t } = useTranslation("admin")
   const [confirmation, setConfirmation] = useState("")
+  const [copied, setCopied] = useState(false)
   const expected = agent?.name ?? ""
   const canDelete = Boolean(agent) && confirmation === expected && !pending
   const msg = errorMessage(error)
 
   useEffect(() => {
     setConfirmation("")
+    setCopied(false)
   }, [agent?.id])
+
+  async function copyAgentName() {
+    if (!expected || pending) return
+    try {
+      await navigator.clipboard?.writeText(expected)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1200)
+    } catch {
+      setCopied(false)
+    }
+  }
 
   return (
     <AlertDialog
@@ -62,8 +75,22 @@ export function DeleteAgentDialog({
           <AlertDialogDescription>{t("agents.delete.description")}</AlertDialogDescription>
         </AlertDialogHeader>
         <div className="space-y-2">
-          <label className="block text-sm font-medium text-fg" htmlFor="delete-agent-confirmation">
-            {t("agents.delete.confirmNameLabel", { name: expected })}
+          <label className="flex flex-wrap items-center gap-1.5 text-sm font-medium text-fg" htmlFor="delete-agent-confirmation">
+            <span>{t("agents.delete.confirmNamePrefix")}</span>
+            <span className="rounded border border-danger-border bg-danger-subtle px-1.5 py-0.5 font-mono text-xs font-semibold text-danger-emphasis">
+              {expected}
+            </span>
+            <button
+              type="button"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md text-fg-subtle transition-colors hover:bg-surface-muted hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-line-strong disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={!expected || pending}
+              title={t("agents.delete.copyName")}
+              aria-label={t("agents.delete.copyName")}
+              onClick={() => void copyAgentName()}
+            >
+              {copied ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
+            </button>
+            <span>{t("agents.delete.confirmNameSuffix")}</span>
           </label>
           <Input
             id="delete-agent-confirmation"

--- a/apps/web/src/pages/admin/agents/DeleteAgentDialog.tsx
+++ b/apps/web/src/pages/admin/agents/DeleteAgentDialog.tsx
@@ -1,0 +1,100 @@
+import { Loader2 } from "lucide-react"
+import { useEffect, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "../../../components/ui/alert-dialog"
+import { Button } from "../../../components/ui/button"
+import { Input } from "../../../components/ui/input"
+import { ApiError } from "../../../lib/api-client"
+import type { Agent } from "../../../lib/api-types"
+
+function errorMessage(error: unknown): string | null {
+  if (!error) return null
+  if (error instanceof ApiError) return error.envelope.message || error.message
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+export function DeleteAgentDialog({
+  agent,
+  pending,
+  error,
+  onCancel,
+  onConfirm,
+}: {
+  agent: Agent | null
+  pending: boolean
+  error: unknown
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const { t } = useTranslation("admin")
+  const [confirmation, setConfirmation] = useState("")
+  const expected = agent?.name ?? ""
+  const canDelete = Boolean(agent) && confirmation === expected && !pending
+  const msg = errorMessage(error)
+
+  useEffect(() => {
+    setConfirmation("")
+  }, [agent?.id])
+
+  return (
+    <AlertDialog
+      open={agent !== null}
+      onOpenChange={(open) => {
+        if (!open && !pending) {
+          setConfirmation("")
+          onCancel()
+        }
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("agents.delete.title", { name: expected })}</AlertDialogTitle>
+          <AlertDialogDescription>{t("agents.delete.description")}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-fg" htmlFor="delete-agent-confirmation">
+            {t("agents.delete.confirmNameLabel", { name: expected })}
+          </label>
+          <Input
+            id="delete-agent-confirmation"
+            value={confirmation}
+            onChange={(event) => setConfirmation(event.target.value)}
+            disabled={pending}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          {msg && <p className="text-sm text-danger">{msg}</p>}
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel asChild>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={pending}
+              onClick={() => {
+                setConfirmation("")
+                onCancel()
+              }}
+            >
+              {t("agents.listActions.cancel")}
+            </Button>
+          </AlertDialogCancel>
+          <Button variant="destructive" size="sm" disabled={!canDelete} onClick={onConfirm}>
+            {pending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {t("agents.delete.confirm")}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}


### PR DESCRIPTION
## Summary
- replace Agent list/detail Disable/Enable controls with Delete actions
- add a shared delete confirmation dialog that requires typing the Agent name
- wire the UI to the existing delete Agent API so removed Agents no longer block model deletion

## Checks
- make typecheck-web
- make check