### PR TITLE
fix: relax Skill zip layout requirements

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -962,11 +962,11 @@
           "paste": "Paste Markdown",
           "zip": "Upload zip"
         },
-        "dropHint": "Drag or click to upload a .zip (SKILL.md + references / scripts)",
+        "dropHint": "Drag or click to upload a Skill .zip",
         "dropActive": "Drop to import",
         "sizeHint": "Up to 8 MiB",
         "zipLabel": "Upload Skill zip",
-        "zipHelp": "The zip must include a SKILL.md (at the root or one subdirectory deep). references/ and scripts/ folders are imported alongside it.",
+        "zipHelp": "The zip must include a SKILL.md at the root or one subdirectory deep. Any supporting files and directories are optional and imported alongside it.",
         "uploading": "Uploading…",
         "parsing": "Parsing…",
         "errors": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -962,11 +962,11 @@
           "paste": "粘贴 Markdown",
           "zip": "上传 zip"
         },
-        "dropHint": "拖拽或点击上传 .zip(SKILL.md + references / scripts)",
+        "dropHint": "拖拽或点击上传 Skill .zip",
         "dropActive": "松开导入 .zip",
         "sizeHint": "最大 8 MiB",
         "zipLabel": "上传 Skill zip",
-        "zipHelp": "zip 内需包含 SKILL.md(可在根目录或一层子目录)。references/、scripts/ 等子目录会一并导入。",
+        "zipHelp": "zip 内需包含 SKILL.md(可在根目录或一层子目录)。其它文件和目录均为可选内容,会一并导入。",
         "uploading": "上传中…",
         "parsing": "解析中…",
         "errors": {

--- a/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
@@ -247,8 +247,8 @@ export function ImportSkillForm({
        *     the right, side-by-side comparison is the point).
        *   zip mode  → single column. The dropzone is a small target that
        *     looks lonely in a half-width column, and the preview wants
-       *     every pixel it can get (SKILL.md source, references/, scripts/
-       *     all stack vertically). Stack input above preview instead. */}
+       *     every pixel it can get (SKILL.md and supporting files all stack
+       *     vertically). Stack input above preview instead. */}
       <div
         className={
           source === "paste"
@@ -310,7 +310,7 @@ export function ImportSkillForm({
               <p className="text-xs text-fg-subtle">
                 {t(
                   "capabilities.import.skill.zipHelp",
-                  "The zip must contain a SKILL.md (at the root or one level deep). references/ and scripts/ subdirectories are imported alongside it.",
+                  "The zip must contain a SKILL.md at the root or one level deep. Any supporting files and directories are optional and imported alongside it.",
                 )}
               </p>
             </>

--- a/apps/web/src/pages/admin/capabilities/SkillZipDropzone.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillZipDropzone.tsx
@@ -73,7 +73,7 @@ export function SkillZipDropzone({
           <span className="text-sm text-fg-muted">
             {isDragActive
               ? t("capabilities.import.skill.dropActive", "Release to import the .zip")
-              : t("capabilities.import.skill.dropHint", "Drag or click to upload a .zip (SKILL.md + references / scripts)")}
+              : t("capabilities.import.skill.dropHint", "Drag or click to upload a Skill .zip")}
           </span>
           <span className="text-xs text-fg-subtle">
             {t("capabilities.import.skill.sizeHint", "Up to 8 MiB")}

--- a/server/internal/capability/parser/skill_zip_parser.go
+++ b/server/internal/capability/parser/skill_zip_parser.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"path"
-	"slices"
 	"sort"
 	"strings"
 
@@ -41,16 +40,10 @@ var ErrInvalidSkillZip = errors.New("parser: invalid skill zip")
 // always emit "SKILL.md" downstream so storage stays predictable.
 const skillRootName = "SKILL.md"
 
-// allowedSkillSubdirs is the closed ingest set. Anything else is dropped
-// with a warning — silent inclusion of arbitrary blobs would inflate
-// canonical_spec for no consumer benefit.
-var allowedSkillSubdirs = []string{"references/", "scripts/"}
-
 // ParseSkillZip extracts a multi-file skill. Layout:
 //
 //	SKILL.md (or one-level wrapping: my-skill/SKILL.md)
-//	references/*.md, references/*.txt, ...
-//	scripts/*.{py,sh,js,ts,json,...}
+//	any additional files or directories used by the Skill
 //
 // SKILL.md goes through ParseSkill so the frontmatter contract is identical
 // between paste and zip imports. Pure: no I/O beyond buf.
@@ -93,6 +86,9 @@ func ParseSkillZip(buf []byte) (SkillParseResult, error) {
 		if p == "" {
 			continue
 		}
+		if path.IsAbs(p) || hasWindowsDrivePrefix(p) {
+			return SkillParseResult{}, fmt.Errorf("%w: zip entry %q uses an absolute path", ErrInvalidSkillZip, zr.File[i].Name)
+		}
 		// Reject the whole zip on traversal: a `..` hint means it was crafted
 		// in a way we don't understand; sanitising could mask intent.
 		if hasParentTraversal(p) {
@@ -124,7 +120,6 @@ func ParseSkillZip(buf []byte) (SkillParseResult, error) {
 
 	warnings := append([]string(nil), skillRes.Warnings...)
 	files := make([]canonical.SkillFile, 0)
-	ignored := make([]string, 0)
 
 	// SKILL.md counts against the cumulative budget too — otherwise a near-
 	// 1 MiB SKILL.md plus 32 MiB of references could slip past since the
@@ -138,15 +133,7 @@ func ParseSkillZip(buf []byte) (SkillParseResult, error) {
 		if strings.EqualFold(se.rel, skillRootName) {
 			continue
 		}
-		// Filter directory markers BEFORE the allowlist check — otherwise
-		// legitimate `references/` / `scripts/` markers (no trailing slash
-		// after normalize) get reported as "ignored files outside SKILL.md
-		// / references/ / scripts/", which is exactly where they live.
 		if se.entry.FileInfo().IsDir() {
-			continue
-		}
-		if !pathHasAllowedSkillPrefix(se.rel) {
-			ignored = append(ignored, se.rel)
 			continue
 		}
 		content, err := readZipEntryDirect(se.entry)
@@ -170,17 +157,6 @@ func ParseSkillZip(buf []byte) (SkillParseResult, error) {
 	// Stable order so re-importing the same zip produces byte-for-byte
 	// identical canonical_spec → capability_version rows.
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
-
-	if len(ignored) > 0 {
-		sort.Strings(ignored)
-		preview := ignored
-		more := ""
-		if len(preview) > 8 {
-			more = fmt.Sprintf(" and %d more", len(ignored)-8)
-			preview = preview[:8]
-		}
-		warnings = append(warnings, fmt.Sprintf("ignored %d files: %s%s", len(ignored), strings.Join(preview, ", "), more))
-	}
 
 	if skillRes.Spec.Skill == nil {
 		// Defensive — ParseSkill always populates Skill on nil error.
@@ -210,16 +186,6 @@ func readZipEntryDirect(f *zip.File) ([]byte, error) {
 	return buf, nil
 }
 
-// pathHasAllowedSkillPrefix is case-sensitive on the prefix segment because
-// skill consumers resolve `[link](references/foo.md)` case-sensitively at
-// read time — accepting `References/foo.md` here would land at a path
-// runtime won't find.
-func pathHasAllowedSkillPrefix(rel string) bool {
-	return slices.ContainsFunc(allowedSkillSubdirs, func(prefix string) bool {
-		return strings.HasPrefix(rel, prefix)
-	})
-}
-
 // inferSkillFileKind: only known script/markdown extensions get a specific
 // Kind; everything else (images, json, yaml, opaque blobs) is Asset.
 func inferSkillFileKind(rel string) canonical.SkillFileKind {
@@ -241,6 +207,10 @@ func hasParentTraversal(p string) bool {
 		}
 	}
 	return false
+}
+
+func hasWindowsDrivePrefix(p string) bool {
+	return len(p) >= 3 && p[1] == ':' && p[2] == '/'
 }
 
 // isMacOSMetadata catches Finder's `__MACOSX/` and `.DS_Store` noise.

--- a/server/internal/capability/parser/skill_zip_parser_test.go
+++ b/server/internal/capability/parser/skill_zip_parser_test.go
@@ -38,6 +38,22 @@ const minimalSkillMd = "---\n" +
 	"---\n" +
 	"You are a careful code reviewer.\n"
 
+func TestParseSkillZip_HappyPath_SkillMdOnly(t *testing.T) {
+	buf := buildZip(t, []struct{ name, content string }{
+		{"SKILL.md", minimalSkillMd},
+	})
+	res, err := ParseSkillZip(buf)
+	if err != nil {
+		t.Fatalf("ParseSkillZip: %v", err)
+	}
+	if res.Spec.Skill == nil {
+		t.Fatal("spec.Skill nil")
+	}
+	if len(res.Spec.Skill.Files) != 0 {
+		t.Fatalf("SKILL.md-only zip should not require supporting files, got %+v", res.Spec.Skill.Files)
+	}
+}
+
 // TestParseSkillZip_HappyPath_RootLayout: SKILL.md + references/ + scripts/
 // at the zip root. Output has stable sort order and correct Kind.
 func TestParseSkillZip_HappyPath_RootLayout(t *testing.T) {
@@ -127,50 +143,22 @@ func TestParseSkillZip_HappyPath_WrappingRootDirWithDirEntries(t *testing.T) {
 	}
 }
 
-// TestParseSkillZip_DirEntriesNotReportedAsIgnored: directory markers used
-// to slip past pathHasAllowedSkillPrefix (normalizeZipPath stripped their
-// slash) and got reported as "ignored outside references/" — confusing
-// because their location IS one of the allowed dirs. IsDir() filter now
-// runs before the allowlist check.
-func TestParseSkillZip_DirEntriesNotReportedAsIgnored(t *testing.T) {
+func TestParseSkillZip_DirectoryEntriesAreNotImported(t *testing.T) {
 	buf := buildZip(t, []struct{ name, content string }{
 		{"SKILL.md", minimalSkillMd},
 		{"references/", ""},
 		{"references/foo.md", "# foo\n"},
-		{".claude-plugin/", ""},
-		{".claude-plugin/plugin.json", "{}\n"},
+		{"docs/", ""},
 	})
 	res, err := ParseSkillZip(buf)
 	if err != nil {
 		t.Fatalf("ParseSkillZip: %v", err)
 	}
-	// references/foo.md is the only legitimate sibling — confirm import succeeded.
 	if got := len(res.Spec.Skill.Files); got != 1 {
 		t.Fatalf("want 1 imported file, got %d: %+v", got, res.Spec.Skill.Files)
 	}
-	// Exactly one ignored-files warning, listing only the genuine stray.
-	var ignoredWarning string
-	for _, w := range res.Warnings {
-		if strings.HasPrefix(w, "ignored ") {
-			ignoredWarning = w
-			break
-		}
-	}
-	if ignoredWarning == "" {
-		t.Fatalf("expected an ignored-files warning, got warnings=%v", res.Warnings)
-	}
-	// Bare "references" / ".claude-plugin" (no slash) here would mean a
-	// dir marker leaked through — the bug we're guarding against.
-	for _, leak := range []string{"references,", "references ", ".claude-plugin,", ".claude-plugin "} {
-		if strings.Contains(ignoredWarning+" ", leak) {
-			t.Fatalf("dir marker leaked into ignored list: %q", ignoredWarning)
-		}
-	}
-	if !strings.Contains(ignoredWarning, ".claude-plugin/plugin.json") {
-		t.Fatalf("expected .claude-plugin/plugin.json in ignored list, got %q", ignoredWarning)
-	}
-	if !strings.Contains(ignoredWarning, "ignored 1 files") {
-		t.Fatalf("expected exactly 1 ignored file, got %q", ignoredWarning)
+	if res.Spec.Skill.Files[0].Path != "references/foo.md" {
+		t.Fatalf("directory marker was imported: %+v", res.Spec.Skill.Files)
 	}
 }
 
@@ -231,34 +219,49 @@ func TestParseSkillZip_PathTraversal_Rejected(t *testing.T) {
 	}
 }
 
-// TestParseSkillZip_IgnoresUnknownDirs_WithWarning: files outside
-// references/ and scripts/ are dropped from canonical_spec with a warning.
-func TestParseSkillZip_IgnoresUnknownDirs_WithWarning(t *testing.T) {
+func TestParseSkillZip_AbsolutePathRejected(t *testing.T) {
+	for _, name := range []string{"/etc/passwd", `C:\\Windows\\system.ini`} {
+		t.Run(name, func(t *testing.T) {
+			buf := buildZip(t, []struct{ name, content string }{
+				{"SKILL.md", minimalSkillMd},
+				{name, "evil"},
+			})
+			_, err := ParseSkillZip(buf)
+			if !errors.Is(err, ErrInvalidSkillZip) {
+				t.Fatalf("want ErrInvalidSkillZip, got %v", err)
+			}
+			if !strings.Contains(err.Error(), "absolute path") {
+				t.Fatalf("error should mention absolute path, got %v", err)
+			}
+		})
+	}
+}
+
+func TestParseSkillZip_ImportsArbitrarySupportingDirectories(t *testing.T) {
 	buf := buildZip(t, []struct{ name, content string }{
 		{"SKILL.md", minimalSkillMd},
 		{"references/foo.md", "ref\n"},
 		{"assets/screenshot.png", "binary blob"},
-		{"docs/readme.md", "not a reference dir we ingest"},
+		{"docs/readme.md", "supporting documentation"},
 	})
 	res, err := ParseSkillZip(buf)
 	if err != nil {
 		t.Fatalf("ParseSkillZip: %v", err)
 	}
 	sk := res.Spec.Skill
-	if len(sk.Files) != 1 {
-		t.Fatalf("want 1 file (only references/foo.md), got %d: %+v", len(sk.Files), sk.Files)
+	if len(sk.Files) != 3 {
+		t.Fatalf("want all 3 supporting files, got %d: %+v", len(sk.Files), sk.Files)
 	}
-	if sk.Files[0].Path != "references/foo.md" {
-		t.Fatalf("kept wrong file: %q", sk.Files[0].Path)
-	}
-	hasIgnoreWarn := false
-	for _, w := range res.Warnings {
-		if strings.Contains(w, "ignored") && strings.Contains(w, "assets/screenshot.png") {
-			hasIgnoreWarn = true
+	wantPaths := []string{"assets/screenshot.png", "docs/readme.md", "references/foo.md"}
+	for i, want := range wantPaths {
+		if sk.Files[i].Path != want {
+			t.Fatalf("files[%d].Path: want %q, got %q", i, want, sk.Files[i].Path)
 		}
 	}
-	if !hasIgnoreWarn {
-		t.Fatalf("missing ignored-files warning; got warnings=%v", res.Warnings)
+	for _, w := range res.Warnings {
+		if strings.Contains(w, "ignored") {
+			t.Fatalf("arbitrary supporting directories should not be ignored: %q", w)
+		}
 	}
 }
 


### PR DESCRIPTION
## What & why

Skill zip uploads implied that `references/` and `scripts/` were required, while the parser discarded supporting files outside those directories. A valid Skill should only require its `SKILL.md` entry and may use any additional directory layout.

## How

- keep `SKILL.md` as the only required Skill zip entry
- import supporting files from any relative directory instead of only `references/` and `scripts/`
- continue rejecting parent traversal, absolute paths, oversized entries, and oversized archives
- update the upload copy in English and Chinese
- add regression coverage for SKILL.md-only zips, arbitrary supporting directories, and unsafe paths

## Verification

- [x] `make check`
- [x] `go test ./server/internal/capability/parser`
- [x] Manual smoke: rebuilt the local Docker image, restarted Parsar, and verified `/healthz`

## Notes for reviewers

This changes only Skill zip parsing and its upload guidance. Paste-based Skill imports are unchanged.
