### PR TITLE
feat: add marketplace capability previews

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -43,14 +43,14 @@ export default tseslint.config(
           selector:
             "Literal[value=/(?:^|\\s)text-\\[\\d+px\\](?:\\s|$)/]",
           message:
-            "Arbitrary font sizes are banned. Use one of: text-xs, text-sm, text-base, text-lg, text-xl, text-2xl, text-3xl.",
+            "Arbitrary font sizes are banned. Use one of: text-2xs, text-xs, text-sm, text-base, text-lg, text-xl, text-2xl, text-3xl.",
         },
         {
           // Same, inside template literals.
           selector:
             "TemplateElement[value.cooked=/(?:^|\\s)text-\\[\\d+px\\](?:\\s|$)/]",
           message:
-            "Arbitrary font sizes are banned. Use one of: text-xs, text-sm, text-base, text-lg, text-xl, text-2xl, text-3xl.",
+            "Arbitrary font sizes are banned. Use one of: text-2xs, text-xs, text-sm, text-base, text-lg, text-xl, text-2xl, text-3xl.",
         },
         {
           // Raw palette: text-slate-500, bg-red-50, border-emerald-200, …

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -837,7 +837,22 @@
       },
       "detail": {
         "back": "Back to market list",
-        "addedCount": "Workspaces added"
+        "addedCount": "Workspaces added",
+        "contentTitle": "Capability contents",
+        "contentDescription": "Review the exact Skill files or MCP launch configuration before adding it to an Agent.",
+        "loadErrorTitle": "Failed to load capability contents",
+        "loadErrorDescription": "The latest published version could not be loaded.",
+        "contentUnavailable": "This older version does not contain previewable Skill or MCP content.",
+        "sourceRepository": "Source repository",
+        "sourceCommit": "Source commit",
+        "sourcePath": "Source path",
+        "skillBadge": "Skill files",
+        "files": "Files",
+        "command": "Launch command",
+        "environment": "Environment variables",
+        "noEnvironment": "No environment variables required.",
+        "redactedSecret": "Configured secret (hidden)",
+        "timeout": "Startup timeout: {{seconds}} seconds"
       },
       "empty": {
         "title": "No capabilities are available in the market yet",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -837,7 +837,22 @@
       },
       "detail": {
         "back": "返回市场列表",
-        "addedCount": "已添加工作区数"
+        "addedCount": "已添加工作区数",
+        "contentTitle": "能力内容",
+        "contentDescription": "添加到 Agent 前，可查看完整的 Skill 文件或 MCP 启动配置。",
+        "loadErrorTitle": "无法加载能力内容",
+        "loadErrorDescription": "无法读取最新发布版本。",
+        "contentUnavailable": "该旧版本未保存可预览的 Skill 或 MCP 内容。",
+        "sourceRepository": "来源仓库",
+        "sourceCommit": "来源提交",
+        "sourcePath": "来源路径",
+        "skillBadge": "Skill 文件",
+        "files": "文件",
+        "command": "启动命令",
+        "environment": "环境变量",
+        "noEnvironment": "不需要环境变量。",
+        "redactedSecret": "已配置 Secret（内容已隐藏）",
+        "timeout": "启动超时：{{seconds}} 秒"
       },
       "empty": {
         "title": "市场暂时没有可用的能力",

--- a/apps/web/src/lib/api-marketplace.ts
+++ b/apps/web/src/lib/api-marketplace.ts
@@ -25,6 +25,52 @@ export interface MarketplaceCapability extends Capability {
   pinned_version?: string
 }
 
+export interface MarketplaceCapabilityDetail {
+  capability_id: string
+  type: Capability["type"]
+  version_id: string
+  version: string
+  git_repo_url?: string
+  git_ref?: string
+  path?: string
+  skill?: MarketplaceSkillDetail
+  mcp?: MarketplaceMCPDetail
+}
+
+export interface MarketplaceSkillDetail {
+  slug: string
+  title: string
+  description?: string
+  instruction: string
+  trigger?: string
+  files?: MarketplaceSkillFile[]
+}
+
+export interface MarketplaceSkillFile {
+  path: string
+  content: string
+  kind: "markdown" | "script" | "asset"
+}
+
+export interface MarketplaceMCPDetail {
+  servers: MarketplaceMCPServer[]
+}
+
+export interface MarketplaceMCPServer {
+  name: string
+  command: string
+  args?: string[]
+  env?: Record<string, MarketplaceMCPEnvValue>
+  startup_timeout_sec?: number
+}
+
+export interface MarketplaceMCPEnvValue {
+  mode: "literal" | "inline_secret" | "credential_ref"
+  value?: string
+  credential_kind_code?: string
+  redacted?: boolean
+}
+
 export interface TargetMarketplaceInstall extends MarketplaceCapability {
   source_workspace_id: string
   source_workspace_name: string
@@ -51,6 +97,10 @@ interface MarketplaceListResponse {
   items?: MarketplaceCapability[]
 }
 
+interface MarketplaceDetailResponse {
+  capability: MarketplaceCapabilityDetail
+}
+
 interface TargetInstallsResponse {
   capabilities?: TargetMarketplaceInstall[]
   installs?: TargetMarketplaceInstall[]
@@ -69,6 +119,8 @@ interface EnabledAgentsResponse {
 }
 
 export const KEY_MARKETPLACE_LIST = (workspaceID: string) => ["admin", "capabilityMarketplace", workspaceID] as const
+export const KEY_MARKETPLACE_DETAIL = (workspaceID: string, capabilityID: string) =>
+  ["admin", "capabilityMarketplaceDetail", workspaceID, capabilityID] as const
 export const KEY_TARGET_MARKETPLACE_INSTALLS = (workspaceID: string) => ["admin", "targetMarketplaceInstalls", workspaceID] as const
 export const KEY_INSTALL_COUNT = (workspaceID: string, capabilityID: string) => ["admin", "capabilityInstallCount", workspaceID, capabilityID] as const
 export const KEY_MARKETPLACE_ENABLED_AGENTS = (workspaceID: string, capabilityID: string) => ["admin", "marketplaceEnabledAgents", workspaceID, capabilityID] as const
@@ -81,6 +133,18 @@ async function listMarketplace(workspaceID: string | null): Promise<MarketplaceC
   )
   if (Array.isArray(data)) return data
   return (data.capabilities ?? data.marketplace ?? data.items ?? []).map(normalizeMarketplaceCapability)
+}
+
+async function getMarketplaceDetail(
+  workspaceID: string | null,
+  capabilityID: string | null,
+): Promise<MarketplaceCapabilityDetail> {
+  if (!workspaceID || !capabilityID) throw new Error("workspace and capability are required")
+  const data = await apiRequest<MarketplaceDetailResponse>(
+    `/api/v1/capabilities/marketplace/${encodeURIComponent(capabilityID)}`,
+    { query: { workspace_id: workspaceID } },
+  )
+  return data.capability
 }
 
 async function listTargetInstalls(workspaceID: string | null): Promise<TargetMarketplaceInstall[]> {
@@ -154,6 +218,16 @@ export function useMarketplaceList(workspaceID: string | null) {
   return useQuery({
     queryKey: KEY_MARKETPLACE_LIST(workspaceID ?? "_none"),
     queryFn: () => listMarketplace(workspaceID),
+    retry: noUnreachableRetry,
+    staleTime: 30_000,
+  })
+}
+
+export function useMarketplaceDetail(workspaceID: string | null, capabilityID: string | null) {
+  return useQuery({
+    queryKey: KEY_MARKETPLACE_DETAIL(workspaceID ?? "_none", capabilityID ?? "_none"),
+    queryFn: () => getMarketplaceDetail(workspaceID, capabilityID),
+    enabled: !!workspaceID && !!capabilityID,
     retry: noUnreachableRetry,
     staleTime: 30_000,
   })

--- a/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
@@ -333,7 +333,7 @@ function SkillPreview({ skill }: { skill: MarketplaceSkillDetail }) {
       </div>
       <div className="grid min-h-[300px] md:grid-cols-[200px_minmax(0,1fr)]">
         <div className="border-b border-line bg-surface-muted/20 p-2 md:border-b-0 md:border-r">
-          <p className="px-2 pb-1.5 pt-0.5 text-xs font-medium uppercase tracking-wider text-fg-faint">
+          <p className="px-2 pb-1.5 pt-0.5 text-2xs font-medium uppercase tracking-wider text-fg-faint">
             {t("capabilities.marketplace.detail.files")}
           </p>
           <SkillFileTree
@@ -437,12 +437,12 @@ function SkillFileTreeItem({ node, selectedPath, onSelect, depth = 0 }: {
           aria-expanded={expanded}
           title={node.path}
           onClick={() => setExpanded((value) => !value)}
-          className="flex w-full items-center gap-1.5 rounded-sm py-1 pr-2 text-left text-xs text-fg-subtle transition-colors hover:bg-surface-muted/70 hover:text-fg"
+          className="flex w-full items-center gap-1.5 rounded-sm py-1 pr-2 text-left text-fg-subtle transition-colors hover:bg-surface-muted/70 hover:text-fg"
           style={{ paddingLeft: depth * 12 + 8 }}
         >
           <ChevronIcon className="h-3 w-3 shrink-0 text-fg-faint" />
           <FolderIcon className="h-3.5 w-3.5 shrink-0 text-fg-faint" />
-          <span className="truncate">{node.name}</span>
+          <span className="truncate text-2xs">{node.name}</span>
         </button>
         {expanded && node.children.map((child) => (
           <SkillFileTreeItem
@@ -465,7 +465,7 @@ function SkillFileTreeItem({ node, selectedPath, onSelect, depth = 0 }: {
       aria-pressed={selected}
       title={node.path}
       onClick={() => onSelect(node.path)}
-      className={`flex w-full items-center gap-1.5 rounded-sm py-1 pr-2 text-left text-xs transition-colors ${
+      className={`flex w-full items-center gap-1.5 rounded-sm py-1 pr-2 text-left transition-colors ${
         selected
           ? "bg-surface-muted text-fg"
           : "text-fg-subtle hover:bg-surface-muted/70 hover:text-fg"
@@ -473,7 +473,7 @@ function SkillFileTreeItem({ node, selectedPath, onSelect, depth = 0 }: {
       style={{ paddingLeft: depth * 12 + 24 }}
     >
       <Icon className="h-3.5 w-3.5 shrink-0 text-fg-faint" />
-      <span className="truncate">{node.name}</span>
+      <span className="truncate text-2xs">{node.name}</span>
     </button>
   )
 }

--- a/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { ArrowLeft, ArrowRight, PackageCheck, Search } from "lucide-react"
+import { ArrowLeft, ArrowRight, ChevronDown, ChevronRight, ExternalLink, File, FileText, Folder, FolderOpen, PackageCheck, Search, Server } from "lucide-react"
 
 import { Badge } from "../../../components/ui/badge"
 import { Button } from "../../../components/ui/button"
@@ -9,7 +9,7 @@ import { ErrorState } from "../../../components/ui/error-state"
 import { Input } from "../../../components/ui/input"
 import { Skeleton } from "../../../components/ui/skeleton"
 import { Tabs, TabsList, TabsTrigger } from "../../../components/ui/tabs"
-import { useMarketplaceList, type MarketplaceCapability, marketplaceSourceName } from "../../../lib/api-marketplace"
+import { marketplaceSourceName, useMarketplaceDetail, useMarketplaceList, type MarketplaceCapability, type MarketplaceCapabilityDetail, type MarketplaceMCPEnvValue, type MarketplaceSkillDetail } from "../../../lib/api-marketplace"
 import { useWorkspaceId } from "../../../lib/workspace"
 import { requiredCredentialsLabel } from "../capability-ui"
 import type { Capability } from "../../../lib/api-types"
@@ -173,7 +173,10 @@ function MarketplaceItemDetail({ capability, language, onBack, onInstall }: {
   onInstall: () => void
 }) {
   const { t } = useTranslation("admin")
+  const workspaceID = useWorkspaceId()
   const source = marketplaceSourceName(capability)
+  const previewable = capability.type === "mcp" || capability.type === "skill"
+  const detailQ = useMarketplaceDetail(workspaceID, previewable ? capability.id : null)
   return (
     <div className="space-y-3">
       <Button variant="ghost" size="sm" onClick={onBack}>
@@ -192,6 +195,36 @@ function MarketplaceItemDetail({ capability, language, onBack, onInstall }: {
           <Detail label={t("capabilities.table.credentials")} value={requiredCredentialsLabel(capability.required_credentials, language, t("capabilities.credentials.none"))} />
           <Detail label={t("capabilities.marketplace.detail.addedCount")} value={String(capability.install_count ?? capability.installed_workspace_count ?? 0)} />
         </div>
+        {previewable && (
+          <div className="mt-5 border-t border-line pt-5">
+            <div className="mb-3">
+              <h4 className="text-sm font-medium text-fg">
+                {t("capabilities.marketplace.detail.contentTitle")}
+              </h4>
+              <p className="mt-1 text-xs leading-5 text-fg-subtle">
+                {t("capabilities.marketplace.detail.contentDescription")}
+              </p>
+            </div>
+            {detailQ.isLoading ? (
+              <div className="space-y-2">
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-64 w-full" />
+              </div>
+            ) : detailQ.error ? (
+              <ErrorState
+                title={t("capabilities.marketplace.detail.loadErrorTitle")}
+                description={
+                  detailQ.error instanceof Error
+                    ? detailQ.error.message
+                    : t("capabilities.marketplace.detail.loadErrorDescription")
+                }
+                onRetry={() => void detailQ.refetch()}
+              />
+            ) : detailQ.data ? (
+              <MarketplaceContentPreview key={detailQ.data.capability_id} detail={detailQ.data} />
+            ) : null}
+          </div>
+        )}
         <div className="mt-5 flex justify-end">
           <Button size="sm" disabled={capability.self_published} onClick={onInstall}>
             {capability.self_published ? t("capabilities.marketplace.card.selfPublished") : t("capabilities.marketplace.card.install")}
@@ -200,6 +233,327 @@ function MarketplaceItemDetail({ capability, language, onBack, onInstall }: {
       </div>
     </div>
   )
+}
+
+function MarketplaceContentPreview({ detail }: { detail: MarketplaceCapabilityDetail }) {
+  const { t } = useTranslation("admin")
+  const sourceURL = safeExternalURL(detail.git_repo_url)
+  return (
+    <div className="space-y-4">
+      {(detail.git_repo_url || detail.git_ref || detail.path) && (
+        <div className="grid gap-3 rounded-lg border border-line bg-surface-muted/35 p-3 text-xs sm:grid-cols-3">
+          <SourceDetail
+            label={t("capabilities.marketplace.detail.sourceRepository")}
+            value={detail.git_repo_url}
+            href={sourceURL}
+          />
+          <SourceDetail
+            label={t("capabilities.marketplace.detail.sourceCommit")}
+            value={detail.git_ref}
+            mono
+          />
+          <SourceDetail
+            label={t("capabilities.marketplace.detail.sourcePath")}
+            value={detail.path}
+            mono
+          />
+        </div>
+      )}
+      {detail.skill ? <SkillPreview skill={detail.skill} /> : null}
+      {detail.mcp ? <MCPPreview detail={detail} /> : null}
+      {!detail.skill && !detail.mcp ? (
+        <p className="rounded-lg border border-line bg-surface-muted/20 p-4 text-sm text-fg-subtle">
+          {t("capabilities.marketplace.detail.contentUnavailable")}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function safeExternalURL(value?: string): string | undefined {
+  if (!value) return undefined
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function SourceDetail({
+  label,
+  value,
+  href,
+  mono,
+}: {
+  label: string
+  value?: string
+  href?: string
+  mono?: boolean
+}) {
+  if (!value) return <div />
+  return (
+    <div className="min-w-0">
+      <p className="text-fg-faint">{label}</p>
+      {href ? (
+        <a
+          href={href}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-1 flex items-center gap-1 break-all text-fg underline decoration-line-strong underline-offset-2 hover:decoration-fg"
+        >
+          <span>{value.replace(/^https?:\/\//, "")}</span>
+          <ExternalLink className="h-3 w-3 shrink-0" />
+        </a>
+      ) : (
+        <p className={`mt-1 break-all text-fg ${mono ? "font-mono" : ""}`}>{value}</p>
+      )}
+    </div>
+  )
+}
+
+function SkillPreview({ skill }: { skill: MarketplaceSkillDetail }) {
+  const { t } = useTranslation("admin")
+  const files = useMemo(
+    () => [
+      { path: "SKILL.md", content: skill.instruction, kind: "markdown" as const },
+      ...(skill.files ?? []),
+    ],
+    [skill],
+  )
+  const [selectedPath, setSelectedPath] = useState("SKILL.md")
+  const selected = files.find((file) => file.path === selectedPath) ?? files[0]
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-line">
+      <div className="flex items-center gap-2 border-b border-line bg-surface-muted/45 px-3 py-2">
+        <FileText className="h-3.5 w-3.5 text-fg-subtle" />
+        <span className="text-xs font-medium text-fg">{skill.title || skill.slug}</span>
+        <Badge variant="neutral">{t("capabilities.marketplace.detail.skillBadge")}</Badge>
+      </div>
+      <div className="grid min-h-[300px] md:grid-cols-[200px_minmax(0,1fr)]">
+        <div className="border-b border-line bg-surface-muted/20 p-2 md:border-b-0 md:border-r">
+          <p className="px-2 pb-1.5 pt-0.5 text-xs font-medium uppercase tracking-wider text-fg-faint">
+            {t("capabilities.marketplace.detail.files")}
+          </p>
+          <SkillFileTree
+            paths={files.map((file) => file.path)}
+            selectedPath={selected.path}
+            onSelect={setSelectedPath}
+          />
+        </div>
+        <div className="min-w-0 bg-surface-emphasis/[0.025]">
+          <div className="border-b border-line px-4 py-2 font-mono text-xs text-fg-subtle">
+            {selected.path}
+          </div>
+          <pre className="max-h-[480px] overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-xs leading-5 text-fg">
+            {selected.content}
+          </pre>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface SkillFileTreeNode {
+  name: string
+  path: string
+  directory: boolean
+  children: SkillFileTreeNode[]
+}
+
+function buildSkillFileTree(paths: string[]): SkillFileTreeNode[] {
+  const roots: SkillFileTreeNode[] = []
+
+  paths.forEach((path) => {
+    const parts = path.split("/")
+    let siblings = roots
+
+    parts.forEach((name, index) => {
+      const nodePath = parts.slice(0, index + 1).join("/")
+      let node = siblings.find((candidate) => candidate.name === name)
+      if (!node) {
+        node = {
+          name,
+          path: nodePath,
+          directory: index < parts.length - 1,
+          children: [],
+        }
+        siblings.push(node)
+      }
+      siblings = node.children
+    })
+  })
+
+  const sortNodes = (nodes: SkillFileTreeNode[]) => {
+    nodes.sort((left, right) => {
+      if (left.path === "SKILL.md") return -1
+      if (right.path === "SKILL.md") return 1
+      if (left.directory !== right.directory) return left.directory ? -1 : 1
+      return left.name.localeCompare(right.name)
+    })
+    nodes.forEach((node) => sortNodes(node.children))
+  }
+  sortNodes(roots)
+
+  return roots
+}
+
+function SkillFileTree({ paths, selectedPath, onSelect }: {
+  paths: string[]
+  selectedPath: string
+  onSelect: (path: string) => void
+}) {
+  const nodes = useMemo(() => buildSkillFileTree(paths), [paths])
+  return (
+    <div className="py-0.5">
+      {nodes.map((node) => (
+        <SkillFileTreeItem
+          key={node.path}
+          node={node}
+          selectedPath={selectedPath}
+          onSelect={onSelect}
+        />
+      ))}
+    </div>
+  )
+}
+
+function SkillFileTreeItem({ node, selectedPath, onSelect, depth = 0 }: {
+  node: SkillFileTreeNode
+  selectedPath: string
+  onSelect: (path: string) => void
+  depth?: number
+}) {
+  const [expanded, setExpanded] = useState(true)
+
+  if (node.directory) {
+    const ChevronIcon = expanded ? ChevronDown : ChevronRight
+    const FolderIcon = expanded ? FolderOpen : Folder
+    return (
+      <div>
+        <button
+          type="button"
+          aria-expanded={expanded}
+          title={node.path}
+          onClick={() => setExpanded((value) => !value)}
+          className="flex w-full items-center gap-1.5 rounded-sm py-1 pr-2 text-left text-xs text-fg-subtle transition-colors hover:bg-surface-muted/70 hover:text-fg"
+          style={{ paddingLeft: depth * 12 + 8 }}
+        >
+          <ChevronIcon className="h-3 w-3 shrink-0 text-fg-faint" />
+          <FolderIcon className="h-3.5 w-3.5 shrink-0 text-fg-faint" />
+          <span className="truncate">{node.name}</span>
+        </button>
+        {expanded && node.children.map((child) => (
+          <SkillFileTreeItem
+            key={child.path}
+            node={child}
+            selectedPath={selectedPath}
+            onSelect={onSelect}
+            depth={depth + 1}
+          />
+        ))}
+      </div>
+    )
+  }
+
+  const Icon = node.name.endsWith(".md") || node.name.endsWith(".mdx") ? FileText : File
+  const selected = node.path === selectedPath
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      title={node.path}
+      onClick={() => onSelect(node.path)}
+      className={`flex w-full items-center gap-1.5 rounded-sm py-1 pr-2 text-left text-xs transition-colors ${
+        selected
+          ? "bg-surface-muted text-fg"
+          : "text-fg-subtle hover:bg-surface-muted/70 hover:text-fg"
+      }`}
+      style={{ paddingLeft: depth * 12 + 24 }}
+    >
+      <Icon className="h-3.5 w-3.5 shrink-0 text-fg-faint" />
+      <span className="truncate">{node.name}</span>
+    </button>
+  )
+}
+
+function MCPPreview({ detail }: { detail: MarketplaceCapabilityDetail }) {
+  const { t } = useTranslation("admin")
+  return (
+    <div className="space-y-3">
+      {(detail.mcp?.servers ?? []).map((server) => {
+        const env = Object.entries(server.env ?? {}).sort(([left], [right]) =>
+          left.localeCompare(right),
+        )
+        const command = [server.command, ...(server.args ?? [])].map(formatCommandPart).join(" ")
+        return (
+          <div key={server.name} className="overflow-hidden rounded-lg border border-line">
+            <div className="flex items-center gap-2 border-b border-line bg-surface-muted/45 px-3 py-2">
+              <Server className="h-3.5 w-3.5 text-fg-subtle" />
+              <span className="font-mono text-xs font-medium text-fg">{server.name}</span>
+              <Badge variant="neutral">MCP</Badge>
+            </div>
+            <div className="space-y-4 p-4">
+              <div>
+                <p className="text-xs text-fg-subtle">
+                  {t("capabilities.marketplace.detail.command")}
+                </p>
+                <pre className="mt-1.5 overflow-x-auto rounded-md border border-line bg-surface-emphasis/[0.035] px-3 py-2 font-mono text-xs leading-5 text-fg">
+                  {command}
+                </pre>
+              </div>
+              <div>
+                <p className="text-xs text-fg-subtle">
+                  {t("capabilities.marketplace.detail.environment")}
+                </p>
+                {env.length === 0 ? (
+                  <p className="mt-1.5 text-xs text-fg-faint">
+                    {t("capabilities.marketplace.detail.noEnvironment")}
+                  </p>
+                ) : (
+                  <div className="mt-1.5 divide-y divide-line rounded-md border border-line">
+                    {env.map(([name, value]) => (
+                      <div
+                        key={name}
+                        className="grid gap-1 px-3 py-2 text-xs sm:grid-cols-[minmax(120px,0.45fr)_1fr]"
+                      >
+                        <span className="font-mono text-fg-subtle">{name}</span>
+                        <span className="break-all font-mono text-fg">
+                          {formatMCPEnvValue(
+                            value,
+                            t("capabilities.marketplace.detail.redactedSecret"),
+                          )}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+              {server.startup_timeout_sec ? (
+                <p className="text-xs text-fg-subtle">
+                  {t("capabilities.marketplace.detail.timeout", {
+                    seconds: server.startup_timeout_sec,
+                  })}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function formatCommandPart(value: string): string {
+  return /^[A-Za-z0-9_@%+=:,./-]+$/.test(value) ? value : JSON.stringify(value)
+}
+
+function formatMCPEnvValue(value: MarketplaceMCPEnvValue, redactedLabel: string): string {
+  if (value.mode === "literal") return value.value ?? ""
+  if (value.mode === "credential_ref")
+    return `\${PARSAR_CREDENTIAL:${value.credential_kind_code ?? "unknown"}}`
+  return redactedLabel
 }
 
 function Detail({ label, value, mono }: { label: string; value: string; mono?: boolean }) {

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -1,5 +1,13 @@
 @import "tailwindcss";
 
+/* Tailwind v4 does not emit a utility for this custom scale entry unless it
+   is declared explicitly. Keep the compact file-tree size in the design
+   system while making `text-2xs` usable by components. */
+@utility text-2xs {
+  font-size: var(--text-2xs);
+  line-height: var(--text-2xs--line-height);
+}
+
 /* Geist + Geist Mono are loaded via <link> in index.html (see note there) —
    not here, because Tailwind v4 inlines its own @import above this point,
    which would make a CSS @import spec-invalid and silently dropped. */
@@ -8,10 +16,11 @@
   --animate-fade-out: fade-out 2s ease-out forwards;
 
   /* ------------------------------------------------------------
-   * Type scale — 7 ticks. Every value maps to a Tailwind utility
-   * (`text-xs` … `text-3xl`). Arbitrary sizes (`text-[13px]`)
+   * Type scale — 8 ticks. Every value maps to a Tailwind utility
+   * (`text-2xs` … `text-3xl`). Arbitrary sizes (`text-[13px]`)
    * are forbidden by ESLint and will fail `make check`.
    * ---------------------------------------------------------- */
+  --text-2xs: 0.6875rem;  /* 11px — compact file trees and dense labels */
   --text-xs:   0.75rem;    /* 12px — badges, micro-meta, table footnotes */
   --text-sm:   0.8125rem;  /* 13px — default body in dense admin UI */
   --text-base: 0.875rem;   /* 14px — form labels, buttons, inputs */
@@ -21,6 +30,7 @@
   --text-3xl:  1.75rem;    /* 28px — page titles (display) */
 
   /* Line heights pinned per step so we don't fight `leading-*`. */
+  --text-2xs--line-height: 0.875rem;
   --text-xs--line-height:   1rem;
   --text-sm--line-height:   1.125rem;
   --text-base--line-height: 1.25rem;

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -2976,6 +2976,50 @@ paths:
       summary: List marketplace capabilities
       tags:
       - capabilities
+  /api/v1/capabilities/marketplace/{capabilityID}:
+    get:
+      description: Returns the latest public MCP or Skill definition. Inline secret
+        IDs are redacted.
+      operationId: getDevMarketplaceCapabilityDetail
+      parameters:
+      - description: Capability UUID
+        in: path
+        name: capabilityID
+        required: true
+        type: string
+      - description: Workspace UUID (falls back to X-Parsar-Workspace-ID header)
+        in: query
+        name: workspace_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Marketplace capability detail
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: workspace_id or capabilityID is invalid
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Caller is not an active workspace member
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Capability is not available in the Marketplace
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get marketplace capability detail
+      tags:
+      - capabilities
   /api/v1/connections/github/callback:
     get:
       description: Verifies CSRF state, exchanges the code for a GitHub access token,

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -3530,7 +3530,7 @@ select id::text as id, capability_id::text as capability_id, version,
   git_repo_url, git_ref, path, content,
   source_payload, schema_version, canonical_spec,
   required_credentials, oss_key, sha256,
-  creator_id::text as creator_id, created_at
+  (case when creator_id is null then ''::text else creator_id::text end)::text as creator_id, created_at
 from capability_version
 where id = @id::uuid;
 

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -4535,7 +4535,7 @@ select id::text as id, capability_id::text as capability_id, version,
   git_repo_url, git_ref, path, content,
   source_payload, schema_version, canonical_spec,
   required_credentials, oss_key, sha256,
-  creator_id::text as creator_id, created_at
+  (case when creator_id is null then ''::text else creator_id::text end)::text as creator_id, created_at
 from capability_version
 where id = $1::uuid
 `

--- a/server/internal/dev/capability_routes.go
+++ b/server/internal/dev/capability_routes.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
 )
 
 type capabilityBody struct {
@@ -109,6 +109,37 @@ func lookupBuiltinCapability(key string) (builtinCapability, bool) {
 
 type uninstallMarketplaceBody struct {
 	SourceCapabilityID string `json:"source_capability_id"`
+}
+
+type marketplaceCapabilityDetail struct {
+	CapabilityID string                 `json:"capability_id"`
+	Type         string                 `json:"type"`
+	VersionID    string                 `json:"version_id"`
+	Version      string                 `json:"version"`
+	GitRepoURL   string                 `json:"git_repo_url,omitempty"`
+	GitRef       string                 `json:"git_ref,omitempty"`
+	Path         string                 `json:"path,omitempty"`
+	Skill        *canonical.SkillSpec   `json:"skill,omitempty"`
+	MCP          *marketplaceMCPPreview `json:"mcp,omitempty"`
+}
+
+type marketplaceMCPPreview struct {
+	Servers []marketplaceMCPServerPreview `json:"servers"`
+}
+
+type marketplaceMCPServerPreview struct {
+	Name              string                            `json:"name"`
+	Command           string                            `json:"command"`
+	Args              []string                          `json:"args,omitempty"`
+	Env               map[string]marketplaceMCPEnvValue `json:"env,omitempty"`
+	StartupTimeoutSec int                               `json:"startup_timeout_sec,omitempty"`
+}
+
+type marketplaceMCPEnvValue struct {
+	Mode               canonical.EnvMode `json:"mode"`
+	Value              string            `json:"value,omitempty"`
+	CredentialKindCode string            `json:"credential_kind_code,omitempty"`
+	Redacted           bool              `json:"redacted,omitempty"`
 }
 
 type upgradeAgentCapabilityBody struct {
@@ -246,11 +277,11 @@ func listWorkspaceCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 		}
 
 		type mergedRow struct {
-			OwnIndex     int // -1 when this row is a marketplace install
-			MarketIndex  int // -1 when this row is an own capability
-			Name         string
-			CreatedAt    time.Time
-			IsInstall    bool
+			OwnIndex    int // -1 when this row is a marketplace install
+			MarketIndex int // -1 when this row is an own capability
+			Name        string
+			CreatedAt   time.Time
+			IsInstall   bool
 		}
 		merged := make([]mergedRow, 0, len(caps)+len(marketplaceInstalls))
 		for i, c := range caps {
@@ -339,6 +370,152 @@ func listMarketplaceCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 		}
 		writeJSON(w, http.StatusOK, map[string]any{"workspace_id": workspaceID, "capabilities": capabilities})
 	}
+}
+
+// getMarketplaceCapabilityDetail returns the latest public MCP/Skill body on
+// demand so list responses stay lightweight.
+//
+//	@Summary		Get marketplace capability detail
+//	@Description	Returns the latest public MCP or Skill definition. Inline secret IDs are redacted.
+//	@Tags			capabilities
+//	@ID			getDevMarketplaceCapabilityDetail
+//	@Produce		json
+//	@Param			capabilityID	path	string	true	"Capability UUID"
+//	@Param			workspace_id	query	string	false	"Workspace UUID (falls back to X-Parsar-Workspace-ID header)"
+//	@Success		200 {object} map[string]interface{} "Marketplace capability detail"
+//	@Failure		400 {object} map[string]string "workspace_id or capabilityID is invalid"
+//	@Failure		403 {object} map[string]string "Caller is not an active workspace member"
+//	@Failure		404 {object} map[string]string "Capability is not available in the Marketplace"
+//	@Router			/api/v1/capabilities/marketplace/{capabilityID} [get]
+func getMarketplaceCapabilityDetail(runtimeStore RuntimeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		workspaceID := strings.TrimSpace(r.URL.Query().Get("workspace_id"))
+		if workspaceID == "" {
+			workspaceID = strings.TrimSpace(r.Header.Get("X-Parsar-Workspace-ID"))
+		}
+		if !isUUID(workspaceID) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
+			return
+		}
+		capabilityID := strings.TrimSpace(chi.URLParam(r, "capabilityID"))
+		if !isUUID(capabilityID) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "capabilityID must be a valid uuid"})
+			return
+		}
+		if runtimeStore == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed capability APIs are disabled"})
+			return
+		}
+		if err := requireWorkspaceMember(r, runtimeStore, workspaceID); err != nil {
+			writeRBACError(w, err)
+			return
+		}
+
+		capabilities, err := runtimeStore.ListMarketplaceCapabilities(r.Context(), workspaceID)
+		if err != nil {
+			writeCapabilityError(w, err, "failed to load marketplace capability")
+			return
+		}
+		var capability *store.MarketplaceCapabilityRead
+		for i := range capabilities {
+			if capabilities[i].CapabilityID == capabilityID {
+				capability = &capabilities[i]
+				break
+			}
+		}
+		if capability == nil || capability.Visibility != "public" || capability.Status != "active" || capability.DeprecatedAt != nil || !isPreviewableMarketplaceType(capability.Type) {
+			writeCapabilityError(w, fmt.Errorf("%w: %s", store.ErrUnknownCapability, capabilityID), "failed to load marketplace capability")
+			return
+		}
+
+		version, err := runtimeStore.GetCapabilityVersion(r.Context(), capability.LatestVersionID)
+		if err != nil {
+			writeCapabilityError(w, err, "failed to load marketplace capability version")
+			return
+		}
+		detail, err := buildMarketplaceCapabilityDetail(*capability, version)
+		if err != nil {
+			writeCapabilityError(w, err, "marketplace capability detail is invalid")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"capability": detail})
+	}
+}
+
+func isPreviewableMarketplaceType(capabilityType string) bool {
+	switch strings.ToLower(strings.TrimSpace(capabilityType)) {
+	case string(canonical.KindMCP), string(canonical.KindSkill):
+		return true
+	default:
+		return false
+	}
+}
+
+func buildMarketplaceCapabilityDetail(capability store.MarketplaceCapabilityRead, version store.CapabilityVersionRead) (marketplaceCapabilityDetail, error) {
+	detail := marketplaceCapabilityDetail{
+		CapabilityID: capability.CapabilityID,
+		Type:         capability.Type,
+		VersionID:    version.ID,
+		Version:      version.Version,
+		GitRepoURL:   version.GitRepoURL,
+		GitRef:       version.GitRef,
+		Path:         version.Path,
+	}
+	if len(version.CanonicalSpec) == 0 {
+		return detail, nil
+	}
+	var spec canonical.Spec
+	if err := json.Unmarshal(version.CanonicalSpec, &spec); err != nil {
+		return detail, fmt.Errorf("decode marketplace canonical spec: %w", err)
+	}
+	if err := spec.Validate(); err != nil {
+		return detail, fmt.Errorf("validate marketplace canonical spec: %w", err)
+	}
+	if string(spec.Kind) != strings.ToLower(strings.TrimSpace(capability.Type)) {
+		return detail, fmt.Errorf("marketplace capability type %q does not match canonical kind %q", capability.Type, spec.Kind)
+	}
+
+	switch spec.Kind {
+	case canonical.KindSkill:
+		detail.Skill = spec.Skill
+	case canonical.KindMCP:
+		detail.MCP = previewMarketplaceMCP(spec.MCP)
+	default:
+		return detail, fmt.Errorf("marketplace capability type %q is not previewable", spec.Kind)
+	}
+	return detail, nil
+}
+
+func previewMarketplaceMCP(spec *canonical.MCPSpec) *marketplaceMCPPreview {
+	if spec == nil {
+		return nil
+	}
+	preview := &marketplaceMCPPreview{Servers: make([]marketplaceMCPServerPreview, 0, len(spec.Servers))}
+	for _, server := range spec.Servers {
+		item := marketplaceMCPServerPreview{
+			Name:              server.Name,
+			Command:           server.Command,
+			Args:              append([]string(nil), server.Args...),
+			StartupTimeoutSec: server.StartupTimeoutSec,
+		}
+		if len(server.Env) > 0 {
+			item.Env = make(map[string]marketplaceMCPEnvValue, len(server.Env))
+			for name, value := range server.Env {
+				previewValue := marketplaceMCPEnvValue{Mode: value.Mode}
+				switch value.Mode {
+				case canonical.EnvModeLiteral:
+					previewValue.Value = value.Literal
+				case canonical.EnvModeCredentialRef:
+					previewValue.CredentialKindCode = value.CredentialKindCode
+				case canonical.EnvModeInlineSecret:
+					previewValue.Redacted = true
+				}
+				item.Env[name] = previewValue
+			}
+		}
+		preview.Servers = append(preview.Servers, item)
+	}
+	return preview
 }
 
 // listWorkspaceMarketplaceInstalls returns the marketplace capabilities the

--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -609,6 +609,7 @@ func RegisterRoutesWithStore(r chi.Router, runtimeStore RuntimeStore, opts ...Ro
 			// whether the provider is reachable.
 			r.Get("/workspaces/{workspaceID}/runtime/status", gateWorkspaceMember(runtimeStore, runtimeStatus(cfg.runtimeStatus)))
 			r.Get("/capabilities/marketplace", listMarketplaceCapabilities(runtimeStore))
+			r.Get("/capabilities/marketplace/{capabilityID}", getMarketplaceCapabilityDetail(runtimeStore))
 			r.Get("/workspaces/{workspaceID}/capabilities", listWorkspaceCapabilities(runtimeStore))
 			r.Post("/workspaces/{workspaceID}/capabilities", createWorkspaceCapability(runtimeStore))
 			// Capability import — preview is a pure parse; commit runs

--- a/server/internal/dev/routes_capability_test.go
+++ b/server/internal/dev/routes_capability_test.go
@@ -9,11 +9,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 const (
@@ -223,6 +224,13 @@ func TestCapabilityMarketplaceCrossWorkspaceEnableUpgradeUninstallAndReverseQuer
 	if market.Code != http.StatusOK || !strings.Contains(market.Body.String(), `"installed":true`) || strings.Contains(market.Body.String(), foreignWorkspaceID) {
 		t.Fatalf("marketplace list expected installed without source workspace id leak, got %d: %s", market.Code, market.Body.String())
 	}
+	if _, err := db.Exec(context.Background(), `update capability_version set creator_id = null where id = $1`, v2); err != nil {
+		t.Fatal(err)
+	}
+	detail := serveCapabilityRoute(t, r, http.MethodGet, "/api/v1/capabilities/marketplace/"+capID+"?workspace_id="+store.DefaultDevFixtureIDs().WorkspaceID, ``, testUserAID)
+	if detail.Code != http.StatusOK || !strings.Contains(detail.Body.String(), `"version":"v2"`) {
+		t.Fatalf("marketplace detail with nullable creator expected 200/v2, got %d: %s", detail.Code, detail.Body.String())
+	}
 	upgraded := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/agents/"+agentA+"/capabilities/"+capID+"/upgrade", `{"new_version_id":"`+v2+`"}`, testUserAID)
 	if upgraded.Code != http.StatusOK || !strings.Contains(upgraded.Body.String(), v2) {
 		t.Fatalf("upgrade expected 200/v2, got %d: %s", upgraded.Code, upgraded.Body.String())
@@ -239,6 +247,113 @@ func TestCapabilityMarketplaceCrossWorkspaceEnableUpgradeUninstallAndReverseQuer
 	if uninstalled.Code != http.StatusOK || !strings.Contains(uninstalled.Body.String(), `"removed_agent_count":2`) {
 		t.Fatalf("uninstall expected remove 2, got %d: %s", uninstalled.Code, uninstalled.Body.String())
 	}
+}
+
+type marketplaceDetailStore struct {
+	stubRuntimeStore
+	capability store.MarketplaceCapabilityRead
+	version    store.CapabilityVersionRead
+}
+
+func (s marketplaceDetailStore) ListMarketplaceCapabilities(context.Context, string) ([]store.MarketplaceCapabilityRead, error) {
+	return []store.MarketplaceCapabilityRead{s.capability}, nil
+}
+
+func (s marketplaceDetailStore) GetCapabilityVersion(context.Context, string) (store.CapabilityVersionRead, error) {
+	return s.version, nil
+}
+
+func TestMarketplaceCapabilityDetailShowsSkillAndRedactsMCPSecret(t *testing.T) {
+	const (
+		workspaceID  = "00000000-0000-0000-0000-000000000001"
+		capabilityID = "00000000-0000-0000-0000-000000000099"
+		versionID    = "00000000-0000-0000-0000-000000000098"
+		secretID     = "00000000-0000-0000-0000-000000000097"
+	)
+
+	t.Run("skill", func(t *testing.T) {
+		spec, err := json.Marshal(canonical.Spec{
+			SchemaVersion: canonical.SchemaVersionCurrent,
+			Kind:          canonical.KindSkill,
+			Skill: &canonical.SkillSpec{
+				Slug:        "diagram-maker",
+				Title:       "Diagram Maker",
+				Description: "Draw diagrams",
+				Instruction: "# Diagram Maker\nRender a clear SVG.",
+				Files:       []canonical.SkillFile{{Path: "references/svg.md", Content: "SVG reference", Kind: canonical.SkillFileKindMarkdown}},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		runtimeStore := marketplaceDetailStore{
+			capability: store.MarketplaceCapabilityRead{CapabilityID: capabilityID, Type: "skill", Visibility: "public", Status: "active", LatestVersionID: versionID},
+			version:    store.CapabilityVersionRead{ID: versionID, CapabilityID: capabilityID, Version: "v1", GitRepoURL: "https://example.com/skills", GitRef: "abc123", Path: "skills/diagram-maker", CanonicalSpec: spec},
+		}
+		r := chi.NewRouter()
+		RegisterRoutesWithStore(r, runtimeStore)
+		res := serveCapabilityRoute(t, r, http.MethodGet, "/api/v1/capabilities/marketplace/"+capabilityID+"?workspace_id="+workspaceID, "", store.DefaultDevFixtureIDs().UserID)
+		if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), "Render a clear SVG") || !strings.Contains(res.Body.String(), "references/svg.md") {
+			t.Fatalf("skill detail expected content, got %d: %s", res.Code, res.Body.String())
+		}
+	})
+
+	t.Run("mcp redacts inline secret id", func(t *testing.T) {
+		spec, err := json.Marshal(canonical.Spec{
+			SchemaVersion: canonical.SchemaVersionCurrent,
+			Kind:          canonical.KindMCP,
+			MCP: &canonical.MCPSpec{Servers: []canonical.MCPServer{{
+				Name:    "github",
+				Command: "npx",
+				Args:    []string{"-y", "server"},
+				Env: map[string]canonical.EnvValue{
+					"HOST":  {Mode: canonical.EnvModeLiteral, Literal: "https://api.example.com"},
+					"TOKEN": {Mode: canonical.EnvModeInlineSecret, SecretID: secretID},
+					"PAT":   {Mode: canonical.EnvModeCredentialRef, CredentialKindCode: "github_pat"},
+				},
+			}}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		runtimeStore := marketplaceDetailStore{
+			capability: store.MarketplaceCapabilityRead{CapabilityID: capabilityID, Type: "mcp", Visibility: "public", Status: "active", LatestVersionID: versionID},
+			version:    store.CapabilityVersionRead{ID: versionID, CapabilityID: capabilityID, Version: "v1", CanonicalSpec: spec},
+		}
+		r := chi.NewRouter()
+		RegisterRoutesWithStore(r, runtimeStore)
+		res := serveCapabilityRoute(t, r, http.MethodGet, "/api/v1/capabilities/marketplace/"+capabilityID+"?workspace_id="+workspaceID, "", store.DefaultDevFixtureIDs().UserID)
+		body := res.Body.String()
+		if res.Code != http.StatusOK || !strings.Contains(body, `"redacted":true`) || !strings.Contains(body, `"credential_kind_code":"github_pat"`) || !strings.Contains(body, "https://api.example.com") {
+			t.Fatalf("MCP detail expected sanitized config, got %d: %s", res.Code, body)
+		}
+		if strings.Contains(body, secretID) {
+			t.Fatalf("MCP detail leaked inline secret id: %s", body)
+		}
+	})
+
+	t.Run("private capability is hidden", func(t *testing.T) {
+		runtimeStore := marketplaceDetailStore{capability: store.MarketplaceCapabilityRead{CapabilityID: capabilityID, Type: "skill", Visibility: "workspace", Status: "active", LatestVersionID: versionID}}
+		r := chi.NewRouter()
+		RegisterRoutesWithStore(r, runtimeStore)
+		res := serveCapabilityRoute(t, r, http.MethodGet, "/api/v1/capabilities/marketplace/"+capabilityID+"?workspace_id="+workspaceID, "", store.DefaultDevFixtureIDs().UserID)
+		if res.Code != http.StatusNotFound {
+			t.Fatalf("private capability expected 404, got %d: %s", res.Code, res.Body.String())
+		}
+	})
+
+	t.Run("legacy version returns source metadata without failing", func(t *testing.T) {
+		runtimeStore := marketplaceDetailStore{
+			capability: store.MarketplaceCapabilityRead{CapabilityID: capabilityID, Type: "skill", Visibility: "public", Status: "active", LatestVersionID: versionID},
+			version:    store.CapabilityVersionRead{ID: versionID, CapabilityID: capabilityID, Version: "legacy", GitRepoURL: "https://example.com/legacy", Path: "skills/legacy"},
+		}
+		r := chi.NewRouter()
+		RegisterRoutesWithStore(r, runtimeStore)
+		res := serveCapabilityRoute(t, r, http.MethodGet, "/api/v1/capabilities/marketplace/"+capabilityID+"?workspace_id="+workspaceID, "", store.DefaultDevFixtureIDs().UserID)
+		if res.Code != http.StatusOK || !strings.Contains(res.Body.String(), `"git_repo_url":"https://example.com/legacy"`) {
+			t.Fatalf("legacy detail expected source metadata, got %d: %s", res.Code, res.Body.String())
+		}
+	})
 }
 
 // TestInstallCountRejectsCrossWorkspace verifies that GET


### PR DESCRIPTION
## What & why

Marketplace cards currently expose only summary metadata, so workspace members cannot inspect the exact Skill instructions, supporting files, or MCP launch configuration before adding a capability to an Agent. This adds an authorized, read-only preview flow for public MCP and Skill entries.

## How

- add a workspace-scoped marketplace detail endpoint for the latest public MCP or Skill version
- require active workspace membership before returning marketplace content
- redact inline secret identifiers from MCP environment values
- return Skill instructions and supporting files, or MCP command, arguments, environment, and source metadata
- add a compact, collapsible Skill file tree using the existing typography tokens
- restrict external source links to HTTP and HTTPS
- handle nullable creator IDs used by the built-in catalog
- add route coverage for authorization, Skill files, MCP redaction, and unsupported capability types

## Verification

- [x] `make check`
- [x] Manual smoke: opened Diagram Maker from the local marketplace and verified file selection and folder collapse
- [x] Manual API smoke: verified the five built-in marketplace entries return their expected MCP or Skill detail

## Notes for reviewers

The endpoint is read-only and does not change installation or Agent binding behavior. Plugin and System Prompt entries remain metadata-only.