### PR TITLE
feat: add durable approval and user-input loops

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,16 @@ description and keep ownership on the side listed here.
   protocol request and defer the engine response until
   `SubmitPermission` / `SubmitPromptForUserChoice` arrives. Adapters must not
   silently approve, deny, or synthesize empty answers as a fallback.
+- Codex agents that may call `request_user_input` use `config.mode=plan`.
+  Prompt wording cannot unlock the tool in default mode; the daemon must pass
+  the configured mode through app-server `turn/start.collaborationMode`.
+  Agent create/profile configuration owns this persisted value, accepts only
+  `default` or `plan` for Codex, and clears it when switching engines.
+- Daemon-originated approval and question envelopes keep `Envelope.ID` equal
+  to the run ID so the server can deliver them to the active subscriber. Put
+  the daemon-minted interaction handle in payload `request_id` / `ask_id`;
+  legacy permission IDs in `Envelope.ID` are read only for decision-routing
+  compatibility.
 - Persist the run event and its derived `agent_interactions` row in one
   transaction before publishing an approval or question to SSE/IM surfaces.
   If that canonical write fails, abort the run instead of exposing an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,42 @@ description and keep ownership on the side listed here.
   under `~/.parsar/`; never use the repo checkout, container image working
   directory, or the process CWD as hidden state.
 
+### Human interaction lifecycle
+
+- `agent_interactions` is the canonical durable record for permission prompts
+  and `AskUserQuestion` / `requestUserInput` requests. The Web approval inbox,
+  conversation SSE notices, and IM cards are presentation surfaces over that
+  record.
+- The active Web conversation renders its pending durable interactions as full
+  decision cards. SSE request IDs may prioritize a newly emitted card, but the
+  workspace interaction query must restore the card after refresh. The inbox
+  remains the workspace-wide queue, and both surfaces reuse the same decision
+  component and resolution API.
+- `conversations.metadata.gateway_inflight.permission` and
+  `prompt_for_user_choice` remain channel delivery slots only. Do not make a
+  runtime response depend on an IM card having been rendered first.
+- A daemon adapter that supports approval or user input must emit the shared
+  protocol request and defer the engine response until
+  `SubmitPermission` / `SubmitPromptForUserChoice` arrives. Adapters must not
+  silently approve, deny, or synthesize empty answers as a fallback.
+- Web and IM responders must call the same interaction resolution service.
+  Routes and card callbacks must not implement their own status transition or
+  deliver to the runtime before the canonical compare-and-swap claim succeeds.
+- Question answers use the stable question ID from the adapter and preserve
+  selected values as an array. Headers and positional answers are compatibility
+  fields only; they are not durable identity.
+- Every deferred request has a bounded lifetime. The server expiry worker is
+  authoritative: it explicitly denies a permission or cancels user input,
+  unblocks the runtime, and leaves an `expired` terminal record. Daemon timers
+  are a safety net and must make the same deny/cancel choice. Neither path may
+  silently continue the requested action.
+- Human responses are workspace-scoped, reject viewer writes, claim a single
+  winner before contacting the runtime, persist a terminal state, clear the
+  matching inflight slot, and emit an approval audit event. A terminal run
+  cancels any still-open interactions. Multi-pod daemon routing resolves
+  `request_id` through the canonical interaction's `device_id`; IM slots are
+  only a legacy fallback.
+
 ### Sandbox and local runtime lifecycle
 
 - The default local install path provides one ready-to-use sandbox runtime.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,17 +179,41 @@ description and keep ownership on the side listed here.
   protocol request and defer the engine response until
   `SubmitPermission` / `SubmitPromptForUserChoice` arrives. Adapters must not
   silently approve, deny, or synthesize empty answers as a fallback.
+- Persist the run event and its derived `agent_interactions` row in one
+  transaction before publishing an approval or question to SSE/IM surfaces.
+  If that canonical write fails, abort the run instead of exposing an
+  actionable card that cannot be claimed or recovered.
 - Web and IM responders must call the same interaction resolution service.
   Routes and card callbacks must not implement their own status transition or
   deliver to the runtime before the canonical compare-and-swap claim succeeds.
 - Question answers use the stable question ID from the adapter and preserve
   selected values as an array. Headers and positional answers are compatibility
   fields only; they are not durable identity.
+- Preserve adapter question metadata end to end. `is_other=false` forbids a
+  free-text answer, `is_secret=true` uses a masked input wherever that surface
+  collects free text, and secret answer values may travel to the waiting
+  runtime but must be redacted from
+  `agent_interactions.response`, interaction-resolution run and audit events,
+  logs, API reads, and rendered chat receipts or callback summaries.
 - Every deferred request has a bounded lifetime. The server expiry worker is
   authoritative: it explicitly denies a permission or cancels user input,
   unblocks the runtime, and leaves an `expired` terminal record. Daemon timers
   are a safety net and must make the same deny/cancel choice. Neither path may
   silently continue the requested action.
+- A server-to-daemon WebSocket write is not proof that the engine accepted a
+  decision. The daemon must return an application-level decision ack after
+  `SubmitPermission` / `SubmitPromptForUserChoice` succeeds; only then may the
+  server persist the terminal interaction state. Missing or negative acks keep
+  the canonical interaction retryable (except a definitive `not_pending` or
+  replay `decision_conflict`, which closes it as runtime-gone).
+- Every transport attempt uses a unique delivery ID so a late ack cannot
+  satisfy a newer resolver. Daemon replay is keyed by runtime request plus the
+  decision payload with that delivery ID excluded: identical retries are
+  acknowledged without a second apply, while changed retries conflict.
+- The decision-ack wire contract starts at agent-daemon protocol `0.2`.
+  Server and daemon keep the existing strict major/minor handshake so a `0.1`
+  peer fails closed and must be upgraded instead of applying an unacknowledged
+  decision during a rolling-version mismatch.
 - Human responses are workspace-scoped, reject viewer writes, claim a single
   winner before contacting the runtime, persist a terminal state, clear the
   matching inflight slot, and emit an approval audit event. A terminal run

--- a/apps/parsar-daemon/internal/agent/claudecode/ask.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/ask.go
@@ -297,7 +297,10 @@ func parseAskUserQuestionInput(input map[string]any) ([]proto.PromptForUserChoic
 			Header:      header,
 			Question:    question,
 			MultiSelect: multiSelect,
-			Options:     options,
+			// Claude Code's AskUserQuestion always permits the built-in
+			// "Other" free-text answer in addition to declared options.
+			IsOther: true,
+			Options: options,
 		})
 	}
 	return out, true

--- a/apps/parsar-daemon/internal/agent/claudecode/ask.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/ask.go
@@ -2,6 +2,7 @@ package claudecode
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 
@@ -262,7 +263,7 @@ func parseAskUserQuestionInput(input map[string]any) ([]proto.PromptForUserChoic
 	}
 
 	out := make([]proto.PromptForUserChoiceQuestion, 0, len(list))
-	for _, rawEntry := range list {
+	for index, rawEntry := range list {
 		q, isMap := rawEntry.(map[string]any)
 		if !isMap {
 			return nil, false
@@ -292,6 +293,7 @@ func parseAskUserQuestionInput(input map[string]any) ([]proto.PromptForUserChoic
 			return nil, false
 		}
 		out = append(out, proto.PromptForUserChoiceQuestion{
+			ID:          fmt.Sprintf("q%d", index),
 			Header:      header,
 			Question:    question,
 			MultiSelect: multiSelect,
@@ -395,12 +397,9 @@ func formatAskUserResultText(entry pendingAskEntry, decision proto.PromptForUser
 		}
 	}
 
-	// Multi-question path: pair answers with questions by INDEX, not by
-	// Header. Two questions can share the same Header (or both be blank
-	// — claude-code's AskUserQuestion treats `header` as optional), so a
-	// header-keyed map would collapse them and feed the model the wrong
-	// answer. inbound builds QuestionAnswers in the same order as
-	// entry.Questions, so positional indexing is the source of truth.
+	// Multi-question path: stable QuestionID is authoritative. Positional
+	// pairing remains only as a compatibility fallback for older peers;
+	// Header is never a key because duplicate or blank headers are valid.
 	if len(entry.Questions) > 0 {
 		out := make([]map[string]any, 0, len(entry.Questions))
 		anyAnswer := false
@@ -419,6 +418,18 @@ func formatAskUserResultText(entry pendingAskEntry, decision proto.PromptForUser
 			answer := ""
 			if i < len(decision.QuestionAnswers) {
 				answer = decision.QuestionAnswers[i].Answer
+				if len(decision.QuestionAnswers[i].Answers) > 0 {
+					answer = strings.Join(decision.QuestionAnswers[i].Answers, "、")
+				}
+			}
+			for _, candidate := range decision.QuestionAnswers {
+				if q.ID != "" && candidate.QuestionID == q.ID {
+					answer = candidate.Answer
+					if len(candidate.Answers) > 0 {
+						answer = strings.Join(candidate.Answers, "、")
+					}
+					break
+				}
 			}
 			// Legacy callback path: a single-question slot answered via
 			// the flat Answers slice. Multi-question slots always populate

--- a/apps/parsar-daemon/internal/agent/claudecode/ask_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/ask_test.go
@@ -337,6 +337,35 @@ func TestBuildAskUserToolResultMultiQuestionPositional(t *testing.T) {
 	}
 }
 
+func TestBuildAskUserToolResultMatchesStableQuestionIDs(t *testing.T) {
+	body, err := claudecode.BuildAskUserToolResultForTest(
+		claudecode.PendingAskEntry{
+			ToolUseID: "toolu_ids",
+			Questions: []proto.PromptForUserChoiceQuestion{
+				{ID: "environment", Header: "Environment"},
+				{ID: "checks", Header: "Checks"},
+			},
+		},
+		proto.PromptForUserChoiceDecisionPayload{
+			QuestionAnswers: []proto.PromptForUserChoiceQuestionAnswer{
+				{QuestionID: "checks", Answers: []string{"Unit", "Integration"}},
+				{QuestionID: "environment", Answers: []string{"Staging"}},
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("buildAskUserToolResult: %v", err)
+	}
+	v := decodeAskResult(t, body)
+	text := v.Message.Content[0].Content[0].Text
+	if !strings.Contains(text, `"answer":"Staging","header":"Environment"`) {
+		t.Fatalf("stable environment answer missing: %s", text)
+	}
+	if !strings.Contains(text, `"answer":"Unit、Integration","header":"Checks"`) {
+		t.Fatalf("stable multi-select answer missing: %s", text)
+	}
+}
+
 // TestBuildAskUserToolResultTimeoutKeepsSuccessShape is the contract
 // "don't trigger a retry": even on timeout we set is_error=false and
 // rely on the body text to redirect the agent.

--- a/apps/parsar-daemon/internal/agent/claudecode/parser.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/parser.go
@@ -325,10 +325,11 @@ func (t *translator) translateControlRequest(line []byte) (translation, error) {
 	if title == "" {
 		title = "Permission request"
 	}
-	env, err := proto.NewEnvelope(proto.TypePermissionRequest, permID, proto.PermissionRequestPayload{
-		Tool:    msg.Request.ToolName,
-		Title:   title,
-		Payload: msg.Request.Input,
+	env, err := proto.NewEnvelope(proto.TypePermissionRequest, t.runID, proto.PermissionRequestPayload{
+		RequestID: permID,
+		Tool:      msg.Request.ToolName,
+		Title:     title,
+		Payload:   msg.Request.Input,
 	})
 	if err != nil {
 		return translation{}, err

--- a/apps/parsar-daemon/internal/agent/claudecode/parser_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/parser_test.go
@@ -223,15 +223,16 @@ func TestTranslateControlRequestMintsPermIDAndRecords(t *testing.T) {
 		t.Fatalf("want one permission_request env, got %#v", out.Envelopes)
 	}
 	env := out.Envelopes[0]
-	if env.ID != "perm_001" {
-		t.Errorf("env.ID = %q, want perm_001", env.ID)
+	if env.ID != "run_z" {
+		t.Errorf("env.ID = %q, want run_z", env.ID)
 	}
 	pr := mustDecode[struct {
-		Tool    string         `json:"tool"`
-		Title   string         `json:"title"`
-		Payload map[string]any `json:"payload"`
+		RequestID string         `json:"request_id"`
+		Tool      string         `json:"tool"`
+		Title     string         `json:"title"`
+		Payload   map[string]any `json:"payload"`
 	}](t, env.Payload)
-	if pr.Tool != "Bash" || pr.Title != "Bash" {
+	if pr.RequestID != "perm_001" || pr.Tool != "Bash" || pr.Title != "Bash" {
 		t.Errorf("permission payload mismatch: %+v", pr)
 	}
 	if pr.Payload["command"] != "rm -rf /tmp/a" {

--- a/apps/parsar-daemon/internal/agent/claudecode/permission.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/permission.go
@@ -48,6 +48,24 @@ func (p *pendingTable) Resolve(permID string) (pendingEntry, bool) {
 	return e, ok
 }
 
+// Take atomically returns and removes one permission. Human submissions and
+// the timeout watchdog race through this method so only one control_response
+// can reach Claude Code.
+func (p *pendingTable) Take(permID string) (pendingEntry, bool) {
+	if permID == "" {
+		return pendingEntry{}, false
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	e, ok := p.byPerm[permID]
+	if !ok {
+		return pendingEntry{}, false
+	}
+	delete(p.byPerm, permID)
+	delete(p.byCCReq, e.CCRequestID)
+	return e, true
+}
+
 // LookupByCC reverses the mapping for control_cancel_request handling.
 func (p *pendingTable) LookupByCC(ccRequestID string) (string, bool) {
 	if ccRequestID == "" {

--- a/apps/parsar-daemon/internal/agent/claudecode/session.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/session.go
@@ -541,8 +541,18 @@ func (s *Session) run(stdout io.Reader) {
 					if err := env.DecodePayload(&p); err == nil && p.AskID != "" {
 						s.startAskTimer(p.AskID)
 					}
-				} else if env.Type == proto.TypePermissionRequest && env.ID != "" {
-					s.startPermissionTimer(env.ID)
+				} else if env.Type == proto.TypePermissionRequest {
+					var p proto.PermissionRequestPayload
+					requestID := ""
+					if err := env.DecodePayload(&p); err == nil {
+						requestID = strings.TrimSpace(p.RequestID)
+					}
+					if requestID == "" {
+						requestID = strings.TrimSpace(env.ID)
+					}
+					if requestID != "" {
+						s.startPermissionTimer(requestID)
+					}
 				}
 			case <-s.cancelCtx.Done():
 				s.cfg.logger.Info("claudecode: cancelled during out send", "run_id", s.runID)

--- a/apps/parsar-daemon/internal/agent/claudecode/session.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/session.go
@@ -34,8 +34,8 @@ type sessionConfig struct {
 	// before SIGKILL. 3s in production; tests pin it short.
 	killTimeout time.Duration
 
-	// askTimeout bounds how long the daemon waits for the human to
-	// answer a prompt_for_user_choice (AskUserQuestion). 10 minutes in
+	// askTimeout bounds how long the daemon waits for the human to answer a
+	// permission or prompt_for_user_choice (AskUserQuestion). 10 minutes in
 	// production; tests pin it short so timeout paths are exercisable.
 	// Zero disables the timer — leftover scaffolding for very early
 	// adapter wiring; production always picks defaultAskTimeout.
@@ -87,10 +87,11 @@ type Session struct {
 
 	cancelOnce sync.Once
 
-	// askTimersMu guards askTimers. The ask-timeout watchdog goroutines
-	// race with SubmitPromptForUserChoice; only one wins per askID.
-	askTimersMu sync.Mutex
-	askTimers   map[string]*time.Timer
+	// interactionTimersMu guards permission and AskUserQuestion watchdogs.
+	// Timeout callbacks and human responses race through atomic pending
+	// tables, so only one response can reach Claude Code.
+	interactionTimersMu sync.Mutex
+	interactionTimers   map[string]*time.Timer
 
 	// latestSessionID is the most recent upstream session id seen on a
 	// system-init / result frame. The cancel-path done envelope reads
@@ -242,17 +243,17 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 	pending := newPendingTable()
 	askPending := newPendingAskTable()
 	s := &Session{
-		runID:        req.RunID,
-		cfg:          cfg,
-		proc:         proc,
-		stdin:        proc.Stdin,
-		pending:      pending,
-		askPending:   askPending,
-		translator:   newTranslator(req.RunID, pending, askPending, defaultPermIDMinter, defaultAskIDMinter),
-		out:          out,
-		cancelCtx:    proc.Context(),
-		askTimers:    make(map[string]*time.Timer),
-		buildCleanup: buildRes.Cleanup,
+		runID:             req.RunID,
+		cfg:               cfg,
+		proc:              proc,
+		stdin:             proc.Stdin,
+		pending:           pending,
+		askPending:        askPending,
+		translator:        newTranslator(req.RunID, pending, askPending, defaultPermIDMinter, defaultAskIDMinter),
+		out:               out,
+		cancelCtx:         proc.Context(),
+		interactionTimers: make(map[string]*time.Timer),
+		buildCleanup:      buildRes.Cleanup,
 	}
 
 	// Write the initial user message before launching pumps so the
@@ -294,20 +295,20 @@ func (s *Session) writeStdin(b []byte) (int, error) {
 // close) happens asynchronously via the pump.
 func (s *Session) Cancel(_ context.Context) error {
 	s.cancelOnce.Do(func() {
-		s.stopAllAskTimers()
+		s.stopAllInteractionTimers()
 		s.proc.Cancel()
 	})
 	return nil
 }
 
-// stopAllAskTimers cancels every outstanding ask watchdog. Called on
-// session Cancel so a hard shutdown doesn't leave timers firing into
-// a closed stdin.
-func (s *Session) stopAllAskTimers() {
-	s.askTimersMu.Lock()
-	timers := s.askTimers
-	s.askTimers = make(map[string]*time.Timer)
-	s.askTimersMu.Unlock()
+// stopAllInteractionTimers cancels every outstanding human-response
+// watchdog. Called on session Cancel/terminal so timers cannot fire into a
+// closed stdin.
+func (s *Session) stopAllInteractionTimers() {
+	s.interactionTimersMu.Lock()
+	timers := s.interactionTimers
+	s.interactionTimers = make(map[string]*time.Timer)
+	s.interactionTimersMu.Unlock()
 	for _, t := range timers {
 		t.Stop()
 	}
@@ -317,10 +318,11 @@ func (s *Session) stopAllAskTimers() {
 // given perm_id. Returns agent.ErrUnknownPermission when permID isn't
 // in the pending table.
 func (s *Session) SubmitPermission(_ context.Context, permID string, decision proto.PermissionDecisionPayload) error {
-	entry, ok := s.pending.Resolve(permID)
+	entry, ok := s.pending.Take(permID)
 	if !ok {
 		return agent.ErrUnknownPermission
 	}
+	s.stopInteractionTimer(permID)
 
 	var inner map[string]any
 	if decision.Approved {
@@ -357,13 +359,12 @@ func (s *Session) SubmitPermission(_ context.Context, permID string, decision pr
 	body = append(body, '\n')
 
 	if _, err := s.writeStdin(body); err != nil {
-		// Don't Delete the pending entry: a transient stdin write
-		// failure may want a retry, and leaving the entry surfaces a
-		// more useful "unknown permission" on the retry once cleanup
-		// completes.
+		// Restore the entry so a transient stdin write failure remains
+		// retryable and still has a bounded lifetime.
+		s.pending.Record(permID, entry.CCRequestID, entry.Input)
+		s.startPermissionTimer(permID)
 		return fmt.Errorf("claudecode: write control_response: %w", err)
 	}
-	s.pending.Delete(permID)
 	return nil
 }
 
@@ -434,25 +435,49 @@ func (s *Session) startAskTimer(askID string) {
 			Reason:    "timeout",
 		})
 	})
-	s.askTimersMu.Lock()
-	if prev, ok := s.askTimers[askID]; ok {
+	s.interactionTimersMu.Lock()
+	if prev, ok := s.interactionTimers[askID]; ok {
 		// Same askID seen twice: cancel the old timer so we don't fire
 		// two decisions. Shouldn't happen on a clean stream, but two
 		// stdout-pump dispatches with the same env.ID would otherwise
 		// race.
 		prev.Stop()
 	}
-	s.askTimers[askID] = timer
-	s.askTimersMu.Unlock()
+	s.interactionTimers[askID] = timer
+	s.interactionTimersMu.Unlock()
 }
 
 func (s *Session) stopAskTimer(askID string) {
-	s.askTimersMu.Lock()
-	timer, ok := s.askTimers[askID]
-	if ok {
-		delete(s.askTimers, askID)
+	s.stopInteractionTimer(askID)
+}
+
+// startPermissionTimer applies the same bounded human-response window to
+// tool approvals. Expiry is an explicit deny, never an implicit allow.
+func (s *Session) startPermissionTimer(permID string) {
+	if s.cfg.askTimeout <= 0 || permID == "" {
+		return
 	}
-	s.askTimersMu.Unlock()
+	timer := time.AfterFunc(s.cfg.askTimeout, func() {
+		_ = s.SubmitPermission(context.Background(), permID, proto.PermissionDecisionPayload{
+			Approved: false,
+			Message:  "permission request timed out",
+		})
+	})
+	s.interactionTimersMu.Lock()
+	if prev, ok := s.interactionTimers[permID]; ok {
+		prev.Stop()
+	}
+	s.interactionTimers[permID] = timer
+	s.interactionTimersMu.Unlock()
+}
+
+func (s *Session) stopInteractionTimer(id string) {
+	s.interactionTimersMu.Lock()
+	timer, ok := s.interactionTimers[id]
+	if ok {
+		delete(s.interactionTimers, id)
+	}
+	s.interactionTimersMu.Unlock()
 	if ok {
 		timer.Stop()
 	}
@@ -516,6 +541,8 @@ func (s *Session) run(stdout io.Reader) {
 					if err := env.DecodePayload(&p); err == nil && p.AskID != "" {
 						s.startAskTimer(p.AskID)
 					}
+				} else if env.Type == proto.TypePermissionRequest && env.ID != "" {
+					s.startPermissionTimer(env.ID)
 				}
 			case <-s.cancelCtx.Done():
 				s.cfg.logger.Info("claudecode: cancelled during out send", "run_id", s.runID)
@@ -525,7 +552,7 @@ func (s *Session) run(stdout io.Reader) {
 		}
 		if tx.Terminal {
 			terminal = true
-			s.stopAllAskTimers()
+			s.stopAllInteractionTimers()
 			s.closeOut()
 			break
 		}

--- a/apps/parsar-daemon/internal/agent/claudecode/session_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/session_test.go
@@ -425,6 +425,34 @@ func TestSessionPermissionRoundTrip(t *testing.T) {
 	}
 }
 
+func TestSessionPermissionTimeoutDeniesInsteadOfHanging(t *testing.T) {
+	out := make(chan proto.Envelope, 32)
+	cfg := helperConfig()
+	cfg.AskTimeout = 150 * time.Millisecond
+	sess, err := claudecode.NewSessionForTest(context.Background(),
+		helperReq("run_permission_timeout", "approve me", "permission"), out, cfg)
+	if err != nil {
+		t.Fatalf("NewSessionForTest: %v", err)
+	}
+	defer sess.Cancel(context.Background())
+
+	envs, closed := drain(t, out, 5*time.Second)
+	if !closed {
+		t.Fatal("out did not close after permission timeout")
+	}
+	final := envs[len(envs)-1]
+	if final.Type != proto.TypeDone {
+		t.Fatalf("final env type = %q, want done; types=%v", final.Type, envTypes(envs))
+	}
+	var done proto.DonePayload
+	if err := final.DecodePayload(&done); err != nil {
+		t.Fatalf("decode done: %v", err)
+	}
+	if !strings.Contains(done.Content, "denied for req_cc_42") {
+		t.Fatalf("timeout did not deny the request: %q", done.Content)
+	}
+}
+
 func TestSessionRejectsEmptyPrompt(t *testing.T) {
 	// Pure-image inbound (empty Prompt, non-empty Attachments) is a
 	// valid prompt today and must NOT be rejected.

--- a/apps/parsar-daemon/internal/agent/claudecode/session_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/session_test.go
@@ -382,7 +382,14 @@ func TestSessionPermissionRoundTrip(t *testing.T) {
 			}
 			collected = append(collected, env)
 			if env.Type == "permission_request" {
-				permID = env.ID
+				if env.ID != "run_p" {
+					t.Fatalf("permission env.ID = %q, want run_p", env.ID)
+				}
+				var request proto.PermissionRequestPayload
+				if err := env.DecodePayload(&request); err != nil {
+					t.Fatalf("decode permission request: %v", err)
+				}
+				permID = request.RequestID
 			}
 		case <-deadline:
 			t.Fatalf("timeout waiting for permission_request; collected %d", len(collected))

--- a/apps/parsar-daemon/internal/agent/codex/approval_policy.go
+++ b/apps/parsar-daemon/internal/agent/codex/approval_policy.go
@@ -5,19 +5,29 @@ import (
 	"fmt"
 )
 
-// SilentGranularPolicy is the default policy daemon-managed codex sessions
-// run under: every gate set to false, so codex auto-accepts every
-// command / file / permission server-request without surfacing it.
-// Equivalent to claude_code's --allow-dangerously-skip-permissions.
+// SilentGranularPolicy disables every Codex approval surface. It is retained
+// for wire-compatibility tests and explicit callers; daemon sessions default
+// to HumanApprovalPolicy so normal runs never auto-accept requests.
 func SilentGranularPolicy() AskForApproval {
 	g := GranularAskForApproval{} // zero value = every gate false
 	return AskForApproval{Granular: &g}
 }
 
+// HumanApprovalPolicy surfaces every Codex approval gate to Parsar. The
+// daemon turns those server requests into the same permission envelopes used
+// by Claude Code, so Web and IM users make the decision explicitly.
+func HumanApprovalPolicy() AskForApproval {
+	g := GranularAskForApproval{
+		SandboxApproval: true, Rules: true, SkillApproval: true,
+		RequestPermissions: true, MCPElicitations: true,
+	}
+	return AskForApproval{Granular: &g}
+}
+
 // IsSilent reports whether p suppresses every approval surface. The
-// daemon uses this to decide whether to register a server-request
-// handler that auto-accepts (silent) versus one that turns the request
-// into a proto.PermissionRequest envelope (loud).
+// daemon logs this distinction when it starts a thread. Server-request
+// handlers are always registered so explicit policy overrides cannot leave
+// Codex waiting on an unhandled request.
 //
 // A nil pointer is treated as silent — the safe default when callers
 // forget to wire a policy.
@@ -53,9 +63,9 @@ func (a AskForApproval) MarshalJSON() ([]byte, error) {
 			Granular *GranularAskForApproval `json:"granular"`
 		}{Granular: a.Granular})
 	}
-	// Neither set — default to silent granular to keep daemon sessions
-	// non-interactive. An empty marshal would produce `null` which
-	// codex-rs rejects.
+	// Neither set — preserve the historical zero-value encoding. Production
+	// plans always set HumanApprovalPolicy explicitly; an empty marshal would
+	// produce `null`, which codex-rs rejects.
 	return json.Marshal(struct {
 		Granular GranularAskForApproval `json:"granular"`
 	}{})

--- a/apps/parsar-daemon/internal/agent/codex/approval_policy.go
+++ b/apps/parsar-daemon/internal/agent/codex/approval_policy.go
@@ -13,16 +13,9 @@ func SilentGranularPolicy() AskForApproval {
 	return AskForApproval{Granular: &g}
 }
 
-// HumanApprovalPolicy surfaces every Codex approval gate that Parsar can
-// complete through its permission and user-input protocols. MCP elicitations
-// stay disabled until Parsar supports their typed form and URL response modes;
-// advertising an unhandled server request would leave Codex waiting forever.
+// HumanApprovalPolicy lets Codex request sandbox escalation from Parsar.
 func HumanApprovalPolicy() AskForApproval {
-	g := GranularAskForApproval{
-		SandboxApproval: true, Rules: true, SkillApproval: true,
-		RequestPermissions: true, MCPElicitations: false,
-	}
-	return AskForApproval{Granular: &g}
+	return AskForApproval{String: "on-request"}
 }
 
 // IsSilent reports whether p suppresses every approval surface. The

--- a/apps/parsar-daemon/internal/agent/codex/approval_policy.go
+++ b/apps/parsar-daemon/internal/agent/codex/approval_policy.go
@@ -13,13 +13,14 @@ func SilentGranularPolicy() AskForApproval {
 	return AskForApproval{Granular: &g}
 }
 
-// HumanApprovalPolicy surfaces every Codex approval gate to Parsar. The
-// daemon turns those server requests into the same permission envelopes used
-// by Claude Code, so Web and IM users make the decision explicitly.
+// HumanApprovalPolicy surfaces every Codex approval gate that Parsar can
+// complete through its permission and user-input protocols. MCP elicitations
+// stay disabled until Parsar supports their typed form and URL response modes;
+// advertising an unhandled server request would leave Codex waiting forever.
 func HumanApprovalPolicy() AskForApproval {
 	g := GranularAskForApproval{
 		SandboxApproval: true, Rules: true, SkillApproval: true,
-		RequestPermissions: true, MCPElicitations: true,
+		RequestPermissions: true, MCPElicitations: false,
 	}
 	return AskForApproval{Granular: &g}
 }

--- a/apps/parsar-daemon/internal/agent/codex/approval_policy_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/approval_policy_test.go
@@ -19,17 +19,10 @@ func TestSilentGranularPolicy_AllFalse(t *testing.T) {
 	}
 }
 
-func TestHumanApprovalPolicy_EnablesOnlyHandledGates(t *testing.T) {
+func TestHumanApprovalPolicy_UsesOnRequest(t *testing.T) {
 	p := HumanApprovalPolicy()
-	if p.Granular == nil {
-		t.Fatal("HumanApprovalPolicy must populate Granular")
-	}
-	g := *p.Granular
-	if !g.SandboxApproval || !g.Rules || !g.SkillApproval || !g.RequestPermissions {
-		t.Fatalf("human policy must enable supported approval gates, got %+v", g)
-	}
-	if g.MCPElicitations {
-		t.Fatalf("human policy must not advertise the unhandled MCP elicitation surface, got %+v", g)
+	if p.String != "on-request" || p.Granular != nil {
+		t.Fatalf("HumanApprovalPolicy = %+v, want on-request string policy", p)
 	}
 	if IsSilent(&p) {
 		t.Fatal("HumanApprovalPolicy must surface app-server requests")
@@ -50,7 +43,6 @@ func TestIsSilent_StringPolicies(t *testing.T) {
 	}{
 		{"never silences", AskForApproval{String: "never"}, true},
 		{"on-request loud", AskForApproval{String: "on-request"}, false},
-		{"on-failure loud", AskForApproval{String: "on-failure"}, false},
 		{"untrusted loud", AskForApproval{String: "untrusted"}, false},
 	}
 	for _, tc := range cases {

--- a/apps/parsar-daemon/internal/agent/codex/approval_policy_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/approval_policy_test.go
@@ -19,14 +19,17 @@ func TestSilentGranularPolicy_AllFalse(t *testing.T) {
 	}
 }
 
-func TestHumanApprovalPolicy_AllGatesEnabled(t *testing.T) {
+func TestHumanApprovalPolicy_EnablesOnlyHandledGates(t *testing.T) {
 	p := HumanApprovalPolicy()
 	if p.Granular == nil {
 		t.Fatal("HumanApprovalPolicy must populate Granular")
 	}
 	g := *p.Granular
-	if !g.SandboxApproval || !g.Rules || !g.SkillApproval || !g.RequestPermissions || !g.MCPElicitations {
-		t.Fatalf("human policy must enable every approval gate, got %+v", g)
+	if !g.SandboxApproval || !g.Rules || !g.SkillApproval || !g.RequestPermissions {
+		t.Fatalf("human policy must enable supported approval gates, got %+v", g)
+	}
+	if g.MCPElicitations {
+		t.Fatalf("human policy must not advertise the unhandled MCP elicitation surface, got %+v", g)
 	}
 	if IsSilent(&p) {
 		t.Fatal("HumanApprovalPolicy must surface app-server requests")

--- a/apps/parsar-daemon/internal/agent/codex/approval_policy_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/approval_policy_test.go
@@ -19,6 +19,20 @@ func TestSilentGranularPolicy_AllFalse(t *testing.T) {
 	}
 }
 
+func TestHumanApprovalPolicy_AllGatesEnabled(t *testing.T) {
+	p := HumanApprovalPolicy()
+	if p.Granular == nil {
+		t.Fatal("HumanApprovalPolicy must populate Granular")
+	}
+	g := *p.Granular
+	if !g.SandboxApproval || !g.Rules || !g.SkillApproval || !g.RequestPermissions || !g.MCPElicitations {
+		t.Fatalf("human policy must enable every approval gate, got %+v", g)
+	}
+	if IsSilent(&p) {
+		t.Fatal("HumanApprovalPolicy must surface app-server requests")
+	}
+}
+
 func TestIsSilent_NilIsSilent(t *testing.T) {
 	if !IsSilent(nil) {
 		t.Fatal("nil policy must be treated as silent (safe default)")

--- a/apps/parsar-daemon/internal/agent/codex/options.go
+++ b/apps/parsar-daemon/internal/agent/codex/options.go
@@ -49,6 +49,9 @@ type SessionPlan struct {
 	// SystemPrompt is forwarded as developerInstructions on thread/start.
 	SystemPrompt string
 
+	// CollaborationMode selects Codex's default or plan tool surface.
+	CollaborationMode CollaborationModeKind
+
 	// ApprovalPolicy + Sandbox steer thread/start. Defaults surface human
 	// approvals and confine writes to the workspace.
 	ApprovalPolicy AskForApproval
@@ -90,6 +93,7 @@ type SessionPlan struct {
 //	                                      stream_max_retries (number).
 //	reasoning_summary     string          one of auto/concise/detailed/none —
 //	                                      routed via -c model_reasoning_summary
+//	mode                  string          Codex collaboration mode: default/plan
 //	enable_features       []any           string list, forwarded as --enable
 //	disable_features      []any           string list, forwarded as --disable
 //
@@ -118,6 +122,14 @@ func BuildSessionPlan(runID, agentStateKey, workDir string, opts map[string]any)
 	plan.SystemPrompt = stringOpt(opts, "system_prompt")
 	if override := stringOpt(opts, "override_system_prompt"); override != "" {
 		plan.SystemPrompt = override
+	}
+	if mode := CollaborationModeKind(stringOpt(opts, "mode")); mode != "" {
+		switch mode {
+		case CollaborationModeDefault, CollaborationModePlan:
+			plan.CollaborationMode = mode
+		default:
+			return plan, fmt.Errorf("codex: unsupported collaboration mode %q", mode)
+		}
 	}
 
 	env, err := buildSessionEnv(opts)

--- a/apps/parsar-daemon/internal/agent/codex/options.go
+++ b/apps/parsar-daemon/internal/agent/codex/options.go
@@ -49,10 +49,8 @@ type SessionPlan struct {
 	// SystemPrompt is forwarded as developerInstructions on thread/start.
 	SystemPrompt string
 
-	// ApprovalPolicy + Sandbox steer thread/start. Defaults are
-	// SilentGranularPolicy() and SandboxDangerFullAcces — match the
-	// user's "sandbox runs full-open" decision and equivalent to
-	// claudecode's bypassPermissions.
+	// ApprovalPolicy + Sandbox steer thread/start. Defaults surface human
+	// approvals and confine writes to the workspace.
 	ApprovalPolicy AskForApproval
 	Sandbox        SandboxMode
 
@@ -100,14 +98,13 @@ type SessionPlan struct {
 // location, set it via the daemon's process environment (PATH /
 // codexBinary in sessionConfig) rather than per-call.
 //
-// Approval / sandbox keys are not exposed to admin yet — the daemon
-// always runs silent + full-access. Wire them through once a UI to flip
-// them lands.
+// Approval / sandbox keys are not exposed to admin yet. Parsar's Inbox is
+// the default decision surface; per-agent overrides can be added later.
 func BuildSessionPlan(runID, agentStateKey, workDir string, opts map[string]any) (SessionPlan, error) {
 	cleanup := func() {}
 	plan := SessionPlan{
-		ApprovalPolicy: SilentGranularPolicy(),
-		Sandbox:        SandboxDangerFullAcces,
+		ApprovalPolicy: HumanApprovalPolicy(),
+		Sandbox:        SandboxWorkspaceWrite,
 		Cleanup:        cleanup,
 	}
 

--- a/apps/parsar-daemon/internal/agent/codex/options_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/options_test.go
@@ -7,16 +7,16 @@ import (
 	"testing"
 )
 
-func TestBuildSessionPlan_DefaultsSilentAndFullAccess(t *testing.T) {
+func TestBuildSessionPlan_DefaultsToHumanApprovalAndWorkspaceWrite(t *testing.T) {
 	plan, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", nil)
 	if err != nil {
 		t.Fatalf("BuildSessionPlan: %v", err)
 	}
-	if !IsSilent(&plan.ApprovalPolicy) {
-		t.Fatalf("default policy must be silent, got %+v", plan.ApprovalPolicy)
+	if IsSilent(&plan.ApprovalPolicy) {
+		t.Fatalf("default policy must surface approvals, got %+v", plan.ApprovalPolicy)
 	}
-	if plan.Sandbox != SandboxDangerFullAcces {
-		t.Fatalf("default sandbox = %s, want danger-full-access", plan.Sandbox)
+	if plan.Sandbox != SandboxWorkspaceWrite {
+		t.Fatalf("default sandbox = %s, want workspace-write", plan.Sandbox)
 	}
 	if plan.Cleanup == nil {
 		t.Fatal("Cleanup must be non-nil")

--- a/apps/parsar-daemon/internal/agent/codex/options_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/options_test.go
@@ -130,6 +130,28 @@ func TestBuildSessionPlan_EmptyOverrideKeepsSystemPrompt(t *testing.T) {
 	}
 }
 
+func TestBuildSessionPlan_ParsesCollaborationMode(t *testing.T) {
+	plan, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", map[string]any{
+		"mode": "plan",
+	})
+	if err != nil {
+		t.Fatalf("BuildSessionPlan: %v", err)
+	}
+	defer plan.Cleanup()
+	if plan.CollaborationMode != CollaborationModePlan {
+		t.Fatalf("CollaborationMode = %q, want plan", plan.CollaborationMode)
+	}
+}
+
+func TestBuildSessionPlan_RejectsUnknownCollaborationMode(t *testing.T) {
+	_, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", map[string]any{
+		"mode": "autopilot",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unsupported collaboration mode") {
+		t.Fatalf("expected unsupported collaboration mode error, got %v", err)
+	}
+}
+
 func TestBuildSessionPlan_RejectsRelativeWorkDir(t *testing.T) {
 	_, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "relative/dir", nil)
 	if err == nil {

--- a/apps/parsar-daemon/internal/agent/codex/protocol.go
+++ b/apps/parsar-daemon/internal/agent/codex/protocol.go
@@ -213,8 +213,26 @@ type UserInput struct {
 }
 
 type TurnStartParams struct {
-	ThreadID string      `json:"threadId"`
-	Input    []UserInput `json:"input"`
+	ThreadID          string             `json:"threadId"`
+	Input             []UserInput        `json:"input"`
+	CollaborationMode *CollaborationMode `json:"collaborationMode,omitempty"`
+}
+
+type CollaborationModeKind string
+
+const (
+	CollaborationModePlan    CollaborationModeKind = "plan"
+	CollaborationModeDefault CollaborationModeKind = "default"
+)
+
+type CollaborationMode struct {
+	Mode     CollaborationModeKind     `json:"mode"`
+	Settings CollaborationModeSettings `json:"settings"`
+}
+
+type CollaborationModeSettings struct {
+	Model                 string  `json:"model"`
+	DeveloperInstructions *string `json:"developer_instructions"`
 }
 
 type TurnInterruptParams struct {

--- a/apps/parsar-daemon/internal/agent/codex/protocol.go
+++ b/apps/parsar-daemon/internal/agent/codex/protocol.go
@@ -367,12 +367,12 @@ type FileChangeRequestApprovalParams struct {
 }
 
 type PermissionsRequestApprovalParams struct {
-	ThreadID    string  `json:"threadId"`
-	TurnID      string  `json:"turnId"`
-	ItemID      string  `json:"itemId"`
-	Cwd         string  `json:"cwd"`
-	Reason      *string `json:"reason,omitempty"`
-	Permissions any     `json:"permissions,omitempty"`
+	ThreadID    string         `json:"threadId"`
+	TurnID      string         `json:"turnId"`
+	ItemID      string         `json:"itemId"`
+	Cwd         string         `json:"cwd"`
+	Reason      *string        `json:"reason,omitempty"`
+	Permissions map[string]any `json:"permissions,omitempty"`
 }
 
 // CommandExecutionApprovalDecision is the verdict the daemon writes
@@ -380,10 +380,19 @@ type PermissionsRequestApprovalParams struct {
 // / "acceptForSession".
 type CommandExecutionApprovalDecision = string
 
-// ApprovalDecisionResult is the result body in a JSON-RPC response for
-// any of the three approval requests.
+// ApprovalDecisionResult is the result body for command-execution and
+// file-change approvals. item/permissions/requestApproval uses the distinct
+// PermissionsRequestApprovalResponse contract below.
 type ApprovalDecisionResult struct {
 	Decision CommandExecutionApprovalDecision `json:"decision"`
+}
+
+// PermissionsRequestApprovalResponse mirrors Codex app-server's dedicated
+// response contract. Approving echoes the requested permission profile;
+// denying returns an empty profile, which grants no additional capability.
+type PermissionsRequestApprovalResponse struct {
+	Permissions map[string]any `json:"permissions"`
+	Scope       string         `json:"scope,omitempty"`
 }
 
 type ToolRequestUserInputOption struct {

--- a/apps/parsar-daemon/internal/agent/codex/protocol.go
+++ b/apps/parsar-daemon/internal/agent/codex/protocol.go
@@ -344,9 +344,9 @@ type ErrorNotification struct {
 }
 
 // ---------------------------------------------------------------------------
-// Approval ServerRequest params (suppressed by the all-false granular
-// policy today; left here so server_requests.go can compile against
-// these shapes when surfaceApprovals is later flipped on).
+// Approval and user-input ServerRequest params. Daemon sessions use a
+// human approval policy, so server_requests.go defers each matching JSON-RPC
+// response until Web or IM submits the decision.
 // ---------------------------------------------------------------------------
 
 type CommandExecutionRequestApprovalParams struct {
@@ -384,4 +384,34 @@ type CommandExecutionApprovalDecision = string
 // any of the three approval requests.
 type ApprovalDecisionResult struct {
 	Decision CommandExecutionApprovalDecision `json:"decision"`
+}
+
+type ToolRequestUserInputOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+type ToolRequestUserInputQuestion struct {
+	ID       string                       `json:"id"`
+	Header   string                       `json:"header"`
+	Question string                       `json:"question"`
+	Options  []ToolRequestUserInputOption `json:"options,omitempty"`
+	IsOther  bool                         `json:"isOther,omitempty"`
+	IsSecret bool                         `json:"isSecret,omitempty"`
+}
+
+type ToolRequestUserInputParams struct {
+	ThreadID         string                         `json:"threadId"`
+	TurnID           string                         `json:"turnId"`
+	ItemID           string                         `json:"itemId"`
+	Questions        []ToolRequestUserInputQuestion `json:"questions"`
+	AutoResolutionMs *uint64                        `json:"autoResolutionMs,omitempty"`
+}
+
+type ToolRequestUserInputAnswer struct {
+	Answers []string `json:"answers"`
+}
+
+type ToolRequestUserInputResponse struct {
+	Answers map[string]ToolRequestUserInputAnswer `json:"answers"`
 }

--- a/apps/parsar-daemon/internal/agent/codex/protocol_wire_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/protocol_wire_test.go
@@ -105,3 +105,29 @@ func TestThreadStartParams_ModelProviderIsCamelCaseField(t *testing.T) {
 		t.Fatalf("snake_case model_provider leaked: %s", body)
 	}
 }
+
+func TestTurnStartParams_CollaborationModeUsesPlanWireShape(t *testing.T) {
+	developerInstructions := "stay within the configured workspace"
+	params := TurnStartParams{
+		ThreadID: "thread-1",
+		Input:    FirstUserInput("ask me a question"),
+		CollaborationMode: &CollaborationMode{
+			Mode: CollaborationModePlan,
+			Settings: CollaborationModeSettings{
+				Model:                 "MiniMax-M3",
+				DeveloperInstructions: &developerInstructions,
+			},
+		},
+	}
+	raw, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(raw)
+	if !strings.Contains(body, `"collaborationMode":{"mode":"plan","settings":{"model":"MiniMax-M3","developer_instructions":"stay within the configured workspace"}}`) {
+		t.Fatalf("collaboration mode missing or malformed: %s", body)
+	}
+	if strings.Contains(body, `"collaboration_mode"`) {
+		t.Fatalf("snake_case collaboration_mode leaked: %s", body)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/server_requests.go
+++ b/apps/parsar-daemon/internal/agent/codex/server_requests.go
@@ -111,8 +111,8 @@ func (s *Session) deferCodexPermission(rpcID any, kind codexPermissionKind, tool
 	pending.timer = time.AfterFunc(pending.timeout, func() { s.expireCodexPermission(requestID) })
 	s.interactions.permissions[requestID] = pending
 	s.interactions.mu.Unlock()
-	env, err := proto.NewEnvelope(proto.TypePermissionRequest, requestID, proto.PermissionRequestPayload{
-		Tool: tool, Title: title, Detail: detail, Payload: payload,
+	env, err := proto.NewEnvelope(proto.TypePermissionRequest, s.runID, proto.PermissionRequestPayload{
+		RequestID: requestID, Tool: tool, Title: title, Detail: detail, Payload: payload,
 	})
 	if err != nil {
 		s.interactions.mu.Lock()

--- a/apps/parsar-daemon/internal/agent/codex/server_requests.go
+++ b/apps/parsar-daemon/internal/agent/codex/server_requests.go
@@ -15,18 +15,29 @@ import (
 )
 
 type pendingCodexPermission struct {
-	rpcID any
-	timer *time.Timer
+	rpcID       any
+	kind        codexPermissionKind
+	permissions map[string]any
+	timeout     time.Duration
+	timer       *time.Timer
 }
 
 type pendingCodexAsk struct {
 	rpcID       any
 	questionIDs []string
 	answerKeys  []string
+	timeout     time.Duration
 	timer       *time.Timer
 }
 
 const codexInteractionTimeout = 10 * time.Minute
+
+type codexPermissionKind uint8
+
+const (
+	codexDecisionApproval codexPermissionKind = iota
+	codexPermissionsApproval
+)
 
 type pendingCodexInteractions struct {
 	mu          sync.Mutex
@@ -58,7 +69,7 @@ func (s *Session) handleCodexCommandApproval(raw json.RawMessage, rpcID any) (an
 	if title == "" {
 		title = "Run command"
 	}
-	return s.deferCodexPermission(rpcID, "command_execution", title, stringPointer(params.Reason), raw)
+	return s.deferCodexPermission(rpcID, codexDecisionApproval, "command_execution", title, stringPointer(params.Reason), raw, nil)
 }
 
 func (s *Session) handleCodexFileApproval(raw json.RawMessage, rpcID any) (any, error) {
@@ -70,7 +81,7 @@ func (s *Session) handleCodexFileApproval(raw json.RawMessage, rpcID any) (any, 
 	if title == "" {
 		title = "Apply file changes"
 	}
-	return s.deferCodexPermission(rpcID, "file_change", title, stringPointer(params.Reason), raw)
+	return s.deferCodexPermission(rpcID, codexDecisionApproval, "file_change", title, stringPointer(params.Reason), raw, nil)
 }
 
 func (s *Session) handleCodexPermissionsApproval(raw json.RawMessage, rpcID any) (any, error) {
@@ -82,21 +93,37 @@ func (s *Session) handleCodexPermissionsApproval(raw json.RawMessage, rpcID any)
 	if title == "" {
 		title = "Grant additional permissions"
 	}
-	return s.deferCodexPermission(rpcID, "permission_request", title, stringPointer(params.Reason), raw)
+	return s.deferCodexPermission(rpcID, codexPermissionsApproval, "permission_request", title, stringPointer(params.Reason), raw, params.Permissions)
 }
 
-func (s *Session) deferCodexPermission(rpcID any, tool, title, detail string, raw json.RawMessage) (any, error) {
+func (s *Session) deferCodexPermission(rpcID any, kind codexPermissionKind, tool, title, detail string, raw json.RawMessage, permissions map[string]any) (any, error) {
 	requestID := codexInteractionID("perm")
 	payload := map[string]any{}
 	_ = json.Unmarshal(raw, &payload)
-	timer := time.AfterFunc(codexInteractionTimeout, func() { s.expireCodexPermission(requestID) })
+	pending := pendingCodexPermission{
+		rpcID: rpcID, kind: kind, permissions: permissions,
+		timeout: codexInteractionTimeout,
+	}
 	s.interactions.mu.Lock()
-	s.interactions.permissions[requestID] = pendingCodexPermission{rpcID: rpcID, timer: timer}
+	// Start the timer while holding the table lock. Even a future very short
+	// timeout then blocks in expireCodexPermission until the entry is visible,
+	// rather than firing before insertion and leaving an immortal request.
+	pending.timer = time.AfterFunc(pending.timeout, func() { s.expireCodexPermission(requestID) })
+	s.interactions.permissions[requestID] = pending
 	s.interactions.mu.Unlock()
 	env, err := proto.NewEnvelope(proto.TypePermissionRequest, requestID, proto.PermissionRequestPayload{
 		Tool: tool, Title: title, Detail: detail, Payload: payload,
 	})
 	if err != nil {
+		s.interactions.mu.Lock()
+		pending, ok := s.interactions.permissions[requestID]
+		if ok {
+			delete(s.interactions.permissions, requestID)
+		}
+		s.interactions.mu.Unlock()
+		if ok && pending.timer != nil {
+			pending.timer.Stop()
+		}
 		return nil, err
 	}
 	s.trySend(env)
@@ -132,16 +159,34 @@ func (s *Session) handleCodexUserInput(raw json.RawMessage, rpcID any) (any, err
 		answerKeys = append(answerKeys, header)
 		questions = append(questions, proto.PromptForUserChoiceQuestion{
 			ID: questionID, Header: header, Question: question.Question, Options: options,
+			IsOther: question.IsOther, IsSecret: question.IsSecret,
 		})
 	}
+	timeout := codexInteractionTimeout
+	if params.AutoResolutionMs != nil && *params.AutoResolutionMs > 0 {
+		const maxMillis = uint64(^uint64(0)>>1) / uint64(time.Millisecond)
+		if *params.AutoResolutionMs <= maxMillis {
+			timeout = time.Duration(*params.AutoResolutionMs) * time.Millisecond
+		}
+	}
+	pending := pendingCodexAsk{rpcID: rpcID, questionIDs: questionIDs, answerKeys: answerKeys, timeout: timeout}
 	s.interactions.mu.Lock()
-	timer := time.AfterFunc(codexInteractionTimeout, func() { s.expireCodexAsk(askID) })
-	s.interactions.asks[askID] = pendingCodexAsk{rpcID: rpcID, questionIDs: questionIDs, answerKeys: answerKeys, timer: timer}
+	pending.timer = time.AfterFunc(pending.timeout, func() { s.expireCodexAsk(askID) })
+	s.interactions.asks[askID] = pending
 	s.interactions.mu.Unlock()
 	env, err := proto.NewEnvelope(proto.TypePromptForUserChoice, s.runID, proto.PromptForUserChoicePayload{
-		AskID: askID, Questions: questions,
+		AskID: askID, Questions: questions, AutoResolutionMs: params.AutoResolutionMs,
 	})
 	if err != nil {
+		s.interactions.mu.Lock()
+		pending, ok := s.interactions.asks[askID]
+		if ok {
+			delete(s.interactions.asks, askID)
+		}
+		s.interactions.mu.Unlock()
+		if ok && pending.timer != nil {
+			pending.timer.Stop()
+		}
 		return nil, err
 	}
 	s.trySend(env)
@@ -161,18 +206,32 @@ func (s *Session) submitCodexPermission(requestID string, decision proto.Permiss
 	if pending.timer != nil {
 		pending.timer.Stop()
 	}
-	value := "decline"
-	if decision.Approved {
-		value = "accept"
-	}
-	if err := s.rpc.SendServerReply(pending.rpcID, ApprovalDecisionResult{Decision: value}); err != nil {
-		pending.timer = time.AfterFunc(codexInteractionTimeout, func() { s.expireCodexPermission(requestID) })
+	if err := s.sendCodexPermissionReply(pending, decision.Approved); err != nil {
 		s.interactions.mu.Lock()
+		pending.timer = time.AfterFunc(pending.timeout, func() { s.expireCodexPermission(requestID) })
 		s.interactions.permissions[requestID] = pending
 		s.interactions.mu.Unlock()
 		return err
 	}
 	return nil
+}
+
+func (s *Session) sendCodexPermissionReply(pending pendingCodexPermission, approved bool) error {
+	if pending.kind == codexPermissionsApproval {
+		permissions := map[string]any{}
+		if approved && pending.permissions != nil {
+			permissions = pending.permissions
+		}
+		return s.rpc.SendServerReply(pending.rpcID, PermissionsRequestApprovalResponse{
+			Permissions: permissions,
+			Scope:       "turn",
+		})
+	}
+	value := "decline"
+	if approved {
+		value = "accept"
+	}
+	return s.rpc.SendServerReply(pending.rpcID, ApprovalDecisionResult{Decision: value})
 }
 
 func (s *Session) submitCodexUserInput(askID string, decision proto.PromptForUserChoiceDecisionPayload) error {
@@ -194,8 +253,8 @@ func (s *Session) submitCodexUserInput(askID string, decision proto.PromptForUse
 			reason = "user cancelled input request"
 		}
 		if err := s.rpc.SendServerError(pending.rpcID, -32001, reason, nil); err != nil {
-			pending.timer = time.AfterFunc(codexInteractionTimeout, func() { s.expireCodexAsk(askID) })
 			s.interactions.mu.Lock()
+			pending.timer = time.AfterFunc(pending.timeout, func() { s.expireCodexAsk(askID) })
 			s.interactions.asks[askID] = pending
 			s.interactions.mu.Unlock()
 			return err
@@ -234,8 +293,8 @@ func (s *Session) submitCodexUserInput(askID string, decision proto.PromptForUse
 		result.Answers[questionID] = ToolRequestUserInputAnswer{Answers: values}
 	}
 	if err := s.rpc.SendServerReply(pending.rpcID, result); err != nil {
-		pending.timer = time.AfterFunc(codexInteractionTimeout, func() { s.expireCodexAsk(askID) })
 		s.interactions.mu.Lock()
+		pending.timer = time.AfterFunc(pending.timeout, func() { s.expireCodexAsk(askID) })
 		s.interactions.asks[askID] = pending
 		s.interactions.mu.Unlock()
 		return err
@@ -254,7 +313,7 @@ func (s *Session) expireCodexPermission(requestID string) {
 		if pending.timer != nil {
 			pending.timer.Stop()
 		}
-		_ = s.rpc.SendServerReply(pending.rpcID, ApprovalDecisionResult{Decision: "decline"})
+		_ = s.sendCodexPermissionReply(pending, false)
 	}
 }
 

--- a/apps/parsar-daemon/internal/agent/codex/server_requests.go
+++ b/apps/parsar-daemon/internal/agent/codex/server_requests.go
@@ -1,0 +1,309 @@
+package codex
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+type pendingCodexPermission struct {
+	rpcID any
+	timer *time.Timer
+}
+
+type pendingCodexAsk struct {
+	rpcID       any
+	questionIDs []string
+	answerKeys  []string
+	timer       *time.Timer
+}
+
+const codexInteractionTimeout = 10 * time.Minute
+
+type pendingCodexInteractions struct {
+	mu          sync.Mutex
+	permissions map[string]pendingCodexPermission
+	asks        map[string]pendingCodexAsk
+}
+
+func newPendingCodexInteractions() *pendingCodexInteractions {
+	return &pendingCodexInteractions{
+		permissions: make(map[string]pendingCodexPermission),
+		asks:        make(map[string]pendingCodexAsk),
+	}
+}
+
+func codexInteractionID(prefix string) string {
+	var bytes [8]byte
+	if _, err := rand.Read(bytes[:]); err == nil {
+		return prefix + "_" + hex.EncodeToString(bytes[:])
+	}
+	return fmt.Sprintf("%s_fallback", prefix)
+}
+
+func (s *Session) handleCodexCommandApproval(raw json.RawMessage, rpcID any) (any, error) {
+	var params CommandExecutionRequestApprovalParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, fmt.Errorf("decode command approval: %w", err)
+	}
+	title := stringPointer(params.Command)
+	if title == "" {
+		title = "Run command"
+	}
+	return s.deferCodexPermission(rpcID, "command_execution", title, stringPointer(params.Reason), raw)
+}
+
+func (s *Session) handleCodexFileApproval(raw json.RawMessage, rpcID any) (any, error) {
+	var params FileChangeRequestApprovalParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, fmt.Errorf("decode file approval: %w", err)
+	}
+	title := stringPointer(params.GrantRoot)
+	if title == "" {
+		title = "Apply file changes"
+	}
+	return s.deferCodexPermission(rpcID, "file_change", title, stringPointer(params.Reason), raw)
+}
+
+func (s *Session) handleCodexPermissionsApproval(raw json.RawMessage, rpcID any) (any, error) {
+	var params PermissionsRequestApprovalParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, fmt.Errorf("decode permissions approval: %w", err)
+	}
+	title := strings.TrimSpace(params.Cwd)
+	if title == "" {
+		title = "Grant additional permissions"
+	}
+	return s.deferCodexPermission(rpcID, "permission_request", title, stringPointer(params.Reason), raw)
+}
+
+func (s *Session) deferCodexPermission(rpcID any, tool, title, detail string, raw json.RawMessage) (any, error) {
+	requestID := codexInteractionID("perm")
+	payload := map[string]any{}
+	_ = json.Unmarshal(raw, &payload)
+	timer := time.AfterFunc(codexInteractionTimeout, func() { s.expireCodexPermission(requestID) })
+	s.interactions.mu.Lock()
+	s.interactions.permissions[requestID] = pendingCodexPermission{rpcID: rpcID, timer: timer}
+	s.interactions.mu.Unlock()
+	env, err := proto.NewEnvelope(proto.TypePermissionRequest, requestID, proto.PermissionRequestPayload{
+		Tool: tool, Title: title, Detail: detail, Payload: payload,
+	})
+	if err != nil {
+		return nil, err
+	}
+	s.trySend(env)
+	return DeferReply, nil
+}
+
+func (s *Session) handleCodexUserInput(raw json.RawMessage, rpcID any) (any, error) {
+	var params ToolRequestUserInputParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, fmt.Errorf("decode requestUserInput: %w", err)
+	}
+	if len(params.Questions) == 0 {
+		return nil, errors.New("requestUserInput contains no questions")
+	}
+	askID := codexInteractionID("ask")
+	questions := make([]proto.PromptForUserChoiceQuestion, 0, len(params.Questions))
+	questionIDs := make([]string, 0, len(params.Questions))
+	answerKeys := make([]string, 0, len(params.Questions))
+	for index, question := range params.Questions {
+		options := make([]proto.PromptForUserChoiceOption, 0, len(question.Options))
+		for _, option := range question.Options {
+			options = append(options, proto.PromptForUserChoiceOption{Label: option.Label, Description: option.Description})
+		}
+		header := strings.TrimSpace(question.Header)
+		if header == "" {
+			header = fmt.Sprintf("q%d", index)
+		}
+		questionID := strings.TrimSpace(question.ID)
+		if questionID == "" {
+			questionID = header
+		}
+		questionIDs = append(questionIDs, questionID)
+		answerKeys = append(answerKeys, header)
+		questions = append(questions, proto.PromptForUserChoiceQuestion{
+			ID: questionID, Header: header, Question: question.Question, Options: options,
+		})
+	}
+	s.interactions.mu.Lock()
+	timer := time.AfterFunc(codexInteractionTimeout, func() { s.expireCodexAsk(askID) })
+	s.interactions.asks[askID] = pendingCodexAsk{rpcID: rpcID, questionIDs: questionIDs, answerKeys: answerKeys, timer: timer}
+	s.interactions.mu.Unlock()
+	env, err := proto.NewEnvelope(proto.TypePromptForUserChoice, s.runID, proto.PromptForUserChoicePayload{
+		AskID: askID, Questions: questions,
+	})
+	if err != nil {
+		return nil, err
+	}
+	s.trySend(env)
+	return DeferReply, nil
+}
+
+func (s *Session) submitCodexPermission(requestID string, decision proto.PermissionDecisionPayload) error {
+	s.interactions.mu.Lock()
+	pending, ok := s.interactions.permissions[requestID]
+	if ok {
+		delete(s.interactions.permissions, requestID)
+	}
+	s.interactions.mu.Unlock()
+	if !ok {
+		return agent.ErrUnknownPermission
+	}
+	if pending.timer != nil {
+		pending.timer.Stop()
+	}
+	value := "decline"
+	if decision.Approved {
+		value = "accept"
+	}
+	if err := s.rpc.SendServerReply(pending.rpcID, ApprovalDecisionResult{Decision: value}); err != nil {
+		pending.timer = time.AfterFunc(codexInteractionTimeout, func() { s.expireCodexPermission(requestID) })
+		s.interactions.mu.Lock()
+		s.interactions.permissions[requestID] = pending
+		s.interactions.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (s *Session) submitCodexUserInput(askID string, decision proto.PromptForUserChoiceDecisionPayload) error {
+	s.interactions.mu.Lock()
+	pending, ok := s.interactions.asks[askID]
+	if ok {
+		delete(s.interactions.asks, askID)
+	}
+	s.interactions.mu.Unlock()
+	if !ok {
+		return agent.ErrUnknownAsk
+	}
+	if pending.timer != nil {
+		pending.timer.Stop()
+	}
+	if decision.Cancelled {
+		reason := strings.TrimSpace(decision.Reason)
+		if reason == "" {
+			reason = "user cancelled input request"
+		}
+		if err := s.rpc.SendServerError(pending.rpcID, -32001, reason, nil); err != nil {
+			pending.timer = time.AfterFunc(codexInteractionTimeout, func() { s.expireCodexAsk(askID) })
+			s.interactions.mu.Lock()
+			s.interactions.asks[askID] = pending
+			s.interactions.mu.Unlock()
+			return err
+		}
+		return nil
+	}
+	byID := make(map[string][]string, len(decision.QuestionAnswers))
+	byHeader := make(map[string][]string, len(decision.QuestionAnswers))
+	for _, answer := range decision.QuestionAnswers {
+		values := answer.Answers
+		if len(values) == 0 {
+			values = splitCodexAnswers(answer.Answer)
+		}
+		if answer.QuestionID != "" {
+			byID[answer.QuestionID] = values
+		}
+		if answer.Header != "" {
+			byHeader[answer.Header] = values
+		}
+	}
+	result := ToolRequestUserInputResponse{Answers: make(map[string]ToolRequestUserInputAnswer, len(pending.questionIDs))}
+	for index, questionID := range pending.questionIDs {
+		values := byID[questionID]
+		if len(values) == 0 && index < len(pending.answerKeys) {
+			values = byHeader[pending.answerKeys[index]]
+		}
+		if len(values) == 0 && index < len(decision.QuestionAnswers) {
+			values = decision.QuestionAnswers[index].Answers
+			if len(values) == 0 {
+				values = splitCodexAnswers(decision.QuestionAnswers[index].Answer)
+			}
+		}
+		if len(values) == 0 && index == 0 && len(decision.Answers) > 0 {
+			values = decision.Answers
+		}
+		result.Answers[questionID] = ToolRequestUserInputAnswer{Answers: values}
+	}
+	if err := s.rpc.SendServerReply(pending.rpcID, result); err != nil {
+		pending.timer = time.AfterFunc(codexInteractionTimeout, func() { s.expireCodexAsk(askID) })
+		s.interactions.mu.Lock()
+		s.interactions.asks[askID] = pending
+		s.interactions.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+func (s *Session) expireCodexPermission(requestID string) {
+	s.interactions.mu.Lock()
+	pending, ok := s.interactions.permissions[requestID]
+	if ok {
+		delete(s.interactions.permissions, requestID)
+	}
+	s.interactions.mu.Unlock()
+	if ok {
+		if pending.timer != nil {
+			pending.timer.Stop()
+		}
+		_ = s.rpc.SendServerReply(pending.rpcID, ApprovalDecisionResult{Decision: "decline"})
+	}
+}
+
+func (s *Session) expireCodexAsk(askID string) {
+	s.interactions.mu.Lock()
+	pending, ok := s.interactions.asks[askID]
+	if ok {
+		delete(s.interactions.asks, askID)
+	}
+	s.interactions.mu.Unlock()
+	if ok {
+		if pending.timer != nil {
+			pending.timer.Stop()
+		}
+		_ = s.rpc.SendServerError(pending.rpcID, -32001, "input request timed out", nil)
+	}
+}
+
+func (s *Session) stopCodexInteractionTimers() {
+	s.interactions.mu.Lock()
+	defer s.interactions.mu.Unlock()
+	for id, pending := range s.interactions.permissions {
+		if pending.timer != nil {
+			pending.timer.Stop()
+		}
+		delete(s.interactions.permissions, id)
+	}
+	for id, pending := range s.interactions.asks {
+		if pending.timer != nil {
+			pending.timer.Stop()
+		}
+		delete(s.interactions.asks, id)
+	}
+}
+
+func splitCodexAnswers(answer string) []string {
+	parts := strings.Split(strings.TrimSpace(answer), ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if value := strings.TrimSpace(part); value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func stringPointer(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(*value)
+}

--- a/apps/parsar-daemon/internal/agent/codex/server_requests_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/server_requests_test.go
@@ -50,13 +50,16 @@ func TestCodexPermissionRequestWaitsForHumanDecision(t *testing.T) {
 	if err := env.DecodePayload(&request); err != nil {
 		t.Fatalf("decode permission payload: %v", err)
 	}
+	if env.ID != "run-test" || request.RequestID == "" {
+		t.Fatalf("permission correlation = env.ID %q request.ID %q", env.ID, request.RequestID)
+	}
 	if request.Tool != "command_execution" || request.Title != command || request.Detail != reason {
 		t.Fatalf("permission payload = %+v", request)
 	}
 
 	submitDone := make(chan error, 1)
 	go func() {
-		submitDone <- s.SubmitPermission(context.Background(), env.ID, proto.PermissionDecisionPayload{Approved: true})
+		submitDone <- s.SubmitPermission(context.Background(), request.RequestID, proto.PermissionDecisionPayload{Approved: true})
 	}()
 	reply := readCodexServerReply(t, srv)
 	if err := <-submitDone; err != nil {
@@ -90,9 +93,13 @@ func TestCodexPermissionsApprovalUsesDedicatedResponseSchema(t *testing.T) {
 				t.Fatalf("send permissions request: %v", err)
 			}
 			env := <-out
+			var request proto.PermissionRequestPayload
+			if err := env.DecodePayload(&request); err != nil {
+				t.Fatalf("decode permission payload: %v", err)
+			}
 			done := make(chan error, 1)
 			go func() {
-				done <- s.SubmitPermission(context.Background(), env.ID, proto.PermissionDecisionPayload{Approved: tt.approved})
+				done <- s.SubmitPermission(context.Background(), request.RequestID, proto.PermissionDecisionPayload{Approved: tt.approved})
 			}()
 			var reply struct {
 				ID     string `json:"id"`
@@ -242,14 +249,18 @@ func TestCodexInteractionExpiryUnblocksRuntime(t *testing.T) {
 			t.Fatalf("send permission request: %v", err)
 		}
 		env := <-out
+		var request proto.PermissionRequestPayload
+		if err := env.DecodePayload(&request); err != nil {
+			t.Fatalf("decode permission payload: %v", err)
+		}
 		expireDone := make(chan struct{})
-		go func() { s.expireCodexPermission(env.ID); close(expireDone) }()
+		go func() { s.expireCodexPermission(request.RequestID); close(expireDone) }()
 		reply := readCodexServerReply(t, srv)
 		<-expireDone
 		if reply.Result.Decision != "decline" {
 			t.Fatalf("expiry decision = %q", reply.Result.Decision)
 		}
-		if err := s.SubmitPermission(context.Background(), env.ID, proto.PermissionDecisionPayload{Approved: true}); !errors.Is(err, agent.ErrUnknownPermission) {
+		if err := s.SubmitPermission(context.Background(), request.RequestID, proto.PermissionDecisionPayload{Approved: true}); !errors.Is(err, agent.ErrUnknownPermission) {
 			t.Fatalf("late permission error = %v, want ErrUnknownPermission", err)
 		}
 	})
@@ -264,8 +275,12 @@ func TestCodexInteractionExpiryUnblocksRuntime(t *testing.T) {
 			t.Fatalf("send permission profile request: %v", err)
 		}
 		env := <-out
+		var request proto.PermissionRequestPayload
+		if err := env.DecodePayload(&request); err != nil {
+			t.Fatalf("decode permission payload: %v", err)
+		}
 		done := make(chan struct{})
-		go func() { s.expireCodexPermission(env.ID); close(done) }()
+		go func() { s.expireCodexPermission(request.RequestID); close(done) }()
 		var reply struct {
 			Result PermissionsRequestApprovalResponse `json:"result"`
 		}

--- a/apps/parsar-daemon/internal/agent/codex/server_requests_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/server_requests_test.go
@@ -1,0 +1,251 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func newInteractionTestSession(rpc *JSONRPCClient) (*Session, <-chan proto.Envelope) {
+	out := make(chan proto.Envelope, 1)
+	s := &Session{
+		runID:        "run-test",
+		out:          out,
+		rpc:          rpc,
+		cancelCtx:    context.Background(),
+		interactions: newPendingCodexInteractions(),
+	}
+	s.registerHandlers()
+	return s, out
+}
+
+func TestCodexPermissionRequestWaitsForHumanDecision(t *testing.T) {
+	tc, srv, cleanup := NewTestClient()
+	defer cleanup()
+	s, out := newInteractionTestSession(tc.JSONRPCClient)
+
+	command := "go test ./..."
+	reason := "requires process execution"
+	if err := SendServerRequest(srv, "rpc-perm-1", "item/commandExecution/requestApproval", CommandExecutionRequestApprovalParams{
+		ThreadID: "thread-1", TurnID: "turn-1", ItemID: "item-1", Command: &command, Reason: &reason,
+	}); err != nil {
+		t.Fatalf("send server request: %v", err)
+	}
+
+	var env proto.Envelope
+	select {
+	case env = <-out:
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission request was not surfaced to Parsar")
+	}
+	if env.Type != proto.TypePermissionRequest {
+		t.Fatalf("envelope type = %q, want %q", env.Type, proto.TypePermissionRequest)
+	}
+	var request proto.PermissionRequestPayload
+	if err := env.DecodePayload(&request); err != nil {
+		t.Fatalf("decode permission payload: %v", err)
+	}
+	if request.Tool != "command_execution" || request.Title != command || request.Detail != reason {
+		t.Fatalf("permission payload = %+v", request)
+	}
+
+	submitDone := make(chan error, 1)
+	go func() {
+		submitDone <- s.SubmitPermission(context.Background(), env.ID, proto.PermissionDecisionPayload{Approved: true})
+	}()
+	reply := readCodexServerReply(t, srv)
+	if err := <-submitDone; err != nil {
+		t.Fatalf("submit permission: %v", err)
+	}
+	if reply.ID != "rpc-perm-1" || reply.Result.Decision != "accept" {
+		t.Fatalf("reply = %+v", reply)
+	}
+}
+
+func TestCodexUserInputMapsAnswersByQuestionID(t *testing.T) {
+	tc, srv, cleanup := NewTestClient()
+	defer cleanup()
+	s, out := newInteractionTestSession(tc.JSONRPCClient)
+
+	if err := SendServerRequest(srv, "rpc-ask-1", "item/tool/requestUserInput", ToolRequestUserInputParams{
+		ThreadID: "thread-1", TurnID: "turn-1", ItemID: "item-ask",
+		Questions: []ToolRequestUserInputQuestion{
+			{ID: "deployment", Header: "Deploy", Question: "Where?", Options: []ToolRequestUserInputOption{{Label: "Staging"}, {Label: "Production"}}},
+			{ID: "checks", Header: "Checks", Question: "Which checks?", Options: []ToolRequestUserInputOption{{Label: "Unit"}, {Label: "E2E"}}},
+		},
+	}); err != nil {
+		t.Fatalf("send server request: %v", err)
+	}
+
+	var env proto.Envelope
+	select {
+	case env = <-out:
+	case <-time.After(2 * time.Second):
+		t.Fatal("requestUserInput was not surfaced to Parsar")
+	}
+	if env.Type != proto.TypePromptForUserChoice {
+		t.Fatalf("envelope type = %q, want %q", env.Type, proto.TypePromptForUserChoice)
+	}
+	var request proto.PromptForUserChoicePayload
+	if err := env.DecodePayload(&request); err != nil {
+		t.Fatalf("decode user input payload: %v", err)
+	}
+	if len(request.Questions) != 2 || request.Questions[0].ID != "deployment" || request.Questions[1].ID != "checks" || request.Questions[0].Header != "Deploy" {
+		t.Fatalf("user input payload = %+v", request)
+	}
+
+	submitDone := make(chan error, 1)
+	go func() {
+		submitDone <- s.SubmitPromptForUserChoice(context.Background(), request.AskID, proto.PromptForUserChoiceDecisionPayload{
+			QuestionAnswers: []proto.PromptForUserChoiceQuestionAnswer{
+				{QuestionID: "checks", Answers: []string{"Unit", "E2E"}},
+				{QuestionID: "deployment", Answers: []string{"Staging"}},
+			},
+		})
+	}()
+
+	var reply struct {
+		ID     string                       `json:"id"`
+		Result ToolRequestUserInputResponse `json:"result"`
+	}
+	decodeCodexReply(t, srv, &reply)
+	if err := <-submitDone; err != nil {
+		t.Fatalf("submit user input: %v", err)
+	}
+	if reply.ID != "rpc-ask-1" {
+		t.Fatalf("reply id = %q", reply.ID)
+	}
+	if got := reply.Result.Answers["deployment"].Answers; len(got) != 1 || got[0] != "Staging" {
+		t.Fatalf("deployment answers = %v", got)
+	}
+	if got := reply.Result.Answers["checks"].Answers; len(got) != 2 || got[0] != "Unit" || got[1] != "E2E" {
+		t.Fatalf("checks answers = %v", got)
+	}
+}
+
+func TestCodexUserInputCancellationReturnsErrorInsteadOfEmptyAnswers(t *testing.T) {
+	tc, srv, cleanup := NewTestClient()
+	defer cleanup()
+	s, out := newInteractionTestSession(tc.JSONRPCClient)
+
+	if err := SendServerRequest(srv, "rpc-ask-cancel", "item/tool/requestUserInput", ToolRequestUserInputParams{
+		Questions: []ToolRequestUserInputQuestion{{ID: "confirm", Header: "Confirm", Question: "Continue?"}},
+	}); err != nil {
+		t.Fatalf("send server request: %v", err)
+	}
+	var env proto.Envelope
+	select {
+	case env = <-out:
+	case <-time.After(2 * time.Second):
+		t.Fatal("requestUserInput was not surfaced to Parsar")
+	}
+	var request proto.PromptForUserChoicePayload
+	if err := env.DecodePayload(&request); err != nil {
+		t.Fatalf("decode user input payload: %v", err)
+	}
+	submitDone := make(chan error, 1)
+	go func() {
+		submitDone <- s.SubmitPromptForUserChoice(context.Background(), request.AskID, proto.PromptForUserChoiceDecisionPayload{
+			Cancelled: true, Reason: "cancelled by user",
+		})
+	}()
+
+	var reply struct {
+		ID    string `json:"id"`
+		Error *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	decodeCodexReply(t, srv, &reply)
+	if err := <-submitDone; err != nil {
+		t.Fatalf("cancel user input: %v", err)
+	}
+	if reply.ID != "rpc-ask-cancel" || reply.Error == nil || reply.Error.Code != -32001 {
+		t.Fatalf("cancel reply = %+v", reply)
+	}
+}
+
+func TestCodexInteractionExpiryUnblocksRuntime(t *testing.T) {
+	t.Run("permission declines", func(t *testing.T) {
+		tc, srv, cleanup := NewTestClient()
+		defer cleanup()
+		s, out := newInteractionTestSession(tc.JSONRPCClient)
+		command := "deploy"
+		if err := SendServerRequest(srv, "rpc-perm-timeout", "item/commandExecution/requestApproval", CommandExecutionRequestApprovalParams{Command: &command}); err != nil {
+			t.Fatalf("send permission request: %v", err)
+		}
+		env := <-out
+		expireDone := make(chan struct{})
+		go func() { s.expireCodexPermission(env.ID); close(expireDone) }()
+		reply := readCodexServerReply(t, srv)
+		<-expireDone
+		if reply.Result.Decision != "decline" {
+			t.Fatalf("expiry decision = %q", reply.Result.Decision)
+		}
+		if err := s.SubmitPermission(context.Background(), env.ID, proto.PermissionDecisionPayload{Approved: true}); !errors.Is(err, agent.ErrUnknownPermission) {
+			t.Fatalf("late permission error = %v, want ErrUnknownPermission", err)
+		}
+	})
+
+	t.Run("user input returns timeout error", func(t *testing.T) {
+		tc, srv, cleanup := NewTestClient()
+		defer cleanup()
+		s, out := newInteractionTestSession(tc.JSONRPCClient)
+		if err := SendServerRequest(srv, "rpc-ask-timeout", "item/tool/requestUserInput", ToolRequestUserInputParams{
+			Questions: []ToolRequestUserInputQuestion{{ID: "q1", Header: "Confirm", Question: "Continue?"}},
+		}); err != nil {
+			t.Fatalf("send input request: %v", err)
+		}
+		var request proto.PromptForUserChoicePayload
+		if err := (<-out).DecodePayload(&request); err != nil {
+			t.Fatalf("decode input request: %v", err)
+		}
+		expireDone := make(chan struct{})
+		go func() { s.expireCodexAsk(request.AskID); close(expireDone) }()
+		var reply struct {
+			Error *struct {
+				Code int `json:"code"`
+			} `json:"error"`
+		}
+		decodeCodexReply(t, srv, &reply)
+		<-expireDone
+		if reply.Error == nil || reply.Error.Code != -32001 {
+			t.Fatalf("expiry reply = %+v", reply)
+		}
+		if err := s.SubmitPromptForUserChoice(context.Background(), request.AskID, proto.PromptForUserChoiceDecisionPayload{Answers: []string{"yes"}}); !errors.Is(err, agent.ErrUnknownAsk) {
+			t.Fatalf("late input error = %v, want ErrUnknownAsk", err)
+		}
+	})
+}
+
+type approvalReply struct {
+	ID     string                 `json:"id"`
+	Result ApprovalDecisionResult `json:"result"`
+}
+
+func readCodexServerReply(t *testing.T, srv ServerSide) approvalReply {
+	t.Helper()
+	var reply approvalReply
+	decodeCodexReply(t, srv, &reply)
+	return reply
+}
+
+func decodeCodexReply(t *testing.T, srv ServerSide, target any) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- json.NewDecoder(srv.FromClient).Decode(target) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("decode Codex reply: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Codex reply timed out")
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/server_requests_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/server_requests_test.go
@@ -67,16 +67,68 @@ func TestCodexPermissionRequestWaitsForHumanDecision(t *testing.T) {
 	}
 }
 
+func TestCodexPermissionsApprovalUsesDedicatedResponseSchema(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		approved   bool
+		wantGrants bool
+	}{
+		{name: "approve echoes requested grants", approved: true, wantGrants: true},
+		{name: "deny grants nothing", approved: false, wantGrants: false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tc, srv, cleanup := NewTestClient()
+			defer cleanup()
+			s, out := newInteractionTestSession(tc.JSONRPCClient)
+			requested := map[string]any{
+				"network":    map[string]any{"enabled": true},
+				"fileSystem": map[string]any{"write": []any{"/workspace"}},
+			}
+			if err := SendServerRequest(srv, "rpc-permissions", "item/permissions/requestApproval", PermissionsRequestApprovalParams{
+				Cwd: "/workspace", Permissions: requested,
+			}); err != nil {
+				t.Fatalf("send permissions request: %v", err)
+			}
+			env := <-out
+			done := make(chan error, 1)
+			go func() {
+				done <- s.SubmitPermission(context.Background(), env.ID, proto.PermissionDecisionPayload{Approved: tt.approved})
+			}()
+			var reply struct {
+				ID     string `json:"id"`
+				Result struct {
+					Permissions map[string]any `json:"permissions"`
+					Scope       string         `json:"scope"`
+					Decision    string         `json:"decision"`
+				} `json:"result"`
+			}
+			decodeCodexReply(t, srv, &reply)
+			if err := <-done; err != nil {
+				t.Fatalf("submit permissions: %v", err)
+			}
+			if reply.Result.Scope != "turn" || reply.Result.Decision != "" {
+				t.Fatalf("permissions reply = %+v", reply.Result)
+			}
+			_, granted := reply.Result.Permissions["network"]
+			if granted != tt.wantGrants {
+				t.Fatalf("permissions = %+v, want grants=%v", reply.Result.Permissions, tt.wantGrants)
+			}
+		})
+	}
+}
+
 func TestCodexUserInputMapsAnswersByQuestionID(t *testing.T) {
 	tc, srv, cleanup := NewTestClient()
 	defer cleanup()
 	s, out := newInteractionTestSession(tc.JSONRPCClient)
 
+	autoResolutionMs := uint64(120_000)
 	if err := SendServerRequest(srv, "rpc-ask-1", "item/tool/requestUserInput", ToolRequestUserInputParams{
 		ThreadID: "thread-1", TurnID: "turn-1", ItemID: "item-ask",
+		AutoResolutionMs: &autoResolutionMs,
 		Questions: []ToolRequestUserInputQuestion{
-			{ID: "deployment", Header: "Deploy", Question: "Where?", Options: []ToolRequestUserInputOption{{Label: "Staging"}, {Label: "Production"}}},
-			{ID: "checks", Header: "Checks", Question: "Which checks?", Options: []ToolRequestUserInputOption{{Label: "Unit"}, {Label: "E2E"}}},
+			{ID: "deployment", Header: "Deploy", Question: "Where?", IsOther: true, Options: []ToolRequestUserInputOption{{Label: "Staging"}, {Label: "Production"}}},
+			{ID: "checks", Header: "Checks", Question: "Which checks?", IsSecret: true, Options: []ToolRequestUserInputOption{{Label: "Unit"}, {Label: "E2E"}}},
 		},
 	}); err != nil {
 		t.Fatalf("send server request: %v", err)
@@ -97,6 +149,15 @@ func TestCodexUserInputMapsAnswersByQuestionID(t *testing.T) {
 	}
 	if len(request.Questions) != 2 || request.Questions[0].ID != "deployment" || request.Questions[1].ID != "checks" || request.Questions[0].Header != "Deploy" {
 		t.Fatalf("user input payload = %+v", request)
+	}
+	if !request.Questions[0].IsOther || !request.Questions[1].IsSecret || request.AutoResolutionMs == nil || *request.AutoResolutionMs != autoResolutionMs {
+		t.Fatalf("user input metadata = %+v", request)
+	}
+	s.interactions.mu.Lock()
+	pending := s.interactions.asks[request.AskID]
+	s.interactions.mu.Unlock()
+	if pending.timeout != 2*time.Minute {
+		t.Fatalf("ask timeout = %v, want 2m", pending.timeout)
 	}
 
 	submitDone := make(chan error, 1)
@@ -190,6 +251,28 @@ func TestCodexInteractionExpiryUnblocksRuntime(t *testing.T) {
 		}
 		if err := s.SubmitPermission(context.Background(), env.ID, proto.PermissionDecisionPayload{Approved: true}); !errors.Is(err, agent.ErrUnknownPermission) {
 			t.Fatalf("late permission error = %v, want ErrUnknownPermission", err)
+		}
+	})
+
+	t.Run("permission profile grants nothing", func(t *testing.T) {
+		tc, srv, cleanup := NewTestClient()
+		defer cleanup()
+		s, out := newInteractionTestSession(tc.JSONRPCClient)
+		if err := SendServerRequest(srv, "rpc-profile-timeout", "item/permissions/requestApproval", PermissionsRequestApprovalParams{
+			Permissions: map[string]any{"network": map[string]any{"enabled": true}},
+		}); err != nil {
+			t.Fatalf("send permission profile request: %v", err)
+		}
+		env := <-out
+		done := make(chan struct{})
+		go func() { s.expireCodexPermission(env.ID); close(done) }()
+		var reply struct {
+			Result PermissionsRequestApprovalResponse `json:"result"`
+		}
+		decodeCodexReply(t, srv, &reply)
+		<-done
+		if len(reply.Result.Permissions) != 0 || reply.Result.Scope != "turn" {
+			t.Fatalf("expiry permissions response = %+v", reply.Result)
 		}
 	})
 

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -226,11 +226,30 @@ func (s *Session) run(plan SessionPlan, req proto.PromptRequestPayload) {
 		s.emitTerminal("codex: empty prompt", true)
 		return
 	}
-	turnCtx, turnCancel := context.WithTimeout(s.cancelCtx, 10*time.Second)
-	_, ackErr := s.rpc.Request(turnCtx, "turn/start", TurnStartParams{
+	turnParams := TurnStartParams{
 		ThreadID: s.currentThreadID(),
 		Input:    input,
-	})
+	}
+	if plan.CollaborationMode != "" {
+		model := strings.TrimSpace(s.resolvedModel)
+		if model == "" {
+			s.emitTerminal("codex: collaboration mode requires a resolved model", true)
+			return
+		}
+		var developerInstructions *string
+		if plan.SystemPrompt != "" {
+			developerInstructions = &plan.SystemPrompt
+		}
+		turnParams.CollaborationMode = &CollaborationMode{
+			Mode: plan.CollaborationMode,
+			Settings: CollaborationModeSettings{
+				Model:                 model,
+				DeveloperInstructions: developerInstructions,
+			},
+		}
+	}
+	turnCtx, turnCancel := context.WithTimeout(s.cancelCtx, 10*time.Second)
+	_, ackErr := s.rpc.Request(turnCtx, "turn/start", turnParams)
 	turnCancel()
 	if ackErr != nil {
 		s.cfg.logger.Warn("codex: turn/start ack failed", "run_id", s.runID, "err", ackErr)

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -86,6 +86,8 @@ type Session struct {
 	finalTextMu sync.Mutex
 	finalText   string
 	lastErrText string
+
+	interactions *pendingCodexInteractions
 }
 
 var _ agent.Session = (*Session)(nil)
@@ -137,6 +139,7 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		cleanup:       plan.Cleanup,
 		bufs:          NewItemBuffers(),
 		resolvedModel: plan.Model,
+		interactions:  newPendingCodexInteractions(),
 	}
 	s.registerHandlers()
 
@@ -160,6 +163,7 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 
 func (s *Session) Cancel(_ context.Context) error {
 	s.cancelOnce.Do(func() {
+		s.stopCodexInteractionTimers()
 		// Best-effort turn/interrupt — codex will translate this into
 		// a graceful turn termination. If the RPC is already dead the
 		// kill path below cleans up.
@@ -175,18 +179,16 @@ func (s *Session) Cancel(_ context.Context) error {
 	return nil
 }
 
-// SubmitPermission is not wired today: the daemon runs codex under the
-// silent granular policy, so codex never raises an approval ServerRequest.
-// Returns agent.ErrUnknownPermission so the router knows it's a benign
-// pass-through, matching the opencode adapter.
-func (s *Session) SubmitPermission(_ context.Context, _ string, _ proto.PermissionDecisionPayload) error {
-	return agent.ErrUnknownPermission
+// SubmitPermission completes the deferred Codex app-server request that
+// produced the Parsar permission envelope.
+func (s *Session) SubmitPermission(_ context.Context, permID string, decision proto.PermissionDecisionPayload) error {
+	return s.submitCodexPermission(permID, decision)
 }
 
-// SubmitPromptForUserChoice: codex has no AskUserQuestion equivalent
-// today, so this is a no-op the dispatcher logs and moves on.
-func (s *Session) SubmitPromptForUserChoice(_ context.Context, _ string, _ proto.PromptForUserChoiceDecisionPayload) error {
-	return agent.ErrUnknownAsk
+// SubmitPromptForUserChoice maps Parsar's header/answer pairs back to
+// Codex's question-id keyed requestUserInput response.
+func (s *Session) SubmitPromptForUserChoice(_ context.Context, askID string, decision proto.PromptForUserChoiceDecisionPayload) error {
+	return s.submitCodexUserInput(askID, decision)
 }
 
 // ---------------------------------------------------------------------------
@@ -195,6 +197,7 @@ func (s *Session) SubmitPromptForUserChoice(_ context.Context, _ string, _ proto
 
 func (s *Session) run(plan SessionPlan, req proto.PromptRequestPayload) {
 	defer close(s.waitDone)
+	defer s.stopCodexInteractionTimers()
 	defer s.cleanup()
 	defer s.closeOut()
 
@@ -317,21 +320,12 @@ func (s *Session) registerHandlers() {
 	rpc.OnNotification("thread/tokenUsage/updated", s.onUsageUpdated)
 	rpc.OnNotification("error", s.onErrorNotif)
 
-	// Approval ServerRequests under silent granular policy should not
-	// fire; if codex sends one anyway, auto-accept so the turn proceeds
-	// rather than dangling. (TODO: surface as PermissionRequest when
-	// the agent admin opts surface_approvals on.)
-	autoAccept := func(_ json.RawMessage, _ any) (any, error) {
-		return ApprovalDecisionResult{Decision: "accept"}, nil
-	}
-	rpc.OnServerRequest("item/commandExecution/requestApproval", autoAccept)
-	rpc.OnServerRequest("item/fileChange/requestApproval", autoAccept)
-	rpc.OnServerRequest("item/permissionsRequestApproval", autoAccept)
-	// item/tool/requestUserInput (ARC) under silent policy: decline so
-	// codex doesn't block waiting for an answer we can't supply.
-	rpc.OnServerRequest("item/tool/requestUserInput", func(_ json.RawMessage, _ any) (any, error) {
-		return map[string]any{"answers": map[string]any{}}, nil
-	})
+	rpc.OnServerRequest("item/commandExecution/requestApproval", s.handleCodexCommandApproval)
+	rpc.OnServerRequest("item/fileChange/requestApproval", s.handleCodexFileApproval)
+	rpc.OnServerRequest("item/permissions/requestApproval", s.handleCodexPermissionsApproval)
+	// Older app-server releases used this unseparated method name.
+	rpc.OnServerRequest("item/permissionsRequestApproval", s.handleCodexPermissionsApproval)
+	rpc.OnServerRequest("item/tool/requestUserInput", s.handleCodexUserInput)
 }
 
 func (s *Session) onThreadStarted(raw json.RawMessage) {

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -250,12 +250,10 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 		Codex: proto.SupportedAgentKind{
 			Kind: "codex",
 			Capabilities: proto.AgentKindCapabilities{
-				// First-cut adapter runs silent (no permission cards),
-				// but streaming + usage + resume are all wired via
-				// the JSON-RPC notification stream + thread/resume RPC.
-				Streaming: true,
-				Usage:     true,
-				Resume:    true,
+				Streaming:   true,
+				Permissions: true,
+				Usage:       true,
+				Resume:      true,
 			},
 		},
 		Pi: proto.SupportedAgentKind{

--- a/apps/parsar-daemon/internal/cli/connect_test.go
+++ b/apps/parsar-daemon/internal/cli/connect_test.go
@@ -170,8 +170,8 @@ func TestDiscoverAgentCLIsBothAvailable(t *testing.T) {
 	if !got.ClaudeCode.Capabilities.Permissions || !got.ClaudeCode.Capabilities.Resume {
 		t.Fatalf("ClaudeCode capabilities = %#v", got.ClaudeCode.Capabilities)
 	}
-	if !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Resume || got.Codex.Capabilities.Permissions {
-		t.Fatalf("Codex capabilities = %#v (want Streaming+Resume, no Permissions)", got.Codex.Capabilities)
+	if !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
+		t.Fatalf("Codex capabilities = %#v (want Streaming+Permissions+Resume)", got.Codex.Capabilities)
 	}
 	if !got.Pi.Available || got.Pi.Version != "pi 0.1.0" {
 		t.Fatalf("Pi descriptor = %#v", got.Pi)
@@ -212,9 +212,10 @@ func TestRegisterAgentKindsPreservesDescriptors(t *testing.T) {
 			Available: true,
 			Version:   "codex 0.141.0",
 			Capabilities: proto.AgentKindCapabilities{
-				Streaming: true,
-				Usage:     true,
-				Resume:    true,
+				Streaming:   true,
+				Permissions: true,
+				Usage:       true,
+				Resume:      true,
 			},
 		},
 		Pi: proto.SupportedAgentKind{

--- a/apps/parsar-daemon/internal/dispatch/router.go
+++ b/apps/parsar-daemon/internal/dispatch/router.go
@@ -11,6 +11,8 @@ package dispatch
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -39,10 +41,18 @@ type Router struct {
 	idle        map[string]map[*sessionState]struct{}
 	permIndex   map[string]string // permID  → RunID
 	askIndex    map[string]string // askID   → RunID
-	shutdownCh  chan struct{}     // closed by Shutdown
-	shutdownWG  sync.WaitGroup    // waits for all pump goroutines
+	applied     map[string]appliedInteractionDecision
+	shutdownCh  chan struct{}  // closed by Shutdown
+	shutdownWG  sync.WaitGroup // waits for all pump goroutines
 	idleTimeout time.Duration
 	closed      bool
+}
+
+type appliedInteractionDecision struct {
+	requestID   string
+	kind        string
+	fingerprint [32]byte
+	recordedAt  time.Time
 }
 
 // sessionState is the dispatcher's per-run bookkeeping. The agent
@@ -100,6 +110,7 @@ func New(cfg Config) (*Router, error) {
 		idle:        make(map[string]map[*sessionState]struct{}),
 		permIndex:   make(map[string]string),
 		askIndex:    make(map[string]string),
+		applied:     make(map[string]appliedInteractionDecision),
 		shutdownCh:  make(chan struct{}),
 		idleTimeout: idleTimeout,
 	}, nil
@@ -335,6 +346,16 @@ func (r *Router) handlePermissionDecision(ctx context.Context, env proto.Envelop
 	if err := env.DecodePayload(&payload); err != nil {
 		return fmt.Errorf("dispatch: decode permission_decision: %w", err)
 	}
+	if payload.DeliveryID == "" {
+		return errors.New("dispatch: permission_decision missing delivery_id")
+	}
+	fingerprint, err := interactionDecisionFingerprint(payload)
+	if err != nil {
+		return fmt.Errorf("dispatch: fingerprint permission_decision: %w", err)
+	}
+	if handled, err := r.replayAppliedInteractionDecision(ctx, env.ID, payload.DeliveryID, proto.TypePermissionDecision, fingerprint); handled {
+		return err
+	}
 
 	r.mu.Lock()
 	runID, known := r.permIndex[env.ID]
@@ -348,17 +369,28 @@ func (r *Router) handlePermissionDecision(ctx context.Context, env proto.Envelop
 		// Server's perm timeout / cancel race; common enough that info
 		// is right.
 		r.log.InfoContext(ctx, "permission_decision for unknown perm (run gone)", "perm_id", env.ID)
-		return nil
+		return r.sendInteractionDecisionAck(ctx, env.ID, payload.DeliveryID, false, "not_pending", "permission request is no longer pending")
 	}
 
 	if err := state.session.SubmitPermission(ctx, env.ID, payload); err != nil {
 		if errors.Is(err, agent.ErrUnknownPermission) {
 			r.log.InfoContext(ctx, "agent reports unknown perm (race with cancel)", "perm_id", env.ID, "run_id", runID)
-			return nil
+			r.dropPermission(state, env.ID)
+			return r.sendInteractionDecisionAck(ctx, env.ID, payload.DeliveryID, false, "not_pending", err.Error())
 		}
-		return fmt.Errorf("dispatch: forward permission_decision perm=%s run=%s: %w", env.ID, runID, err)
+		r.log.WarnContext(ctx, "agent rejected permission decision", "perm_id", env.ID, "run_id", runID, "err", err)
+		return r.sendInteractionDecisionAck(ctx, env.ID, payload.DeliveryID, false, "runtime_error", err.Error())
 	}
-	return nil
+	r.dropPermission(state, env.ID)
+	r.rememberAppliedInteractionDecision(env.ID, proto.TypePermissionDecision, fingerprint)
+	return r.sendInteractionDecisionAck(ctx, env.ID, payload.DeliveryID, true, "", "")
+}
+
+func (r *Router) dropPermission(s *sessionState, permissionID string) {
+	r.mu.Lock()
+	delete(r.permIndex, permissionID)
+	delete(s.pendingIDs, permissionID)
+	r.mu.Unlock()
 }
 
 // handlePromptForUserChoiceDecision is the ask-side twin of
@@ -381,6 +413,16 @@ func (r *Router) handlePromptForUserChoiceDecision(ctx context.Context, env prot
 	if err := env.DecodePayload(&payload); err != nil {
 		return fmt.Errorf("dispatch: decode prompt_for_user_choice_decision: %w", err)
 	}
+	if payload.DeliveryID == "" {
+		return errors.New("dispatch: prompt_for_user_choice_decision missing delivery_id")
+	}
+	fingerprint, err := interactionDecisionFingerprint(payload)
+	if err != nil {
+		return fmt.Errorf("dispatch: fingerprint prompt_for_user_choice_decision: %w", err)
+	}
+	if handled, err := r.replayAppliedInteractionDecision(ctx, env.ID, payload.DeliveryID, proto.TypePromptForUserChoiceDecision, fingerprint); handled {
+		return err
+	}
 
 	r.mu.Lock()
 	runID, known := r.askIndex[env.ID]
@@ -392,20 +434,106 @@ func (r *Router) handlePromptForUserChoiceDecision(ctx context.Context, env prot
 
 	if !known || state == nil {
 		r.log.InfoContext(ctx, "prompt_for_user_choice_decision for unknown ask (run gone)", "ask_id", env.ID)
-		return nil
+		return r.sendInteractionDecisionAck(ctx, env.ID, payload.DeliveryID, false, "not_pending", "user-input request is no longer pending")
 	}
 
-	err := state.session.SubmitPromptForUserChoice(ctx, env.ID, payload)
-	// Resolved one way or another — the ask is done from the router's
-	// point of view. Drop it from both indices so subsequent retries
-	// short-circuit as "run gone" rather than re-entering Submit.
-	r.dropAsk(state, env.ID)
+	err = state.session.SubmitPromptForUserChoice(ctx, env.ID, payload)
 	if err != nil {
 		if errors.Is(err, agent.ErrUnknownAsk) {
 			r.log.InfoContext(ctx, "agent reports unknown ask (race with cancel)", "ask_id", env.ID, "run_id", runID)
-			return nil
+			r.dropAsk(state, env.ID)
+			return r.sendInteractionDecisionAck(ctx, env.ID, payload.DeliveryID, false, "not_pending", err.Error())
 		}
-		return fmt.Errorf("dispatch: forward prompt_for_user_choice_decision ask=%s run=%s: %w", env.ID, runID, err)
+		// Keep the routing entry for transient runtime failures. Codex, for
+		// example, restores its pending request when a JSON-RPC reply write
+		// fails, so dropping the ask here would turn a retryable error into a
+		// permanent not_pending response on the next attempt.
+		r.log.WarnContext(ctx, "agent rejected user-input decision", "ask_id", env.ID, "run_id", runID, "err", err)
+		return r.sendInteractionDecisionAck(ctx, env.ID, payload.DeliveryID, false, "runtime_error", err.Error())
+	}
+	r.dropAsk(state, env.ID)
+	r.rememberAppliedInteractionDecision(env.ID, proto.TypePromptForUserChoiceDecision, fingerprint)
+	return r.sendInteractionDecisionAck(ctx, env.ID, payload.DeliveryID, true, "", "")
+}
+
+func (r *Router) replayAppliedInteractionDecision(ctx context.Context, requestID, deliveryID, kind string, fingerprint [32]byte) (bool, error) {
+	key := appliedInteractionDecisionKey(requestID, kind)
+	r.mu.Lock()
+	applied, ok := r.applied[key]
+	r.mu.Unlock()
+	if !ok {
+		return false, nil
+	}
+	if applied.requestID != requestID || applied.kind != kind || applied.fingerprint != fingerprint {
+		return true, r.sendInteractionDecisionAck(ctx, requestID, deliveryID, false, "decision_conflict", "request was already applied with a different decision")
+	}
+	return true, r.sendInteractionDecisionAck(ctx, requestID, deliveryID, true, "", "")
+}
+
+func (r *Router) rememberAppliedInteractionDecision(requestID, kind string, fingerprint [32]byte) {
+	now := time.Now().UTC()
+	key := appliedInteractionDecisionKey(requestID, kind)
+	r.mu.Lock()
+	if len(r.applied) >= 1024 {
+		cutoff := now.Add(-time.Hour)
+		for id, entry := range r.applied {
+			if entry.recordedAt.Before(cutoff) {
+				delete(r.applied, id)
+			}
+		}
+	}
+	if len(r.applied) >= 1024 {
+		for id := range r.applied {
+			delete(r.applied, id)
+			break
+		}
+	}
+	r.applied[key] = appliedInteractionDecision{
+		requestID: requestID, kind: kind, fingerprint: fingerprint, recordedAt: now,
+	}
+	r.mu.Unlock()
+}
+
+func appliedInteractionDecisionKey(requestID, kind string) string {
+	return kind + "\x00" + requestID
+}
+
+// interactionDecisionFingerprint excludes the transport delivery id. Each
+// retry gets a fresh delivery id so a late ack cannot satisfy a newer waiter,
+// while the request plus decision content remains stable for daemon replay.
+func interactionDecisionFingerprint(payload any) ([32]byte, error) {
+	switch decision := payload.(type) {
+	case proto.PermissionDecisionPayload:
+		decision.DeliveryID = ""
+		encoded, err := json.Marshal(decision)
+		if err != nil {
+			return [32]byte{}, err
+		}
+		return sha256.Sum256(encoded), nil
+	case proto.PromptForUserChoiceDecisionPayload:
+		decision.DeliveryID = ""
+		encoded, err := json.Marshal(decision)
+		if err != nil {
+			return [32]byte{}, err
+		}
+		return sha256.Sum256(encoded), nil
+	default:
+		return [32]byte{}, fmt.Errorf("unsupported interaction decision %T", payload)
+	}
+}
+
+func (r *Router) sendInteractionDecisionAck(ctx context.Context, requestID, deliveryID string, applied bool, errorCode, message string) error {
+	env, err := proto.NewEnvelope(proto.TypeInteractionDecisionAck, requestID, proto.InteractionDecisionAckPayload{
+		DeliveryID: deliveryID,
+		Applied:    applied,
+		ErrorCode:  errorCode,
+		Error:      message,
+	})
+	if err != nil {
+		return fmt.Errorf("dispatch: build interaction decision ack: %w", err)
+	}
+	if err := r.sender.Send(ctx, env); err != nil {
+		return fmt.Errorf("dispatch: send interaction decision ack: %w", err)
 	}
 	return nil
 }

--- a/apps/parsar-daemon/internal/dispatch/router.go
+++ b/apps/parsar-daemon/internal/dispatch/router.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -672,12 +673,20 @@ func (r *Router) pump(s *sessionState) {
 func (r *Router) indexPermissionFrame(s *sessionState, env proto.Envelope) {
 	switch env.Type {
 	case proto.TypePermissionRequest:
-		if env.ID == "" {
+		var p proto.PermissionRequestPayload
+		if err := env.DecodePayload(&p); err != nil {
+			return
+		}
+		requestID := strings.TrimSpace(p.RequestID)
+		if requestID == "" {
+			requestID = strings.TrimSpace(env.ID)
+		}
+		if requestID == "" {
 			return
 		}
 		r.mu.Lock()
-		r.permIndex[env.ID] = s.runID
-		s.pendingIDs[env.ID] = struct{}{}
+		r.permIndex[requestID] = s.runID
+		s.pendingIDs[requestID] = struct{}{}
 		r.mu.Unlock()
 	case proto.TypePermissionCancel:
 		if env.ID == "" {

--- a/apps/parsar-daemon/internal/dispatch/router_test.go
+++ b/apps/parsar-daemon/internal/dispatch/router_test.go
@@ -351,8 +351,8 @@ func TestPermissionRequestIsIndexedAndDecisionRoutes(t *testing.T) {
 	sess := <-h.gotSess
 
 	// Session emits a permission_request; pump should index it.
-	permEnv := mustEnv(t, proto.TypePermissionRequest, "perm_abcd1234", proto.PermissionRequestPayload{
-		Tool: "Bash", Title: "rm -rf /",
+	permEnv := mustEnv(t, proto.TypePermissionRequest, "run_p", proto.PermissionRequestPayload{
+		RequestID: "perm_abcd1234", Tool: "Bash", Title: "rm -rf /",
 	})
 	sess.out <- permEnv
 	// Wait until sender records — indexing happens before send.
@@ -393,7 +393,7 @@ func TestPermissionCancelDeindexes(t *testing.T) {
 	<-h.gotReq
 	sess := <-h.gotSess
 
-	sess.out <- mustEnv(t, proto.TypePermissionRequest, "perm_xx", proto.PermissionRequestPayload{Tool: "Bash"})
+	sess.out <- mustEnv(t, proto.TypePermissionRequest, "run_p2", proto.PermissionRequestPayload{RequestID: "perm_xx", Tool: "Bash"})
 	waitFor(t, func() bool { return len(h.sender.snapshot()) >= 1 }, "perm forwarded")
 	sess.out <- mustEnv(t, proto.TypePermissionCancel, "perm_xx", nil)
 	waitFor(t, func() bool { return len(h.sender.snapshot()) >= 2 }, "perm_cancel forwarded")

--- a/apps/parsar-daemon/internal/dispatch/router_test.go
+++ b/apps/parsar-daemon/internal/dispatch/router_test.go
@@ -358,7 +358,7 @@ func TestPermissionRequestIsIndexedAndDecisionRoutes(t *testing.T) {
 	// Wait until sender records — indexing happens before send.
 	waitFor(t, func() bool { return len(h.sender.snapshot()) >= 1 }, "permission_request to be forwarded")
 
-	dec := mustEnv(t, proto.TypePermissionDecision, "perm_abcd1234", proto.PermissionDecisionPayload{Approved: true})
+	dec := mustEnv(t, proto.TypePermissionDecision, "perm_abcd1234", proto.PermissionDecisionPayload{DeliveryID: "delivery-perm-1", Approved: true})
 	if err := h.router.Handle(context.Background(), dec); err != nil {
 		t.Fatalf("permission_decision: %v", err)
 	}
@@ -366,6 +366,20 @@ func TestPermissionRequestIsIndexedAndDecisionRoutes(t *testing.T) {
 	if len(calls) != 1 || calls[0].id != "perm_abcd1234" || !calls[0].decision.Approved {
 		t.Errorf("submissions = %+v, want one approved perm_abcd1234", calls)
 	}
+	assertDecisionAck(t, h.sender, "delivery-perm-1", true, "")
+	retry := mustEnv(t, proto.TypePermissionDecision, "perm_abcd1234", proto.PermissionDecisionPayload{DeliveryID: "delivery-perm-2", Approved: true})
+	if err := h.router.Handle(context.Background(), retry); err != nil {
+		t.Fatalf("idempotent permission replay: %v", err)
+	}
+	if calls := sess.submissions(); len(calls) != 1 {
+		t.Fatalf("idempotent replay reached agent twice: %+v", calls)
+	}
+	assertDecisionAck(t, h.sender, "delivery-perm-2", true, "")
+	conflict := mustEnv(t, proto.TypePermissionDecision, "perm_abcd1234", proto.PermissionDecisionPayload{DeliveryID: "delivery-perm-3", Approved: false})
+	if err := h.router.Handle(context.Background(), conflict); err != nil {
+		t.Fatalf("conflicting permission replay: %v", err)
+	}
+	assertDecisionAck(t, h.sender, "delivery-perm-3", false, "decision_conflict")
 
 	close(sess.out)
 }
@@ -385,12 +399,13 @@ func TestPermissionCancelDeindexes(t *testing.T) {
 	waitFor(t, func() bool { return len(h.sender.snapshot()) >= 2 }, "perm_cancel forwarded")
 
 	// A decision for the cancelled perm should be a no-op (session never sees it).
-	if err := h.router.Handle(context.Background(), mustEnv(t, proto.TypePermissionDecision, "perm_xx", proto.PermissionDecisionPayload{})); err != nil {
+	if err := h.router.Handle(context.Background(), mustEnv(t, proto.TypePermissionDecision, "perm_xx", proto.PermissionDecisionPayload{DeliveryID: "delivery-cancelled"})); err != nil {
 		t.Fatalf("decision: %v", err)
 	}
 	if calls := sess.submissions(); len(calls) != 0 {
 		t.Errorf("expected zero submissions after cancel, got %+v", calls)
 	}
+	assertDecisionAck(t, h.sender, "delivery-cancelled", false, "not_pending")
 
 	close(sess.out)
 }
@@ -399,9 +414,10 @@ func TestPermissionDecisionUnknownPermIsNoop(t *testing.T) {
 	h := newHarness(t)
 	defer h.router.Shutdown(context.Background())
 
-	if err := h.router.Handle(context.Background(), mustEnv(t, proto.TypePermissionDecision, "perm_unknown", proto.PermissionDecisionPayload{})); err != nil {
+	if err := h.router.Handle(context.Background(), mustEnv(t, proto.TypePermissionDecision, "perm_unknown", proto.PermissionDecisionPayload{DeliveryID: "delivery-unknown-perm"})); err != nil {
 		t.Errorf("decision for unknown perm = %v, want nil", err)
 	}
+	assertDecisionAck(t, h.sender, "delivery-unknown-perm", false, "not_pending")
 }
 
 func TestPromptForUserChoiceDecisionRoutesToSession(t *testing.T) {
@@ -428,7 +444,7 @@ func TestPromptForUserChoiceDecisionRoutesToSession(t *testing.T) {
 	waitFor(t, func() bool { return len(h.sender.snapshot()) >= 1 }, "prompt_for_user_choice forwarded")
 
 	dec := mustEnv(t, proto.TypePromptForUserChoiceDecision, "ask_abcd1234", proto.PromptForUserChoiceDecisionPayload{
-		Answers: []string{"yes"},
+		DeliveryID: "delivery-ask-1", Answers: []string{"yes"},
 	})
 	if err := h.router.Handle(context.Background(), dec); err != nil {
 		t.Fatalf("prompt_for_user_choice_decision: %v", err)
@@ -443,6 +459,7 @@ func TestPromptForUserChoiceDecisionRoutesToSession(t *testing.T) {
 	if len(calls[0].decision.Answers) != 1 || calls[0].decision.Answers[0] != "yes" {
 		t.Errorf("answer payload mismatch: %+v", calls[0].decision)
 	}
+	assertDecisionAck(t, h.sender, "delivery-ask-1", true, "")
 
 	// Cleanup contract: a successful decision drops the ask from both
 	// the router-level index and the session's pendingAsks set, so a
@@ -483,7 +500,7 @@ func TestPromptForUserChoiceDecisionClearsIndexOnAgentUnknown(t *testing.T) {
 	waitFor(t, func() bool { return len(h.sender.snapshot()) >= 1 }, "prompt_for_user_choice forwarded")
 
 	dec := mustEnv(t, proto.TypePromptForUserChoiceDecision, "ask_xxxxxxxx", proto.PromptForUserChoiceDecisionPayload{
-		Answers: []string{"yes"},
+		DeliveryID: "delivery-ask-gone", Answers: []string{"yes"},
 	})
 	if err := h.router.Handle(context.Background(), dec); err != nil {
 		t.Fatalf("prompt_for_user_choice_decision: %v", err)
@@ -495,7 +512,50 @@ func TestPromptForUserChoiceDecisionClearsIndexOnAgentUnknown(t *testing.T) {
 	if got := h.router.PendingAsksLenForTest("run_ask_u"); got != 0 {
 		t.Errorf("pendingAsks len = %d, want 0 after ErrUnknownAsk", got)
 	}
+	assertDecisionAck(t, h.sender, "delivery-ask-gone", false, "not_pending")
 
+	close(sess.out)
+}
+
+func TestPromptForUserChoiceDecisionKeepsIndexOnTransientAgentError(t *testing.T) {
+	h := newHarness(t)
+	defer h.router.Shutdown(context.Background())
+
+	env := mustEnv(t, proto.TypePromptRequest, "run_ask_retry", proto.PromptRequestPayload{AgentKind: "claude_code"})
+	if err := h.router.Handle(context.Background(), env); err != nil {
+		t.Fatalf("prompt_request: %v", err)
+	}
+	<-h.gotReq
+	sess := <-h.gotSess
+	sess.askErr = errors.New("temporary stdin failure")
+
+	sess.out <- mustEnv(t, proto.TypePromptForUserChoice, "run_ask_retry", proto.PromptForUserChoicePayload{
+		AskID: "ask_retry", Questions: []proto.PromptForUserChoiceQuestion{{ID: "q0", Question: "Retry?"}},
+	})
+	waitFor(t, func() bool { return len(h.sender.snapshot()) >= 1 }, "prompt_for_user_choice forwarded")
+
+	decision := mustEnv(t, proto.TypePromptForUserChoiceDecision, "ask_retry", proto.PromptForUserChoiceDecisionPayload{
+		DeliveryID: "delivery-ask-retry", Answers: []string{"yes"},
+	})
+	if err := h.router.Handle(context.Background(), decision); err != nil {
+		t.Fatalf("first decision: %v", err)
+	}
+	assertDecisionAck(t, h.sender, "delivery-ask-retry", false, "runtime_error")
+	if got := h.router.AskIndexLenForTest(); got != 1 {
+		t.Fatalf("askIndex len = %d, want 1 after transient error", got)
+	}
+	if got := h.router.PendingAsksLenForTest("run_ask_retry"); got != 1 {
+		t.Fatalf("pendingAsks len = %d, want 1 after transient error", got)
+	}
+
+	sess.askErr = nil
+	if err := h.router.Handle(context.Background(), decision); err != nil {
+		t.Fatalf("retry decision: %v", err)
+	}
+	assertDecisionAck(t, h.sender, "delivery-ask-retry", true, "")
+	if got := h.router.AskIndexLenForTest(); got != 0 {
+		t.Fatalf("askIndex len = %d, want 0 after successful retry", got)
+	}
 	close(sess.out)
 }
 
@@ -503,9 +563,31 @@ func TestPromptForUserChoiceDecisionUnknownAskIsNoop(t *testing.T) {
 	h := newHarness(t)
 	defer h.router.Shutdown(context.Background())
 
-	if err := h.router.Handle(context.Background(), mustEnv(t, proto.TypePromptForUserChoiceDecision, "ask_unknown", proto.PromptForUserChoiceDecisionPayload{})); err != nil {
+	if err := h.router.Handle(context.Background(), mustEnv(t, proto.TypePromptForUserChoiceDecision, "ask_unknown", proto.PromptForUserChoiceDecisionPayload{DeliveryID: "delivery-unknown-ask"})); err != nil {
 		t.Errorf("decision for unknown ask = %v, want nil", err)
 	}
+	assertDecisionAck(t, h.sender, "delivery-unknown-ask", false, "not_pending")
+}
+
+func assertDecisionAck(t *testing.T, sender *recSender, deliveryID string, applied bool, errorCode string) {
+	t.Helper()
+	frames := sender.snapshot()
+	for index := len(frames) - 1; index >= 0; index-- {
+		if frames[index].Type != proto.TypeInteractionDecisionAck {
+			continue
+		}
+		var ack proto.InteractionDecisionAckPayload
+		if err := frames[index].DecodePayload(&ack); err != nil {
+			t.Fatalf("decode decision ack: %v", err)
+		}
+		if ack.DeliveryID == deliveryID {
+			if ack.Applied != applied || ack.ErrorCode != errorCode {
+				t.Fatalf("decision ack = %+v, want applied=%v error_code=%q", ack, applied, errorCode)
+			}
+			return
+		}
+	}
+	t.Fatalf("no decision ack for delivery %q in %+v", deliveryID, frames)
 }
 
 func TestHandleDeviceShutdownCancelsAllSessions(t *testing.T) {

--- a/apps/parsar-daemon/internal/transport/bootstrap_test.go
+++ b/apps/parsar-daemon/internal/transport/bootstrap_test.go
@@ -35,7 +35,7 @@ func TestBootstrapSendsBearerAndDeviceID(t *testing.T) {
 			"workspace_id":      "ws_xyz",
 			"ws_url":            "wss://example/agent-daemon/ws",
 			"heartbeat_seconds": 15,
-			"protocol_version":  "0.1.0",
+			"protocol_version":  "0.2.0",
 		})
 	}))
 	defer srv.Close()

--- a/apps/web/src/components/admin/InteractionDecisionCard.tsx
+++ b/apps/web/src/components/admin/InteractionDecisionCard.tsx
@@ -1,0 +1,245 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Check, MessageSquare, Play, ShieldAlert, X } from "lucide-react"
+
+import { useAdminView } from "../../lib/admin-router"
+import { useResolveAgentInteraction } from "../../lib/api-interactions"
+import type {
+  AgentInteraction,
+  AgentInteractionQuestion,
+  ResolveAgentInteractionRequest,
+} from "../../lib/api-types"
+import { firstInteractionQuestion, interactionQuestions } from "../../lib/interaction-questions"
+import { useRelativeTime, useTimeUntil } from "../../lib/relative-time"
+import { cn } from "../../lib/utils"
+import { Badge } from "../ui/badge"
+import { Button } from "../ui/button"
+import { Input } from "../ui/input"
+
+export function InteractionDecisionCard({
+  interaction,
+  workspaceID,
+  className,
+}: {
+  interaction: AgentInteraction
+  workspaceID: string
+  className?: string
+}) {
+  const { t } = useTranslation("admin")
+  const { navigate } = useAdminView()
+  const fmtAgo = useRelativeTime()
+  const fmtUntil = useTimeUntil()
+  const resolve = useResolveAgentInteraction(workspaceID)
+  const [answers, setAnswers] = useState<Record<string, string[]>>({})
+  const [custom, setCustom] = useState<Record<string, string>>({})
+  const questions = interactionQuestions(interaction)
+  const pending = interaction.status === "pending"
+  const hasAllAnswers =
+    questions.length > 0 &&
+    questions.every((question, index) => {
+      const key = questionKey(question, index)
+      return (answers[key]?.length ?? 0) > 0 || !!custom[key]?.trim()
+    })
+
+  const submitChoice = () => {
+    const answerPayload = Object.fromEntries(
+      questions.map((question, index) => {
+        const key = questionKey(question, index)
+        const values = [...(answers[key] ?? [])]
+        if (custom[key]?.trim()) values.push(custom[key].trim())
+        return [key, values]
+      }),
+    )
+    resolve.mutate({ id: interaction.id, body: { answers: answerPayload } })
+  }
+
+  const submit = (body: ResolveAgentInteractionRequest) =>
+    resolve.mutate({ id: interaction.id, body })
+
+  return (
+    <article
+      className={cn("flex min-w-0 flex-col gap-5 p-5 sm:p-6", className)}
+      data-testid="interaction-card"
+      data-interaction-kind={interaction.kind}
+      data-request-id={interaction.request_id}
+    >
+      <div>
+        <div className="mb-2 flex flex-wrap items-center gap-2">
+          <Badge variant={interaction.kind === "permission" ? "warning" : "primary"}>
+            {t(`approvals.kind.${interaction.kind === "permission" ? "permission" : "userChoice"}`)}
+          </Badge>
+          <Badge variant={pending ? "warning" : "neutral"}>
+            {t(`approvals.status.${interaction.status}`)}
+          </Badge>
+        </div>
+        <h2 className="break-words text-lg font-semibold text-fg">
+          {interaction.kind === "permission"
+            ? String(
+                interaction.request.resource ||
+                  interaction.request.action ||
+                  t("approvals.kind.permission"),
+              )
+            : firstInteractionQuestion(interaction)?.question}
+        </h2>
+        {interaction.request.detail ? (
+          <p className="mt-2 whitespace-pre-wrap break-words text-sm text-fg-muted">
+            {String(interaction.request.detail)}
+          </p>
+        ) : null}
+      </div>
+
+      <dl className="grid gap-3 rounded-lg bg-surface-subtle p-4 text-sm sm:grid-cols-2">
+        <Meta label={t("approvals.detail.agent")} value={interaction.agent_name || "—"} />
+        <Meta
+          label={t("approvals.detail.conversation")}
+          value={interaction.conversation_title || interaction.conversation_id}
+        />
+        <Meta label={t("approvals.detail.createdAt")} value={fmtAgo(interaction.created_at)} />
+        <Meta label={t("approvals.detail.expiresIn")} value={fmtUntil(interaction.expires_at)} />
+      </dl>
+
+      {interaction.kind === "permission" ? (
+        <pre className="max-h-52 overflow-y-auto whitespace-pre-wrap break-all rounded-lg border border-line bg-surface-subtle p-3 text-xs text-fg-muted">
+          {JSON.stringify(interaction.request.payload ?? {}, null, 2)}
+        </pre>
+      ) : (
+        <div className="space-y-5">
+          {questions.map((question, index) => {
+            const key = questionKey(question, index)
+            const selected = answers[key] ?? []
+            return (
+              <fieldset key={key} disabled={!pending || resolve.isPending} className="space-y-2">
+                <legend className="text-sm font-semibold text-fg">
+                  {question.header ? `${question.header} · ` : ""}
+                  {question.question}
+                </legend>
+                {question.options.map((option) => (
+                  <label
+                    key={option.label}
+                    className="flex cursor-pointer gap-3 rounded-lg border border-line px-3 py-2.5 hover:bg-surface-muted"
+                  >
+                    <input
+                      type={question.multi_select ? "checkbox" : "radio"}
+                      name={key}
+                      checked={selected.includes(option.label)}
+                      onChange={() => {
+                        setAnswers((current) => ({
+                          ...current,
+                          [key]: toggleAnswer(selected, option.label, !!question.multi_select),
+                        }))
+                        if (!question.multi_select)
+                          setCustom((current) => ({ ...current, [key]: "" }))
+                      }}
+                    />
+                    <span className="min-w-0">
+                      <span className="block break-words text-sm font-medium text-fg">
+                        {option.label}
+                      </span>
+                      {option.description ? (
+                        <span className="block break-words text-xs text-fg-subtle">
+                          {option.description}
+                        </span>
+                      ) : null}
+                    </span>
+                  </label>
+                ))}
+                <Input
+                  value={custom[key] ?? ""}
+                  onChange={(event) => {
+                    const value = event.target.value
+                    setCustom((current) => ({ ...current, [key]: value }))
+                    if (!question.multi_select && value.trim())
+                      setAnswers((current) => ({ ...current, [key]: [] }))
+                  }}
+                  placeholder={t("approvals.questions.customAnswer")}
+                />
+              </fieldset>
+            )
+          })}
+        </div>
+      )}
+
+      {resolve.error ? (
+        <p className="break-words rounded-md border border-danger-border bg-danger-subtle px-3 py-2 text-sm text-danger-emphasis">
+          {resolve.error.message}
+        </p>
+      ) : null}
+      {pending ? (
+        <div className="flex flex-wrap gap-2">
+          {interaction.kind === "permission" ? (
+            <>
+              <Button onClick={() => submit({ approved: true })} disabled={resolve.isPending}>
+                <Check className="h-4 w-4" />
+                {t("approvals.actions.allowOnce")}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => submit({ approved: false })}
+                disabled={resolve.isPending}
+              >
+                <X className="h-4 w-4" />
+                {t("approvals.actions.deny")}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button onClick={submitChoice} disabled={resolve.isPending || !hasAllAnswers}>
+                <Check className="h-4 w-4" />
+                {t("approvals.actions.submitAnswers")}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => submit({ cancelled: true, note: "cancelled by user" })}
+                disabled={resolve.isPending}
+              >
+                <X className="h-4 w-4" />
+                {t("approvals.actions.cancel")}
+              </Button>
+            </>
+          )}
+        </div>
+      ) : (
+        <div className="flex items-start gap-2 rounded-lg border border-line bg-surface-subtle px-3 py-3 text-sm text-fg-muted">
+          <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" />
+          {t("approvals.detail.alreadyDecided")}
+        </div>
+      )}
+      <div className="flex flex-wrap gap-2 border-t border-line pt-4">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => navigate("runs", { id: interaction.agent_run_id })}
+        >
+          <Play className="h-4 w-4" />
+          {t("approvals.detail.openRun")}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => navigate("conversations", { id: interaction.conversation_id })}
+        >
+          <MessageSquare className="h-4 w-4" />
+          {t("approvals.detail.openConversation")}
+        </Button>
+      </div>
+    </article>
+  )
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-xs text-fg-faint">{label}</dt>
+      <dd className="mt-0.5 break-words font-medium text-fg">{value}</dd>
+    </div>
+  )
+}
+
+function questionKey(question: AgentInteractionQuestion, index: number) {
+  return question.id || `q${index}`
+}
+
+function toggleAnswer(current: string[], value: string, multi: boolean) {
+  if (!multi) return [value]
+  return current.includes(value) ? current.filter((item) => item !== value) : [...current, value]
+}

--- a/apps/web/src/components/admin/InteractionDecisionCard.tsx
+++ b/apps/web/src/components/admin/InteractionDecisionCard.tsx
@@ -120,7 +120,7 @@ export function InteractionDecisionCard({
                   >
                     <input
                       type={question.multi_select ? "checkbox" : "radio"}
-                      name={key}
+                      name={`${interaction.id}:${key}`}
                       checked={selected.includes(option.label)}
                       onChange={() => {
                         setAnswers((current) => ({
@@ -143,16 +143,20 @@ export function InteractionDecisionCard({
                     </span>
                   </label>
                 ))}
-                <Input
-                  value={custom[key] ?? ""}
-                  onChange={(event) => {
-                    const value = event.target.value
-                    setCustom((current) => ({ ...current, [key]: value }))
-                    if (!question.multi_select && value.trim())
-                      setAnswers((current) => ({ ...current, [key]: [] }))
-                  }}
-                  placeholder={t("approvals.questions.customAnswer")}
-                />
+                {question.is_other !== false ? (
+                  <Input
+                    type={question.is_secret ? "password" : "text"}
+                    autoComplete={question.is_secret ? "new-password" : undefined}
+                    value={custom[key] ?? ""}
+                    onChange={(event) => {
+                      const value = event.target.value
+                      setCustom((current) => ({ ...current, [key]: value }))
+                      if (!question.multi_select && value.trim())
+                        setAnswers((current) => ({ ...current, [key]: [] }))
+                    }}
+                    placeholder={t("approvals.questions.customAnswer")}
+                  />
+                ) : null}
               </fieldset>
             )
           })}

--- a/apps/web/src/components/conversation/ConversationInteractionCards.tsx
+++ b/apps/web/src/components/conversation/ConversationInteractionCards.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from "react"
+import { useTranslation } from "react-i18next"
+import { Inbox, ShieldAlert } from "lucide-react"
+
+import { useAgentInteractions } from "../../lib/api-interactions"
+import { InteractionDecisionCard } from "../admin/InteractionDecisionCard"
+import { Button } from "../ui/button"
+import { Skeleton } from "../ui/skeleton"
+
+export function ConversationInteractionCards({
+  workspaceID,
+  conversationID,
+  preferredRequestID,
+  onOpenInbox,
+}: {
+  workspaceID: string | null
+  conversationID: string
+  preferredRequestID?: string
+  onOpenInbox: () => void
+}) {
+  const { t } = useTranslation("admin")
+  const query = useAgentInteractions(workspaceID, "pending")
+  const interactions = useMemo(() => {
+    const rows = (query.data?.interactions ?? []).filter(
+      (interaction) => interaction.conversation_id === conversationID,
+    )
+    if (!preferredRequestID) return rows
+    return [...rows].sort((left, right) => {
+      if (left.request_id === preferredRequestID) return -1
+      if (right.request_id === preferredRequestID) return 1
+      return 0
+    })
+  }, [conversationID, preferredRequestID, query.data?.interactions])
+
+  if (!workspaceID) return null
+  if (interactions.length === 0 && !preferredRequestID) return null
+
+  return (
+    <section aria-label={t("conversations.stream.interactionTitle")} className="space-y-3">
+      <div className="flex flex-wrap items-center gap-3 rounded-lg border border-warning-border bg-warning-subtle px-4 py-3 text-sm text-warning-emphasis">
+        <ShieldAlert className="h-4 w-4 shrink-0" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <p className="font-semibold">{t("conversations.stream.interactionTitle")}</p>
+          <p className="text-xs">{t("conversations.stream.interactionDescription")}</p>
+        </div>
+        <Button size="sm" variant="outline" onClick={onOpenInbox}>
+          <Inbox className="h-4 w-4" />
+          {t("conversations.stream.viewAllInteractions")}
+        </Button>
+      </div>
+
+      {interactions.length > 0 ? (
+        interactions.map((interaction) => (
+          <InteractionDecisionCard
+            key={interaction.id}
+            interaction={interaction}
+            workspaceID={workspaceID}
+            className="rounded-xl border border-line bg-surface shadow-sm"
+          />
+        ))
+      ) : query.error ? (
+        <div className="rounded-lg border border-danger-border bg-danger-subtle px-4 py-3 text-sm text-danger-emphasis">
+          {t("conversations.stream.interactionLoadError")}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-line bg-surface p-5">
+          <Skeleton className="h-5 w-48" />
+          <Skeleton className="mt-4 h-24 w-full" />
+          <p className="mt-3 text-xs text-fg-subtle">
+            {t("conversations.stream.loadingInteraction")}
+          </p>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/web/src/components/layout/AdminLayout.tsx
+++ b/apps/web/src/components/layout/AdminLayout.tsx
@@ -4,6 +4,7 @@ import { cn } from "../../lib/utils"
 import { useAdminView, type AdminView } from "../../lib/admin-router"
 import {
   MessageSquare,
+  Inbox,
   Play,
   CalendarClock,
   Bot,
@@ -47,6 +48,7 @@ const menuGroups: MenuGroup[] = [
     groupKey: "collaborationGroup",
     items: [
       { id: "conversations", itemKey: "conversations", icon: MessageSquare },
+      { id: "approvals", itemKey: "approvals", icon: Inbox },
       { id: "runs", itemKey: "runs", icon: Play },
       { id: "scheduled", itemKey: "scheduled", icon: CalendarClock },
     ],

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1250,6 +1250,7 @@
         "intelligence": {
           "title": "Intelligence",
           "engine": "Agent engine",
+          "codexMode": "Codex collaboration mode",
           "systemPrompt": "System prompt"
         },
         "runtime": {
@@ -1509,6 +1510,7 @@
         "slug": "Internal ID",
         "executionMode": "Execution mode",
         "agentEngine": "Agent engine",
+        "codexMode": "Codex collaboration mode",
         "device": "Local device",
         "sandboxSize": "Sandbox size",
         "sandboxImage": "Sandbox image",
@@ -1541,6 +1543,11 @@
         "hint": "Changes take effect after the current sandbox is released.",
         "standard": "Standard (2 vCPU / 4 GiB)",
         "xl": "Large (4 vCPU / 8 GiB)"
+      },
+      "codexMode": {
+        "hint": "Plan mode enables Codex to ask structured questions in the conversation. Approval requests work in both modes.",
+        "default": "Default",
+        "plan": "Plan (enables questions)"
       },
       "sandboxImage": {
         "hint": "The server pulls this container image when the Agent's sandbox starts for the first time."

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -233,7 +233,25 @@
     },
     "actions": {
       "allowOnce": "Allow once",
-      "deny": "Deny"
+      "deny": "Deny",
+      "submitAnswers": "Submit answers",
+      "cancel": "Cancel request"
+    },
+    "kind": {
+      "permission": "Approval",
+      "userChoice": "Question"
+    },
+    "status": {
+      "pending": "Pending",
+      "resolving": "Submitting",
+      "approved": "Approved",
+      "denied": "Denied",
+      "answered": "Answered",
+      "cancelled": "Cancelled",
+      "expired": "Expired"
+    },
+    "questions": {
+      "customAnswer": "Optional custom answer"
     },
     "detail": {
       "agent": "Agent",
@@ -372,7 +390,14 @@
       "error": "Streaming interrupted: {{error}}",
       "retry": "Retry",
       "queued": "Queued",
-      "queuedWithPosition": "Queued (position {{position}})"
+      "queuedWithPosition": "Queued (position {{position}})",
+      "waitingForHuman": "The Agent is waiting for your approval or answer.",
+      "openInbox": "Open Inbox",
+      "interactionTitle": "Agent needs your input",
+      "interactionDescription": "Review this request here to let the run continue.",
+      "viewAllInteractions": "View all in Inbox",
+      "loadingInteraction": "Loading the approval request…",
+      "interactionLoadError": "The request could not be loaded here. Open Inbox to retry."
     },
     "permission": {
       "header": "Agent requests approval",

--- a/apps/web/src/i18n/locales/en-US/common.json
+++ b/apps/web/src/i18n/locales/en-US/common.json
@@ -224,7 +224,12 @@
     "justNow": "just now",
     "minutesAgo": "{{count}} min ago",
     "hoursAgo": "{{count}}h ago",
-    "daysAgo": "{{count}}d ago"
+    "daysAgo": "{{count}}d ago",
+    "lessThanMinute": "less than a minute",
+    "minutesRemaining": "{{count}} min",
+    "hoursRemaining": "{{count}}h",
+    "daysRemaining": "{{count}}d",
+    "expired": "expired"
   },
   "scopeRequired": {
     "workspace": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1250,6 +1250,7 @@
         "intelligence": {
           "title": "智能配置",
           "engine": "Agent 引擎",
+          "codexMode": "Codex 协作模式",
           "systemPrompt": "系统提示词"
         },
         "runtime": {
@@ -1509,6 +1510,7 @@
         "slug": "内部标识",
         "executionMode": "执行方式",
         "agentEngine": "Agent 引擎",
+        "codexMode": "Codex 协作模式",
         "device": "本地设备",
         "sandboxSize": "沙盒规格",
         "sandboxImage": "沙盒镜像",
@@ -1541,6 +1543,11 @@
         "hint": "改完规格后,等当前沙盒被释放才会切换到新规格。",
         "standard": "标准 (2 vCPU / 4 GiB)",
         "xl": "大规格 (4 vCPU / 8 GiB)"
+      },
+      "codexMode": {
+        "hint": "Plan 模式允许 Codex 在对话中发起结构化提问；两种模式都支持权限审批。",
+        "default": "Default（默认）",
+        "plan": "Plan（启用提问）"
       },
       "sandboxImage": {
         "hint": "Agent 首次启动沙盒时，服务端会拉取这个容器镜像。"

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -233,7 +233,25 @@
     },
     "actions": {
       "allowOnce": "允许一次",
-      "deny": "拒绝"
+      "deny": "拒绝",
+      "submitAnswers": "提交回答",
+      "cancel": "取消请求"
+    },
+    "kind": {
+      "permission": "审批",
+      "userChoice": "提问"
+    },
+    "status": {
+      "pending": "待处理",
+      "resolving": "提交中",
+      "approved": "已允许",
+      "denied": "已拒绝",
+      "answered": "已回答",
+      "cancelled": "已取消",
+      "expired": "已过期"
+    },
+    "questions": {
+      "customAnswer": "可选：自定义回答"
     },
     "detail": {
       "agent": "Agent",
@@ -372,7 +390,14 @@
       "error": "流式输出中断：{{error}}",
       "retry": "重试",
       "queued": "排队中",
-      "queuedWithPosition": "排队中（第 {{position}} 位）"
+      "queuedWithPosition": "排队中（第 {{position}} 位）",
+      "waitingForHuman": "Agent 正在等待你的审批或回答。",
+      "openInbox": "打开收件箱",
+      "interactionTitle": "Agent 需要你的决定",
+      "interactionDescription": "直接在这里处理，请求完成后 Agent 会继续运行。",
+      "viewAllInteractions": "在收件箱中查看全部",
+      "loadingInteraction": "正在加载审批请求…",
+      "interactionLoadError": "无法在对话中加载该请求，请打开收件箱重试。"
     },
     "permission": {
       "header": "Agent 请求批准",

--- a/apps/web/src/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/i18n/locales/zh-CN/common.json
@@ -224,7 +224,12 @@
     "justNow": "刚刚",
     "minutesAgo": "{{count}} 分钟前",
     "hoursAgo": "{{count}} 小时前",
-    "daysAgo": "{{count}} 天前"
+    "daysAgo": "{{count}} 天前",
+    "lessThanMinute": "不足 1 分钟",
+    "minutesRemaining": "{{count}} 分钟",
+    "hoursRemaining": "{{count}} 小时",
+    "daysRemaining": "{{count}} 天",
+    "expired": "已过期"
   },
   "scopeRequired": {
     "workspace": {

--- a/apps/web/src/lib/agent-view-model.ts
+++ b/apps/web/src/lib/agent-view-model.ts
@@ -2,6 +2,8 @@ import type { Agent, AgentDetail, Model } from "./api-types"
 
 export type AgentEngine = "claude_code" | "codex" | "pi" | "opencode"
 
+export type CodexCollaborationMode = "default" | "plan"
+
 export type AgentExecutionMode = "local_device" | "sandbox" | "external"
 
 export type AgentEngineLabelKey =
@@ -82,6 +84,13 @@ export function agentEngineLabel(engine: AgentEngine): AgentEngineLabelKey {
     case "opencode":
       return "agents.engine.opencode.title"
   }
+}
+
+export function agentCodexModeOf(agent: AgentSource): CodexCollaborationMode {
+  if (agentEngineOf(agent) !== "codex") return "default"
+  const config = configOf(agent)
+  const profile = profileOf(agent)
+  return stringValue(config.mode, profile.mode).toLowerCase() === "plan" ? "plan" : "default"
 }
 
 export function agentExecutionModeOf(agent: AgentSource): AgentExecutionMode {

--- a/apps/web/src/lib/api-conversations.ts
+++ b/apps/web/src/lib/api-conversations.ts
@@ -120,6 +120,7 @@ export interface AgentRunStreamState {
   steps: StreamingStep[]
   final: string | null
   error: string | null
+  pendingInteraction: { kind: "permission" | "user_choice"; requestId: string } | null
 }
 
 const idleStreamState: AgentRunStreamState = {
@@ -128,6 +129,7 @@ const idleStreamState: AgentRunStreamState = {
   steps: [],
   final: null,
   error: null,
+  pendingInteraction: null,
 }
 
 function parseStreamEvent(type: AgentRunStreamEvent["type"], raw: string): AgentRunStreamEvent | null {
@@ -211,7 +213,7 @@ export function useAgentRunStream(
     const source = new EventSource(
       `/api/v1/conversations/${encodeURIComponent(cid)}/runs/${encodeURIComponent(runId)}/stream`
     )
-    setState({ status: "streaming", deltaText: "", steps: [], final: null, error: null })
+    setState({ status: "streaming", deltaText: "", steps: [], final: null, error: null, pendingInteraction: null })
 
     const onDelta = (ev: MessageEvent<string>) => {
       const parsed = parseStreamEvent("delta", ev.data)
@@ -220,6 +222,7 @@ export function useAgentRunStream(
         ...prev,
         status: prev.status === "done" ? prev.status : "streaming",
         deltaText: prev.deltaText + (parsed.delta ?? ""),
+        pendingInteraction: null,
       }))
     }
 
@@ -257,7 +260,7 @@ export function useAgentRunStream(
             })
           }
         }
-        return { ...prev, steps }
+        return { ...prev, steps, pendingInteraction: null }
       })
     }
 
@@ -269,8 +272,21 @@ export function useAgentRunStream(
         status: "done",
         final: parsed.final?.content ?? "",
         error: null,
+        pendingInteraction: null,
       }))
       source.close()
+    }
+
+    const onPermission = (ev: MessageEvent<string>) => {
+      const parsed = parseStreamEvent("permission", ev.data)
+      if (!parsed || parsed.type !== "permission" || !parsed.permission?.id) return
+      setState((prev) => ({ ...prev, pendingInteraction: { kind: "permission", requestId: parsed.permission.id } }))
+    }
+
+    const onUserChoice = (ev: MessageEvent<string>) => {
+      const parsed = parseStreamEvent("prompt_for_user_choice", ev.data)
+      if (!parsed || parsed.type !== "prompt_for_user_choice" || !parsed.prompt_for_user_choice?.id) return
+      setState((prev) => ({ ...prev, pendingInteraction: { kind: "user_choice", requestId: parsed.prompt_for_user_choice.id } }))
     }
 
     const onError = (ev: Event) => {
@@ -278,7 +294,7 @@ export function useAgentRunStream(
       const parsed = data ? parseStreamEvent("error", data) : null
       const message = parsed?.type === "error" ? parsed.error : "stream connection failed"
       if (isCompletedBeforeSubscribeError(message)) {
-        setState((prev) => ({ ...prev, status: "done", final: prev.final, error: null }))
+        setState((prev) => ({ ...prev, status: "done", final: prev.final, error: null, pendingInteraction: null }))
         source.close()
         return
       }
@@ -287,7 +303,7 @@ export function useAgentRunStream(
       // abort took effect. Collapse to status='done' so the red stream-interrupted
       // banner stays hidden.
       if (isUserCancelledError(message)) {
-        setState((prev) => ({ ...prev, status: "done", final: prev.final, error: null }))
+        setState((prev) => ({ ...prev, status: "done", final: prev.final, error: null, pendingInteraction: null }))
         source.close()
         return
       }
@@ -302,15 +318,17 @@ export function useAgentRunStream(
           prev.steps.length > 0 ||
           prev.final !== null
         if (sawContent) {
-          return { ...prev, status: "done", error: null }
+          return { ...prev, status: "done", error: null, pendingInteraction: null }
         }
-        return { ...prev, status: "error", error: message || "stream connection failed" }
+        return { ...prev, status: "error", error: message || "stream connection failed", pendingInteraction: null }
       })
       source.close()
     }
 
     source.addEventListener("delta", onDelta)
     source.addEventListener("tool", onTool)
+    source.addEventListener("permission", onPermission)
+    source.addEventListener("prompt_for_user_choice", onUserChoice)
     source.addEventListener("done", onDone)
     source.addEventListener("error", onError)
 

--- a/apps/web/src/lib/api-interactions.ts
+++ b/apps/web/src/lib/api-interactions.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { apiRequest, noUnreachableRetry } from "./api-client"
+import type {
+  ListAgentInteractionsResponse,
+  ResolveAgentInteractionRequest,
+  ResolveAgentInteractionResponse,
+} from "./api-types"
+
+export type InteractionStatusGroup = "pending" | "decided" | "expired"
+
+const key = (workspaceID: string, status: InteractionStatusGroup) =>
+  ["admin", "interactions", workspaceID, status] as const
+
+export function useAgentInteractions(workspaceID: string | null, status: InteractionStatusGroup) {
+  return useQuery({
+    queryKey: key(workspaceID ?? "_none", status),
+    queryFn: () =>
+      apiRequest<ListAgentInteractionsResponse>(
+        `/api/v1/workspaces/${encodeURIComponent(workspaceID!)}/interactions`,
+        { query: { status, limit: 200 } },
+      ),
+    enabled: !!workspaceID,
+    retry: noUnreachableRetry,
+    refetchInterval: status === "pending" ? 2_000 : 10_000,
+  })
+}
+
+export function useResolveAgentInteraction(workspaceID: string | null) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, body }: { id: string; body: ResolveAgentInteractionRequest }) => {
+      if (!workspaceID) throw new Error("workspace id is required")
+      return apiRequest<ResolveAgentInteractionResponse>(
+        `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/interactions/${encodeURIComponent(id)}/resolve`,
+        { method: "POST", body },
+      )
+    },
+    retry: false,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "admin" &&
+          query.queryKey[1] === "interactions" &&
+          query.queryKey[2] === workspaceID,
+      })
+    },
+  })
+}

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -427,12 +427,7 @@ export interface UserCredentialPatchRequest {
 /* --- Agent Runs --------------------------------------------------------- */
 
 export type AgentRunStatus =
-  | "queued"
-  | "running"
-  | "completed"
-  | "failed"
-  | "cancelled"
-  | "interrupted"
+  "queued" | "running" | "completed" | "failed" | "cancelled" | "interrupted"
 
 export interface AgentRunSummary {
   id: string
@@ -602,23 +597,20 @@ export interface AgentInteractionQuestion {
   header?: string
   question: string
   multi_select?: boolean
+  is_other?: boolean
+  is_secret?: boolean
   options: AgentInteractionOption[]
 }
 
 export interface StreamUserChoiceRequest {
   id: string
   questions: AgentInteractionQuestion[]
+  auto_resolution_ms?: number
 }
 
 export type AgentInteractionKind = "permission" | "user_choice"
 export type AgentInteractionStatus =
-  | "pending"
-  | "resolving"
-  | "approved"
-  | "denied"
-  | "answered"
-  | "cancelled"
-  | "expired"
+  "pending" | "resolving" | "approved" | "denied" | "answered" | "cancelled" | "expired"
 
 export interface AgentInteraction {
   id: string
@@ -657,7 +649,6 @@ export interface ResolveAgentInteractionResponse {
   applied: boolean
   already_resolved: boolean
 }
-
 
 /* --- Audit Records ------------------------------------------------------ */
 

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -434,7 +434,6 @@ export type AgentRunStatus =
   | "cancelled"
   | "interrupted"
 
-
 export interface AgentRunSummary {
   id: string
   workspace_id: string
@@ -574,6 +573,8 @@ export type AgentRunStreamEvent =
   | { type: "done"; final: { content: string } }
   | { type: "error"; error: string }
   | { type: "tool"; tool: StreamToolEvent }
+  | { type: "permission"; permission: StreamPermissionRequest }
+  | { type: "prompt_for_user_choice"; prompt_for_user_choice: StreamUserChoiceRequest }
 
 export interface StreamToolEvent {
   id?: string
@@ -581,6 +582,80 @@ export interface StreamToolEvent {
   stage: string
   args?: Record<string, unknown>
   result?: Record<string, unknown>
+}
+
+export interface StreamPermissionRequest {
+  id: string
+  tool?: string
+  title?: string
+  detail?: string
+  payload?: Record<string, unknown>
+}
+
+export interface AgentInteractionOption {
+  label: string
+  description?: string
+}
+
+export interface AgentInteractionQuestion {
+  id?: string
+  header?: string
+  question: string
+  multi_select?: boolean
+  options: AgentInteractionOption[]
+}
+
+export interface StreamUserChoiceRequest {
+  id: string
+  questions: AgentInteractionQuestion[]
+}
+
+export type AgentInteractionKind = "permission" | "user_choice"
+export type AgentInteractionStatus =
+  | "pending"
+  | "resolving"
+  | "approved"
+  | "denied"
+  | "answered"
+  | "cancelled"
+  | "expired"
+
+export interface AgentInteraction {
+  id: string
+  workspace_id: string
+  conversation_id: string
+  agent_run_id: string
+  request_id: string
+  kind: AgentInteractionKind
+  status: AgentInteractionStatus
+  request: Record<string, unknown>
+  response: Record<string, unknown>
+  resolution_source?: string
+  resolved_actor?: string
+  resolved_by?: string
+  created_at: string
+  expires_at: string
+  resolved_at?: string
+  updated_at: string
+  agent_name: string
+  conversation_title: string
+}
+
+export interface ListAgentInteractionsResponse {
+  interactions: AgentInteraction[]
+}
+
+export interface ResolveAgentInteractionRequest {
+  approved?: boolean
+  note?: string
+  answers?: Record<string, string[]>
+  cancelled?: boolean
+}
+
+export interface ResolveAgentInteractionResponse {
+  interaction: AgentInteraction
+  applied: boolean
+  already_resolved: boolean
 }
 
 

--- a/apps/web/src/lib/interaction-questions.ts
+++ b/apps/web/src/lib/interaction-questions.ts
@@ -1,0 +1,13 @@
+import type { AgentInteraction, AgentInteractionQuestion } from "./api-types"
+
+export function interactionQuestions(row: AgentInteraction): AgentInteractionQuestion[] {
+  return Array.isArray(row.request.questions)
+    ? (row.request.questions as unknown as AgentInteractionQuestion[])
+    : []
+}
+
+export function firstInteractionQuestion(
+  row: AgentInteraction,
+): AgentInteractionQuestion | undefined {
+  return interactionQuestions(row)[0]
+}

--- a/apps/web/src/lib/relative-time.ts
+++ b/apps/web/src/lib/relative-time.ts
@@ -32,3 +32,31 @@ export function useRelativeTime() {
     return t("relativeTime.daysAgo", { count: days })
   }
 }
+
+/**
+ * Locale-aware future duration formatter for deadline fields whose label
+ * already supplies the "expires in" context.
+ */
+export function useTimeUntil() {
+  const { t } = useTranslation("common")
+
+  return (iso: string | null | undefined): string => {
+    if (!iso) return "—"
+    const ms = Date.parse(iso)
+    if (isNaN(ms)) return "—"
+    const diff = ms - Date.now()
+
+    if (diff <= 0) return t("relativeTime.expired")
+    if (diff < MINUTE) return t("relativeTime.lessThanMinute")
+    if (diff < HOUR) {
+      const minutes = Math.ceil(diff / MINUTE)
+      return t("relativeTime.minutesRemaining", { count: minutes })
+    }
+    if (diff < DAY) {
+      const hours = Math.ceil(diff / HOUR)
+      return t("relativeTime.hoursRemaining", { count: hours })
+    }
+    const days = Math.ceil(diff / DAY)
+    return t("relativeTime.daysRemaining", { count: days })
+  }
+}

--- a/apps/web/src/pages/admin/AdminRouter.tsx
+++ b/apps/web/src/pages/admin/AdminRouter.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from "react-i18next"
 import {
   Bot,
   HelpCircle,
-  Inbox,
 } from "lucide-react"
 
 import { useAdminView, useAppRoute } from "../../lib/admin-router"
@@ -22,7 +21,7 @@ import { CredentialsPage } from "./credentials/CredentialsPage"
 import { MembersPage } from "./MembersPage"
 import { RuntimePage } from "./RuntimePage"
 import { RuntimeDetailPage } from "./RuntimeDetailPage"
-import { StubPage } from "./StubPage"
+import { ApprovalsPage } from "./ApprovalsPage"
 import { CapabilitiesPage, CapabilityDetailPage } from "./CapabilitiesPage"
 import { ConnectionsPage } from "./ConnectionsPage"
 import { MyCredentialsPage } from "./MyCredentialsPage"
@@ -71,7 +70,7 @@ export function AdminRouter() {
 
   switch (v) {
     case "approvals":
-      return <StubPage view={v} itemKey="approvals" icon={Inbox} />
+      return <ApprovalsPage />
     case "members":
       return <MembersPage />
     case "secrets":

--- a/apps/web/src/pages/admin/ApprovalsPage.tsx
+++ b/apps/web/src/pages/admin/ApprovalsPage.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Inbox } from "lucide-react"
+
+import { ScopeRequiredState } from "../../components/admin/ScopeRequiredState"
+import { InteractionDecisionCard } from "../../components/admin/InteractionDecisionCard"
+import { AdminLayout } from "../../components/layout/AdminLayout"
+import { PageHeader } from "../../components/layout/PageHeader"
+import { Badge } from "../../components/ui/badge"
+import { EmptyState } from "../../components/ui/empty-state"
+import { ErrorState } from "../../components/ui/error-state"
+import { Skeleton } from "../../components/ui/skeleton"
+import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
+import { ApiError } from "../../lib/api-client"
+import { type InteractionStatusGroup, useAgentInteractions } from "../../lib/api-interactions"
+import type { AgentInteraction } from "../../lib/api-types"
+import { firstInteractionQuestion } from "../../lib/interaction-questions"
+import { useRelativeTime } from "../../lib/relative-time"
+import { cn } from "../../lib/utils"
+import { useWorkspaceId } from "../../lib/workspace"
+
+export function ApprovalsPage() {
+  const { t } = useTranslation("admin")
+  const workspaceID = useWorkspaceId()
+  const [tab, setTab] = useState<InteractionStatusGroup>("pending")
+  const [selectedID, setSelectedID] = useState<string | null>(null)
+  const query = useAgentInteractions(workspaceID, tab)
+  const rows = useMemo(() => query.data?.interactions ?? [], [query.data])
+
+  const selected = rows.find((row) => row.id === selectedID) ?? rows[0] ?? null
+  const error = query.error
+  const unreachable = error instanceof ApiError && error.envelope.unreachable
+
+  return (
+    <AdminLayout activeMenu="approvals">
+      <PageHeader title={t("approvals.page.title")} description={t("approvals.page.description")} />
+      {!workspaceID ? (
+        <ScopeRequiredState scope="workspace" resourceName={t("approvals.page.title")} />
+      ) : error ? (
+        <ErrorState
+          title={
+            unreachable
+              ? t("approvals.loadError.unreachable.title")
+              : t("approvals.loadError.title")
+          }
+          description={
+            unreachable
+              ? t("approvals.loadError.unreachable.description")
+              : error instanceof Error
+                ? error.message
+                : t("approvals.loadError.description")
+          }
+          hint={
+            unreachable ? t("approvals.loadError.unreachable.hint") : t("approvals.loadError.hint")
+          }
+          onRetry={() => void query.refetch()}
+        />
+      ) : (
+        <div className="space-y-4">
+          <Tabs value={tab} onValueChange={(value) => setTab(value as InteractionStatusGroup)}>
+            <TabsList>
+              <TabsTrigger value="pending">{t("approvals.tabs.pending")}</TabsTrigger>
+              <TabsTrigger value="decided">{t("approvals.tabs.decided")}</TabsTrigger>
+              <TabsTrigger value="expired">{t("approvals.tabs.expired")}</TabsTrigger>
+            </TabsList>
+          </Tabs>
+          {query.isLoading ? (
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.35fr)]">
+              <Skeleton className="h-80" />
+              <Skeleton className="h-80" />
+            </div>
+          ) : rows.length === 0 ? (
+            <EmptyState
+              icon={Inbox}
+              title={t("approvals.empty.title")}
+              description={t("approvals.empty.description")}
+            />
+          ) : (
+            <div className="grid min-h-[520px] overflow-hidden rounded-xl border border-line bg-surface lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.35fr)]">
+              <div className="border-b border-line lg:border-b-0 lg:border-r">
+                {rows.map((row) => (
+                  <InteractionListItem
+                    key={row.id}
+                    row={row}
+                    selected={row.id === selected?.id}
+                    onSelect={() => setSelectedID(row.id)}
+                  />
+                ))}
+              </div>
+              {selected ? (
+                <InteractionDecisionCard
+                  key={selected.id}
+                  interaction={selected}
+                  workspaceID={workspaceID}
+                />
+              ) : null}
+            </div>
+          )}
+        </div>
+      )}
+    </AdminLayout>
+  )
+}
+
+function InteractionListItem({
+  row,
+  selected,
+  onSelect,
+}: {
+  row: AgentInteraction
+  selected: boolean
+  onSelect: () => void
+}) {
+  const { t } = useTranslation("admin")
+  const fmtAgo = useRelativeTime()
+  const title =
+    row.kind === "permission"
+      ? String(row.request.resource || row.request.action || t("approvals.kind.permission"))
+      : firstInteractionQuestion(row)?.question || t("approvals.kind.userChoice")
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "w-full border-b border-line px-4 py-4 text-left transition-colors hover:bg-surface-muted",
+        selected && "bg-info-subtle/50",
+      )}
+    >
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <Badge variant={row.kind === "permission" ? "warning" : "primary"}>
+          {t(`approvals.kind.${row.kind === "permission" ? "permission" : "userChoice"}`)}
+        </Badge>
+        <span className="text-xs text-fg-faint">{fmtAgo(row.created_at)}</span>
+      </div>
+      <p className="line-clamp-2 text-sm font-semibold text-fg">{title}</p>
+      <p className="mt-1 truncate text-xs text-fg-subtle">{row.agent_name || row.agent_run_id}</p>
+    </button>
+  )
+}

--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -2,9 +2,27 @@ import { useQueryClient } from "@tanstack/react-query"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
-import { AlertTriangle, Bot, Check, ChevronLeft, ChevronRight, ChevronDown, CircleDot, Clock, MessageSquarePlus, Pencil, Send, ShieldAlert, Square, Trash2, X, Loader2 } from "lucide-react"
+import {
+  AlertTriangle,
+  Bot,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  CircleDot,
+  Clock,
+  MessageSquarePlus,
+  Pencil,
+  Send,
+  ShieldAlert,
+  Square,
+  Trash2,
+  X,
+  Loader2,
+} from "lucide-react"
 
 import { AdminLayout } from "../../components/layout/AdminLayout"
+import { ConversationInteractionCards } from "../../components/conversation/ConversationInteractionCards"
 import { WorkingSteps, StepTrace } from "../../components/conversation/StepDisplay"
 import { Button } from "../../components/ui/button"
 import {
@@ -191,9 +209,7 @@ export function ConversationsPage() {
       // still real and the user can retry from the chat view.
       qc.invalidateQueries({
         predicate: (q) =>
-          q.queryKey[0] === "admin" &&
-          q.queryKey[1] === "conversations" &&
-          q.queryKey[2] === wsId,
+          q.queryKey[0] === "admin" && q.queryKey[1] === "conversations" && q.queryKey[2] === wsId,
       })
       qc.invalidateQueries({ queryKey: ["admin", "conversationTimeline", conv.id] })
     }
@@ -280,14 +296,18 @@ function sandboxSendGuard(
     return { blocked: true, message: t("conversations.sandboxGuard.checking") }
   }
   if (error) {
-    const detail = error instanceof Error ? error.message : t("conversations.sandboxGuard.errorFallback")
+    const detail =
+      error instanceof Error ? error.message : t("conversations.sandboxGuard.errorFallback")
     return { blocked: true, message: t("conversations.sandboxGuard.error", { error: detail }) }
   }
   if (!binding) {
     return { blocked: true, message: t("conversations.sandboxGuard.missing") }
   }
   if (binding.status_kind !== "live") {
-    return { blocked: true, message: t("conversations.sandboxGuard.notLive", { status: binding.status }) }
+    return {
+      blocked: true,
+      message: t("conversations.sandboxGuard.notLive", { status: binding.status }),
+    }
   }
   return { blocked: false, message: "" }
 }
@@ -411,7 +431,9 @@ function ConversationSidebar(p: SidebarProps) {
           className="absolute left-2 right-2 top-[54px] z-10 max-h-72 overflow-y-auto rounded-lg border border-line bg-surface shadow-lg"
         >
           {p.agentsLoading ? (
-            <div className="p-3"><Skeleton className="h-8 w-full" /></div>
+            <div className="p-3">
+              <Skeleton className="h-8 w-full" />
+            </div>
           ) : p.agents.length === 0 ? (
             <p className="p-3 text-sm text-fg-subtle">{t("conversations.sidebar.allAgentsHint")}</p>
           ) : (
@@ -489,7 +511,9 @@ function ConversationSidebar(p: SidebarProps) {
                 }}
                 className={cn(
                   "group/row relative block w-full rounded-lg border px-2.5 py-2 text-left transition-colors",
-                  isActive ? "border-line bg-surface shadow-sm" : "border-transparent hover:border-line hover:bg-surface/80",
+                  isActive
+                    ? "border-line bg-surface shadow-sm"
+                    : "border-transparent hover:border-line hover:bg-surface/80",
                   isRenaming ? "cursor-default" : "cursor-pointer",
                 )}
               >
@@ -518,9 +542,7 @@ function ConversationSidebar(p: SidebarProps) {
                     />
                     <div className="flex items-center justify-end gap-1">
                       {renameError && (
-                        <span className="mr-auto text-xs text-danger">
-                          {renameError}
-                        </span>
+                        <span className="mr-auto text-xs text-danger">{renameError}</span>
                       )}
                       <button
                         type="button"
@@ -555,7 +577,9 @@ function ConversationSidebar(p: SidebarProps) {
                 ) : (
                   <>
                     <div className="flex items-center gap-1.5 pr-12">
-                      {isActive && <CircleDot className="h-3 w-3 shrink-0 text-success" strokeWidth={2.4} />}
+                      {isActive && (
+                        <CircleDot className="h-3 w-3 shrink-0 text-success" strokeWidth={2.4} />
+                      )}
                       <div
                         className={cn(
                           "truncate text-sm",
@@ -567,7 +591,8 @@ function ConversationSidebar(p: SidebarProps) {
                     </div>
                     <div className="mt-1 flex items-center gap-1.5 text-xs text-fg-faint">
                       <span className="min-w-0 flex-1 truncate">
-                        {c.last_message_preview || (c.last_message_at ? fmtAgo(c.last_message_at) : fmtAgo(c.created_at))}
+                        {c.last_message_preview ||
+                          (c.last_message_at ? fmtAgo(c.last_message_at) : fmtAgo(c.created_at))}
                       </span>
                     </div>
                     {/* Hover-only action cluster. opacity-0 → */}
@@ -628,9 +653,7 @@ function ConversationSidebar(p: SidebarProps) {
             </div>
           </DialogHeader>
           <DialogFooter className="flex flex-row items-center justify-end gap-2 border-t border-line-muted bg-surface-subtle/60 px-4 py-3">
-            {deleteError && (
-              <span className="mr-auto text-sm text-danger">{deleteError}</span>
-            )}
+            {deleteError && <span className="mr-auto text-sm text-danger">{deleteError}</span>}
             <Button
               variant="outline"
               size="sm"
@@ -710,7 +733,11 @@ function ConversationMain(p: MainProps) {
         {err ? (
           <div className="flex-1 overflow-y-auto p-6">
             <ErrorState
-              title={isUnreachable ? t("conversations.loadError.unreachable.title") : t("conversations.loadError.title")}
+              title={
+                isUnreachable
+                  ? t("conversations.loadError.unreachable.title")
+                  : t("conversations.loadError.title")
+              }
               description={
                 isUnreachable
                   ? t("conversations.loadError.unreachable.description")
@@ -718,7 +745,11 @@ function ConversationMain(p: MainProps) {
                     ? err.message
                     : t("conversations.loadError.description")
               }
-              hint={isUnreachable ? t("conversations.loadError.unreachable.hint") : t("conversations.loadError.hint")}
+              hint={
+                isUnreachable
+                  ? t("conversations.loadError.unreachable.hint")
+                  : t("conversations.loadError.hint")
+              }
             />
           </div>
         ) : p.convLoading ? (
@@ -742,6 +773,7 @@ function ConversationMain(p: MainProps) {
             agent={p.agent}
             pageDescription={p.onPageDescription}
             conversationId={p.conversationId}
+            workspaceID={p.conv.workspace_id}
             onRenameAfterFirstMessage={p.onRenameAfterFirstMessage}
             focusComposer={p.focusComposer}
             sandboxGuard={p.sandboxGuard}
@@ -767,6 +799,7 @@ function EmptyChat({
   agent,
   pageDescription,
   conversationId,
+  workspaceID,
   onSendFromEmpty,
   onRenameAfterFirstMessage,
   focusComposer,
@@ -776,6 +809,7 @@ function EmptyChat({
   pageDescription: string
   /** When set, composer sends into this conv (in-chat flow). */
   conversationId?: string
+  workspaceID?: string
   /** Create-then-send flow (required when conversationId is unset). */
   onSendFromEmpty?: (content: string) => Promise<void>
   onRenameAfterFirstMessage?: (cid: string, title: string) => Promise<void>
@@ -783,8 +817,9 @@ function EmptyChat({
   sandboxGuard?: SandboxSendGuard
 }) {
   const { t } = useTranslation("admin")
+  const { navigate } = useAdminView()
   return (
-    <div className="flex flex-1 flex-col bg-surface-subtle px-5 py-6 sm:px-8">
+    <div className="flex flex-1 flex-col overflow-y-auto bg-surface-subtle px-5 py-6 sm:px-8">
       <div className="mx-auto flex min-h-0 w-full max-w-4xl flex-1 flex-col">
         <div className="flex items-center justify-between gap-3 text-xs text-fg-subtle">
           <span className="inline-flex items-center gap-1.5 rounded-md border border-line bg-surface/80 px-2 py-1 font-medium shadow-sm">
@@ -795,6 +830,16 @@ function EmptyChat({
             {t("conversations.empty.mode")}
           </span>
         </div>
+
+        {conversationId && workspaceID ? (
+          <div className="mt-5">
+            <ConversationInteractionCards
+              workspaceID={workspaceID}
+              conversationID={conversationId}
+              onOpenInbox={() => navigate("approvals")}
+            />
+          </div>
+        ) : null}
 
         <div className="grid flex-1 place-items-center py-8">
           <div className="w-full max-w-3xl">
@@ -817,7 +862,11 @@ function EmptyChat({
                   : t("conversations.empty.placeholderNoAgent")
               }
               onSendDirect={!conversationId && agent ? onSendFromEmpty : undefined}
-              onAfterSend={conversationId && onRenameAfterFirstMessage ? (title) => onRenameAfterFirstMessage(conversationId, title) : undefined}
+              onAfterSend={
+                conversationId && onRenameAfterFirstMessage
+                  ? (title) => onRenameAfterFirstMessage(conversationId, title)
+                  : undefined
+              }
               blockReason={sandboxGuard?.blocked ? sandboxGuard.message : undefined}
             />
           </div>
@@ -869,7 +918,9 @@ function ChatStream({
   const stream = useAgentRunStream(conversationId, activeRunId, { enabled: !!activeRunId })
   const hasActiveStream = !!activeRunId && stream.status !== "error" && stream.status !== "done"
 
-  const timelineQ = useConversationTimeline(conversationId, undefined, { pollingEnabled: !hasActiveStream })
+  const timelineQ = useConversationTimeline(conversationId, undefined, {
+    pollingEnabled: !hasActiveStream,
+  })
   const messages = useMemo(() => timelineQ.data?.messages ?? [], [timelineQ.data?.messages])
   const runs = useMemo(() => timelineQ.data?.agent_runs ?? [], [timelineQ.data?.agent_runs])
 
@@ -888,8 +939,7 @@ function ChatStream({
   // We trust SSE status while a stream is active; otherwise fall back to
   // the run table (covers external runs or page-refresh-during-run cases).
   const someRunActive =
-    hasActiveStream ||
-    runs.some((r) => r.status === "queued" || r.status === "running")
+    hasActiveStream || runs.some((r) => r.status === "queued" || r.status === "running")
 
   // When the stream finishes, refetch the timeline so the persisted
   // assistant message replaces the in-memory deltaText, then drop the
@@ -909,19 +959,30 @@ function ChatStream({
 
   return (
     <>
-      <div className={cn("border-b border-line/70 bg-surface/80 px-5 py-3 sm:px-6 lg:px-10", sidebarFolded && "pl-14 sm:pl-16 lg:pl-[72px]")}>
+      <div
+        className={cn(
+          "border-b border-line/70 bg-surface/80 px-5 py-3 sm:px-6 lg:px-10",
+          sidebarFolded && "pl-14 sm:pl-16 lg:pl-[72px]",
+        )}
+      >
         <div className="mx-auto flex max-w-4xl items-center justify-between gap-4">
           <div className="min-w-0">
-            <p className="text-xs font-medium uppercase text-fg-faint">{t("conversations.detail.kind")}</p>
+            <p className="text-xs font-medium uppercase text-fg-faint">
+              {t("conversations.detail.kind")}
+            </p>
             <h2 className="truncate text-base font-semibold text-fg">
               {agent?.name || t("conversations.sidebar.allAgentsHint")}
             </h2>
           </div>
           <div className="flex shrink-0 items-center gap-2 text-xs text-fg-subtle">
-            <span className={cn(
-              "rounded-md border px-2 py-1 font-medium",
-              someRunActive ? "border-success-border bg-success-subtle text-success" : "border-line bg-surface text-fg-subtle",
-            )}>
+            <span
+              className={cn(
+                "rounded-md border px-2 py-1 font-medium",
+                someRunActive
+                  ? "border-success-border bg-success-subtle text-success"
+                  : "border-line bg-surface text-fg-subtle",
+              )}
+            >
               {someRunActive ? t("conversations.stream.thinking") : t("conversations.stream.ready")}
             </span>
             {someRunActive && (
@@ -942,10 +1003,15 @@ function ChatStream({
                   // is handled by isUserCancelledError in
                   // api-conversations.ts — no banner shown.
                   setActiveRunId(null)
-                  cancelConvMut.mutate({ conversationID: conversationId, reason: "user_clicked_cancel_all" })
+                  cancelConvMut.mutate({
+                    conversationID: conversationId,
+                    reason: "user_clicked_cancel_all",
+                  })
                 }}
                 className="h-7 gap-1 px-2 text-xs text-danger hover:text-danger-emphasis"
-                title={t("conversations.detail.cancelAllAria", { defaultValue: "Cancel all in-flight tasks in this conversation" })}
+                title={t("conversations.detail.cancelAllAria", {
+                  defaultValue: "Cancel all in-flight tasks in this conversation",
+                })}
               >
                 {cancelConvMut.isPending ? (
                   <Loader2 className="h-3 w-3 animate-spin" strokeWidth={2.5} />
@@ -992,13 +1058,20 @@ function ChatStream({
               conversationId={conversationId}
             />
           )}
+          <ConversationInteractionCards
+            workspaceID={convWorkspaceId}
+            conversationID={conversationId}
+            preferredRequestID={stream.pendingInteraction?.requestId}
+            onOpenInbox={() => navigate("approvals")}
+          />
           {stream.status === "error" && (
             <div className="rounded-lg border border-danger-border bg-danger-subtle px-3 py-2 text-sm text-danger-emphasis">
               {t("conversations.stream.error", { error: stream.error ?? "" })}
             </div>
           )}
-          {someRunActive && !stream.deltaText && (
-            stream.steps.length > 0 ? (
+          {someRunActive &&
+            !stream.deltaText &&
+            (stream.steps.length > 0 ? (
               <WorkingSteps
                 steps={stream.steps}
                 cancelling={cancelRunMut.isPending}
@@ -1021,8 +1094,7 @@ function ChatStream({
                   ? t("conversations.stream.thinking")
                   : t("conversations.detail.agentTyping")}
               </div>
-            )
-          )}
+            ))}
           {/*
             Queued runs render an independent "queued" chip per run,
             distinct from the inflight working/thinking indicator
@@ -1049,9 +1121,7 @@ function ChatStream({
 
       <div className="border-t border-line/60 bg-surface/95 px-5 pb-4 pt-2 sm:px-6 lg:px-10">
         <div className="mx-auto max-w-4xl">
-          {chatToast && (
-            <ChatErrorToast message={chatToast} onDismiss={() => setChatToast(null)} />
-          )}
+          {chatToast && <ChatErrorToast message={chatToast} onDismiss={() => setChatToast(null)} />}
           <ComposerForm
             conversationId={conversationId}
             placeholder={t("conversations.composer.placeholder", { agent: agent?.name ?? "" })}
@@ -1159,7 +1229,9 @@ function MessageRow({
                 {runtimeError.action}
               </a>
             )}
-            <p className="mt-2 text-sm text-danger-emphasis/80">{t("conversations.runtime_error.retryHint")}</p>
+            <p className="mt-2 text-sm text-danger-emphasis/80">
+              {t("conversations.runtime_error.retryHint")}
+            </p>
           </div>
           <div className="mt-1.5 text-xs text-fg-faint">
             {agentName ? `${stamp} · ${agentName}` : stamp}
@@ -1181,9 +1253,7 @@ function MessageRow({
   return (
     <div className="flex">
       <div className="max-w-[82%] border-l border-line pl-4">
-        <div className="mb-1.5 text-xs font-medium text-fg-faint">
-          {agentName || "Agent"}
-        </div>
+        <div className="mb-1.5 text-xs font-medium text-fg-faint">{agentName || "Agent"}</div>
         <div className="text-base leading-[1.7] text-fg">
           <p className="whitespace-pre-wrap">{content}</p>
         </div>
@@ -1210,11 +1280,17 @@ function runtimeErrorViewModel(
   language: string,
   t: ReturnType<typeof useTranslation<"admin">>["t"],
 ) {
-  const subKind = stringMeta(metadata, "sub_kind") || stringMeta(metadata, "payload.sub_kind") || fallback
-  const capabilityName = stringMeta(metadata, "capability_name") || t("conversations.runtime_error.fallbackCapability")
+  const subKind =
+    stringMeta(metadata, "sub_kind") || stringMeta(metadata, "payload.sub_kind") || fallback
+  const capabilityName =
+    stringMeta(metadata, "capability_name") || t("conversations.runtime_error.fallbackCapability")
   const capabilityID = stringMeta(metadata, "capability_id")
   const credentialKind = stringMeta(metadata, "credential_kind")
-  const kindLabel = credentialKindLabel(credentialKind, language, t("capabilities.credentials.none"))
+  const kindLabel = credentialKindLabel(
+    credentialKind,
+    language,
+    t("capabilities.credentials.none"),
+  )
   const current = `${window.location.pathname}${window.location.search || `?admin=conversations&id=${conversationId}`}`
   const href = credentialKind
     ? `?profile=credentials&kind=${encodeURIComponent(credentialKind)}&returnTo=${encodeURIComponent(current)}`
@@ -1225,18 +1301,43 @@ function runtimeErrorViewModel(
 
   switch (subKind) {
     case "capability_credential_missing":
-      return { message: t("conversations.runtime_error.capability_credential_missing", { name: capabilityName, kind: kindLabel }), action: t("conversations.runtime_error.addCredential"), href }
+      return {
+        message: t("conversations.runtime_error.capability_credential_missing", {
+          name: capabilityName,
+          kind: kindLabel,
+        }),
+        action: t("conversations.runtime_error.addCredential"),
+        href,
+      }
     case "capability_credential_decrypt_failed":
-      return { message: t("conversations.runtime_error.capability_credential_decrypt_failed", { name: capabilityName }), action: "", href: "" }
+      return {
+        message: t("conversations.runtime_error.capability_credential_decrypt_failed", {
+          name: capabilityName,
+        }),
+        action: "",
+        href: "",
+      }
     case "capability_credential_kind_mismatch":
-      return { message: t("conversations.runtime_error.capability_credential_kind_mismatch", { name: capabilityName }), action: t("conversations.runtime_error.resetCredential"), href }
+      return {
+        message: t("conversations.runtime_error.capability_credential_kind_mismatch", {
+          name: capabilityName,
+        }),
+        action: t("conversations.runtime_error.resetCredential"),
+        href,
+      }
     case "capability_version_unavailable":
       // Daemon resolver couldn't find a usable zip (empty oss_key) for
       // either the pinned version or the latest version. Direct the
       // user to the capability detail page where they can re-upload or
       // pick a different version. No credential `href`, but
       // manageCapabilityHref is always populated.
-      return { message: t("conversations.runtime_error.capability_version_unavailable", { name: capabilityName }), action: t("conversations.runtime_error.manageCapability"), href: manageCapabilityHref }
+      return {
+        message: t("conversations.runtime_error.capability_version_unavailable", {
+          name: capabilityName,
+        }),
+        action: t("conversations.runtime_error.manageCapability"),
+        href: manageCapabilityHref,
+      }
     default:
       return { message: fallback || t("conversations.runtime_error.generic"), action: "", href: "" }
   }
@@ -1245,7 +1346,13 @@ function runtimeErrorViewModel(
 function stringMeta(metadata: Record<string, unknown> | undefined, key: string): string {
   if (!metadata) return ""
   const value = key.includes(".")
-    ? key.split(".").reduce<unknown>((acc, part) => (acc && typeof acc === "object" ? (acc as Record<string, unknown>)[part] : undefined), metadata)
+    ? key
+        .split(".")
+        .reduce<unknown>(
+          (acc, part) =>
+            acc && typeof acc === "object" ? (acc as Record<string, unknown>)[part] : undefined,
+          metadata,
+        )
     : metadata[key]
   return typeof value === "string" ? value : ""
 }
@@ -1370,11 +1477,7 @@ function ComposerForm({
   // the Feishu side. Empty-state composer (onSendDirect) never shows
   // Stop because no run is in flight there.
   const showStop =
-    !onSendDirect &&
-    !!activeRunId &&
-    !!onCancelActiveRun &&
-    trimmed.length === 0 &&
-    !isBusy
+    !onSendDirect && !!activeRunId && !!onCancelActiveRun && trimmed.length === 0 && !isBusy
 
   return (
     <form onSubmit={submit}>
@@ -1437,7 +1540,6 @@ function ComposerForm({
     </form>
   )
 }
-
 
 /* ============================================================== */
 /*  Utilities                                                        */

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "../../components/ui/input"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
+import { agentCodexModeOf, type CodexCollaborationMode } from "../../lib/agent-view-model"
 import {
   modelProtocols,
   modelSupportedEndpointTypes,
@@ -199,6 +200,9 @@ function configBaseForSubmit(a: Agent | null | undefined, connector: string): Re
     delete cfg.agent_kind
     delete cfg.daemon_mode
     delete cfg.device_id
+    // `mode` has engine-specific semantics. The wizard re-emits it only for
+    // Codex so a stale plan mode cannot leak into another engine.
+    delete cfg.mode
     // work_dir is re-emitted from the wizard state below; strip all legacy
     // aliases so a stale value cannot win over a freshly-cleared input.
     delete cfg.work_dir
@@ -242,6 +246,7 @@ export function CreateAgentDialog({
   const [description, setDescription] = useState("")
   const [executionMode, setExecutionMode] = useState<ExecutionMode>("local_device")
   const [agentEngine, setAgentEngine] = useState<AgentEngine>("claude_code")
+  const [codexMode, setCodexMode] = useState<CodexCollaborationMode>("default")
   const [sandboxSize, setSandboxSize] = useState<SandboxSize>("standard")
   const [modelID, setModelID] = useState("")
   const [modelSearch, setModelSearch] = useState("")
@@ -489,6 +494,7 @@ export function CreateAgentDialog({
       const initialExecutionMode = cloneSource ? executionModeFromAgent(cloneSource) : "local_device"
       setExecutionMode(initialExecutionMode)
       setAgentEngine(cloneSource ? agentEngineFromAgent(cloneSource) : "claude_code")
+      setCodexMode(cloneSource ? agentCodexModeOf(cloneSource) : "default")
       setSandboxSize(cloneSource ? sandboxSizeFromAgent(cloneSource) : "standard")
       setModelID(cloneSource ? modelIDFromAgent(cloneSource) : "")
       setModelSearch("")
@@ -520,6 +526,7 @@ export function CreateAgentDialog({
       setDescription(agent.description ?? "")
       setExecutionMode(executionModeFromAgent(agent))
       setAgentEngine(agentEngineFromAgent(agent))
+      setCodexMode(agentCodexModeOf(agent))
       setSandboxSize(sandboxSizeFromAgent(agent))
       setModelID(modelIDFromAgent(agent) || firstModelID)
       setModelSearch("")
@@ -802,6 +809,7 @@ export function CreateAgentDialog({
       profile,
       ...(connector === "agent_daemon" ? {
         agent_kind: agentEngine,
+        ...(agentEngine === "codex" ? { mode: codexMode } : {}),
         ...(executionMode === "sandbox" ? { daemon_mode: "sandbox", sandbox_size: sandboxSize } : {}),
         ...(executionMode === "local_device" ? { daemon_mode: "local", device_id: deviceID } : {}),
         // Daemon read order is work_dir > workdir > working_directory; emit the
@@ -813,6 +821,11 @@ export function CreateAgentDialog({
     const agentProfileConfig: Record<string, unknown> = {
       profile,
       agent_kind: agentEngine,
+      ...(agentEngine === "codex"
+        ? { mode: codexMode }
+        : agentEngineFromAgent(agent) === "codex"
+          ? { mode: null }
+          : {}),
       daemon_mode: executionMode === "sandbox" ? "sandbox" : "local",
       sandbox_size: executionMode === "sandbox" ? sandboxSize : null,
       device_id: executionMode === "local_device" ? deviceID : null,
@@ -1090,6 +1103,23 @@ export function CreateAgentDialog({
                           disabled
                         />
                       </div>
+                    </Field>
+                  )}
+                  {connector === "agent_daemon" && agentEngine === "codex" && (
+                    <Field
+                      label={t("agents.form.fields.codexMode")}
+                      hint={t("agents.form.codexMode.hint")}
+                    >
+                      <select
+                        value={codexMode}
+                        onChange={(e) => setCodexMode(e.target.value === "plan" ? "plan" : "default")}
+                        disabled={pending}
+                        aria-label={t("agents.form.fields.codexMode")}
+                        className="h-9 rounded-md border border-line bg-surface px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-line-strong disabled:cursor-not-allowed disabled:bg-surface-subtle"
+                      >
+                        <option value="default">{t("agents.form.codexMode.default")}</option>
+                        <option value="plan">{t("agents.form.codexMode.plan")}</option>
+                      </select>
                     </Field>
                   )}
                   {connector === "agent_daemon" && executionMode === "sandbox" && (

--- a/apps/web/src/pages/admin/agents/AgentConfigSummary.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigSummary.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Badge } from "../../../components/ui/badge"
 import {
   agentConnectorLabel,
+  agentCodexModeOf,
   agentEngineLabel,
   agentEngineOf,
   agentExecutionModeOf,
@@ -23,6 +24,7 @@ export function AgentConfigSummary({
   const profile = (config.profile ?? {}) as Record<string, unknown>
   const systemPrompt = String(config.system_prompt ?? profile.system_prompt ?? "").trim()
   const executionMode = agentExecutionModeOf(agent)
+  const agentEngine = agentEngineOf(agent)
 
   return (
     <>
@@ -46,8 +48,14 @@ export function AgentConfigSummary({
       <SummaryCard title={t("agents.detail.config.intelligence.title")}>
         <SummaryField
           label={t("agents.detail.config.intelligence.engine")}
-          value={t(agentEngineLabel(agentEngineOf(agent)))}
+          value={t(agentEngineLabel(agentEngine))}
         />
+        {agentEngine === "codex" && (
+          <SummaryField
+            label={t("agents.detail.config.intelligence.codexMode")}
+            value={t(`agents.form.codexMode.${agentCodexModeOf(agent)}`)}
+          />
+        )}
         <SummaryField label={t("agents.detail.config.runtime.model")} value={modelLabel} mono />
         <SummaryField
           label={t("agents.detail.config.intelligence.systemPrompt")}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -113,6 +113,8 @@ definitions:
       by:
         description: user id
         type: string
+      deviceID:
+        type: string
       note:
         type: string
       requestID:
@@ -128,6 +130,8 @@ definitions:
         type: string
       cancelled:
         type: boolean
+      deviceID:
+        type: string
       questionAnswers:
         items:
           $ref: '#/definitions/connector.PromptForUserChoiceQuestionAnswer'
@@ -141,7 +145,13 @@ definitions:
     properties:
       answer:
         type: string
+      answers:
+        items:
+          type: string
+        type: array
       header:
+        type: string
+      questionID:
         type: string
     type: object
   connector.PromptInput:
@@ -613,6 +623,13 @@ definitions:
           type: string
         type: array
     type: object
+  dev.listAgentInteractionsResponse:
+    properties:
+      interactions:
+        items:
+          $ref: '#/definitions/store.AgentInteractionRead'
+        type: array
+    type: object
   dev.listCredentialKindsResponse:
     properties:
       items:
@@ -749,6 +766,30 @@ definitions:
     properties:
       reason:
         type: string
+    type: object
+  dev.resolveAgentInteractionBody:
+    properties:
+      answers:
+        additionalProperties:
+          items:
+            type: string
+          type: array
+        type: object
+      approved:
+        type: boolean
+      cancelled:
+        type: boolean
+      note:
+        type: string
+    type: object
+  dev.resolveAgentInteractionResponse:
+    properties:
+      already_resolved:
+        type: boolean
+      applied:
+        type: boolean
+      interaction:
+        $ref: '#/definitions/store.AgentInteractionRead'
     type: object
   dev.runtimeCredentialBody:
     properties:
@@ -1391,6 +1432,47 @@ definitions:
       title:
         type: string
       why:
+        type: string
+    type: object
+  store.AgentInteractionRead:
+    properties:
+      agent_name:
+        type: string
+      agent_run_id:
+        type: string
+      conversation_id:
+        type: string
+      conversation_title:
+        type: string
+      created_at:
+        type: string
+      expires_at:
+        type: string
+      id:
+        type: string
+      kind:
+        type: string
+      request:
+        additionalProperties: {}
+        type: object
+      request_id:
+        type: string
+      resolution_source:
+        type: string
+      resolved_actor:
+        type: string
+      resolved_at:
+        type: string
+      resolved_by:
+        type: string
+      response:
+        additionalProperties: {}
+        type: object
+      status:
+        type: string
+      updated_at:
+        type: string
+      workspace_id:
         type: string
     type: object
   store.AgentSummary:
@@ -6667,6 +6749,123 @@ paths:
       summary: List workspace gateways
       tags:
       - workspaces
+  /api/v1/workspaces/{workspaceID}/interactions:
+    get:
+      description: Returns durable permission and AskUserQuestion requests. status
+        accepts pending, decided, or expired.
+      operationId: listAgentInteractions
+      parameters:
+      - description: Workspace UUID
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: pending, decided, or expired
+        in: query
+        name: status
+        type: string
+      - description: Maximum rows (1-200)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dev.listAgentInteractionsResponse'
+        "400":
+          description: Invalid status or limit
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Caller is not a workspace member
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Interaction store unavailable
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List workspace approval and user-question requests
+      tags:
+      - interactions
+  /api/v1/workspaces/{workspaceID}/interactions/{interactionID}/resolve:
+    post:
+      consumes:
+      - application/json
+      description: Permission requests require approved. AskUserQuestion requests
+        require an answers map keyed by stable question ID, or cancelled=true.
+      operationId: resolveAgentInteraction
+      parameters:
+      - description: Workspace UUID
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: Interaction UUID
+        in: path
+        name: interactionID
+        required: true
+        type: string
+      - description: Human decision
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dev.resolveAgentInteractionBody'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dev.resolveAgentInteractionResponse'
+        "400":
+          description: Invalid request body
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Caller is not a writable workspace member
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Interaction not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Interaction is currently being resolved
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "410":
+          description: Interaction expired or runtime request ended
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Runtime temporarily unavailable
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Resolve a pending approval or user question
+      tags:
+      - interactions
   /api/v1/workspaces/{workspaceID}/members:
     get:
       description: Returns members of the workspace. Caller must be a workspace member.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -113,6 +113,8 @@ definitions:
       by:
         description: user id
         type: string
+      deliveryID:
+        type: string
       deviceID:
         type: string
       note:
@@ -130,6 +132,8 @@ definitions:
         type: string
       cancelled:
         type: boolean
+      deliveryID:
+        type: string
       deviceID:
         type: string
       questionAnswers:

--- a/internal/agentdaemon/proto/envelope_test.go
+++ b/internal/agentdaemon/proto/envelope_test.go
@@ -88,8 +88,8 @@ func TestVersionCompatible(t *testing.T) {
 		ok     bool
 	}{
 		{Version, true},    // exact match
-		{"0.1.99", true},   // patch drift OK
-		{"0.2.0", false},   // minor drift NOT OK
+		{"0.2.99", true},   // patch drift OK
+		{"0.1.99", false},  // minor drift NOT OK
 		{"1.0.0", false},   // major drift NOT OK
 		{"", false},        // missing
 		{"garbage", false}, // unparseable

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -102,6 +102,7 @@ type PromptForUserChoiceOption struct {
 // question) AskUserQuestion call. Mirrors the Claude Code built-in
 // schema verbatim so the daemon doesn't translate the shape twice.
 type PromptForUserChoiceQuestion struct {
+	ID          string                      `json:"id"`
 	Header      string                      `json:"header,omitempty"`
 	Question    string                      `json:"question"`
 	MultiSelect bool                        `json:"multi_select,omitempty"`

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -41,6 +41,12 @@ const (
 	// send. Envelope.ID = "ask_<8hex>" minted by the daemon.
 	TypePromptForUserChoice = "prompt_for_user_choice"
 
+	// TypeInteractionDecisionAck confirms that the daemon-side agent
+	// accepted (or definitively rejected) a permission/user-input decision.
+	// The server must not mark the durable interaction terminal before this
+	// frame arrives.
+	TypeInteractionDecisionAck = "interaction_decision_ack"
+
 	// TypeUsage reports incremental token / cost usage.
 	TypeUsage = "usage"
 
@@ -90,6 +96,16 @@ type PermissionRequestPayload struct {
 	Payload map[string]any `json:"payload,omitempty"`
 }
 
+// InteractionDecisionAckPayload is the daemon's application-level receipt
+// for a server decision. DeliveryID correlates one resolve attempt without
+// relying on the request id, which may outlive a reconnect or timeout race.
+type InteractionDecisionAckPayload struct {
+	DeliveryID string `json:"delivery_id"`
+	Applied    bool   `json:"applied"`
+	ErrorCode  string `json:"error_code,omitempty"`
+	Error      string `json:"error,omitempty"`
+}
+
 // PromptForUserChoiceOption is one button / checkbox the user can
 // pick when answering a PromptForUserChoice. Label is the human-
 // readable choice; Description is optional inline help.
@@ -106,6 +122,8 @@ type PromptForUserChoiceQuestion struct {
 	Header      string                      `json:"header,omitempty"`
 	Question    string                      `json:"question"`
 	MultiSelect bool                        `json:"multi_select,omitempty"`
+	IsOther     bool                        `json:"is_other,omitempty"`
+	IsSecret    bool                        `json:"is_secret,omitempty"`
 	Options     []PromptForUserChoiceOption `json:"options"`
 }
 
@@ -125,9 +143,10 @@ type PromptForUserChoiceQuestion struct {
 // decoded. New code writes Questions; readers must call
 // EffectiveQuestions to get a unified view across both shapes.
 type PromptForUserChoicePayload struct {
-	AskID     string                        `json:"ask_id"`
-	Questions []PromptForUserChoiceQuestion `json:"questions,omitempty"`
-	ToolUseID string                        `json:"tool_use_id,omitempty"`
+	AskID            string                        `json:"ask_id"`
+	Questions        []PromptForUserChoiceQuestion `json:"questions,omitempty"`
+	ToolUseID        string                        `json:"tool_use_id,omitempty"`
+	AutoResolutionMs *uint64                       `json:"auto_resolution_ms,omitempty"`
 
 	// Legacy single-question fields — read-only on the new path. Empty
 	// when Questions is populated.

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -87,13 +87,17 @@ type ToolCallPayload struct {
 }
 
 // PermissionRequestPayload carries an agent's request for human
-// approval. The gateway promotes Envelope.ID to PermissionRequest.ID
-// so caller and daemon agree on which request is which.
+// approval. RequestID is the daemon-minted handle used to route a later
+// decision. It lives in the payload because Envelope.ID is the run ID used
+// by the server gateway to deliver the request to the active run subscriber.
+// Readers still accept legacy frames that omit RequestID and put the request
+// handle in Envelope.ID.
 type PermissionRequestPayload struct {
-	Tool    string         `json:"tool"`
-	Title   string         `json:"title"`
-	Detail  string         `json:"detail,omitempty"`
-	Payload map[string]any `json:"payload,omitempty"`
+	RequestID string         `json:"request_id,omitempty"`
+	Tool      string         `json:"tool"`
+	Title     string         `json:"title"`
+	Detail    string         `json:"detail,omitempty"`
+	Payload   map[string]any `json:"payload,omitempty"`
 }
 
 // InteractionDecisionAckPayload is the daemon's application-level receipt

--- a/internal/agentdaemon/proto/outbound.go
+++ b/internal/agentdaemon/proto/outbound.go
@@ -101,6 +101,7 @@ type PromptCancelPayload struct{}
 // lets the approver edit the tool input before letting the call
 // proceed (Claude Code's allow-with-changes path).
 type PermissionDecisionPayload struct {
+	DeliveryID   string         `json:"delivery_id"`
 	Approved     bool           `json:"approved"`
 	Message      string         `json:"message,omitempty"`
 	UpdatedInput map[string]any `json:"updated_input,omitempty"`
@@ -129,6 +130,7 @@ type PromptForUserChoiceQuestionAnswer struct {
 //     a short machine tag (e.g. "timeout"); the daemon converts it
 //     into a tool_result message the LLM understands.
 type PromptForUserChoiceDecisionPayload struct {
+	DeliveryID      string                              `json:"delivery_id"`
 	QuestionAnswers []PromptForUserChoiceQuestionAnswer `json:"question_answers,omitempty"`
 	Answers         []string                            `json:"answers,omitempty"`
 	Cancelled       bool                                `json:"cancelled,omitempty"`

--- a/internal/agentdaemon/proto/outbound.go
+++ b/internal/agentdaemon/proto/outbound.go
@@ -107,26 +107,27 @@ type PermissionDecisionPayload struct {
 }
 
 // PromptForUserChoiceQuestionAnswer carries one (question, answer)
-// pair from a multi-question submit. Header matches the question's
-// Header field on the prompt payload; for blank-header questions the
-// daemon uses the zero-based "q<i>" key instead.
+// pair from a multi-question submit. QuestionID is the canonical key;
+// Header and Answer remain as compatibility fields for older peers.
 type PromptForUserChoiceQuestionAnswer struct {
-	Header string `json:"header,omitempty"`
-	Answer string `json:"answer"`
+	QuestionID string   `json:"question_id,omitempty"`
+	Answers    []string `json:"answers,omitempty"`
+	Header     string   `json:"header,omitempty"`
+	Answer     string   `json:"answer,omitempty"`
 }
 
 // PromptForUserChoiceDecisionPayload carries the human's pick. The
 // daemon turns this into a tool_result JSON the agent's stdin
 // consumes.
 //
-//   - QuestionAnswers carries one entry per question (multi-question
-//     path). Empty for legacy single-question callers.
+//   - QuestionAnswers carries one entry per question, keyed by stable
+//     QuestionID with the selected values preserved as an array.
 //   - Answers length == 1 for single-select; length N for multi-select.
-//     Legacy single-question callback path keeps writing this; the
-//     daemon treats it as "all answers belong to question 0".
+//     Legacy single-question callers may still write this; the daemon
+//     treats it as "all answers belong to question 0".
 //   - Cancelled=true marks a non-answer (timeout, /cancel). Reason is
 //     a short machine tag (e.g. "timeout"); the daemon converts it
-//     into a Chinese tool_result text so the LLM understands.
+//     into a tool_result message the LLM understands.
 type PromptForUserChoiceDecisionPayload struct {
 	QuestionAnswers []PromptForUserChoiceQuestionAnswer `json:"question_answers,omitempty"`
 	Answers         []string                            `json:"answers,omitempty"`

--- a/internal/agentdaemon/proto/version.go
+++ b/internal/agentdaemon/proto/version.go
@@ -5,7 +5,7 @@ package proto
 // upgrade query (`version=<semver>`) and in the bootstrap HTTP
 // response; mismatches fail closed at WS upgrade.
 const (
-	Version = "0.1.0"
+	Version = "0.2.0"
 )
 
 // VersionCompatible returns true when clientVersion's "X.Y" prefix

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
   - "apps/*"
   - "packages/*"
+allowBuilds:
+  # Vite requires esbuild's platform-binary installer. Keep the allowlist
+  # explicit so supply-chain-enforcing pnpm runtimes can run project checks.
+  esbuild: true

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -65,6 +65,7 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/inbound/slackrunner"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/inbound/teamsrunner"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/inflight"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/interaction"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/otlp"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/runstream"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/runtime/scheduler"
@@ -373,6 +374,11 @@ func main() {
 	// below can wrap the agent_daemon AgentConnector as a
 	// PermissionRouter. Stays empty when dbStore is nil.
 	connectorReg := connector.NewRegistry()
+	var interactionService *interaction.Service
+	if dbStore != nil {
+		interactionService = interaction.NewService(dbStore, interaction.RegistryDelivery{Runs: dbStore, Registry: connectorReg}, log.Bg())
+		opts = append(opts, dev.WithInteractionService(interactionService))
+	}
 	// Shared signer for the auto-mounted fetch_chat_history tool. Hoisted to
 	// function scope so both the agent_daemon connector (mints per-conversation
 	// tokens) and the internal history endpoint (verifies them) share one
@@ -796,6 +802,14 @@ func main() {
 	if auditIngester != nil {
 		auditIngester.Start(ctx)
 	}
+	if interactionService != nil {
+		worker := interaction.NewWorker(interactionService, dbStore, interaction.WorkerOptions{})
+		go func() {
+			if err := worker.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+				log.Bg().Error("interaction expiry worker exited", "error", err)
+			}
+		}()
+	}
 
 	// Optional embedded OTLP/HTTP receiver so sandbox sidecars / OTel-
 	// SDK producers can ship tool-lifecycle events into the same
@@ -874,7 +888,7 @@ func main() {
 	// event_mode=websocket and need this manager to turn Feishu
 	// events into Parsar gateway messages.
 	if dbStore != nil {
-		if manager, err := buildFeishuWebSocketManager(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL); err != nil {
+		if manager, err := buildFeishuWebSocketManager(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL, interactionService); err != nil {
 			log.Bg().Error("feishu websocket inbound manager init failed", "error", err)
 			os.Exit(1)
 		} else if manager != nil {
@@ -891,7 +905,7 @@ func main() {
 	// only (agent async answers don't return to Slack until a neutral outbound
 	// worker lands). Shares the router store; no DDL.
 	if dbStore != nil {
-		if runner, err := buildSlackRunner(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL); err != nil {
+		if runner, err := buildSlackRunner(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL, interactionService); err != nil {
 			log.Bg().Error("slack socket mode runner init failed", "error", err)
 			os.Exit(1)
 		} else if runner != nil {
@@ -909,7 +923,7 @@ func main() {
 	// MESSAGE_CONTENT is a privileged gateway intent — enable it in the Discord
 	// Developer Portal or message bodies arrive empty.
 	if dbStore != nil {
-		if runner, err := buildDiscordRunner(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL); err != nil {
+		if runner, err := buildDiscordRunner(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL, interactionService); err != nil {
 			log.Bg().Error("discord gateway runner init failed", "error", err)
 			os.Exit(1)
 		} else if runner != nil {
@@ -927,7 +941,7 @@ func main() {
 	// on the chi router rather than a goroutine. Feeds the same neutral
 	// router.HandleInbound pipeline; inbound only. Shares the router store; no DDL.
 	if dbStore != nil {
-		if runner, err := buildTeamsRunner(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL); err != nil {
+		if runner, err := buildTeamsRunner(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL, interactionService); err != nil {
 			log.Bg().Error("teams webhook runner init failed", "error", err)
 			os.Exit(1)
 		} else if runner != nil {
@@ -941,7 +955,7 @@ func main() {
 	// workspace|app_id, hot-reloading on token rotation — the DB-driven twin of
 	// the env-gated buildSlackRunner above.
 	if dbStore != nil {
-		if mgr, err := buildSlackInboundManager(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL); err != nil {
+		if mgr, err := buildSlackInboundManager(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL, interactionService); err != nil {
 			log.Bg().Error("slack connectors reconciler init failed", "error", err)
 			os.Exit(1)
 		} else if mgr != nil {
@@ -957,7 +971,7 @@ func main() {
 	// true. Reads workspace_im_connectors and keeps one Gateway WebSocket runner
 	// per workspace|app_id — the DB-driven twin of buildDiscordRunner.
 	if dbStore != nil {
-		if mgr, err := buildDiscordInboundManager(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL); err != nil {
+		if mgr, err := buildDiscordInboundManager(os.Getenv, dbStore, connectorReg, cfg.Server.PublicURL, interactionService); err != nil {
 			log.Bg().Error("discord connectors reconciler init failed", "error", err)
 			os.Exit(1)
 		} else if mgr != nil {
@@ -1610,6 +1624,15 @@ func defaultFeishuSharedBotEnv(env func(string) string) feishuSharedBotEnv {
 	}
 }
 
+func firstInteractionResolver(resolvers []inbound.InteractionResolver) inbound.InteractionResolver {
+	for _, resolver := range resolvers {
+		if resolver != nil {
+			return resolver
+		}
+	}
+	return nil
+}
+
 // buildFeishuWebSocketManager constructs the Feishu event-websocket inbound
 // manager for DB-driven workspace connectors and optional legacy env bots.
 //
@@ -1620,7 +1643,7 @@ func defaultFeishuSharedBotEnv(env func(string) string) feishuSharedBotEnv {
 //   - PARSAR_FEISHU_DEFAULT_BOT_APP_SECRET   (optional; falls back to PARSAR_FEISHU_APP_SECRET)
 //   - PARSAR_FEISHU_DEFAULT_BOT_OPEN_ID      (optional; self-message dedup)
 //   - PARSAR_MASTER_KEY                      (REQUIRED when enabled)
-func buildFeishuWebSocketManager(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string) (*inbound.Manager, error) {
+func buildFeishuWebSocketManager(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string, resolvers ...inbound.InteractionResolver) (*inbound.Manager, error) {
 	masterKey := strings.TrimSpace(env("PARSAR_MASTER_KEY"))
 	if masterKey == "" {
 		return nil, nil
@@ -1667,6 +1690,7 @@ func buildFeishuWebSocketManager(env func(string) string, dbStore *store.Store, 
 		},
 		PermissionRouter:          inboundPermissionRouter{registry: connectorReg},
 		PromptForUserChoiceRouter: inboundPromptForUserChoiceRouter{registry: connectorReg},
+		InteractionResolver:       firstInteractionResolver(resolvers),
 		JoinURLBuilder:            feishuJoinURLBuilder,
 		Connectors:                dbStore,
 	})
@@ -1701,7 +1725,7 @@ func buildFeishuWebSocketManager(env func(string) string, dbStore *store.Store, 
 // as Feishu) and inject its CardActionRouter so Slack button clicks resolve
 // permissions / choices / credential forms. Without a master key the adapter
 // runs router-less and a click just echoes a neutral "received" reply.
-func buildSlackRunner(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string) (*slackrunner.Runner, error) {
+func buildSlackRunner(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string, resolvers ...inbound.InteractionResolver) (*slackrunner.Runner, error) {
 	if !truthy(env("PARSAR_SLACK_SOCKET")) {
 		return nil, nil
 	}
@@ -1739,6 +1763,7 @@ func buildSlackRunner(env func(string) string, dbStore *store.Store, connectorRe
 			JoinURLBuilder:            slackJoinURLBuilder,
 			PermissionRouter:          inboundPermissionRouter{registry: connectorReg},
 			PromptForUserChoiceRouter: inboundPromptForUserChoiceRouter{registry: connectorReg},
+			InteractionResolver:       firstInteractionResolver(resolvers),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("slack socket mode: init action manager: %w", err)
@@ -1801,7 +1826,7 @@ func buildSlackRunner(env func(string) string, dbStore *store.Store, connectorRe
 // neutral "received" reply. A MemoryPickStore is always injected so the
 // per-interaction select-pick accumulation (Discord fires one interaction per
 // select change) folds into the Submit click.
-func buildDiscordRunner(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string) (*discordrunner.Runner, error) {
+func buildDiscordRunner(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string, resolvers ...inbound.InteractionResolver) (*discordrunner.Runner, error) {
 	if !truthy(env("PARSAR_DISCORD_GATEWAY")) {
 		return nil, nil
 	}
@@ -1835,6 +1860,7 @@ func buildDiscordRunner(env func(string) string, dbStore *store.Store, connector
 			JoinURLBuilder:            discordJoinURLBuilder,
 			PermissionRouter:          inboundPermissionRouter{registry: connectorReg},
 			PromptForUserChoiceRouter: inboundPromptForUserChoiceRouter{registry: connectorReg},
+			InteractionResolver:       firstInteractionResolver(resolvers),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("discord gateway: init action manager: %w", err)
@@ -1906,7 +1932,7 @@ func buildDiscordRunner(env func(string) string, dbStore *store.Store, connector
 // Adaptive Card button clicks resolve permissions / choices / credential forms;
 // without it the adapter runs router-less and a click just echoes a neutral
 // "received" ack.
-func buildTeamsRunner(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string) (*teamsrunner.Runner, error) {
+func buildTeamsRunner(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string, resolvers ...inbound.InteractionResolver) (*teamsrunner.Runner, error) {
 	connectorsMode := truthy(env("PARSAR_TEAMS_CONNECTORS"))
 	if !truthy(env("PARSAR_TEAMS_WEBHOOK")) && !connectorsMode {
 		return nil, nil
@@ -1978,6 +2004,7 @@ func buildTeamsRunner(env func(string) string, dbStore *store.Store, connectorRe
 			JoinURLBuilder:            teamsJoinURLBuilder,
 			PermissionRouter:          inboundPermissionRouter{registry: connectorReg},
 			PromptForUserChoiceRouter: inboundPromptForUserChoiceRouter{registry: connectorReg},
+			InteractionResolver:       firstInteractionResolver(resolvers),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("teams webhook: init action manager: %w", err)
@@ -2018,7 +2045,7 @@ func buildTeamsRunner(env func(string) string, dbStore *store.Store, connectorRe
 // shared across every per-bot adapter the NewAdapter factory mints — both
 // resolve by store lookup (card payload / app_id), not by a captured token, so a
 // single instance serves all workspace bots.
-func buildSlackInboundManager(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string) (*slackrunner.Manager, error) {
+func buildSlackInboundManager(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string, resolvers ...inbound.InteractionResolver) (*slackrunner.Manager, error) {
 	masterKey := strings.TrimSpace(env("PARSAR_MASTER_KEY"))
 	if masterKey == "" {
 		return nil, nil
@@ -2043,6 +2070,7 @@ func buildSlackInboundManager(env func(string) string, dbStore *store.Store, con
 		JoinURLBuilder:            slackJoinURLBuilder,
 		PermissionRouter:          inboundPermissionRouter{registry: connectorReg},
 		PromptForUserChoiceRouter: inboundPromptForUserChoiceRouter{registry: connectorReg},
+		InteractionResolver:       firstInteractionResolver(resolvers),
 		Connectors:                dbStore,
 	})
 	if err != nil {
@@ -2090,7 +2118,7 @@ func buildSlackInboundManager(env func(string) string, dbStore *store.Store, con
 // WebSocket runner per workspace|app_id. Discord uses one bot token (no app token),
 // so the NewAdapter factory takes only (appID, botToken). A MemoryPickStore is
 // injected per adapter so select-change interactions fold into the Submit click.
-func buildDiscordInboundManager(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string) (*discordrunner.Manager, error) {
+func buildDiscordInboundManager(env func(string) string, dbStore *store.Store, connectorReg *connector.Registry, publicURL string, resolvers ...inbound.InteractionResolver) (*discordrunner.Manager, error) {
 	masterKey := strings.TrimSpace(env("PARSAR_MASTER_KEY"))
 	if masterKey == "" {
 		return nil, nil
@@ -2115,6 +2143,7 @@ func buildDiscordInboundManager(env func(string) string, dbStore *store.Store, c
 		JoinURLBuilder:            discordJoinURLBuilder,
 		PermissionRouter:          inboundPermissionRouter{registry: connectorReg},
 		PromptForUserChoiceRouter: inboundPromptForUserChoiceRouter{registry: connectorReg},
+		InteractionResolver:       firstInteractionResolver(resolvers),
 		Connectors:                dbStore,
 	})
 	if err != nil {

--- a/server/internal/agentdaemon/gateway/session.go
+++ b/server/internal/agentdaemon/gateway/session.go
@@ -32,6 +32,10 @@ var (
 	// Past this we treat the peer as wedged and close the session.
 	WriteTimeout = 10 * time.Second
 
+	// InteractionAckTimeout bounds the application-level round trip for a
+	// permission or user-input decision after it is written to the daemon.
+	InteractionAckTimeout = 15 * time.Second
+
 	// ReadLimit caps a single inbound frame at 4 MiB. tool_call
 	// results can be large but anything past this is almost certainly
 	// a misbehaving daemon (or hostile input).
@@ -99,6 +103,9 @@ type Session struct {
 	subsMu sync.Mutex
 	subs   map[string]chan proto.Envelope
 
+	ackMu      sync.Mutex
+	ackWaiters map[string]chan proto.InteractionDecisionAckPayload
+
 	// sendCh feeds the WS write loop. Capacity is bounded so a slow
 	// peer can't queue unbounded outbound frames; once full, Send
 	// blocks up to WriteTimeout then returns an error.
@@ -139,6 +146,7 @@ func NewSessionWithOwner(conn WSConn, deviceID, workspaceID, daemonVersion strin
 		owner:         owner,
 		lastSeenAt:    now,
 		subs:          map[string]chan proto.Envelope{},
+		ackWaiters:    map[string]chan proto.InteractionDecisionAckPayload{},
 		sendCh:        make(chan proto.Envelope, 64),
 		closed:        make(chan struct{}),
 	}
@@ -298,6 +306,52 @@ func (s *Session) Send(ctx context.Context, env proto.Envelope) error {
 		return ErrSessionClosed
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+// SendAndWaitInteractionAck sends a decision and waits until the daemon
+// confirms that its agent session applied it. Queueing or writing the
+// WebSocket frame alone is not success: without this receipt the canonical
+// database interaction must remain retryable.
+func (s *Session) SendAndWaitInteractionAck(ctx context.Context, env proto.Envelope, deliveryID string) (proto.InteractionDecisionAckPayload, error) {
+	deliveryID = strings.TrimSpace(deliveryID)
+	if deliveryID == "" {
+		return proto.InteractionDecisionAckPayload{}, errors.New("agentdaemon gateway: interaction delivery id is required")
+	}
+	waiter := make(chan proto.InteractionDecisionAckPayload, 1)
+	s.ackMu.Lock()
+	if _, exists := s.ackWaiters[deliveryID]; exists {
+		s.ackMu.Unlock()
+		return proto.InteractionDecisionAckPayload{}, fmt.Errorf("agentdaemon gateway: duplicate interaction delivery id %q", deliveryID)
+	}
+	s.ackWaiters[deliveryID] = waiter
+	s.ackMu.Unlock()
+	defer func() {
+		s.ackMu.Lock()
+		delete(s.ackWaiters, deliveryID)
+		s.ackMu.Unlock()
+	}()
+
+	if err := s.Send(ctx, env); err != nil {
+		return proto.InteractionDecisionAckPayload{}, err
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, InteractionAckTimeout)
+	defer cancel()
+	select {
+	case ack := <-waiter:
+		return ack, nil
+	case <-s.closed:
+		return proto.InteractionDecisionAckPayload{}, ErrSessionClosed
+	case <-waitCtx.Done():
+		// If the ack raced the deadline, prefer the application receipt;
+		// treating an already-applied decision as retryable can trigger a
+		// contradictory second human response.
+		select {
+		case ack := <-waiter:
+			return ack, nil
+		default:
+			return proto.InteractionDecisionAckPayload{}, waitCtx.Err()
+		}
 	}
 }
 
@@ -544,6 +598,24 @@ func (s *Session) dispatch(env proto.Envelope) {
 		if err := env.DecodePayload(&p); err == nil && p.AskID != "" {
 			s.reg.AttachPromptForUserChoice(p.AskID, s)
 		}
+	case proto.TypeInteractionDecisionAck:
+		var ack proto.InteractionDecisionAckPayload
+		if err := env.DecodePayload(&ack); err != nil {
+			s.log("agentdaemon gateway: decode interaction decision ack: %v", err)
+			return
+		}
+		s.ackMu.Lock()
+		waiter := s.ackWaiters[ack.DeliveryID]
+		s.ackMu.Unlock()
+		if waiter == nil {
+			s.log("agentdaemon gateway: interaction decision ack has no waiter delivery=%s request=%s", ack.DeliveryID, env.ID)
+			return
+		}
+		select {
+		case waiter <- ack:
+		default:
+		}
+		return
 	}
 
 	// All run-correlated frames fan to the matching subscriber.

--- a/server/internal/agentdaemon/gateway/session.go
+++ b/server/internal/agentdaemon/gateway/session.go
@@ -582,8 +582,16 @@ func (s *Session) dispatch(env proto.Envelope) {
 		s.handleHeartbeat(env)
 		return
 	case proto.TypePermissionRequest:
-		if env.ID != "" {
-			s.reg.AttachPermission(env.ID, s)
+		var p proto.PermissionRequestPayload
+		requestID := ""
+		if err := env.DecodePayload(&p); err == nil {
+			requestID = strings.TrimSpace(p.RequestID)
+		}
+		if requestID == "" {
+			requestID = strings.TrimSpace(env.ID)
+		}
+		if requestID != "" {
+			s.reg.AttachPermission(requestID, s)
 		}
 	case proto.TypePermissionCancel:
 		if env.ID != "" {
@@ -618,11 +626,11 @@ func (s *Session) dispatch(env proto.Envelope) {
 		return
 	}
 
-	// All run-correlated frames fan to the matching subscriber.
-	// Permission events are stamped with the perm id (not the runID)
-	// and are handled by AttachPermission/DetachPermission above; the
-	// connector routes them via the permission-channel-by-perm-id set,
-	// so they bypass this run-channel path.
+	// All run-correlated frames fan to the matching subscriber. Current
+	// permission and prompt-for-user-choice frames keep their interaction ID
+	// in the payload so Envelope.ID remains the run ID. Legacy permission
+	// frames put the permission ID in Envelope.ID; those are still indexed
+	// above but cannot be correlated to a run subscriber.
 	if env.ID == "" {
 		return
 	}

--- a/server/internal/agentdaemon/gateway/session_test.go
+++ b/server/internal/agentdaemon/gateway/session_test.go
@@ -265,9 +265,14 @@ func TestSession_PermissionRequestIndexedInRegistry(t *testing.T) {
 	sess.Start()
 	defer sess.Close("test done")
 
-	env, _ := proto.NewEnvelope(proto.TypePermissionRequest, "perm-abc", proto.PermissionRequestPayload{
-		Tool:  "Bash",
-		Title: "rm -rf /tmp/scratch",
+	ch, err := sess.Subscribe("run-1")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	env, _ := proto.NewEnvelope(proto.TypePermissionRequest, "run-1", proto.PermissionRequestPayload{
+		RequestID: "perm-abc",
+		Tool:      "Bash",
+		Title:     "rm -rf /tmp/scratch",
 	})
 	raw, _ := jsonMarshal(env)
 	conn.Feed(raw)
@@ -276,12 +281,21 @@ func TestSession_PermissionRequestIndexedInRegistry(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	for {
 		if got, err := reg.LookupPermission("perm-abc"); err == nil && got == sess {
-			return
+			break
 		}
 		if time.Now().After(deadline) {
 			t.Fatal("perm-abc never indexed in registry")
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+
+	select {
+	case got := <-ch:
+		if got.ID != "run-1" || got.Type != proto.TypePermissionRequest {
+			t.Fatalf("subscriber received %+v", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run subscriber never received permission request")
 	}
 }
 

--- a/server/internal/connector/agentdaemon/connector.go
+++ b/server/internal/connector/agentdaemon/connector.go
@@ -24,6 +24,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
+
 	obslog "github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
 
 	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
@@ -691,6 +693,8 @@ func (c *Connector) handleUpstream(
 				Header:      q.Header,
 				Question:    q.Question,
 				MultiSelect: q.MultiSelect,
+				IsOther:     q.IsOther,
+				IsSecret:    q.IsSecret,
 				Options:     opts,
 			})
 		}
@@ -700,10 +704,11 @@ func (c *Connector) handleUpstream(
 		// then routes SubmitPromptForUserChoice back by AskID via the
 		// gateway registry's byAsk index.
 		out <- connector.PromptEvent{Type: connector.EventPromptForUserChoice, PromptForUserChoice: &connector.PromptForUserChoiceRequest{
-			ID:        p.AskID,
-			DeviceID:  bind.DeviceID,
-			Questions: questions,
-			ToolUseID: p.ToolUseID,
+			ID:               p.AskID,
+			DeviceID:         bind.DeviceID,
+			Questions:        questions,
+			ToolUseID:        p.ToolUseID,
+			AutoResolutionMs: p.AutoResolutionMs,
 		}}
 
 	case proto.TypePermissionCancel:
@@ -803,6 +808,12 @@ func (c *Connector) SubmitPermission(ctx context.Context, decision connector.Per
 	if decision.RequestID == "" {
 		return fmt.Errorf("agent_daemon: SubmitPermission requires RequestID")
 	}
+	if strings.TrimSpace(decision.DeliveryID) == "" {
+		// Legacy IM callers do not own a canonical interaction id. Keep a
+		// stable request-derived base; the local owner adds a unique transport
+		// attempt id, while the daemon replays by request and decision content.
+		decision.DeliveryID = "permission:" + strings.TrimSpace(decision.RequestID)
+	}
 	if c.ownerResolver != nil {
 		deviceID := strings.TrimSpace(decision.DeviceID)
 		if deviceID == "" && c.submitSlots != nil {
@@ -840,6 +851,10 @@ func (c *Connector) SubmitPermissionLocal(ctx context.Context, decision connecto
 	if decision.RequestID == "" {
 		return fmt.Errorf("agent_daemon: SubmitPermissionLocal requires RequestID")
 	}
+	if strings.TrimSpace(decision.DeliveryID) == "" {
+		decision.DeliveryID = "permission:" + strings.TrimSpace(decision.RequestID)
+	}
+	deliveryID := interactionDeliveryAttemptID(decision.DeliveryID)
 	sess, err := c.registry.LookupPermission(decision.RequestID)
 	if err != nil {
 		if errors.Is(err, gateway.ErrPermissionNotRegistered) {
@@ -848,18 +863,24 @@ func (c *Connector) SubmitPermissionLocal(ctx context.Context, decision connecto
 		return fmt.Errorf("agent_daemon: %w", err)
 	}
 	env, err := proto.NewEnvelope(proto.TypePermissionDecision, decision.RequestID, proto.PermissionDecisionPayload{
-		Approved: decision.Approved,
-		Message:  decision.Note,
+		DeliveryID: deliveryID,
+		Approved:   decision.Approved,
+		Message:    decision.Note,
 	})
 	if err != nil {
 		return fmt.Errorf("agent_daemon: build permission_decision: %w", err)
 	}
-	if err := sess.Send(ctx, env); err != nil {
+	ack, err := sess.SendAndWaitInteractionAck(ctx, env, deliveryID)
+	if err != nil {
 		return fmt.Errorf("agent_daemon: %w: send permission_decision: %v", connector.ErrInteractionRuntimeUnavailable, err)
 	}
-	// Clear the perm mapping so a duplicate SubmitPermission for the
-	// same id returns ErrPermissionNotRegistered rather than silently
-	// re-sending the verdict.
+	if !ack.Applied {
+		if ack.ErrorCode == "not_pending" || ack.ErrorCode == "decision_conflict" {
+			c.registry.DetachPermission(decision.RequestID)
+			return fmt.Errorf("agent_daemon: %w: %s", connector.ErrInteractionNoLongerPending, ack.Error)
+		}
+		return fmt.Errorf("agent_daemon: %w: %s", connector.ErrInteractionRuntimeUnavailable, ack.Error)
+	}
 	c.registry.DetachPermission(decision.RequestID)
 	return nil
 }
@@ -872,6 +893,9 @@ func (c *Connector) SubmitPermissionLocal(ctx context.Context, decision connecto
 func (c *Connector) SubmitPromptForUserChoice(ctx context.Context, decision connector.PromptForUserChoiceDecision) error {
 	if decision.RequestID == "" {
 		return fmt.Errorf("agent_daemon: SubmitPromptForUserChoice requires RequestID")
+	}
+	if strings.TrimSpace(decision.DeliveryID) == "" {
+		decision.DeliveryID = "user-choice:" + strings.TrimSpace(decision.RequestID)
 	}
 	if c.ownerResolver != nil {
 		deviceID := strings.TrimSpace(decision.DeviceID)
@@ -907,6 +931,10 @@ func (c *Connector) SubmitPromptForUserChoiceLocal(ctx context.Context, decision
 	if decision.RequestID == "" {
 		return fmt.Errorf("agent_daemon: SubmitPromptForUserChoiceLocal requires RequestID")
 	}
+	if strings.TrimSpace(decision.DeliveryID) == "" {
+		decision.DeliveryID = "user-choice:" + strings.TrimSpace(decision.RequestID)
+	}
+	deliveryID := interactionDeliveryAttemptID(decision.DeliveryID)
 	sess, err := c.registry.LookupPromptForUserChoice(decision.RequestID)
 	if err != nil {
 		if errors.Is(err, gateway.ErrPromptForUserChoiceNotRegistered) {
@@ -921,6 +949,7 @@ func (c *Connector) SubmitPromptForUserChoiceLocal(ctx context.Context, decision
 		})
 	}
 	env, err := proto.NewEnvelope(proto.TypePromptForUserChoiceDecision, decision.RequestID, proto.PromptForUserChoiceDecisionPayload{
+		DeliveryID:      deliveryID,
 		QuestionAnswers: qas,
 		Answers:         decision.Answers,
 		Cancelled:       decision.Cancelled,
@@ -929,11 +958,23 @@ func (c *Connector) SubmitPromptForUserChoiceLocal(ctx context.Context, decision
 	if err != nil {
 		return fmt.Errorf("agent_daemon: build prompt_for_user_choice_decision: %w", err)
 	}
-	if err := sess.Send(ctx, env); err != nil {
+	ack, err := sess.SendAndWaitInteractionAck(ctx, env, deliveryID)
+	if err != nil {
 		return fmt.Errorf("agent_daemon: %w: send prompt_for_user_choice_decision: %v", connector.ErrInteractionRuntimeUnavailable, err)
+	}
+	if !ack.Applied {
+		if ack.ErrorCode == "not_pending" || ack.ErrorCode == "decision_conflict" {
+			c.registry.DetachPromptForUserChoice(decision.RequestID)
+			return fmt.Errorf("agent_daemon: %w: %s", connector.ErrInteractionNoLongerPending, ack.Error)
+		}
+		return fmt.Errorf("agent_daemon: %w: %s", connector.ErrInteractionRuntimeUnavailable, ack.Error)
 	}
 	c.registry.DetachPromptForUserChoice(decision.RequestID)
 	return nil
+}
+
+func interactionDeliveryAttemptID(base string) string {
+	return strings.TrimSpace(base) + ":" + uuid.NewString()
 }
 
 // Close drops every binding for the conversation so the next prompt

--- a/server/internal/connector/agentdaemon/connector.go
+++ b/server/internal/connector/agentdaemon/connector.go
@@ -667,7 +667,7 @@ func (c *Connector) handleUpstream(
 			return
 		}
 		out <- connector.PromptEvent{Type: connector.EventPermissionRequest, Permission: &connector.PermissionRequest{
-			ID: env.ID, Tool: p.Tool, Title: p.Title, Detail: p.Detail, Payload: p.Payload,
+			ID: env.ID, DeviceID: bind.DeviceID, Tool: p.Tool, Title: p.Title, Detail: p.Detail, Payload: p.Payload,
 		}}
 
 	case proto.TypePromptForUserChoice:
@@ -687,6 +687,7 @@ func (c *Connector) handleUpstream(
 				opts = append(opts, connector.PromptForUserChoiceOption{Label: opt.Label, Description: opt.Description})
 			}
 			questions = append(questions, connector.PromptForUserChoiceQuestion{
+				ID:          q.ID,
 				Header:      q.Header,
 				Question:    q.Question,
 				MultiSelect: q.MultiSelect,
@@ -700,6 +701,7 @@ func (c *Connector) handleUpstream(
 		// gateway registry's byAsk index.
 		out <- connector.PromptEvent{Type: connector.EventPromptForUserChoice, PromptForUserChoice: &connector.PromptForUserChoiceRequest{
 			ID:        p.AskID,
+			DeviceID:  bind.DeviceID,
 			Questions: questions,
 			ToolUseID: p.ToolUseID,
 		}}
@@ -801,15 +803,20 @@ func (c *Connector) SubmitPermission(ctx context.Context, decision connector.Per
 	if decision.RequestID == "" {
 		return fmt.Errorf("agent_daemon: SubmitPermission requires RequestID")
 	}
-	if c.submitSlots != nil && c.ownerResolver != nil {
-		deviceID, err := c.submitSlots.DeviceIDForPermissionRequest(ctx, decision.RequestID)
-		if err != nil {
-			// Slot already cleared or DB transient — fall through to
-			// local lookup; the in-process registry will reject with a
-			// clear "not pending" error if appropriate.
-			c.log.Warn("agent_daemon: SubmitPermission slot lookup failed; trying local",
-				"request_id", decision.RequestID, "err", err.Error())
-		} else if strings.TrimSpace(deviceID) != "" {
+	if c.ownerResolver != nil {
+		deviceID := strings.TrimSpace(decision.DeviceID)
+		if deviceID == "" && c.submitSlots != nil {
+			resolved, err := c.submitSlots.DeviceIDForPermissionRequest(ctx, decision.RequestID)
+			if err != nil {
+				// Legacy direct callers have no canonical device id. Fall
+				// through to the local registry when their slot lookup fails.
+				c.log.Warn("agent_daemon: SubmitPermission slot lookup failed; trying local",
+					"request_id", decision.RequestID, "err", err.Error())
+			} else {
+				deviceID = strings.TrimSpace(resolved)
+			}
+		}
+		if deviceID != "" {
 			outcome, err := c.resolveOwnerForSubmit(ctx, decision.RequestID, deviceID, "permission")
 			if err != nil {
 				return err
@@ -835,6 +842,9 @@ func (c *Connector) SubmitPermissionLocal(ctx context.Context, decision connecto
 	}
 	sess, err := c.registry.LookupPermission(decision.RequestID)
 	if err != nil {
+		if errors.Is(err, gateway.ErrPermissionNotRegistered) {
+			return fmt.Errorf("agent_daemon: %w: %v", connector.ErrInteractionNoLongerPending, err)
+		}
 		return fmt.Errorf("agent_daemon: %w", err)
 	}
 	env, err := proto.NewEnvelope(proto.TypePermissionDecision, decision.RequestID, proto.PermissionDecisionPayload{
@@ -845,7 +855,7 @@ func (c *Connector) SubmitPermissionLocal(ctx context.Context, decision connecto
 		return fmt.Errorf("agent_daemon: build permission_decision: %w", err)
 	}
 	if err := sess.Send(ctx, env); err != nil {
-		return fmt.Errorf("agent_daemon: send permission_decision: %w", err)
+		return fmt.Errorf("agent_daemon: %w: send permission_decision: %v", connector.ErrInteractionRuntimeUnavailable, err)
 	}
 	// Clear the perm mapping so a duplicate SubmitPermission for the
 	// same id returns ErrPermissionNotRegistered rather than silently
@@ -863,12 +873,18 @@ func (c *Connector) SubmitPromptForUserChoice(ctx context.Context, decision conn
 	if decision.RequestID == "" {
 		return fmt.Errorf("agent_daemon: SubmitPromptForUserChoice requires RequestID")
 	}
-	if c.submitSlots != nil && c.ownerResolver != nil {
-		deviceID, err := c.submitSlots.DeviceIDForPromptForUserChoiceRequest(ctx, decision.RequestID)
-		if err != nil {
-			c.log.Warn("agent_daemon: SubmitPromptForUserChoice slot lookup failed; trying local",
-				"request_id", decision.RequestID, "err", err.Error())
-		} else if strings.TrimSpace(deviceID) != "" {
+	if c.ownerResolver != nil {
+		deviceID := strings.TrimSpace(decision.DeviceID)
+		if deviceID == "" && c.submitSlots != nil {
+			resolved, err := c.submitSlots.DeviceIDForPromptForUserChoiceRequest(ctx, decision.RequestID)
+			if err != nil {
+				c.log.Warn("agent_daemon: SubmitPromptForUserChoice slot lookup failed; trying local",
+					"request_id", decision.RequestID, "err", err.Error())
+			} else {
+				deviceID = strings.TrimSpace(resolved)
+			}
+		}
+		if deviceID != "" {
 			outcome, err := c.resolveOwnerForSubmit(ctx, decision.RequestID, deviceID, "prompt_for_user_choice")
 			if err != nil {
 				return err
@@ -893,11 +909,16 @@ func (c *Connector) SubmitPromptForUserChoiceLocal(ctx context.Context, decision
 	}
 	sess, err := c.registry.LookupPromptForUserChoice(decision.RequestID)
 	if err != nil {
+		if errors.Is(err, gateway.ErrPromptForUserChoiceNotRegistered) {
+			return fmt.Errorf("agent_daemon: %w: %v", connector.ErrInteractionNoLongerPending, err)
+		}
 		return fmt.Errorf("agent_daemon: %w", err)
 	}
 	qas := make([]proto.PromptForUserChoiceQuestionAnswer, 0, len(decision.QuestionAnswers))
 	for _, qa := range decision.QuestionAnswers {
-		qas = append(qas, proto.PromptForUserChoiceQuestionAnswer{Header: qa.Header, Answer: qa.Answer})
+		qas = append(qas, proto.PromptForUserChoiceQuestionAnswer{
+			QuestionID: qa.QuestionID, Answers: qa.Answers, Header: qa.Header, Answer: qa.Answer,
+		})
 	}
 	env, err := proto.NewEnvelope(proto.TypePromptForUserChoiceDecision, decision.RequestID, proto.PromptForUserChoiceDecisionPayload{
 		QuestionAnswers: qas,
@@ -909,7 +930,7 @@ func (c *Connector) SubmitPromptForUserChoiceLocal(ctx context.Context, decision
 		return fmt.Errorf("agent_daemon: build prompt_for_user_choice_decision: %w", err)
 	}
 	if err := sess.Send(ctx, env); err != nil {
-		return fmt.Errorf("agent_daemon: send prompt_for_user_choice_decision: %w", err)
+		return fmt.Errorf("agent_daemon: %w: send prompt_for_user_choice_decision: %v", connector.ErrInteractionRuntimeUnavailable, err)
 	}
 	c.registry.DetachPromptForUserChoice(decision.RequestID)
 	return nil

--- a/server/internal/connector/agentdaemon/connector.go
+++ b/server/internal/connector/agentdaemon/connector.go
@@ -668,8 +668,12 @@ func (c *Connector) handleUpstream(
 			c.log.Warn("agent_daemon: decode permission_request", "err", err, "run_id", in.RunID)
 			return
 		}
+		requestID := strings.TrimSpace(p.RequestID)
+		if requestID == "" {
+			requestID = strings.TrimSpace(env.ID)
+		}
 		out <- connector.PromptEvent{Type: connector.EventPermissionRequest, Permission: &connector.PermissionRequest{
-			ID: env.ID, DeviceID: bind.DeviceID, Tool: p.Tool, Title: p.Title, Detail: p.Detail, Payload: p.Payload,
+			ID: requestID, DeviceID: bind.DeviceID, Tool: p.Tool, Title: p.Title, Detail: p.Detail, Payload: p.Payload,
 		}}
 
 	case proto.TypePromptForUserChoice:

--- a/server/internal/connector/agentdaemon/connector_test.go
+++ b/server/internal/connector/agentdaemon/connector_test.go
@@ -1364,6 +1364,23 @@ func TestSubmitPermission_ForwardsToRemoteOwnerPod(t *testing.T) {
 	}
 }
 
+func TestSubmitPermission_UsesCanonicalDeviceWithoutIMSlot(t *testing.T) {
+	remote := &fakeRemoteSubmitter{}
+	c := New(Config{
+		Registry: gateway.NewRegistry(), Binder: binding.NewInMemoryBinder(),
+		OwnerResolver: fakeOwnerResolver{owner: remoteOwner("dev-canonical"), ok: true},
+		OwnerPodID:    "pod-a", RemoteSubmit: remote,
+	})
+	if err := c.SubmitPermission(context.Background(), connector.PermissionDecision{
+		RequestID: "perm-canonical", DeviceID: "dev-canonical", Approved: true,
+	}); err != nil {
+		t.Fatalf("SubmitPermission: %v", err)
+	}
+	if !remote.permCalled || remote.permOwner.DeviceID != "dev-canonical" || remote.permDec.DeviceID != "dev-canonical" {
+		t.Fatalf("remote submission = called:%v owner:%+v decision:%+v", remote.permCalled, remote.permOwner, remote.permDec)
+	}
+}
+
 // TestSubmitPermission_ThisPodHandlesLocally covers the "I am the
 // owner" branch — owner check passes, so we must NOT POST out, we must
 // fall into the registry lookup path. A missing perm registration
@@ -1442,6 +1459,23 @@ func TestSubmitPromptForUserChoice_ForwardsToRemoteOwnerPod(t *testing.T) {
 	}
 	if remote.askDec.RequestID != "ask-y" || len(remote.askDec.Answers) != 1 || remote.askDec.Answers[0] != "yes" {
 		t.Fatalf("decision payload mismatch: %+v", remote.askDec)
+	}
+}
+
+func TestSubmitPromptForUserChoice_UsesCanonicalDeviceWithoutIMSlot(t *testing.T) {
+	remote := &fakeRemoteSubmitter{}
+	c := New(Config{
+		Registry: gateway.NewRegistry(), Binder: binding.NewInMemoryBinder(),
+		OwnerResolver: fakeOwnerResolver{owner: remoteOwner("dev-canonical"), ok: true},
+		OwnerPodID:    "pod-a", RemoteSubmit: remote,
+	})
+	if err := c.SubmitPromptForUserChoice(context.Background(), connector.PromptForUserChoiceDecision{
+		RequestID: "ask-canonical", DeviceID: "dev-canonical", Answers: []string{"yes"},
+	}); err != nil {
+		t.Fatalf("SubmitPromptForUserChoice: %v", err)
+	}
+	if !remote.askCalled || remote.askOwner.DeviceID != "dev-canonical" || remote.askDec.DeviceID != "dev-canonical" {
+		t.Fatalf("remote submission = called:%v owner:%+v decision:%+v", remote.askCalled, remote.askOwner, remote.askDec)
 	}
 }
 

--- a/server/internal/connector/agentdaemon/connector_test.go
+++ b/server/internal/connector/agentdaemon/connector_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -547,6 +548,36 @@ func TestStreamPrompt_PermissionRequestPropagates(t *testing.T) {
 	}
 }
 
+func TestStreamPrompt_UserChoiceMetadataPropagates(t *testing.T) {
+	c, _, sess, conn, _ := newWiredHarness(t, "dev-1", "conv-1", "pa-1")
+	defer sess.Close("test done")
+	ch, err := c.StreamPrompt(context.Background(), basicInput())
+	if err != nil {
+		t.Fatalf("StreamPrompt: %v", err)
+	}
+	waitForWrite(t, conn, proto.TypePromptRequest, 2*time.Second)
+	autoResolutionMs := uint64(90_000)
+	askEnv, _ := proto.NewEnvelope(proto.TypePromptForUserChoice, "run-1", proto.PromptForUserChoicePayload{
+		AskID: "ask-metadata", AutoResolutionMs: &autoResolutionMs,
+		Questions: []proto.PromptForUserChoiceQuestion{{
+			ID: "token", Question: "Token?", IsOther: true, IsSecret: true,
+		}},
+	})
+	conn.Feed(askEnv)
+	select {
+	case ev := <-ch:
+		if ev.PromptForUserChoice == nil || len(ev.PromptForUserChoice.Questions) != 1 {
+			t.Fatalf("user choice event = %+v", ev)
+		}
+		question := ev.PromptForUserChoice.Questions[0]
+		if !question.IsOther || !question.IsSecret || ev.PromptForUserChoice.AutoResolutionMs == nil || *ev.PromptForUserChoice.AutoResolutionMs != autoResolutionMs {
+			t.Fatalf("user choice metadata = %+v", ev.PromptForUserChoice)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("user choice event timed out")
+	}
+}
+
 // ----------------------------------------------------------------------
 // Abort / SubmitPermission / Close
 // ----------------------------------------------------------------------
@@ -615,9 +646,9 @@ func TestSubmitPermission_RoutesThroughRegistry(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 
-	if err := c.SubmitPermission(context.Background(), connector.PermissionDecision{
+	if err := submitPermissionAndAck(t, c, conn, connector.PermissionDecision{
 		RequestID: "perm-xyz", Approved: true, Note: "lgtm",
-	}); err != nil {
+	}, true, ""); err != nil {
 		t.Fatalf("SubmitPermission: %v", err)
 	}
 
@@ -632,6 +663,34 @@ func TestSubmitPermission_RoutesThroughRegistry(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error on duplicate SubmitPermission, got nil")
+	}
+}
+
+func TestSubmitPermission_DoesNotSucceedBeforeRuntimeAck(t *testing.T) {
+	c, _, sess, conn, _ := newWiredHarness(t, "dev-1", "conv-1", "pa-1")
+	defer sess.Close("test done")
+	if _, err := c.StreamPrompt(context.Background(), basicInput()); err != nil {
+		t.Fatalf("StreamPrompt: %v", err)
+	}
+	waitForWrite(t, conn, proto.TypePromptRequest, 2*time.Second)
+	permEnv, _ := proto.NewEnvelope(proto.TypePermissionRequest, "perm-rejected", proto.PermissionRequestPayload{Tool: "Bash"})
+	conn.Feed(permEnv)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := c.registry.LookupPermission("perm-rejected"); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("permission registration timed out")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	err := submitPermissionAndAck(t, c, conn, connector.PermissionDecision{
+		RequestID: "perm-rejected", Approved: true,
+	}, false, "runtime_error")
+	if !errors.Is(err, connector.ErrInteractionRuntimeUnavailable) {
+		t.Fatalf("SubmitPermission error = %v, want ErrInteractionRuntimeUnavailable", err)
 	}
 }
 
@@ -650,6 +709,165 @@ func TestSubmitPermission_RequiresRequestID(t *testing.T) {
 	err := c.SubmitPermission(context.Background(), connector.PermissionDecision{Approved: true})
 	if err == nil {
 		t.Fatal("expected error for empty RequestID, got nil")
+	}
+}
+
+func TestSubmitPromptForUserChoice_WaitsForRuntimeAck(t *testing.T) {
+	c, _, sess, conn, _ := newWiredHarness(t, "dev-1", "conv-1", "pa-1")
+	defer sess.Close("test done")
+	askEnv, _ := proto.NewEnvelope(proto.TypePromptForUserChoice, "run-1", proto.PromptForUserChoicePayload{
+		AskID: "ask-xyz", Questions: []proto.PromptForUserChoiceQuestion{{ID: "q0", Question: "Continue?"}},
+	})
+	conn.Feed(askEnv)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := c.registry.LookupPromptForUserChoice("ask-xyz"); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("user-input registration timed out")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- c.SubmitPromptForUserChoice(context.Background(), connector.PromptForUserChoiceDecision{
+			RequestID: "ask-xyz", QuestionAnswers: []connector.PromptForUserChoiceQuestionAnswer{{QuestionID: "q0", Answers: []string{"yes"}}},
+		})
+	}()
+	var decisionEnv proto.Envelope
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, env := range conn.Writes() {
+			if env.Type == proto.TypePromptForUserChoiceDecision && env.ID == "ask-xyz" {
+				decisionEnv = env
+				break
+			}
+		}
+		if decisionEnv.Type != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if decisionEnv.Type == "" {
+		t.Fatal("prompt_for_user_choice_decision never written")
+	}
+	select {
+	case err := <-done:
+		t.Fatalf("SubmitPromptForUserChoice returned before ack: %v", err)
+	default:
+	}
+	var payload proto.PromptForUserChoiceDecisionPayload
+	if err := decisionEnv.DecodePayload(&payload); err != nil {
+		t.Fatalf("decode user-input decision: %v", err)
+	}
+	ack, _ := proto.NewEnvelope(proto.TypeInteractionDecisionAck, "ask-xyz", proto.InteractionDecisionAckPayload{
+		DeliveryID: payload.DeliveryID, Applied: true,
+	})
+	conn.Feed(ack)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("SubmitPromptForUserChoice: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("SubmitPromptForUserChoice did not return after ack")
+	}
+}
+
+func TestSubmitPermission_AckTimeoutIsRetryableAndLateAckIsIsolated(t *testing.T) {
+	oldTimeout := gateway.InteractionAckTimeout
+	gateway.InteractionAckTimeout = 25 * time.Millisecond
+	defer func() { gateway.InteractionAckTimeout = oldTimeout }()
+	c, _, sess, conn, _ := newWiredHarness(t, "dev-1", "conv-1", "pa-1")
+	defer sess.Close("test done")
+	permEnv, _ := proto.NewEnvelope(proto.TypePermissionRequest, "perm-timeout", proto.PermissionRequestPayload{Tool: "Bash"})
+	conn.Feed(permEnv)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := c.registry.LookupPermission("perm-timeout"); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("permission registration timed out")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	err := c.SubmitPermission(context.Background(), connector.PermissionDecision{RequestID: "perm-timeout", Approved: false})
+	if !errors.Is(err, connector.ErrInteractionRuntimeUnavailable) {
+		t.Fatalf("SubmitPermission error = %v, want retryable runtime unavailable", err)
+	}
+	if _, err := c.registry.LookupPermission("perm-timeout"); err != nil {
+		t.Fatalf("permission mapping was detached after missing ack: %v", err)
+	}
+	var firstDeliveryID string
+	for _, env := range conn.Writes() {
+		if env.Type != proto.TypePermissionDecision || env.ID != "perm-timeout" {
+			continue
+		}
+		var payload proto.PermissionDecisionPayload
+		if err := env.DecodePayload(&payload); err != nil {
+			t.Fatalf("decode permission decision: %v", err)
+		}
+		firstDeliveryID = payload.DeliveryID
+	}
+	if !strings.HasPrefix(firstDeliveryID, "permission:perm-timeout:") {
+		t.Fatalf("first delivery id = %q, want request-derived base plus unique attempt", firstDeliveryID)
+	}
+
+	// A retry uses a different transport id. An ack for the timed-out first
+	// attempt must not satisfy this newer waiter, especially when the human
+	// changed the decision while the first result was uncertain.
+	gateway.InteractionAckTimeout = 2 * time.Second
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- c.SubmitPermission(context.Background(), connector.PermissionDecision{
+			RequestID: "perm-timeout", Approved: true,
+		})
+	}()
+	var secondDeliveryID string
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, env := range conn.Writes() {
+			if env.Type != proto.TypePermissionDecision || env.ID != "perm-timeout" {
+				continue
+			}
+			var payload proto.PermissionDecisionPayload
+			if err := env.DecodePayload(&payload); err != nil {
+				t.Fatalf("decode retry permission decision: %v", err)
+			}
+			if payload.DeliveryID != firstDeliveryID {
+				secondDeliveryID = payload.DeliveryID
+			}
+		}
+		if secondDeliveryID != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if secondDeliveryID == "" || secondDeliveryID == firstDeliveryID {
+		t.Fatalf("retry delivery id = %q, first = %q", secondDeliveryID, firstDeliveryID)
+	}
+	lateAck, _ := proto.NewEnvelope(proto.TypeInteractionDecisionAck, "perm-timeout", proto.InteractionDecisionAckPayload{
+		DeliveryID: firstDeliveryID, Applied: true,
+	})
+	conn.Feed(lateAck)
+	select {
+	case err := <-secondDone:
+		t.Fatalf("new attempt consumed stale ack: %v", err)
+	case <-time.After(75 * time.Millisecond):
+	}
+	conflictAck, _ := proto.NewEnvelope(proto.TypeInteractionDecisionAck, "perm-timeout", proto.InteractionDecisionAckPayload{
+		DeliveryID: secondDeliveryID, Applied: false, ErrorCode: "decision_conflict", Error: "decision_conflict",
+	})
+	conn.Feed(conflictAck)
+	select {
+	case err := <-secondDone:
+		if !errors.Is(err, connector.ErrInteractionNoLongerPending) {
+			t.Fatalf("retry error = %v, want no longer pending conflict", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("retry did not return after its own ack")
 	}
 }
 
@@ -735,6 +953,44 @@ func waitForWrite(t *testing.T, conn *fakeConn, typ string, within time.Duration
 			return false
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func submitPermissionAndAck(t *testing.T, c *Connector, conn *fakeConn, decision connector.PermissionDecision, applied bool, errorCode string) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- c.SubmitPermission(context.Background(), decision) }()
+	var decisionEnv proto.Envelope
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, env := range conn.Writes() {
+			if env.Type == proto.TypePermissionDecision && env.ID == decision.RequestID {
+				decisionEnv = env
+				break
+			}
+		}
+		if decisionEnv.Type != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if decisionEnv.Type == "" {
+		t.Fatal("permission_decision never written")
+	}
+	var payload proto.PermissionDecisionPayload
+	if err := decisionEnv.DecodePayload(&payload); err != nil {
+		t.Fatalf("decode permission decision: %v", err)
+	}
+	ack, _ := proto.NewEnvelope(proto.TypeInteractionDecisionAck, decision.RequestID, proto.InteractionDecisionAckPayload{
+		DeliveryID: payload.DeliveryID, Applied: applied, ErrorCode: errorCode, Error: errorCode,
+	})
+	conn.Feed(ack)
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(2 * time.Second):
+		t.Fatal("SubmitPermission did not return after runtime ack")
+		return nil
 	}
 }
 

--- a/server/internal/connector/agentdaemon/connector_test.go
+++ b/server/internal/connector/agentdaemon/connector_test.go
@@ -504,11 +504,11 @@ func TestStreamPrompt_PermissionRequestPropagates(t *testing.T) {
 	}
 	waitForWrite(t, conn, proto.TypePromptRequest, 2*time.Second)
 
-	// Daemon emits a permission_request. Envelope.ID is the perm id,
-	// not the runID. The gateway dispatch path indexes it in the
-	// registry's perm map but does NOT fan it to the runID subscriber.
-	permEnv, _ := proto.NewEnvelope(proto.TypePermissionRequest, "perm-xyz", proto.PermissionRequestPayload{
-		Tool: "Bash", Title: "rm -rf /tmp/scratch",
+	// Daemon emits a run-correlated permission request. The request ID stays
+	// in the payload so the gateway can both fan the frame to this stream and
+	// index the later decision route.
+	permEnv, _ := proto.NewEnvelope(proto.TypePermissionRequest, "run-1", proto.PermissionRequestPayload{
+		RequestID: "perm-xyz", Tool: "Bash", Title: "rm -rf /tmp/scratch",
 	})
 	conn.Feed(permEnv)
 
@@ -522,6 +522,15 @@ func TestStreamPrompt_PermissionRequestPropagates(t *testing.T) {
 			t.Fatal("perm-xyz never indexed in registry")
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+
+	select {
+	case ev := <-ch:
+		if ev.Type != connector.EventPermissionRequest || ev.Permission == nil || ev.Permission.ID != "perm-xyz" {
+			t.Fatalf("permission event = %+v", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission request never reached run stream")
 	}
 
 	// Daemon ends the run; the subscriber should see EventDone and close.

--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -91,13 +91,14 @@ func (c *Connector) buildAgentOptions(ctx context.Context, in connector.PromptIn
 		c.log.Error("agent_daemon: injectManagedModel failed", "run_id", in.RunID, "err", err)
 		return nil, err
 	}
-	// Default to bypassPermissions when the agent config does not set
-	// a permission mode. Without this, Claude Code prompts for tool
-	// approval on every call; the daemon's permission-prompt-tool=stdio
-	// path works for interactive CLI use but the web UI does not surface
-	// approval buttons, so tools stall until the read loop times out.
-	if _, ok := opts["mode"]; !ok {
-		opts["mode"] = "bypassPermissions"
+	// Web and IM now share a durable permission loop, so Claude Code must
+	// surface tool approval requests instead of silently bypassing them.
+	// Explicit agent configuration still wins for operators that choose a
+	// different Claude permission mode.
+	if agentKind == "claude_code" {
+		if _, ok := opts["mode"]; !ok {
+			opts["mode"] = "default"
+		}
 	}
 
 	mergeSkillsIntoOptions(opts, additions.Skills)

--- a/server/internal/connector/agentdaemon/remote_http.go
+++ b/server/internal/connector/agentdaemon/remote_http.go
@@ -189,6 +189,12 @@ func (s HTTPRemoteStreamer) postSubmit(ctx context.Context, owner store.AgentDae
 		}
 		log.Bg().Error("agent_daemon: HTTP remote "+label+" non-2xx",
 			"request_id", requestID, "owner_pod_id", owner.OwnerPodID, "status", resp.StatusCode, "err", errBody.Error)
+		if strings.Contains(errBody.Error, connector.ErrInteractionNoLongerPending.Error()) {
+			return fmt.Errorf("agent_daemon: %w: remote %s %s", connector.ErrInteractionNoLongerPending, label, errBody.Error)
+		}
+		if strings.Contains(errBody.Error, connector.ErrInteractionRuntimeUnavailable.Error()) {
+			return fmt.Errorf("agent_daemon: %w: remote %s %s", connector.ErrInteractionRuntimeUnavailable, label, errBody.Error)
+		}
 		return fmt.Errorf("agent_daemon: remote %s %s returned %s", label, owner.OwnerPodID, errBody.Error)
 	}
 	log.Bg().Info("agent_daemon: HTTP remote "+label+" POST ok",

--- a/server/internal/connector/agentdaemon/remote_http_test.go
+++ b/server/internal/connector/agentdaemon/remote_http_test.go
@@ -44,7 +44,9 @@ func TestInternalSubmitPermission_AppliesLocallyOnOwnerPod(t *testing.T) {
 	})
 	req, _ := http.NewRequest(http.MethodPost, srv.URL+internalSubmitPermissionPath, bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer tok")
-	resp, err := srv.Client().Do(req)
+	result := doHTTPAsync(srv.Client(), req)
+	ackInteractionDecisionWrite(t, conn, proto.TypePermissionDecision, "perm-x")
+	resp, err := awaitHTTPResult(t, result)
 	if err != nil {
 		t.Fatalf("POST: %v", err)
 	}
@@ -81,6 +83,66 @@ func TestInternalSubmitPermission_RejectsBadToken(t *testing.T) {
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("status=%d, want 401", resp.StatusCode)
 	}
+}
+
+type asyncHTTPResult struct {
+	response *http.Response
+	err      error
+}
+
+func doHTTPAsync(client *http.Client, request *http.Request) <-chan asyncHTTPResult {
+	done := make(chan asyncHTTPResult, 1)
+	go func() {
+		response, err := client.Do(request)
+		done <- asyncHTTPResult{response: response, err: err}
+	}()
+	return done
+}
+
+func awaitHTTPResult(t *testing.T, result <-chan asyncHTTPResult) (*http.Response, error) {
+	t.Helper()
+	select {
+	case response := <-result:
+		return response.response, response.err
+	case <-time.After(2 * time.Second):
+		t.Fatal("internal submit endpoint did not return after runtime ack")
+		return nil, nil
+	}
+}
+
+func ackInteractionDecisionWrite(t *testing.T, conn *fakeConn, envelopeType, requestID string) {
+	t.Helper()
+	var decision proto.Envelope
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, env := range conn.Writes() {
+			if env.Type == envelopeType && env.ID == requestID {
+				decision = env
+				break
+			}
+		}
+		if decision.Type != "" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if decision.Type == "" {
+		t.Fatalf("%s envelope was not written", envelopeType)
+	}
+	var payload struct {
+		DeliveryID string `json:"delivery_id"`
+	}
+	if err := decision.DecodePayload(&payload); err != nil {
+		t.Fatalf("decode %s: %v", envelopeType, err)
+	}
+	ack, err := proto.NewEnvelope(proto.TypeInteractionDecisionAck, requestID, proto.InteractionDecisionAckPayload{
+		DeliveryID: payload.DeliveryID,
+		Applied:    true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn.Feed(ack)
 }
 
 func TestInternalSubmitPermission_RejectsBadJSON(t *testing.T) {
@@ -125,7 +187,9 @@ func TestInternalSubmitPromptForUserChoice_AppliesLocallyOnOwnerPod(t *testing.T
 	})
 	req, _ := http.NewRequest(http.MethodPost, srv.URL+internalSubmitPromptForUserChoicePath, bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer tok")
-	resp, err := srv.Client().Do(req)
+	result := doHTTPAsync(srv.Client(), req)
+	ackInteractionDecisionWrite(t, conn, proto.TypePromptForUserChoiceDecision, "ask-y")
+	resp, err := awaitHTTPResult(t, result)
 	if err != nil {
 		t.Fatalf("POST: %v", err)
 	}

--- a/server/internal/connector/connector.go
+++ b/server/internal/connector/connector.go
@@ -22,6 +22,14 @@ var ErrUnknownConnector = errors.New("connector: unknown type")
 // of the given type is already registered.
 var ErrDuplicateConnector = errors.New("connector: type already registered")
 
+// ErrInteractionNoLongerPending means the runtime already resolved,
+// cancelled, or expired the referenced human-interaction request.
+var ErrInteractionNoLongerPending = errors.New("connector: interaction is no longer pending")
+
+// ErrInteractionRuntimeUnavailable means the decision was not delivered and
+// the canonical interaction may safely return to pending for a later retry.
+var ErrInteractionRuntimeUnavailable = errors.New("connector: interaction runtime unavailable")
+
 // Capabilities is the static feature declaration of a connector.
 type Capabilities struct {
 	Sync bool

--- a/server/internal/connector/types.go
+++ b/server/internal/connector/types.go
@@ -192,11 +192,14 @@ type PermissionRequest struct {
 // PermissionDecision is the human verdict for a PermissionRequest,
 // submitted via AgentConnector.SubmitPermission.
 type PermissionDecision struct {
-	RequestID string
-	DeviceID  string
-	Approved  bool
-	Note      string
-	By        string // user id
+	RequestID  string
+	// DeliveryID is the caller's stable idempotency base. The agent-daemon
+	// connector adds a unique suffix for each wire attempt before awaiting ack.
+	DeliveryID string
+	DeviceID   string
+	Approved   bool
+	Note       string
+	By         string // user id
 }
 
 // PromptForUserChoiceOption is one selectable answer the human can
@@ -214,6 +217,8 @@ type PromptForUserChoiceQuestion struct {
 	Header      string
 	Question    string
 	MultiSelect bool
+	IsOther     bool
+	IsSecret    bool
 	Options     []PromptForUserChoiceOption
 }
 
@@ -226,9 +231,10 @@ type PromptForUserChoiceQuestion struct {
 // populated by daemons that haven't been upgraded so server callers
 // have a uniform read path via EffectiveQuestions.
 type PromptForUserChoiceRequest struct {
-	ID        string
-	DeviceID  string
-	Questions []PromptForUserChoiceQuestion
+	ID               string
+	DeviceID         string
+	Questions        []PromptForUserChoiceQuestion
+	AutoResolutionMs *uint64
 
 	// Legacy single-question fields. New daemons leave these empty.
 	Question    string
@@ -280,6 +286,8 @@ type PromptForUserChoiceQuestionAnswer struct {
 //     daemon can emit a "stop, don't retry" tool_result.
 type PromptForUserChoiceDecision struct {
 	RequestID       string
+	// DeliveryID follows PermissionDecision's stable-base semantics.
+	DeliveryID      string
 	DeviceID        string
 	QuestionAnswers []PromptForUserChoiceQuestionAnswer
 	Answers         []string

--- a/server/internal/connector/types.go
+++ b/server/internal/connector/types.go
@@ -181,17 +181,19 @@ type ToolCallEvent struct {
 // Connectors with Capabilities.Permissions=true emit one of these and
 // wait (inside the connector) for the matching SubmitPermission call.
 type PermissionRequest struct {
-	ID      string
-	Tool    string
-	Title   string
-	Detail  string
-	Payload map[string]any
+	ID       string
+	DeviceID string
+	Tool     string
+	Title    string
+	Detail   string
+	Payload  map[string]any
 }
 
 // PermissionDecision is the human verdict for a PermissionRequest,
 // submitted via AgentConnector.SubmitPermission.
 type PermissionDecision struct {
 	RequestID string
+	DeviceID  string
 	Approved  bool
 	Note      string
 	By        string // user id
@@ -208,6 +210,7 @@ type PromptForUserChoiceOption struct {
 // PromptForUserChoiceQuestion is one question in a (possibly multi-
 // question) AskUserQuestion call. Mirrors proto.PromptForUserChoiceQuestion.
 type PromptForUserChoiceQuestion struct {
+	ID          string
 	Header      string
 	Question    string
 	MultiSelect bool
@@ -224,6 +227,7 @@ type PromptForUserChoiceQuestion struct {
 // have a uniform read path via EffectiveQuestions.
 type PromptForUserChoiceRequest struct {
 	ID        string
+	DeviceID  string
 	Questions []PromptForUserChoiceQuestion
 
 	// Legacy single-question fields. New daemons leave these empty.
@@ -255,12 +259,14 @@ func (r PromptForUserChoiceRequest) EffectiveQuestions() []PromptForUserChoiceQu
 	}}
 }
 
-// PromptForUserChoiceQuestionAnswer carries one (question, answer)
-// pair from a multi-question submit. Header matches the question's
-// Header field; the daemon falls back to "q<i>" when Header is blank.
+// PromptForUserChoiceQuestionAnswer carries one structured response.
+// QuestionID is canonical and Answers preserves multi-select values;
+// Header and Answer remain compatibility fields for older peers.
 type PromptForUserChoiceQuestionAnswer struct {
-	Header string
-	Answer string
+	QuestionID string
+	Answers    []string
+	Header     string
+	Answer     string
 }
 
 // PromptForUserChoiceDecision is the human's answer, submitted via
@@ -274,6 +280,7 @@ type PromptForUserChoiceQuestionAnswer struct {
 //     daemon can emit a "stop, don't retry" tool_result.
 type PromptForUserChoiceDecision struct {
 	RequestID       string
+	DeviceID        string
 	QuestionAnswers []PromptForUserChoiceQuestionAnswer
 	Answers         []string
 	Cancelled       bool

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -2923,6 +2923,7 @@ select
   @created_at
 from agent_runs r
 where r.id = @agent_run_id::uuid
+  and r.status not in ('completed', 'failed', 'cancelled', 'interrupted')
 on conflict (workspace_id, device_id, kind, request_id) do nothing;
 
 -- name: ReleaseStaleResolvingAgentInteractions :execrows

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -2904,6 +2904,242 @@ where agent_run_id = @agent_run_id::uuid
   and sequence > @after_sequence::bigint
 order by sequence asc;
 
+-- name: InsertAgentInteractionFromRun :exec
+insert into agent_interactions(
+  workspace_id, conversation_id, agent_run_id,
+  request_id, kind, request, device_id,
+  created_at, expires_at, updated_at
+)
+select
+  r.workspace_id,
+  r.conversation_id,
+  r.id,
+  @request_id,
+  @kind,
+  @request::jsonb,
+  @device_id,
+  @created_at,
+  @expires_at,
+  @created_at
+from agent_runs r
+where r.id = @agent_run_id::uuid
+on conflict (workspace_id, device_id, kind, request_id) do nothing;
+
+-- name: ReleaseStaleResolvingAgentInteractions :execrows
+update agent_interactions
+set status = 'pending',
+    claim_token = null,
+    claimed_at = null,
+    resolution_source = null,
+    resolved_actor = null,
+    resolved_by = null,
+    updated_at = @now
+where status = 'resolving'
+  and claimed_at < @stale_before;
+
+-- name: ListWorkspaceAgentInteractions :many
+select
+  ai.id::text,
+  ai.workspace_id::text,
+  ai.conversation_id::text,
+  ai.agent_run_id::text,
+  ai.request_id,
+  ai.kind,
+  ai.status,
+  ai.request,
+  ai.response,
+  ai.device_id,
+  coalesce(ai.resolution_source, '')::text as resolution_source,
+  coalesce(ai.resolved_actor, '')::text as resolved_actor,
+  coalesce(ai.resolved_by::text, '')::text as resolved_by,
+  ai.created_at,
+  ai.expires_at,
+  ai.resolved_at,
+  ai.updated_at,
+  coalesce(a.name, '')::text as agent_name,
+  coalesce(c.title, '')::text as conversation_title
+from agent_interactions ai
+join conversations c on c.id = ai.conversation_id
+left join agent_runs r on r.id = ai.agent_run_id
+left join agents a on a.id = r.agent_id
+where ai.workspace_id = @workspace_id::uuid
+  and (
+    @status_group::text = ''
+    or (@status_group::text = 'pending' and ai.status in ('pending', 'resolving'))
+    or (@status_group::text = 'decided' and ai.status in ('approved', 'denied', 'answered'))
+    or (@status_group::text = 'expired' and ai.status in ('cancelled', 'expired'))
+  )
+order by ai.created_at desc
+limit @item_limit;
+
+-- name: GetAgentInteraction :one
+select
+  ai.id::text,
+  ai.workspace_id::text,
+  ai.conversation_id::text,
+  ai.agent_run_id::text,
+  ai.request_id,
+  ai.kind,
+  ai.status,
+  ai.request,
+  ai.response,
+  ai.device_id,
+  coalesce(ai.resolution_source, '')::text as resolution_source,
+  coalesce(ai.resolved_actor, '')::text as resolved_actor,
+  coalesce(ai.resolved_by::text, '')::text as resolved_by,
+  ai.created_at,
+  ai.expires_at,
+  ai.resolved_at,
+  ai.updated_at,
+  coalesce(a.name, '')::text as agent_name,
+  coalesce(c.title, '')::text as conversation_title
+from agent_interactions ai
+join conversations c on c.id = ai.conversation_id
+left join agent_runs r on r.id = ai.agent_run_id
+left join agents a on a.id = r.agent_id
+where ai.id = @interaction_id::uuid;
+
+-- name: GetAgentInteractionByRequestID :one
+select
+  ai.id::text,
+  ai.workspace_id::text,
+  ai.conversation_id::text,
+  ai.agent_run_id::text,
+  ai.request_id,
+  ai.kind,
+  ai.status,
+  ai.request,
+  ai.response,
+  ai.device_id,
+  coalesce(ai.resolution_source, '')::text as resolution_source,
+  coalesce(ai.resolved_actor, '')::text as resolved_actor,
+  coalesce(ai.resolved_by::text, '')::text as resolved_by,
+  ai.created_at,
+  ai.expires_at,
+  ai.resolved_at,
+  ai.updated_at,
+  coalesce(a.name, '')::text as agent_name,
+  coalesce(c.title, '')::text as conversation_title
+from agent_interactions ai
+join conversations c on c.id = ai.conversation_id
+left join agent_runs r on r.id = ai.agent_run_id
+left join agents a on a.id = r.agent_id
+where ai.kind = @kind
+  and ai.request_id = @request_id
+  and ai.agent_run_id = @agent_run_id::uuid
+order by ai.created_at desc
+limit 1;
+
+-- name: ClaimAgentInteraction :one
+update agent_interactions
+set status = 'resolving',
+    claim_token = gen_random_uuid(),
+    claimed_at = @now,
+    resolution_source = @resolution_source,
+    resolved_actor = nullif(@resolved_actor::text, ''),
+    resolved_by = nullif(@resolved_by::text, '')::uuid,
+    updated_at = @now
+where id = @interaction_id::uuid
+  and workspace_id = @workspace_id::uuid
+  and status = 'pending'
+  and expires_at > @now
+returning id::text, workspace_id::text, request_id, kind, agent_run_id::text,
+  conversation_id::text, request, device_id, claim_token::text;
+
+-- name: ClaimAgentInteractionByRequestID :one
+update agent_interactions
+set status = 'resolving',
+    claim_token = gen_random_uuid(),
+    claimed_at = @now,
+    resolution_source = @resolution_source,
+    resolved_actor = nullif(@resolved_actor::text, ''),
+    resolved_by = nullif(@resolved_by::text, '')::uuid,
+    updated_at = @now
+where kind = @kind
+  and request_id = @request_id
+  and agent_run_id = @agent_run_id::uuid
+  and status = 'pending'
+  and expires_at > @now
+returning id::text, workspace_id::text, request_id, kind, agent_run_id::text,
+  conversation_id::text, request, device_id, claim_token::text;
+
+-- name: ClaimExpiredAgentInteraction :one
+update agent_interactions
+set status = 'resolving',
+    claim_token = gen_random_uuid(),
+    claimed_at = @now,
+    resolution_source = 'system_timeout',
+    resolved_actor = 'system_timeout',
+    resolved_by = null,
+    updated_at = @now
+where id = @interaction_id::uuid
+  and status = 'pending'
+  and expires_at <= @now
+returning id::text, workspace_id::text, request_id, kind, agent_run_id::text,
+  conversation_id::text, request, device_id, claim_token::text;
+
+-- name: ListExpiredPendingAgentInteractionIDs :many
+select id::text
+from agent_interactions
+where status = 'pending'
+  and expires_at <= @now
+order by expires_at asc
+limit @item_limit;
+
+-- name: CompleteAgentInteraction :one
+update agent_interactions
+set status = @status,
+    response = @response::jsonb,
+    claim_token = null,
+    resolved_at = @now,
+    updated_at = @now
+where id = @interaction_id::uuid
+  and status = 'resolving'
+  and claim_token = @claim_token::uuid
+returning id::text;
+
+-- name: ReleaseAgentInteractionClaim :exec
+update agent_interactions
+set status = 'pending',
+    claim_token = null,
+    claimed_at = null,
+    resolution_source = null,
+    resolved_actor = null,
+    resolved_by = null,
+    updated_at = @now
+where id = @interaction_id::uuid
+  and status = 'resolving'
+  and claim_token = @claim_token::uuid;
+
+-- name: ResolveAgentInteractionByRequestID :execrows
+update agent_interactions
+set status = @status,
+    response = @response::jsonb,
+    claim_token = null,
+    resolved_at = @now,
+    updated_at = @now
+where kind = @kind
+  and request_id = @request_id
+  and status in ('pending', 'resolving');
+
+-- name: CancelOpenAgentInteractionsByRunID :execrows
+update agent_interactions
+set status = 'cancelled',
+    response = jsonb_build_object('reason', @reason::text),
+    claim_token = null,
+    resolved_at = @now,
+    updated_at = @now,
+    resolution_source = 'runtime',
+    resolved_actor = 'runtime'
+where agent_run_id = @agent_run_id::uuid
+  and status in ('pending', 'resolving');
+
+-- name: GetAgentInteractionDeviceByRequestID :one
+select device_id
+from agent_interactions
+where kind = @kind
+  and request_id = @request_id;
+
 -- name: ListToolEventsForRuns :many
 select id::text, agent_run_id::text, sequence, event_kind, payload, occurred_at
 from agent_run_events

--- a/server/internal/db/sqlc/models.go
+++ b/server/internal/db/sqlc/models.go
@@ -125,7 +125,7 @@ type AgentInteraction struct {
 	Status string `json:"status"`
 	// Immutable request snapshot rendered by Web and IM clients
 	Request []byte `json:"request"`
-	// Human decision snapshot, populated only after resolution
+	// Human decision snapshot populated only after runtime ack; secret answer values are redacted
 	Response []byte `json:"response"`
 	// Agent-daemon device used to route a response to the pod owning the runtime WebSocket
 	DeviceID string `json:"device_id"`

--- a/server/internal/db/sqlc/models.go
+++ b/server/internal/db/sqlc/models.go
@@ -112,6 +112,37 @@ type AgentEngineSession struct {
 	UpdatedAt   pgtype.Timestamptz `json:"updated_at"`
 }
 
+// Durable human interaction requests shared by Web and IM surfaces
+type AgentInteraction struct {
+	ID             pgtype.UUID `json:"id"`
+	WorkspaceID    pgtype.UUID `json:"workspace_id"`
+	ConversationID pgtype.UUID `json:"conversation_id"`
+	AgentRunID     pgtype.UUID `json:"agent_run_id"`
+	RequestID      string      `json:"request_id"`
+	// permission = approve or deny a tool action; user_choice = answer an AskUserQuestion request
+	Kind string `json:"kind"`
+	// Lifecycle: pending, transient resolving, or terminal approved/denied/answered/cancelled/expired
+	Status string `json:"status"`
+	// Immutable request snapshot rendered by Web and IM clients
+	Request []byte `json:"request"`
+	// Human decision snapshot, populated only after resolution
+	Response []byte `json:"response"`
+	// Agent-daemon device used to route a response to the pod owning the runtime WebSocket
+	DeviceID string `json:"device_id"`
+	// CAS token held by the single resolver currently delivering a decision
+	ClaimToken pgtype.UUID        `json:"claim_token"`
+	ClaimedAt  pgtype.Timestamptz `json:"claimed_at"`
+	// web, IM platform, system_timeout, or runtime
+	ResolutionSource pgtype.Text `json:"resolution_source"`
+	// User UUID or external platform subject that submitted the decision
+	ResolvedActor pgtype.Text        `json:"resolved_actor"`
+	ResolvedBy    pgtype.UUID        `json:"resolved_by"`
+	CreatedAt     pgtype.Timestamptz `json:"created_at"`
+	ExpiresAt     pgtype.Timestamptz `json:"expires_at"`
+	ResolvedAt    pgtype.Timestamptz `json:"resolved_at"`
+	UpdatedAt     pgtype.Timestamptz `json:"updated_at"`
+}
+
 // Agent execution records
 type AgentRun struct {
 	// Run ID

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -6615,6 +6615,7 @@ select
   $5
 from agent_runs r
 where r.id = $7::uuid
+  and r.status not in ('completed', 'failed', 'cancelled', 'interrupted')
 on conflict (workspace_id, device_id, kind, request_id) do nothing
 `
 

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -360,6 +360,33 @@ func (q *Queries) ArchiveWorkspace(ctx context.Context, arg ArchiveWorkspacePara
 	return i, err
 }
 
+const cancelOpenAgentInteractionsByRunID = `-- name: CancelOpenAgentInteractionsByRunID :execrows
+update agent_interactions
+set status = 'cancelled',
+    response = jsonb_build_object('reason', $1::text),
+    claim_token = null,
+    resolved_at = $2,
+    updated_at = $2,
+    resolution_source = 'runtime',
+    resolved_actor = 'runtime'
+where agent_run_id = $3::uuid
+  and status in ('pending', 'resolving')
+`
+
+type CancelOpenAgentInteractionsByRunIDParams struct {
+	Reason     string             `json:"reason"`
+	Now        pgtype.Timestamptz `json:"now"`
+	AgentRunID pgtype.UUID        `json:"agent_run_id"`
+}
+
+func (q *Queries) CancelOpenAgentInteractionsByRunID(ctx context.Context, arg CancelOpenAgentInteractionsByRunIDParams) (int64, error) {
+	result, err := q.db.Exec(ctx, cancelOpenAgentInteractionsByRunID, arg.Reason, arg.Now, arg.AgentRunID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const claimActiveFeishuInflightConversations = `-- name: ClaimActiveFeishuInflightConversations :many
 with run_event_max as (
   select agent_run_id, max(sequence)::bigint as max_seq
@@ -654,6 +681,133 @@ func (q *Queries) ClaimActiveFeishuInflightConversations(ctx context.Context, ar
 	return items, nil
 }
 
+const claimAgentInteraction = `-- name: ClaimAgentInteraction :one
+update agent_interactions
+set status = 'resolving',
+    claim_token = gen_random_uuid(),
+    claimed_at = $1,
+    resolution_source = $2,
+    resolved_actor = nullif($3::text, ''),
+    resolved_by = nullif($4::text, '')::uuid,
+    updated_at = $1
+where id = $5::uuid
+  and workspace_id = $6::uuid
+  and status = 'pending'
+  and expires_at > $1
+returning id::text, workspace_id::text, request_id, kind, agent_run_id::text,
+  conversation_id::text, request, device_id, claim_token::text
+`
+
+type ClaimAgentInteractionParams struct {
+	Now              pgtype.Timestamptz `json:"now"`
+	ResolutionSource pgtype.Text        `json:"resolution_source"`
+	ResolvedActor    string             `json:"resolved_actor"`
+	ResolvedBy       string             `json:"resolved_by"`
+	InteractionID    pgtype.UUID        `json:"interaction_id"`
+	WorkspaceID      pgtype.UUID        `json:"workspace_id"`
+}
+
+type ClaimAgentInteractionRow struct {
+	ID             string `json:"id"`
+	WorkspaceID    string `json:"workspace_id"`
+	RequestID      string `json:"request_id"`
+	Kind           string `json:"kind"`
+	AgentRunID     string `json:"agent_run_id"`
+	ConversationID string `json:"conversation_id"`
+	Request        []byte `json:"request"`
+	DeviceID       string `json:"device_id"`
+	ClaimToken     string `json:"claim_token"`
+}
+
+func (q *Queries) ClaimAgentInteraction(ctx context.Context, arg ClaimAgentInteractionParams) (ClaimAgentInteractionRow, error) {
+	row := q.db.QueryRow(ctx, claimAgentInteraction,
+		arg.Now,
+		arg.ResolutionSource,
+		arg.ResolvedActor,
+		arg.ResolvedBy,
+		arg.InteractionID,
+		arg.WorkspaceID,
+	)
+	var i ClaimAgentInteractionRow
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.RequestID,
+		&i.Kind,
+		&i.AgentRunID,
+		&i.ConversationID,
+		&i.Request,
+		&i.DeviceID,
+		&i.ClaimToken,
+	)
+	return i, err
+}
+
+const claimAgentInteractionByRequestID = `-- name: ClaimAgentInteractionByRequestID :one
+update agent_interactions
+set status = 'resolving',
+    claim_token = gen_random_uuid(),
+    claimed_at = $1,
+    resolution_source = $2,
+    resolved_actor = nullif($3::text, ''),
+    resolved_by = nullif($4::text, '')::uuid,
+    updated_at = $1
+where kind = $5
+  and request_id = $6
+  and agent_run_id = $7::uuid
+  and status = 'pending'
+  and expires_at > $1
+returning id::text, workspace_id::text, request_id, kind, agent_run_id::text,
+  conversation_id::text, request, device_id, claim_token::text
+`
+
+type ClaimAgentInteractionByRequestIDParams struct {
+	Now              pgtype.Timestamptz `json:"now"`
+	ResolutionSource pgtype.Text        `json:"resolution_source"`
+	ResolvedActor    string             `json:"resolved_actor"`
+	ResolvedBy       string             `json:"resolved_by"`
+	Kind             string             `json:"kind"`
+	RequestID        string             `json:"request_id"`
+	AgentRunID       pgtype.UUID        `json:"agent_run_id"`
+}
+
+type ClaimAgentInteractionByRequestIDRow struct {
+	ID             string `json:"id"`
+	WorkspaceID    string `json:"workspace_id"`
+	RequestID      string `json:"request_id"`
+	Kind           string `json:"kind"`
+	AgentRunID     string `json:"agent_run_id"`
+	ConversationID string `json:"conversation_id"`
+	Request        []byte `json:"request"`
+	DeviceID       string `json:"device_id"`
+	ClaimToken     string `json:"claim_token"`
+}
+
+func (q *Queries) ClaimAgentInteractionByRequestID(ctx context.Context, arg ClaimAgentInteractionByRequestIDParams) (ClaimAgentInteractionByRequestIDRow, error) {
+	row := q.db.QueryRow(ctx, claimAgentInteractionByRequestID,
+		arg.Now,
+		arg.ResolutionSource,
+		arg.ResolvedActor,
+		arg.ResolvedBy,
+		arg.Kind,
+		arg.RequestID,
+		arg.AgentRunID,
+	)
+	var i ClaimAgentInteractionByRequestIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.RequestID,
+		&i.Kind,
+		&i.AgentRunID,
+		&i.ConversationID,
+		&i.Request,
+		&i.DeviceID,
+		&i.ClaimToken,
+	)
+	return i, err
+}
+
 const claimDueScheduledTasks = `-- name: ClaimDueScheduledTasks :many
 with picked as (
   select t.id
@@ -726,6 +880,56 @@ func (q *Queries) ClaimDueScheduledTasks(ctx context.Context, arg ClaimDueSchedu
 		return nil, err
 	}
 	return items, nil
+}
+
+const claimExpiredAgentInteraction = `-- name: ClaimExpiredAgentInteraction :one
+update agent_interactions
+set status = 'resolving',
+    claim_token = gen_random_uuid(),
+    claimed_at = $1,
+    resolution_source = 'system_timeout',
+    resolved_actor = 'system_timeout',
+    resolved_by = null,
+    updated_at = $1
+where id = $2::uuid
+  and status = 'pending'
+  and expires_at <= $1
+returning id::text, workspace_id::text, request_id, kind, agent_run_id::text,
+  conversation_id::text, request, device_id, claim_token::text
+`
+
+type ClaimExpiredAgentInteractionParams struct {
+	Now           pgtype.Timestamptz `json:"now"`
+	InteractionID pgtype.UUID        `json:"interaction_id"`
+}
+
+type ClaimExpiredAgentInteractionRow struct {
+	ID             string `json:"id"`
+	WorkspaceID    string `json:"workspace_id"`
+	RequestID      string `json:"request_id"`
+	Kind           string `json:"kind"`
+	AgentRunID     string `json:"agent_run_id"`
+	ConversationID string `json:"conversation_id"`
+	Request        []byte `json:"request"`
+	DeviceID       string `json:"device_id"`
+	ClaimToken     string `json:"claim_token"`
+}
+
+func (q *Queries) ClaimExpiredAgentInteraction(ctx context.Context, arg ClaimExpiredAgentInteractionParams) (ClaimExpiredAgentInteractionRow, error) {
+	row := q.db.QueryRow(ctx, claimExpiredAgentInteraction, arg.Now, arg.InteractionID)
+	var i ClaimExpiredAgentInteractionRow
+	err := row.Scan(
+		&i.ID,
+		&i.WorkspaceID,
+		&i.RequestID,
+		&i.Kind,
+		&i.AgentRunID,
+		&i.ConversationID,
+		&i.Request,
+		&i.DeviceID,
+		&i.ClaimToken,
+	)
+	return i, err
 }
 
 const claimNextQueuedHTTPAgentRun = `-- name: ClaimNextQueuedHTTPAgentRun :one
@@ -981,6 +1185,40 @@ type ClearWorkspaceRuntimeCredentialSecretParams struct {
 func (q *Queries) ClearWorkspaceRuntimeCredentialSecret(ctx context.Context, arg ClearWorkspaceRuntimeCredentialSecretParams) error {
 	_, err := q.db.Exec(ctx, clearWorkspaceRuntimeCredentialSecret, arg.Now, arg.WorkspaceID)
 	return err
+}
+
+const completeAgentInteraction = `-- name: CompleteAgentInteraction :one
+update agent_interactions
+set status = $1,
+    response = $2::jsonb,
+    claim_token = null,
+    resolved_at = $3,
+    updated_at = $3
+where id = $4::uuid
+  and status = 'resolving'
+  and claim_token = $5::uuid
+returning id::text
+`
+
+type CompleteAgentInteractionParams struct {
+	Status        string             `json:"status"`
+	Response      []byte             `json:"response"`
+	Now           pgtype.Timestamptz `json:"now"`
+	InteractionID pgtype.UUID        `json:"interaction_id"`
+	ClaimToken    pgtype.UUID        `json:"claim_token"`
+}
+
+func (q *Queries) CompleteAgentInteraction(ctx context.Context, arg CompleteAgentInteractionParams) (string, error) {
+	row := q.db.QueryRow(ctx, completeAgentInteraction,
+		arg.Status,
+		arg.Response,
+		arg.Now,
+		arg.InteractionID,
+		arg.ClaimToken,
+	)
+	var id string
+	err := row.Scan(&id)
+	return id, err
 }
 
 const completeAgentRun = `-- name: CompleteAgentRun :exec
@@ -4032,6 +4270,189 @@ func (q *Queries) GetAgentForUpdate(ctx context.Context, id pgtype.UUID) (GetAge
 	return i, err
 }
 
+const getAgentInteraction = `-- name: GetAgentInteraction :one
+select
+  ai.id::text,
+  ai.workspace_id::text,
+  ai.conversation_id::text,
+  ai.agent_run_id::text,
+  ai.request_id,
+  ai.kind,
+  ai.status,
+  ai.request,
+  ai.response,
+  ai.device_id,
+  coalesce(ai.resolution_source, '')::text as resolution_source,
+  coalesce(ai.resolved_actor, '')::text as resolved_actor,
+  coalesce(ai.resolved_by::text, '')::text as resolved_by,
+  ai.created_at,
+  ai.expires_at,
+  ai.resolved_at,
+  ai.updated_at,
+  coalesce(a.name, '')::text as agent_name,
+  coalesce(c.title, '')::text as conversation_title
+from agent_interactions ai
+join conversations c on c.id = ai.conversation_id
+left join agent_runs r on r.id = ai.agent_run_id
+left join agents a on a.id = r.agent_id
+where ai.id = $1::uuid
+`
+
+type GetAgentInteractionRow struct {
+	AiID              string             `json:"ai_id"`
+	AiWorkspaceID     string             `json:"ai_workspace_id"`
+	AiConversationID  string             `json:"ai_conversation_id"`
+	AiAgentRunID      string             `json:"ai_agent_run_id"`
+	RequestID         string             `json:"request_id"`
+	Kind              string             `json:"kind"`
+	Status            string             `json:"status"`
+	Request           []byte             `json:"request"`
+	Response          []byte             `json:"response"`
+	DeviceID          string             `json:"device_id"`
+	ResolutionSource  string             `json:"resolution_source"`
+	ResolvedActor     string             `json:"resolved_actor"`
+	ResolvedBy        string             `json:"resolved_by"`
+	CreatedAt         pgtype.Timestamptz `json:"created_at"`
+	ExpiresAt         pgtype.Timestamptz `json:"expires_at"`
+	ResolvedAt        pgtype.Timestamptz `json:"resolved_at"`
+	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
+	AgentName         string             `json:"agent_name"`
+	ConversationTitle string             `json:"conversation_title"`
+}
+
+func (q *Queries) GetAgentInteraction(ctx context.Context, interactionID pgtype.UUID) (GetAgentInteractionRow, error) {
+	row := q.db.QueryRow(ctx, getAgentInteraction, interactionID)
+	var i GetAgentInteractionRow
+	err := row.Scan(
+		&i.AiID,
+		&i.AiWorkspaceID,
+		&i.AiConversationID,
+		&i.AiAgentRunID,
+		&i.RequestID,
+		&i.Kind,
+		&i.Status,
+		&i.Request,
+		&i.Response,
+		&i.DeviceID,
+		&i.ResolutionSource,
+		&i.ResolvedActor,
+		&i.ResolvedBy,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.ResolvedAt,
+		&i.UpdatedAt,
+		&i.AgentName,
+		&i.ConversationTitle,
+	)
+	return i, err
+}
+
+const getAgentInteractionByRequestID = `-- name: GetAgentInteractionByRequestID :one
+select
+  ai.id::text,
+  ai.workspace_id::text,
+  ai.conversation_id::text,
+  ai.agent_run_id::text,
+  ai.request_id,
+  ai.kind,
+  ai.status,
+  ai.request,
+  ai.response,
+  ai.device_id,
+  coalesce(ai.resolution_source, '')::text as resolution_source,
+  coalesce(ai.resolved_actor, '')::text as resolved_actor,
+  coalesce(ai.resolved_by::text, '')::text as resolved_by,
+  ai.created_at,
+  ai.expires_at,
+  ai.resolved_at,
+  ai.updated_at,
+  coalesce(a.name, '')::text as agent_name,
+  coalesce(c.title, '')::text as conversation_title
+from agent_interactions ai
+join conversations c on c.id = ai.conversation_id
+left join agent_runs r on r.id = ai.agent_run_id
+left join agents a on a.id = r.agent_id
+where ai.kind = $1
+  and ai.request_id = $2
+  and ai.agent_run_id = $3::uuid
+order by ai.created_at desc
+limit 1
+`
+
+type GetAgentInteractionByRequestIDParams struct {
+	Kind       string      `json:"kind"`
+	RequestID  string      `json:"request_id"`
+	AgentRunID pgtype.UUID `json:"agent_run_id"`
+}
+
+type GetAgentInteractionByRequestIDRow struct {
+	AiID              string             `json:"ai_id"`
+	AiWorkspaceID     string             `json:"ai_workspace_id"`
+	AiConversationID  string             `json:"ai_conversation_id"`
+	AiAgentRunID      string             `json:"ai_agent_run_id"`
+	RequestID         string             `json:"request_id"`
+	Kind              string             `json:"kind"`
+	Status            string             `json:"status"`
+	Request           []byte             `json:"request"`
+	Response          []byte             `json:"response"`
+	DeviceID          string             `json:"device_id"`
+	ResolutionSource  string             `json:"resolution_source"`
+	ResolvedActor     string             `json:"resolved_actor"`
+	ResolvedBy        string             `json:"resolved_by"`
+	CreatedAt         pgtype.Timestamptz `json:"created_at"`
+	ExpiresAt         pgtype.Timestamptz `json:"expires_at"`
+	ResolvedAt        pgtype.Timestamptz `json:"resolved_at"`
+	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
+	AgentName         string             `json:"agent_name"`
+	ConversationTitle string             `json:"conversation_title"`
+}
+
+func (q *Queries) GetAgentInteractionByRequestID(ctx context.Context, arg GetAgentInteractionByRequestIDParams) (GetAgentInteractionByRequestIDRow, error) {
+	row := q.db.QueryRow(ctx, getAgentInteractionByRequestID, arg.Kind, arg.RequestID, arg.AgentRunID)
+	var i GetAgentInteractionByRequestIDRow
+	err := row.Scan(
+		&i.AiID,
+		&i.AiWorkspaceID,
+		&i.AiConversationID,
+		&i.AiAgentRunID,
+		&i.RequestID,
+		&i.Kind,
+		&i.Status,
+		&i.Request,
+		&i.Response,
+		&i.DeviceID,
+		&i.ResolutionSource,
+		&i.ResolvedActor,
+		&i.ResolvedBy,
+		&i.CreatedAt,
+		&i.ExpiresAt,
+		&i.ResolvedAt,
+		&i.UpdatedAt,
+		&i.AgentName,
+		&i.ConversationTitle,
+	)
+	return i, err
+}
+
+const getAgentInteractionDeviceByRequestID = `-- name: GetAgentInteractionDeviceByRequestID :one
+select device_id
+from agent_interactions
+where kind = $1
+  and request_id = $2
+`
+
+type GetAgentInteractionDeviceByRequestIDParams struct {
+	Kind      string `json:"kind"`
+	RequestID string `json:"request_id"`
+}
+
+func (q *Queries) GetAgentInteractionDeviceByRequestID(ctx context.Context, arg GetAgentInteractionDeviceByRequestIDParams) (string, error) {
+	row := q.db.QueryRow(ctx, getAgentInteractionDeviceByRequestID, arg.Kind, arg.RequestID)
+	var device_id string
+	err := row.Scan(&device_id)
+	return device_id, err
+}
+
 const getAgentMetrics = `-- name: GetAgentMetrics :one
 select
   count(*) filter (where r.status = 'completed')::bigint as completed_count,
@@ -6175,6 +6596,51 @@ func (q *Queries) HasMarketplaceDependentsForWorkspace(ctx context.Context, work
 	return exists, err
 }
 
+const insertAgentInteractionFromRun = `-- name: InsertAgentInteractionFromRun :exec
+insert into agent_interactions(
+  workspace_id, conversation_id, agent_run_id,
+  request_id, kind, request, device_id,
+  created_at, expires_at, updated_at
+)
+select
+  r.workspace_id,
+  r.conversation_id,
+  r.id,
+  $1,
+  $2,
+  $3::jsonb,
+  $4,
+  $5,
+  $6,
+  $5
+from agent_runs r
+where r.id = $7::uuid
+on conflict (workspace_id, device_id, kind, request_id) do nothing
+`
+
+type InsertAgentInteractionFromRunParams struct {
+	RequestID  string             `json:"request_id"`
+	Kind       string             `json:"kind"`
+	Request    []byte             `json:"request"`
+	DeviceID   string             `json:"device_id"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	ExpiresAt  pgtype.Timestamptz `json:"expires_at"`
+	AgentRunID pgtype.UUID        `json:"agent_run_id"`
+}
+
+func (q *Queries) InsertAgentInteractionFromRun(ctx context.Context, arg InsertAgentInteractionFromRunParams) error {
+	_, err := q.db.Exec(ctx, insertAgentInteractionFromRun,
+		arg.RequestID,
+		arg.Kind,
+		arg.Request,
+		arg.DeviceID,
+		arg.CreatedAt,
+		arg.ExpiresAt,
+		arg.AgentRunID,
+	)
+	return err
+}
+
 const insertAgentRunEvent = `-- name: InsertAgentRunEvent :one
 insert into agent_run_events(
   workspace_id, agent_run_id, sequence,
@@ -7702,6 +8168,40 @@ func (q *Queries) ListEnabledAgentsForMarketplaceCapability(ctx context.Context,
 	return items, nil
 }
 
+const listExpiredPendingAgentInteractionIDs = `-- name: ListExpiredPendingAgentInteractionIDs :many
+select id::text
+from agent_interactions
+where status = 'pending'
+  and expires_at <= $1
+order by expires_at asc
+limit $2
+`
+
+type ListExpiredPendingAgentInteractionIDsParams struct {
+	Now       pgtype.Timestamptz `json:"now"`
+	ItemLimit int32              `json:"item_limit"`
+}
+
+func (q *Queries) ListExpiredPendingAgentInteractionIDs(ctx context.Context, arg ListExpiredPendingAgentInteractionIDsParams) ([]string, error) {
+	rows, err := q.db.Query(ctx, listExpiredPendingAgentInteractionIDs, arg.Now, arg.ItemLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listIdleSandboxBindings = `-- name: ListIdleSandboxBindings :many
 select
   id::text            as id,
@@ -8830,6 +9330,110 @@ func (q *Queries) ListUserWorkspaces(ctx context.Context, arg ListUserWorkspaces
 	return items, nil
 }
 
+const listWorkspaceAgentInteractions = `-- name: ListWorkspaceAgentInteractions :many
+select
+  ai.id::text,
+  ai.workspace_id::text,
+  ai.conversation_id::text,
+  ai.agent_run_id::text,
+  ai.request_id,
+  ai.kind,
+  ai.status,
+  ai.request,
+  ai.response,
+  ai.device_id,
+  coalesce(ai.resolution_source, '')::text as resolution_source,
+  coalesce(ai.resolved_actor, '')::text as resolved_actor,
+  coalesce(ai.resolved_by::text, '')::text as resolved_by,
+  ai.created_at,
+  ai.expires_at,
+  ai.resolved_at,
+  ai.updated_at,
+  coalesce(a.name, '')::text as agent_name,
+  coalesce(c.title, '')::text as conversation_title
+from agent_interactions ai
+join conversations c on c.id = ai.conversation_id
+left join agent_runs r on r.id = ai.agent_run_id
+left join agents a on a.id = r.agent_id
+where ai.workspace_id = $1::uuid
+  and (
+    $2::text = ''
+    or ($2::text = 'pending' and ai.status in ('pending', 'resolving'))
+    or ($2::text = 'decided' and ai.status in ('approved', 'denied', 'answered'))
+    or ($2::text = 'expired' and ai.status in ('cancelled', 'expired'))
+  )
+order by ai.created_at desc
+limit $3
+`
+
+type ListWorkspaceAgentInteractionsParams struct {
+	WorkspaceID pgtype.UUID `json:"workspace_id"`
+	StatusGroup string      `json:"status_group"`
+	ItemLimit   int32       `json:"item_limit"`
+}
+
+type ListWorkspaceAgentInteractionsRow struct {
+	AiID              string             `json:"ai_id"`
+	AiWorkspaceID     string             `json:"ai_workspace_id"`
+	AiConversationID  string             `json:"ai_conversation_id"`
+	AiAgentRunID      string             `json:"ai_agent_run_id"`
+	RequestID         string             `json:"request_id"`
+	Kind              string             `json:"kind"`
+	Status            string             `json:"status"`
+	Request           []byte             `json:"request"`
+	Response          []byte             `json:"response"`
+	DeviceID          string             `json:"device_id"`
+	ResolutionSource  string             `json:"resolution_source"`
+	ResolvedActor     string             `json:"resolved_actor"`
+	ResolvedBy        string             `json:"resolved_by"`
+	CreatedAt         pgtype.Timestamptz `json:"created_at"`
+	ExpiresAt         pgtype.Timestamptz `json:"expires_at"`
+	ResolvedAt        pgtype.Timestamptz `json:"resolved_at"`
+	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
+	AgentName         string             `json:"agent_name"`
+	ConversationTitle string             `json:"conversation_title"`
+}
+
+func (q *Queries) ListWorkspaceAgentInteractions(ctx context.Context, arg ListWorkspaceAgentInteractionsParams) ([]ListWorkspaceAgentInteractionsRow, error) {
+	rows, err := q.db.Query(ctx, listWorkspaceAgentInteractions, arg.WorkspaceID, arg.StatusGroup, arg.ItemLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListWorkspaceAgentInteractionsRow{}
+	for rows.Next() {
+		var i ListWorkspaceAgentInteractionsRow
+		if err := rows.Scan(
+			&i.AiID,
+			&i.AiWorkspaceID,
+			&i.AiConversationID,
+			&i.AiAgentRunID,
+			&i.RequestID,
+			&i.Kind,
+			&i.Status,
+			&i.Request,
+			&i.Response,
+			&i.DeviceID,
+			&i.ResolutionSource,
+			&i.ResolvedActor,
+			&i.ResolvedBy,
+			&i.CreatedAt,
+			&i.ExpiresAt,
+			&i.ResolvedAt,
+			&i.UpdatedAt,
+			&i.AgentName,
+			&i.ConversationTitle,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listWorkspaceAgentRunsPage = `-- name: ListWorkspaceAgentRunsPage :many
 select
   r.id::text,
@@ -9918,6 +10522,57 @@ func (q *Queries) RejectJoinRequest(ctx context.Context, arg RejectJoinRequestPa
 	return i, err
 }
 
+const releaseAgentInteractionClaim = `-- name: ReleaseAgentInteractionClaim :exec
+update agent_interactions
+set status = 'pending',
+    claim_token = null,
+    claimed_at = null,
+    resolution_source = null,
+    resolved_actor = null,
+    resolved_by = null,
+    updated_at = $1
+where id = $2::uuid
+  and status = 'resolving'
+  and claim_token = $3::uuid
+`
+
+type ReleaseAgentInteractionClaimParams struct {
+	Now           pgtype.Timestamptz `json:"now"`
+	InteractionID pgtype.UUID        `json:"interaction_id"`
+	ClaimToken    pgtype.UUID        `json:"claim_token"`
+}
+
+func (q *Queries) ReleaseAgentInteractionClaim(ctx context.Context, arg ReleaseAgentInteractionClaimParams) error {
+	_, err := q.db.Exec(ctx, releaseAgentInteractionClaim, arg.Now, arg.InteractionID, arg.ClaimToken)
+	return err
+}
+
+const releaseStaleResolvingAgentInteractions = `-- name: ReleaseStaleResolvingAgentInteractions :execrows
+update agent_interactions
+set status = 'pending',
+    claim_token = null,
+    claimed_at = null,
+    resolution_source = null,
+    resolved_actor = null,
+    resolved_by = null,
+    updated_at = $1
+where status = 'resolving'
+  and claimed_at < $2
+`
+
+type ReleaseStaleResolvingAgentInteractionsParams struct {
+	Now         pgtype.Timestamptz `json:"now"`
+	StaleBefore pgtype.Timestamptz `json:"stale_before"`
+}
+
+func (q *Queries) ReleaseStaleResolvingAgentInteractions(ctx context.Context, arg ReleaseStaleResolvingAgentInteractionsParams) (int64, error) {
+	result, err := q.db.Exec(ctx, releaseStaleResolvingAgentInteractions, arg.Now, arg.StaleBefore)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const requeueFailedAgentRun = `-- name: RequeueFailedAgentRun :one
 update agent_runs
 set status = 'queued',
@@ -10065,6 +10720,40 @@ func (q *Queries) ResolveAgentDaemonDeviceByConversation(ctx context.Context, co
 	var runtime_id string
 	err := row.Scan(&runtime_id)
 	return runtime_id, err
+}
+
+const resolveAgentInteractionByRequestID = `-- name: ResolveAgentInteractionByRequestID :execrows
+update agent_interactions
+set status = $1,
+    response = $2::jsonb,
+    claim_token = null,
+    resolved_at = $3,
+    updated_at = $3
+where kind = $4
+  and request_id = $5
+  and status in ('pending', 'resolving')
+`
+
+type ResolveAgentInteractionByRequestIDParams struct {
+	Status    string             `json:"status"`
+	Response  []byte             `json:"response"`
+	Now       pgtype.Timestamptz `json:"now"`
+	Kind      string             `json:"kind"`
+	RequestID string             `json:"request_id"`
+}
+
+func (q *Queries) ResolveAgentInteractionByRequestID(ctx context.Context, arg ResolveAgentInteractionByRequestIDParams) (int64, error) {
+	result, err := q.db.Exec(ctx, resolveAgentInteractionByRequestID,
+		arg.Status,
+		arg.Response,
+		arg.Now,
+		arg.Kind,
+		arg.RequestID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const resolveAgentNameForConversation = `-- name: ResolveAgentNameForConversation :one

--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
 	gatewaypkg "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/httprunner"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/interaction"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/runstream"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/storage/blob"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
@@ -224,9 +225,14 @@ func RegisterRoutes(r chi.Router) {
 // through connectorRegistry.
 type RouterOption func(*routerConfig)
 
+type interactionResolver interface {
+	Resolve(ctx context.Context, req interaction.ResolveRequest) (interaction.ResolveResult, error)
+}
+
 type routerConfig struct {
 	openCodeConnector    connector.AgentConnector
 	connectorRegistry    *connector.Registry
+	interactionService   interactionResolver
 	authMiddleware       *auth.Middleware
 	oauthDeps            *OAuthHandlerDeps
 	authProviders        AuthProviderRegistry
@@ -291,6 +297,12 @@ type feishuRegistrationConfig struct {
 func WithConnectorRegistry(r *connector.Registry) RouterOption {
 	return func(cfg *routerConfig) {
 		cfg.connectorRegistry = r
+	}
+}
+
+func WithInteractionService(service interactionResolver) RouterOption {
+	return func(cfg *routerConfig) {
+		cfg.interactionService = service
 	}
 }
 
@@ -659,6 +671,8 @@ func RegisterRoutesWithStore(r chi.Router, runtimeStore RuntimeStore, opts ...Ro
 			r.Get("/workspaces/{workspaceID}/agents", listWorkspaceEnabledAgents(runtimeStore))
 			r.Get("/workspaces/{workspaceID}/agents/{agentID}", getWorkspaceAgent(runtimeStore))
 			r.Get("/workspaces/{workspaceID}/agent-runs", listWorkspaceAgentRuns(runtimeStore))
+			r.Get("/workspaces/{workspaceID}/interactions", gateWorkspaceMember(runtimeStore, listAgentInteractions(runtimeStore)))
+			r.Post("/workspaces/{workspaceID}/interactions/{interactionID}/resolve", resolveAgentInteraction(runtimeStore, cfg))
 			r.Get("/workspaces/{workspaceID}/agents/{agentID}/metrics", getAgentMetrics(runtimeStore))
 			r.Get("/workspaces/{workspaceID}/agent-runs/{runID}/events", listAgentRunEvents(runtimeStore))
 			r.Get("/workspaces/{workspaceID}/audit-records", listWorkspaceAuditRecords(runtimeStore))

--- a/server/internal/dev/routes_agents.go
+++ b/server/internal/dev/routes_agents.go
@@ -152,6 +152,8 @@ func configureAgentProfile(runtimeStore RuntimeStore) http.HandlerFunc {
 		result, err := runtimeStore.ConfigureAgentProfile(r.Context(), store.ConfigureAgentProfileInput{AgentID: agentID, ModelID: req.ModelID, Workdir: req.Workdir, SystemPrompt: req.SystemPrompt, Config: req.Config})
 		if err != nil {
 			switch {
+			case errors.Is(err, store.ErrInvalidInput):
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
 			case errors.Is(err, store.ErrUnknownAgent):
 				writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
 			case errors.Is(err, store.ErrUnknownModel):

--- a/server/internal/dev/routes_interactions.go
+++ b/server/internal/dev/routes_interactions.go
@@ -1,0 +1,160 @@
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/audit"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/interaction"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+type agentInteractionRuntimeStore interface {
+	ListWorkspaceAgentInteractions(ctx context.Context, workspaceID, statusGroup string, limit int32) ([]store.AgentInteractionRead, error)
+}
+
+type listAgentInteractionsResponse struct {
+	Interactions []store.AgentInteractionRead `json:"interactions"`
+}
+
+type resolveAgentInteractionBody struct {
+	Approved  *bool               `json:"approved,omitempty"`
+	Note      string              `json:"note,omitempty"`
+	Answers   map[string][]string `json:"answers,omitempty"`
+	Cancelled bool                `json:"cancelled,omitempty"`
+}
+
+type resolveAgentInteractionResponse struct {
+	Interaction     store.AgentInteractionRead `json:"interaction"`
+	Applied         bool                       `json:"applied"`
+	AlreadyResolved bool                       `json:"already_resolved"`
+}
+
+// listAgentInteractions returns durable human requests for the workspace.
+//
+//	@Summary		List workspace approval and user-question requests
+//	@Description	Returns durable permission and AskUserQuestion requests. status accepts pending, decided, or expired.
+//	@Tags			interactions
+//	@ID				listAgentInteractions
+//	@Produce		json
+//	@Param			workspaceID	path		string	true	"Workspace UUID"
+//	@Param			status		query		string	false	"pending, decided, or expired"
+//	@Param			limit		query		int		false	"Maximum rows (1-200)"
+//	@Success		200			{object}	listAgentInteractionsResponse
+//	@Failure		400			{object}	map[string]string	"Invalid status or limit"
+//	@Failure		403			{object}	map[string]string	"Caller is not a workspace member"
+//	@Failure		503			{object}	map[string]string	"Interaction store unavailable"
+//	@Router			/api/v1/workspaces/{workspaceID}/interactions [get]
+func listAgentInteractions(runtimeStore RuntimeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		interactions, ok := runtimeStore.(agentInteractionRuntimeStore)
+		if !ok {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "interaction store is unavailable"})
+			return
+		}
+		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
+		status := strings.TrimSpace(r.URL.Query().Get("status"))
+		if status != "" && status != "pending" && status != "decided" && status != "expired" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "status must be pending, decided, or expired"})
+			return
+		}
+		limit := parseLimit(r, 100)
+		if limit > 200 {
+			limit = 200
+		}
+		rows, err := interactions.ListWorkspaceAgentInteractions(r.Context(), workspaceID, status, limit)
+		if err != nil {
+			writeReadError(w, err, "failed to list interactions")
+			return
+		}
+		writeJSON(w, http.StatusOK, listAgentInteractionsResponse{Interactions: rows})
+	}
+}
+
+// resolveAgentInteraction resolves a pending request through the canonical service.
+//
+//	@Summary		Resolve a pending approval or user question
+//	@Description	Permission requests require approved. AskUserQuestion requests require an answers map keyed by stable question ID, or cancelled=true.
+//	@Tags			interactions
+//	@ID				resolveAgentInteraction
+//	@Accept			json
+//	@Produce		json
+//	@Param			workspaceID	path		string					true	"Workspace UUID"
+//	@Param			interactionID	path		string					true	"Interaction UUID"
+//	@Param			body			body		resolveAgentInteractionBody	true	"Human decision"
+//	@Success		200				{object}	resolveAgentInteractionResponse
+//	@Failure		400				{object}	map[string]string	"Invalid request body"
+//	@Failure		403				{object}	map[string]string	"Caller is not a writable workspace member"
+//	@Failure		404				{object}	map[string]string	"Interaction not found"
+//	@Failure		409				{object}	map[string]string	"Interaction is currently being resolved"
+//	@Failure		410				{object}	map[string]string	"Interaction expired or runtime request ended"
+//	@Failure		503				{object}	map[string]string	"Runtime temporarily unavailable"
+//	@Router			/api/v1/workspaces/{workspaceID}/interactions/{interactionID}/resolve [post]
+func resolveAgentInteraction(runtimeStore RuntimeStore, cfg *routerConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if cfg == nil || cfg.interactionService == nil {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "interaction service is unavailable"})
+			return
+		}
+		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
+		interactionID := strings.TrimSpace(chi.URLParam(r, "interactionID"))
+		if !isUUID(interactionID) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "interaction_id must be a valid uuid"})
+			return
+		}
+		if err := requireWorkspaceMemberNotViewer(r, runtimeStore, workspaceID); err != nil {
+			if errors.Is(err, auth.ErrNotMember) {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+				return
+			}
+			writeRBACError(w, err)
+			return
+		}
+		var body resolveAgentInteractionBody
+		decoder := json.NewDecoder(r.Body)
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+			return
+		}
+		answers := make([]interaction.QuestionAnswer, 0, len(body.Answers))
+		for questionID, values := range body.Answers {
+			answers = append(answers, interaction.QuestionAnswer{QuestionID: questionID, Answers: values})
+		}
+		actorID := actorIDFromRequest(r)
+		result, err := cfg.interactionService.Resolve(r.Context(), interaction.ResolveRequest{
+			WorkspaceID: workspaceID, InteractionID: interactionID,
+			Actor:    interaction.Actor{UserID: actorID, ActorID: actorID, Source: store.AgentInteractionSourceWeb, ActorType: audit.ActorTypeUser},
+			Decision: interaction.Decision{Approved: body.Approved, Note: body.Note, QuestionAnswers: answers, Cancelled: body.Cancelled},
+		})
+		if err != nil {
+			writeInteractionError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, resolveAgentInteractionResponse{
+			Interaction: result.Interaction, Applied: result.Applied, AlreadyResolved: result.AlreadyResolved,
+		})
+	}
+}
+
+func writeInteractionError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, interaction.ErrInvalidDecision):
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+	case errors.Is(err, interaction.ErrNotFound):
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "interaction not found"})
+	case errors.Is(err, interaction.ErrAlreadyResolving):
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+	case errors.Is(err, interaction.ErrExpired), errors.Is(err, interaction.ErrRuntimeGone):
+		writeJSON(w, http.StatusGone, map[string]string{"error": err.Error()})
+	case errors.Is(err, interaction.ErrRuntimeUnavailable):
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "runtime temporarily unavailable"})
+	default:
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to resolve interaction"})
+	}
+}

--- a/server/internal/dev/routes_interactions_test.go
+++ b/server/internal/dev/routes_interactions_test.go
@@ -1,0 +1,155 @@
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/interaction"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+const testInteractionID = "00000000-0000-0000-0000-000000000901"
+
+type stubInteractionResolver struct {
+	request interaction.ResolveRequest
+	result  interaction.ResolveResult
+	err     error
+}
+
+func (s *stubInteractionResolver) Resolve(_ context.Context, req interaction.ResolveRequest) (interaction.ResolveResult, error) {
+	s.request = req
+	return s.result, s.err
+}
+
+type interactionListStore struct {
+	stubRuntimeStore
+	rows        []store.AgentInteractionRead
+	statusGroup string
+	limit       int32
+}
+
+func (s *interactionListStore) ListWorkspaceAgentInteractions(_ context.Context, _ string, statusGroup string, limit int32) ([]store.AgentInteractionRead, error) {
+	s.statusGroup = statusGroup
+	s.limit = limit
+	return s.rows, nil
+}
+
+func TestResolveAgentInteractionMapsStableAnswerArrays(t *testing.T) {
+	resolver := &stubInteractionResolver{result: interaction.ResolveResult{
+		Applied:     true,
+		Interaction: store.AgentInteractionRead{ID: testInteractionID, Status: store.AgentInteractionStatusAnswered},
+	}}
+	r := chi.NewRouter()
+	r.Post("/api/v1/workspaces/{workspaceID}/interactions/{interactionID}/resolve", resolveAgentInteraction(stubRuntimeStore{}, &routerConfig{interactionService: resolver}))
+	req := withTestUser(httptest.NewRequest(http.MethodPost,
+		"/api/v1/workspaces/"+testWorkspaceID+"/interactions/"+testInteractionID+"/resolve",
+		strings.NewReader(`{"answers":{"environment":["staging"],"checks":["unit","integration"]}}`)))
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", res.Code, res.Body.String())
+	}
+	if resolver.request.WorkspaceID != testWorkspaceID || resolver.request.InteractionID != testInteractionID {
+		t.Fatalf("request scope = %+v", resolver.request)
+	}
+	got := map[string][]string{}
+	for _, answer := range resolver.request.Decision.QuestionAnswers {
+		got[answer.QuestionID] = answer.Answers
+	}
+	if strings.Join(got["environment"], ",") != "staging" || strings.Join(got["checks"], ",") != "unit,integration" {
+		t.Fatalf("answers = %+v", got)
+	}
+	if resolver.request.Actor.Source != store.AgentInteractionSourceWeb || resolver.request.Actor.UserID == "" {
+		t.Fatalf("actor = %+v", resolver.request.Actor)
+	}
+	var body resolveAgentInteractionResponse
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !body.Applied || body.AlreadyResolved {
+		t.Fatalf("response = %+v", body)
+	}
+}
+
+func TestResolveAgentInteractionRejectsUnknownJSONField(t *testing.T) {
+	resolver := &stubInteractionResolver{}
+	r := chi.NewRouter()
+	r.Post("/api/v1/workspaces/{workspaceID}/interactions/{interactionID}/resolve", resolveAgentInteraction(stubRuntimeStore{}, &routerConfig{interactionService: resolver}))
+	req := withTestUser(httptest.NewRequest(http.MethodPost,
+		"/api/v1/workspaces/"+testWorkspaceID+"/interactions/"+testInteractionID+"/resolve",
+		strings.NewReader(`{"approved":true,"answer":"legacy-string"}`)))
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d: %s", res.Code, res.Body.String())
+	}
+	if resolver.request.InteractionID != "" {
+		t.Fatal("invalid body reached resolver")
+	}
+}
+
+func TestResolveAgentInteractionRejectsViewerBeforeResolution(t *testing.T) {
+	resolver := &stubInteractionResolver{}
+	viewerStore := newRoleStubStore(map[string]string{store.DefaultDevFixtureIDs().UserID: "viewer"})
+	r := chi.NewRouter()
+	r.Post("/api/v1/workspaces/{workspaceID}/interactions/{interactionID}/resolve", resolveAgentInteraction(viewerStore, &routerConfig{interactionService: resolver}))
+	req := withTestUser(httptest.NewRequest(http.MethodPost,
+		"/api/v1/workspaces/"+testWorkspaceID+"/interactions/"+testInteractionID+"/resolve",
+		strings.NewReader(`{"approved":true}`)))
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+	if res.Code != http.StatusForbidden {
+		t.Fatalf("status = %d: %s", res.Code, res.Body.String())
+	}
+	if resolver.request.InteractionID != "" {
+		t.Fatal("viewer decision reached resolver")
+	}
+}
+
+func TestResolveAgentInteractionMapsServiceErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "invalid", err: ErrWrap(interaction.ErrInvalidDecision), want: http.StatusBadRequest},
+		{name: "missing", err: interaction.ErrNotFound, want: http.StatusNotFound},
+		{name: "resolving", err: interaction.ErrAlreadyResolving, want: http.StatusConflict},
+		{name: "expired", err: interaction.ErrExpired, want: http.StatusGone},
+		{name: "runtime gone", err: interaction.ErrRuntimeGone, want: http.StatusGone},
+		{name: "offline", err: interaction.ErrRuntimeUnavailable, want: http.StatusServiceUnavailable},
+		{name: "unknown", err: errors.New("boom"), want: http.StatusInternalServerError},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := httptest.NewRecorder()
+			writeInteractionError(res, tt.err)
+			if res.Code != tt.want {
+				t.Fatalf("status = %d, want %d: %s", res.Code, tt.want, res.Body.String())
+			}
+		})
+	}
+}
+
+func ErrWrap(err error) error { return errors.Join(errors.New("context"), err) }
+
+func TestListAgentInteractionsIsReadOnlyAndBounded(t *testing.T) {
+	listStore := &interactionListStore{rows: []store.AgentInteractionRead{{ID: testInteractionID, Status: store.AgentInteractionStatusPending}}}
+	r := chi.NewRouter()
+	r.Get("/api/v1/workspaces/{workspaceID}/interactions", listAgentInteractions(listStore))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/workspaces/"+testWorkspaceID+"/interactions?status=pending&limit=999", nil)
+	res := httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+	if res.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", res.Code, res.Body.String())
+	}
+	if listStore.statusGroup != "pending" || listStore.limit != 200 {
+		t.Fatalf("list arguments = %q/%d", listStore.statusGroup, listStore.limit)
+	}
+}

--- a/server/internal/dev/routes_test.go
+++ b/server/internal/dev/routes_test.go
@@ -3073,6 +3073,9 @@ func (stubRuntimeStore) ConfigureAgentProfile(ctx context.Context, input store.C
 	if input.ModelID == "00000000-0000-0000-0000-000000000902" {
 		return store.ConfigureDevAgentConnectorResult{}, store.ErrUnknownModel
 	}
+	if input.Config["mode"] == "autopilot" {
+		return store.ConfigureDevAgentConnectorResult{}, fmt.Errorf("%w: Codex collaboration mode must be default or plan", store.ErrInvalidInput)
+	}
 	return store.ConfigureDevAgentConnectorResult{
 		AgentID:       input.AgentID,
 		Name:          "Backend Agent",
@@ -3717,6 +3720,19 @@ func TestConfigureAgentProfileAPIErrors(t *testing.T) {
 	}
 	if !strings.Contains(res.Body.String(), "disabled") {
 		t.Fatalf("expected error to mention disabled, got %s", res.Body.String())
+	}
+
+	// invalid profile config -> 400
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/agents/00000000-0000-0000-0000-000000000007/profile",
+		strings.NewReader(`{"config":{"mode":"autopilot"}}`))
+	req.Header.Set("Content-Type", "application/json")
+	res = httptest.NewRecorder()
+	r.ServeHTTP(res, req)
+	if res.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid profile config, got %d: %s", res.Code, res.Body.String())
+	}
+	if !strings.Contains(res.Body.String(), "default or plan") {
+		t.Fatalf("expected validation detail, got %s", res.Body.String())
 	}
 
 	// unknown model -> 404

--- a/server/internal/dev/run_lifecycle_events.go
+++ b/server/internal/dev/run_lifecycle_events.go
@@ -2,7 +2,6 @@ package dev
 
 import (
 	"context"
-
 	"time"
 
 	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
@@ -15,8 +14,18 @@ type runLifecycleEventRecorder interface {
 }
 
 func recordRunLifecycleEvent(recorder runLifecycleEventRecorder, runID string, eventKind string, payload map[string]any, occurredAt time.Time) {
+	if err := persistRunLifecycleEvent(context.Background(), recorder, runID, eventKind, payload, occurredAt); err != nil {
+		log.Bg().Warn("record agent run lifecycle event failed", "run_id", runID, "event_kind", eventKind, "error", err)
+	}
+}
+
+// persistRunLifecycleEvent writes synchronously. The canonical event row and
+// any interaction derived from it must exist before callers publish a card or
+// continue to a later lifecycle event; a detached best-effort goroutine can
+// reorder terminal and interaction events or lose the only approval record.
+func persistRunLifecycleEvent(ctx context.Context, recorder runLifecycleEventRecorder, runID string, eventKind string, payload map[string]any, occurredAt time.Time) error {
 	if recorder == nil || runID == "" || eventKind == "" {
-		return
+		return nil
 	}
 	if payload == nil {
 		payload = map[string]any{}
@@ -24,11 +33,7 @@ func recordRunLifecycleEvent(recorder runLifecycleEventRecorder, runID string, e
 	if occurredAt.IsZero() {
 		occurredAt = time.Now().UTC()
 	}
-	go func() {
-		writeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		if err := recorder.RecordAgentRunEvent(writeCtx, store.RecordAgentRunEventInput{RunID: runID, EventKind: eventKind, Payload: payload, OccurredAt: occurredAt.UTC()}); err != nil {
-			log.Bg().Warn("record agent run lifecycle event failed", "run_id", runID, "event_kind", eventKind, "error", err)
-		}
-	}()
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	return recorder.RecordAgentRunEvent(writeCtx, store.RecordAgentRunEventInput{RunID: runID, EventKind: eventKind, Payload: payload, OccurredAt: occurredAt.UTC()})
 }

--- a/server/internal/dev/run_stream.go
+++ b/server/internal/dev/run_stream.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/runstream"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
 )
 
 type runStreamStore interface {
@@ -470,7 +470,7 @@ func eventPersistencePayload(ev connector.PromptEvent) (string, map[string]any, 
 		if ev.Permission == nil {
 			return "permission.asked", map[string]any{"sequence": ev.Sequence}, true
 		}
-		return "permission.asked", map[string]any{"request_id": ev.Permission.ID, "action": ev.Permission.Tool, "resource": ev.Permission.Title, "detail": ev.Permission.Detail, "payload": ev.Permission.Payload, "sequence": ev.Sequence}, true
+		return "permission.asked", map[string]any{"request_id": ev.Permission.ID, "device_id": ev.Permission.DeviceID, "action": ev.Permission.Tool, "resource": ev.Permission.Title, "detail": ev.Permission.Detail, "payload": ev.Permission.Payload, "sequence": ev.Sequence}, true
 	case connector.EventPromptForUserChoice:
 		if ev.PromptForUserChoice == nil {
 			return "prompt_for_user_choice.asked", map[string]any{"sequence": ev.Sequence}, true
@@ -486,6 +486,7 @@ func eventPersistencePayload(ev connector.PromptEvent) (string, map[string]any, 
 				opts = append(opts, map[string]any{"label": opt.Label, "description": opt.Description})
 			}
 			questionsOut = append(questionsOut, map[string]any{
+				"id":           q.ID,
 				"header":       q.Header,
 				"question":     q.Question,
 				"multi_select": q.MultiSelect,
@@ -494,6 +495,7 @@ func eventPersistencePayload(ev connector.PromptEvent) (string, map[string]any, 
 		}
 		payload := map[string]any{
 			"request_id":  ev.PromptForUserChoice.ID,
+			"device_id":   ev.PromptForUserChoice.DeviceID,
 			"questions":   questionsOut,
 			"tool_use_id": ev.PromptForUserChoice.ToolUseID,
 			"sequence":    ev.Sequence,

--- a/server/internal/dev/run_stream.go
+++ b/server/internal/dev/run_stream.go
@@ -392,8 +392,18 @@ func dispatchConversationRun(ctx context.Context, runtimeStore RuntimeStore, cfg
 	var streamErr string
 	var sawFinalFailure bool
 	for ev := range events {
+		if err := recordPromptEvent(ctx, streamStore, runID, ev); err != nil {
+			reason := fmt.Sprintf("persist agent event %s: %v", ev.Type, err)
+			log.Bg().Error("dispatchConversationRun: canonical event persistence failed", "run_id", runID, "event_type", ev.Type, "err", err)
+			abortCtx, abortCancel := context.WithTimeout(context.Background(), 5*time.Second)
+			_ = target.Abort(abortCtx, connector.AbortInput{ConversationID: invocation.ConversationID, RunID: runID})
+			abortCancel()
+			broker.Publish(runID, connector.PromptEvent{Type: connector.EventError, Error: reason})
+			broker.Publish(runID, connector.PromptEvent{Type: connector.EventDone, Final: &connector.PromptOutput{Metadata: map[string]any{"source": source, "error": reason}}})
+			failRunRowOnly(ctx, runtimeStore, runID, source, reason)
+			return
+		}
 		broker.Publish(runID, ev)
-		recordPromptEvent(ctx, streamStore, runID, ev)
 		if ev.Type == connector.EventDone {
 			final = ev.Final
 			if ev.Final == nil || strings.TrimSpace(ev.Final.Content) == "" {
@@ -443,12 +453,12 @@ func userConversationInitiatorID(invocation store.AgentRunInvocation) string {
 	return strings.TrimSpace(invocation.RequestedByID)
 }
 
-func recordPromptEvent(ctx context.Context, streamStore runStreamStore, runID string, ev connector.PromptEvent) {
+func recordPromptEvent(ctx context.Context, streamStore runLifecycleEventRecorder, runID string, ev connector.PromptEvent) error {
 	kind, payload, ok := eventPersistencePayload(ev)
 	if !ok {
-		return
+		return nil
 	}
-	recordRunLifecycleEvent(streamStore, runID, kind, payload, time.Now().UTC())
+	return persistRunLifecycleEvent(ctx, streamStore, runID, kind, payload, time.Now().UTC())
 }
 
 func eventPersistencePayload(ev connector.PromptEvent) (string, map[string]any, bool) {
@@ -490,6 +500,8 @@ func eventPersistencePayload(ev connector.PromptEvent) (string, map[string]any, 
 				"header":       q.Header,
 				"question":     q.Question,
 				"multi_select": q.MultiSelect,
+				"is_other":     q.IsOther,
+				"is_secret":    q.IsSecret,
 				"options":      opts,
 			})
 		}
@@ -500,6 +512,9 @@ func eventPersistencePayload(ev connector.PromptEvent) (string, map[string]any, 
 			"tool_use_id": ev.PromptForUserChoice.ToolUseID,
 			"sequence":    ev.Sequence,
 		}
+		if ev.PromptForUserChoice.AutoResolutionMs != nil {
+			payload["auto_resolution_ms"] = *ev.PromptForUserChoice.AutoResolutionMs
+		}
 		// Mirror the first question into the legacy top-level fields so
 		// rollback-compatible readers (older outbound code paths) still
 		// see a card. Safe even when len(qList) == 0 — both branches are
@@ -508,6 +523,8 @@ func eventPersistencePayload(ev connector.PromptEvent) (string, map[string]any, 
 			payload["question"] = qList[0].Question
 			payload["header"] = qList[0].Header
 			payload["multi_select"] = qList[0].MultiSelect
+			payload["is_other"] = qList[0].IsOther
+			payload["is_secret"] = qList[0].IsSecret
 			legacyOpts := make([]map[string]any, 0, len(qList[0].Options))
 			for _, opt := range qList[0].Options {
 				legacyOpts = append(legacyOpts, map[string]any{"label": opt.Label, "description": opt.Description})
@@ -618,8 +635,8 @@ func publishAndFailRun(ctx context.Context, runtimeStore RuntimeStore, broker in
 		// EventDone-empty already records run.failed via
 		// eventPersistencePayload; use failRunRowOnly to avoid a
 		// duplicate event row.
-		recordPromptEvent(ctx, streamStore, runID, errorEvent)
-		recordPromptEvent(ctx, streamStore, runID, doneEvent)
+		_ = recordPromptEvent(ctx, streamStore, runID, errorEvent)
+		_ = recordPromptEvent(ctx, streamStore, runID, doneEvent)
 	}
 	failRunRowOnly(ctx, runtimeStore, runID, source, msg)
 }

--- a/server/internal/dev/run_stream_test.go
+++ b/server/internal/dev/run_stream_test.go
@@ -9,12 +9,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/runstream"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func TestConversationRunStreamStartAndLateReplayPersistsFinal(t *testing.T) {
@@ -197,7 +197,7 @@ func TestConversationRunStreamInBandFailureEmitsSingleRunFailed(t *testing.T) {
 	}
 }
 
-func TestConversationRunStartPersistsEventsAfterRequestContextCancel(t *testing.T) {
+func TestConversationRunStartPersistsEventsSynchronouslyAfterRequestContextCancel(t *testing.T) {
 	db := openDevRouteTestDB(t)
 	ctx := context.Background()
 	ids := store.DefaultDevFixtureIDs()
@@ -220,13 +220,27 @@ func TestConversationRunStartPersistsEventsAfterRequestContextCancel(t *testing.
 	startCtx, cancel := context.WithCancel(ctx)
 	startPath := "/api/v1/conversations/" + ids.ConversationID + "/runs/" + runID + "/start"
 	startReq := newConversationMessageRequest(http.MethodPost, startPath, "", ids.UserID).WithContext(startCtx)
-	start := serveConversationMessageRequest(r, startReq)
-	if start.Code != http.StatusAccepted {
-		t.Fatalf("start status/body = %d %s, want 202", start.Code, start.Body.String())
+	type startResult struct {
+		code int
+		body string
+	}
+	startDone := make(chan startResult, 1)
+	go func() {
+		response := serveConversationMessageRequest(r, startReq)
+		startDone <- startResult{code: response.Code, body: response.Body.String()}
+	}()
+	waitForDelayedEventWrite(t, delayedStore.started)
+	select {
+	case <-startDone:
+		t.Fatal("start returned before its lifecycle event was durably recorded")
+	default:
 	}
 	cancel()
-	waitForDelayedEventWrite(t, delayedStore.started)
 	close(delayedStore.release)
+	start := <-startDone
+	if start.code != http.StatusAccepted {
+		t.Fatalf("start status/body = %d %s, want 202", start.code, start.body)
+	}
 
 	events := waitForPersistedRunEvents(t, db, runID, 1)
 	if events < 1 {
@@ -689,6 +703,23 @@ func TestEventPersistencePayload_Thinking(t *testing.T) {
 	}
 	if got, _ := payload["sequence"].(uint64); got != 42 {
 		t.Errorf("payload[\"sequence\"] = %v, want 42", payload["sequence"])
+	}
+}
+
+type failingRunEventRecorder struct{ err error }
+
+func (r failingRunEventRecorder) RecordAgentRunEvent(context.Context, store.RecordAgentRunEventInput) error {
+	return r.err
+}
+
+func TestRecordPromptEventReturnsCanonicalInteractionWriteFailure(t *testing.T) {
+	want := errors.New("database unavailable")
+	err := recordPromptEvent(context.Background(), failingRunEventRecorder{err: want}, "run-1", connector.PromptEvent{
+		Type:       connector.EventPermissionRequest,
+		Permission: &connector.PermissionRequest{ID: "perm-1", DeviceID: "device-1"},
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("recordPromptEvent error = %v, want %v", err, want)
 	}
 }
 

--- a/server/internal/dev/stream.go
+++ b/server/internal/dev/stream.go
@@ -32,25 +32,28 @@ import (
 //
 // HTTP behaviour
 // --------------
+//
 //   - 503 if no OpenCode AgentConnector is wired.
+//
 //   - 400 on body parse / required-field errors.
+//
 //   - 200 + Content-Type: text/event-stream once streaming starts.
 //     Errors AFTER the stream is open are surfaced as an SSE EventError +
 //     EventDone pair before the connection closes.
 //
-//	@Summary		Stream a raw connector prompt (dev SSE)
-//	@Description	Dev-only Server-Sent Events endpoint that forwards the OpenCode connector's StreamPrompt output. Does NOT manage agent_run state — callers drive lifecycle via the regular dev endpoints.
-//	@Tags			gateway
-//	@ID				streamDevConnectorPrompt
-//	@Accept			json
-//	@Produce		json-stream
-//	@Param			body	body		connector.PromptInput	true	"Prompt input (workspace_id, conversation_id, run_id, agent_config required)"
-//	@Success		200		"SSE stream opened"
-//	@Failure		400		{object}	map[string]string	"Body decode or validation error"
-//	@Failure		500		{object}	map[string]string	"ResponseWriter does not support flushing or connector failure"
-//	@Failure		501		{object}	map[string]string	"Connector does not support streaming"
-//	@Failure		503		{object}	map[string]string	"OpenCode AgentConnector is not registered"
-//	@Router			/dev/connectors/opencode/stream [post]
+//     @Summary		Stream a raw connector prompt (dev SSE)
+//     @Description	Dev-only Server-Sent Events endpoint that forwards the OpenCode connector's StreamPrompt output. Does NOT manage agent_run state — callers drive lifecycle via the regular dev endpoints.
+//     @Tags			gateway
+//     @ID				streamDevConnectorPrompt
+//     @Accept			json
+//     @Produce		json-stream
+//     @Param			body	body		connector.PromptInput	true	"Prompt input (workspace_id, conversation_id, run_id, agent_config required)"
+//     @Success		200		"SSE stream opened"
+//     @Failure		400		{object}	map[string]string	"Body decode or validation error"
+//     @Failure		500		{object}	map[string]string	"ResponseWriter does not support flushing or connector failure"
+//     @Failure		501		{object}	map[string]string	"Connector does not support streaming"
+//     @Failure		503		{object}	map[string]string	"OpenCode AgentConnector is not registered"
+//     @Router			/dev/connectors/opencode/stream [post]
 func streamConnectorPrompt(cfg *routerConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if cfg == nil || cfg.openCodeConnector == nil {
@@ -199,14 +202,15 @@ type streamEventWire struct {
 }
 
 type wireEvent struct {
-	Type     string        `json:"type"`
-	Sequence uint64        `json:"sequence,omitempty"`
-	Delta    string        `json:"delta,omitempty"`
-	Thinking string        `json:"thinking,omitempty"`
-	Error    string        `json:"error,omitempty"`
-	Final    *wireFinal    `json:"final,omitempty"`
-	Tool     *wireToolCall `json:"tool,omitempty"`
-	Perm     *wirePermReq  `json:"permission,omitempty"`
+	Type     string             `json:"type"`
+	Sequence uint64             `json:"sequence,omitempty"`
+	Delta    string             `json:"delta,omitempty"`
+	Thinking string             `json:"thinking,omitempty"`
+	Error    string             `json:"error,omitempty"`
+	Final    *wireFinal         `json:"final,omitempty"`
+	Tool     *wireToolCall      `json:"tool,omitempty"`
+	Perm     *wirePermReq       `json:"permission,omitempty"`
+	Choice   *wireUserChoiceReq `json:"prompt_for_user_choice,omitempty"`
 }
 
 type wireFinal struct {
@@ -236,6 +240,24 @@ type wirePermReq struct {
 	Payload map[string]any `json:"payload,omitempty"`
 }
 
+type wireUserChoiceOption struct {
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+}
+
+type wireUserChoiceQuestion struct {
+	ID          string                 `json:"id"`
+	Header      string                 `json:"header,omitempty"`
+	Question    string                 `json:"question"`
+	MultiSelect bool                   `json:"multi_select,omitempty"`
+	Options     []wireUserChoiceOption `json:"options"`
+}
+
+type wireUserChoiceReq struct {
+	ID        string                   `json:"id"`
+	Questions []wireUserChoiceQuestion `json:"questions"`
+}
+
 func toWireToolCall(t *connector.ToolCallEvent) *wireToolCall {
 	if t == nil {
 		return nil
@@ -262,6 +284,24 @@ func toWirePermReq(p *connector.PermissionRequest) *wirePermReq {
 	}
 }
 
+func toWireUserChoiceReq(request *connector.PromptForUserChoiceRequest) *wireUserChoiceReq {
+	if request == nil {
+		return nil
+	}
+	questions := make([]wireUserChoiceQuestion, 0, len(request.EffectiveQuestions()))
+	for _, question := range request.EffectiveQuestions() {
+		options := make([]wireUserChoiceOption, 0, len(question.Options))
+		for _, option := range question.Options {
+			options = append(options, wireUserChoiceOption{Label: option.Label, Description: option.Description})
+		}
+		questions = append(questions, wireUserChoiceQuestion{
+			ID: question.ID, Header: question.Header, Question: question.Question,
+			MultiSelect: question.MultiSelect, Options: options,
+		})
+	}
+	return &wireUserChoiceReq{ID: request.ID, Questions: questions}
+}
+
 func newStreamEventWire(ev connector.PromptEvent) streamEventWire {
 	w := streamEventWire{
 		wireEvent: wireEvent{
@@ -272,6 +312,7 @@ func newStreamEventWire(ev connector.PromptEvent) streamEventWire {
 			Error:    ev.Error,
 			Tool:     toWireToolCall(ev.Tool),
 			Perm:     toWirePermReq(ev.Permission),
+			Choice:   toWireUserChoiceReq(ev.PromptForUserChoice),
 		},
 		EmittedAt: time.Now().UTC().Format(time.RFC3339Nano),
 	}

--- a/server/internal/dev/stream.go
+++ b/server/internal/dev/stream.go
@@ -250,12 +250,15 @@ type wireUserChoiceQuestion struct {
 	Header      string                 `json:"header,omitempty"`
 	Question    string                 `json:"question"`
 	MultiSelect bool                   `json:"multi_select,omitempty"`
+	IsOther     bool                   `json:"is_other"`
+	IsSecret    bool                   `json:"is_secret"`
 	Options     []wireUserChoiceOption `json:"options"`
 }
 
 type wireUserChoiceReq struct {
-	ID        string                   `json:"id"`
-	Questions []wireUserChoiceQuestion `json:"questions"`
+	ID               string                   `json:"id"`
+	Questions        []wireUserChoiceQuestion `json:"questions"`
+	AutoResolutionMs *uint64                  `json:"auto_resolution_ms,omitempty"`
 }
 
 func toWireToolCall(t *connector.ToolCallEvent) *wireToolCall {
@@ -296,10 +299,11 @@ func toWireUserChoiceReq(request *connector.PromptForUserChoiceRequest) *wireUse
 		}
 		questions = append(questions, wireUserChoiceQuestion{
 			ID: question.ID, Header: question.Header, Question: question.Question,
-			MultiSelect: question.MultiSelect, Options: options,
+			MultiSelect: question.MultiSelect, IsOther: question.IsOther,
+			IsSecret: question.IsSecret, Options: options,
 		})
 	}
-	return &wireUserChoiceReq{ID: request.ID, Questions: questions}
+	return &wireUserChoiceReq{ID: request.ID, Questions: questions, AutoResolutionMs: request.AutoResolutionMs}
 }
 
 func newStreamEventWire(ev connector.PromptEvent) streamEventWire {

--- a/server/internal/dev/stream_test.go
+++ b/server/internal/dev/stream_test.go
@@ -373,9 +373,11 @@ func TestWriteSSEEventSerializesUserChoiceQuestions(t *testing.T) {
 	t.Parallel()
 	buf := &bytes.Buffer{}
 	rec := &writeFlusherRecorder{ResponseRecorder: httptest.NewRecorder(), buf: buf}
+	autoResolutionMs := uint64(90_000)
 	ev := connector.PromptEvent{Type: connector.EventPromptForUserChoice, PromptForUserChoice: &connector.PromptForUserChoiceRequest{
-		ID: "ask1", Questions: []connector.PromptForUserChoiceQuestion{{
-			ID: "checks", Header: "Checks", Question: "Which checks?", MultiSelect: true,
+		AutoResolutionMs: &autoResolutionMs,
+		ID:               "ask1", Questions: []connector.PromptForUserChoiceQuestion{{
+			ID: "checks", Header: "Checks", Question: "Which checks?", MultiSelect: true, IsOther: true, IsSecret: true,
 			Options: []connector.PromptForUserChoiceOption{{Label: "Unit"}, {Label: "E2E", Description: "Browser flow"}},
 		}},
 	}}
@@ -390,13 +392,41 @@ func TestWriteSSEEventSerializesUserChoiceQuestions(t *testing.T) {
 	if !ok || choice["id"] != "ask1" {
 		t.Fatalf("choice payload = %#v", frames[0]["prompt_for_user_choice"])
 	}
+	if choice["auto_resolution_ms"] != float64(autoResolutionMs) {
+		t.Fatalf("auto_resolution_ms = %#v", choice["auto_resolution_ms"])
+	}
 	questions, ok := choice["questions"].([]any)
 	if !ok || len(questions) != 1 {
 		t.Fatalf("questions = %#v", choice["questions"])
 	}
 	question, _ := questions[0].(map[string]any)
-	if question["id"] != "checks" || question["header"] != "Checks" || question["multi_select"] != true {
+	if question["id"] != "checks" || question["header"] != "Checks" || question["multi_select"] != true || question["is_other"] != true || question["is_secret"] != true {
 		t.Fatalf("question = %#v", question)
+	}
+}
+
+func TestWriteSSEEventPreservesClosedListQuestionMetadata(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	rec := &writeFlusherRecorder{ResponseRecorder: httptest.NewRecorder(), buf: buf}
+	ev := connector.PromptEvent{Type: connector.EventPromptForUserChoice, PromptForUserChoice: &connector.PromptForUserChoiceRequest{
+		ID: "ask-closed", Questions: []connector.PromptForUserChoiceQuestion{{
+			ID: "environment", Question: "Where?", IsOther: false, IsSecret: false,
+			Options: []connector.PromptForUserChoiceOption{{Label: "Staging"}},
+		}},
+	}}
+	if err := writeSSEEvent(rec, ev); err != nil {
+		t.Fatalf("writeSSEEvent: %v", err)
+	}
+	frames := parseSSEFrames(t, buf)
+	choice, _ := frames[0]["prompt_for_user_choice"].(map[string]any)
+	questions, _ := choice["questions"].([]any)
+	question, _ := questions[0].(map[string]any)
+	if other, ok := question["is_other"]; !ok || other != false {
+		t.Fatalf("is_other = %#v, present = %v, want explicit false", other, ok)
+	}
+	if secret, ok := question["is_secret"]; !ok || secret != false {
+		t.Fatalf("is_secret = %#v, present = %v, want explicit false", secret, ok)
 	}
 }
 

--- a/server/internal/dev/stream_test.go
+++ b/server/internal/dev/stream_test.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
+	"github.com/go-chi/chi/v5"
 )
 
 // fakeStreamConnector lets the stream-handler tests drive a
@@ -314,6 +314,7 @@ func TestWireEventNameMapsConnectorEnumsToShortNames(t *testing.T) {
 		{connector.EventError, "error"},
 		{connector.EventToolCall, "tool"},
 		{connector.EventPermissionRequest, "permission"},
+		{connector.EventPromptForUserChoice, "prompt_for_user_choice"},
 		{"", "message"},
 		{"unknown_future_type", "unknown_future_type"},
 	}
@@ -329,7 +330,7 @@ func TestWireEventNameMapsConnectorEnumsToShortNames(t *testing.T) {
 // the SSE `event:` header AND the payload `type` field both use the
 // short names, not the connector enum strings. A regression that
 // only fixes one of the two surfaces would still ship a broken UI.
-func TestWriteSSEEventUsesWireNamesForToolAndPermission(t *testing.T) {
+func TestWriteSSEEventUsesWireNamesForInteractiveEvents(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
 		ev   connector.PromptEvent
@@ -342,6 +343,14 @@ func TestWriteSSEEventUsesWireNamesForToolAndPermission(t *testing.T) {
 		{
 			ev:   connector.PromptEvent{Type: connector.EventPermissionRequest, Permission: &connector.PermissionRequest{ID: "p1", Tool: "bash"}},
 			want: "permission",
+		},
+		{
+			ev: connector.PromptEvent{Type: connector.EventPromptForUserChoice, PromptForUserChoice: &connector.PromptForUserChoiceRequest{
+				ID: "ask1", Questions: []connector.PromptForUserChoiceQuestion{{
+					Header: "Deploy", Question: "Where?", Options: []connector.PromptForUserChoiceOption{{Label: "Staging"}},
+				}},
+			}},
+			want: "prompt_for_user_choice",
 		},
 	} {
 		buf := &bytes.Buffer{}
@@ -357,6 +366,37 @@ func TestWriteSSEEventUsesWireNamesForToolAndPermission(t *testing.T) {
 		if !strings.Contains(out, `"type":"`+tc.want+`"`) {
 			t.Errorf("SSE payload missing `\"type\":\"%s\"`: %q", tc.want, out)
 		}
+	}
+}
+
+func TestWriteSSEEventSerializesUserChoiceQuestions(t *testing.T) {
+	t.Parallel()
+	buf := &bytes.Buffer{}
+	rec := &writeFlusherRecorder{ResponseRecorder: httptest.NewRecorder(), buf: buf}
+	ev := connector.PromptEvent{Type: connector.EventPromptForUserChoice, PromptForUserChoice: &connector.PromptForUserChoiceRequest{
+		ID: "ask1", Questions: []connector.PromptForUserChoiceQuestion{{
+			ID: "checks", Header: "Checks", Question: "Which checks?", MultiSelect: true,
+			Options: []connector.PromptForUserChoiceOption{{Label: "Unit"}, {Label: "E2E", Description: "Browser flow"}},
+		}},
+	}}
+	if err := writeSSEEvent(rec, ev); err != nil {
+		t.Fatalf("writeSSEEvent: %v", err)
+	}
+	frames := parseSSEFrames(t, buf)
+	if len(frames) != 1 {
+		t.Fatalf("frames = %d, want 1", len(frames))
+	}
+	choice, ok := frames[0]["prompt_for_user_choice"].(map[string]any)
+	if !ok || choice["id"] != "ask1" {
+		t.Fatalf("choice payload = %#v", frames[0]["prompt_for_user_choice"])
+	}
+	questions, ok := choice["questions"].([]any)
+	if !ok || len(questions) != 1 {
+		t.Fatalf("questions = %#v", choice["questions"])
+	}
+	question, _ := questions[0].(map[string]any)
+	if question["id"] != "checks" || question["header"] != "Checks" || question["multi_select"] != true {
+		t.Fatalf("question = %#v", question)
 	}
 }
 

--- a/server/internal/gateway/channel/channel.go
+++ b/server/internal/gateway/channel/channel.go
@@ -147,6 +147,8 @@ type ChoiceQuestion struct {
 	Header      string
 	Question    string
 	MultiSelect bool
+	IsOther     bool
+	IsSecret    bool
 	Options     []string
 }
 

--- a/server/internal/gateway/channel/feishu/cards.go
+++ b/server/internal/gateway/channel/feishu/cards.go
@@ -120,6 +120,8 @@ func (c *Channel) RenderChoiceForm(_ context.Context, _ channel.ReplyTarget, for
 			Header:      q.Header,
 			Question:    q.Question,
 			MultiSelect: q.MultiSelect,
+			IsOther:     q.IsOther,
+			IsSecret:    q.IsSecret,
 			Options:     opts,
 		})
 	}

--- a/server/internal/gateway/feishu_cards.go
+++ b/server/internal/gateway/feishu_cards.go
@@ -1214,6 +1214,8 @@ type PromptForUserChoiceCardQuestion struct {
 	Header      string
 	Question    string
 	MultiSelect bool
+	IsOther     bool
+	IsSecret    bool
 	Options     []PromptForUserChoiceCardOption
 }
 
@@ -1259,13 +1261,17 @@ func BuildPromptForUserChoiceCard(title string, questions []PromptForUserChoiceC
 		// `name`. Empty options list shouldn't happen but renders as
 		// a free-text input so the card still works.
 		if len(q.Options) == 0 {
-			formElements = append(formElements, map[string]any{
+			input := map[string]any{
 				"tag":            "input",
 				"name":           fieldName,
 				"placeholder":    map[string]any{"tag": "plain_text", "content": "Enter your answer"},
 				"label":          map[string]any{"tag": "plain_text", "content": "Answer"},
 				"label_position": "top",
-			})
+			}
+			if q.IsSecret {
+				input["input_type"] = "password"
+			}
+			formElements = append(formElements, input)
 		} else {
 			options := make([]map[string]any, 0, len(q.Options))
 			for _, opt := range q.Options {
@@ -1291,6 +1297,19 @@ func BuildPromptForUserChoiceCard(title string, questions []PromptForUserChoiceC
 				"options":     options,
 				"width":       "fill",
 			})
+			if q.IsOther {
+				input := map[string]any{
+					"tag":            "input",
+					"name":           fieldName + "_other",
+					"placeholder":    map[string]any{"tag": "plain_text", "content": "Enter another answer"},
+					"label":          map[string]any{"tag": "plain_text", "content": "Other"},
+					"label_position": "top",
+				}
+				if q.IsSecret {
+					input["input_type"] = "password"
+				}
+				formElements = append(formElements, input)
+			}
 		}
 
 		// Per-option description hints render as a single grey
@@ -1365,8 +1384,9 @@ func BuildPromptForUserChoiceCard(title string, questions []PromptForUserChoiceC
 // PromptForUserChoiceCardAnswer carries one question's answer for the
 // done card. Header pairs with the question shown on the original card.
 type PromptForUserChoiceCardAnswer struct {
-	Header string
-	Answer string
+	Header   string
+	Answer   string
+	IsSecret bool
 }
 
 // BuildPromptForUserChoiceDoneCard renders the post-answer card the
@@ -1383,6 +1403,8 @@ func BuildPromptForUserChoiceDoneCard(title string, answers []PromptForUserChoic
 		answer := strings.TrimSpace(a.Answer)
 		if answer == "" {
 			answer = "(no selection)"
+		} else if a.IsSecret {
+			answer = "[REDACTED]"
 		}
 		parts = append(parts, fmt.Sprintf("**%s**: %s", header, answer))
 	}

--- a/server/internal/gateway/feishu_cards_test.go
+++ b/server/internal/gateway/feishu_cards_test.go
@@ -7,6 +7,32 @@ import (
 	"time"
 )
 
+func TestPromptForUserChoiceSecretOtherInputAndDoneCardAreSafe(t *testing.T) {
+	card := BuildPromptForUserChoiceCard("Agent", []PromptForUserChoiceCardQuestion{{
+		Header: "Token", Question: "Which token?", IsOther: true, IsSecret: true,
+		Options: []PromptForUserChoiceCardOption{{Label: "Use stored token"}},
+	}}, "ask-secret")
+	raw, err := json.Marshal(card)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := string(raw)
+	if !strings.Contains(encoded, `"name":"q0_other"`) || !strings.Contains(encoded, `"input_type":"password"`) {
+		t.Fatalf("secret Other input is not password-masked: %s", encoded)
+	}
+
+	done := BuildPromptForUserChoiceDoneCard("Agent", []PromptForUserChoiceCardAnswer{{
+		Header: "Token", Answer: "super-secret-token", IsSecret: true,
+	}})
+	doneRaw, err := json.Marshal(done)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(doneRaw), "super-secret-token") || !strings.Contains(string(doneRaw), "[REDACTED]") {
+		t.Fatalf("secret answer was not redacted from done card: %s", doneRaw)
+	}
+}
+
 // TestBuildDoneCard_Shape locks the shape of the green "Completed" card so
 // drift in the builder is caught at PR time, not when a user notices
 // their card looks wrong in Feishu. We assert structural keys + the
@@ -948,9 +974,9 @@ func TestBuildCredentialFormSubmittedCard_Green(t *testing.T) {
 func TestCredentialFormCards_DeclareUpdateMulti(t *testing.T) {
 	t.Parallel()
 	cards := map[string]map[string]any{
-		"orange":    BuildCredentialFormCard("", []CredentialFormField{{Kind: "x"}}, "qkey"),
-		"green":     BuildCredentialFormSubmittedCard(""),
-		"red":       BuildCredentialFormRejectedCard("", CredentialFormRejectOperatorMismatch),
+		"orange": BuildCredentialFormCard("", []CredentialFormField{{Kind: "x"}}, "qkey"),
+		"green":  BuildCredentialFormSubmittedCard(""),
+		"red":    BuildCredentialFormRejectedCard("", CredentialFormRejectOperatorMismatch),
 	}
 	for name, card := range cards {
 		t.Run(name, func(t *testing.T) {

--- a/server/internal/gateway/inbound/action_router.go
+++ b/server/internal/gateway/inbound/action_router.go
@@ -597,13 +597,14 @@ func (m *Manager) routeUserChoiceSubmit(ctx context.Context, action channel.Card
 	canonicalAnswers := make([]interaction.QuestionAnswer, 0, len(questions))
 	anyAnswer := false
 	for idx, q := range questions {
-		answer := extractPromptForUserChoiceFormAnswer(action.FormValues, idx)
+		answer := extractPromptForUserChoiceFormAnswer(action.FormValues, idx, q.MultiSelect)
 		if answer != "" {
 			anyAnswer = true
 		}
 		answers = append(answers, PromptForUserChoiceQuestionAnswer{
-			Header: q.Header,
-			Answer: answer,
+			Header:   q.Header,
+			Answer:   answer,
+			IsSecret: q.IsSecret,
 		})
 		questionID := strings.TrimSpace(q.ID)
 		if questionID == "" {

--- a/server/internal/gateway/inbound/action_router.go
+++ b/server/internal/gateway/inbound/action_router.go
@@ -25,12 +25,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/audit"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel"
 	feishuchannel "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel/feishu"
 	sharedrouter "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/router"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/interaction"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 )
 
 // errCardActionUnrouted signals RouteAction does not (yet) handle a kind, so
@@ -149,6 +151,7 @@ func (m *Manager) routePermissionDecision(ctx context.Context, action channel.Ca
 		return channel.ActionAck{ToastKind: "info", ToastContent: "Received"}, nil
 	}
 	approved := action.Kind == channel.CardActionPermissionAllow
+	resolvedCanonically := false
 
 	conv, err := m.store.FindConversationByPermissionRequestID(ctx, requestID)
 	if err != nil {
@@ -173,23 +176,32 @@ func (m *Manager) routePermissionDecision(ctx context.Context, action channel.Ca
 		return channel.ActionAck{ToastKind: "info", ToastContent: "This request has already been handled or expired"}, nil
 	}
 
-	if m.permRouter == nil {
-		m.logger.Warn("feishu permission callback: permission router not configured",
-			"permission_request_id", requestID,
-		)
-		return channel.ActionAck{ToastKind: "error", ToastContent: "Service not configured; contact an administrator"}, nil
-	}
-	if err := m.permRouter.SubmitPermission(ctx, PermissionDecision{
-		RequestID:  requestID,
-		Approved:   approved,
-		OperatorID: action.OperatorID,
-	}); err != nil {
-		m.logger.Warn("feishu permission callback: SubmitPermission failed",
-			"permission_request_id", requestID,
-			"approved", approved,
-			"err", err.Error(),
-		)
-		return channel.ActionAck{ToastKind: "error", ToastContent: "Update failed, please retry later"}, nil
+	if m.interactionResolver != nil {
+		result, err := m.interactionResolver.Resolve(ctx, interaction.ResolveRequest{
+			Kind: store.AgentInteractionKindPermission, RequestID: requestID, AgentRunID: conv.Permission.AgentRunID,
+			Actor:    interaction.Actor{ActorID: action.OperatorID, Source: interactionSource(action.Platform), ActorType: audit.ActorTypeExternal},
+			Decision: interaction.Decision{Approved: &approved},
+		})
+		if err != nil {
+			return interactionActionAck(err), nil
+		}
+		resolvedCanonically = true
+		if result.Interaction.Status == store.AgentInteractionStatusApproved {
+			approved = true
+		} else if result.Interaction.Status == store.AgentInteractionStatusDenied {
+			approved = false
+		}
+	} else {
+		if m.permRouter == nil {
+			m.logger.Warn("feishu permission callback: permission router not configured", "permission_request_id", requestID)
+			return channel.ActionAck{ToastKind: "error", ToastContent: "Service not configured; contact an administrator"}, nil
+		}
+		if err := m.permRouter.SubmitPermission(ctx, PermissionDecision{
+			RequestID: requestID, Approved: approved, OperatorID: action.OperatorID,
+		}); err != nil {
+			m.logger.Warn("feishu permission callback: SubmitPermission failed", "permission_request_id", requestID, "approved", approved, "err", err.Error())
+			return channel.ActionAck{ToastKind: "error", ToastContent: "Update failed, please retry later"}, nil
+		}
 	}
 
 	// Patch the card into its green / red result shape under the bot that
@@ -207,12 +219,14 @@ func (m *Manager) routePermissionDecision(ctx context.Context, action channel.Ca
 			)
 		}
 	}
-	if err := m.store.ClearConversationInflightSlot(ctx, conv.ConversationID, store.InflightSlotPermission, conv.Permission.AgentRunID); err != nil {
-		m.logger.Warn("feishu permission callback: clear slot failed",
-			"permission_request_id", requestID,
-			"conversation_id", conv.ConversationID,
-			"err", err.Error(),
-		)
+	if !resolvedCanonically {
+		if err := m.store.ClearConversationInflightSlot(ctx, conv.ConversationID, store.InflightSlotPermission, conv.Permission.AgentRunID); err != nil {
+			m.logger.Warn("feishu permission callback: clear slot failed",
+				"permission_request_id", requestID,
+				"conversation_id", conv.ConversationID,
+				"err", err.Error(),
+			)
+		}
 	}
 	toastKind, toastContent := "info", "Rejected"
 	if approved {
@@ -572,7 +586,7 @@ func (m *Manager) routeUserChoiceSubmit(ctx context.Context, action channel.Card
 		return channel.ActionAck{ToastKind: "info", ToastContent: "This request has already been handled or expired"}, nil
 	}
 
-	if m.pfucRouter == nil {
+	if m.pfucRouter == nil && m.interactionResolver == nil {
 		m.logger.Warn("feishu prompt_for_user_choice callback: router not configured",
 			"request_id", requestID)
 		return channel.ActionAck{ToastKind: "error", ToastContent: "Service not configured; contact an administrator"}, nil
@@ -580,6 +594,7 @@ func (m *Manager) routeUserChoiceSubmit(ctx context.Context, action channel.Card
 
 	questions := conv.PromptForUserChoice.EffectiveQuestions()
 	answers := make([]PromptForUserChoiceQuestionAnswer, 0, len(questions))
+	canonicalAnswers := make([]interaction.QuestionAnswer, 0, len(questions))
 	anyAnswer := false
 	for idx, q := range questions {
 		answer := extractPromptForUserChoiceFormAnswer(action.FormValues, idx)
@@ -590,6 +605,13 @@ func (m *Manager) routeUserChoiceSubmit(ctx context.Context, action channel.Card
 			Header: q.Header,
 			Answer: answer,
 		})
+		questionID := strings.TrimSpace(q.ID)
+		if questionID == "" {
+			questionID = fmt.Sprintf("q%d", idx)
+		}
+		canonicalAnswers = append(canonicalAnswers, interaction.QuestionAnswer{
+			QuestionID: questionID, Answers: interactionAnswerValues(answer, q.MultiSelect),
+		})
 	}
 
 	decision := PromptForUserChoiceDecision{
@@ -597,13 +619,26 @@ func (m *Manager) routeUserChoiceSubmit(ctx context.Context, action channel.Card
 		QuestionAnswers: answers,
 		OperatorID:      action.OperatorID,
 	}
+	resolvedCanonically := false
 	if !anyAnswer {
 		decision.Cancelled = true
 		decision.Reason = "cancelled"
 	}
-	if err := m.pfucRouter.SubmitPromptForUserChoice(ctx, decision); err != nil {
-		m.logger.Warn("feishu prompt_for_user_choice callback: SubmitPromptForUserChoice failed",
-			"request_id", requestID, "err", err.Error())
+	if m.interactionResolver != nil {
+		if decision.Cancelled {
+			canonicalAnswers = nil
+		}
+		_, err := m.interactionResolver.Resolve(ctx, interaction.ResolveRequest{
+			Kind: store.AgentInteractionKindUserChoice, RequestID: requestID, AgentRunID: conv.PromptForUserChoice.AgentRunID,
+			Actor:    interaction.Actor{ActorID: action.OperatorID, Source: interactionSource(action.Platform), ActorType: audit.ActorTypeExternal},
+			Decision: interaction.Decision{QuestionAnswers: canonicalAnswers, Cancelled: decision.Cancelled, Note: decision.Reason},
+		})
+		if err != nil {
+			return interactionActionAck(err), nil
+		}
+		resolvedCanonically = true
+	} else if err := m.pfucRouter.SubmitPromptForUserChoice(ctx, decision); err != nil {
+		m.logger.Warn("feishu prompt_for_user_choice callback: SubmitPromptForUserChoice failed", "request_id", requestID, "err", err.Error())
 		return channel.ActionAck{ToastKind: "error", ToastContent: "Update failed, please retry later"}, nil
 	}
 
@@ -617,9 +652,11 @@ func (m *Manager) routeUserChoiceSubmit(ctx context.Context, action channel.Card
 		replaceCard = m.replaceCardJSON(doneCard, "prompt_for_user_choice done")
 	}
 
-	if err := m.store.ClearConversationInflightSlot(ctx, conv.ConversationID, store.InflightSlotPromptForUserChoice, conv.PromptForUserChoice.AgentRunID); err != nil {
-		m.logger.Warn("feishu prompt_for_user_choice callback: clear slot failed",
-			"request_id", requestID, "conversation_id", conv.ConversationID, "err", err.Error())
+	if !resolvedCanonically {
+		if err := m.store.ClearConversationInflightSlot(ctx, conv.ConversationID, store.InflightSlotPromptForUserChoice, conv.PromptForUserChoice.AgentRunID); err != nil {
+			m.logger.Warn("feishu prompt_for_user_choice callback: clear slot failed",
+				"request_id", requestID, "conversation_id", conv.ConversationID, "err", err.Error())
+		}
 	}
 
 	toastKind, toastContent := "success", "Recorded: "+summarizePromptForUserChoiceAnswers(answers)
@@ -637,4 +674,43 @@ func (m *Manager) routeUserChoiceSubmit(ctx context.Context, action channel.Card
 		}
 	}
 	return ack, nil
+}
+
+func interactionSource(platform channel.Platform) string {
+	source := strings.TrimSpace(string(platform))
+	if source == "" {
+		return store.AgentInteractionSourceFeishu
+	}
+	return source
+}
+
+func interactionActionAck(err error) channel.ActionAck {
+	switch {
+	case errors.Is(err, interaction.ErrNotFound), errors.Is(err, interaction.ErrExpired), errors.Is(err, interaction.ErrRuntimeGone):
+		return channel.ActionAck{ToastKind: "info", ToastContent: "This request has already been handled or expired"}
+	case errors.Is(err, interaction.ErrAlreadyResolving):
+		return channel.ActionAck{ToastKind: "info", ToastContent: "This request is being handled"}
+	case errors.Is(err, interaction.ErrInvalidDecision):
+		return channel.ActionAck{ToastKind: "error", ToastContent: "Please answer every question before submitting"}
+	default:
+		return channel.ActionAck{ToastKind: "error", ToastContent: "Update failed, please retry later"}
+	}
+}
+
+func interactionAnswerValues(answer string, multi bool) []string {
+	answer = strings.TrimSpace(answer)
+	if answer == "" {
+		return nil
+	}
+	if !multi {
+		return []string{answer}
+	}
+	parts := strings.FieldsFunc(answer, func(r rune) bool { return r == ',' || r == '，' || r == '、' })
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if value := strings.TrimSpace(part); value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
 }

--- a/server/internal/gateway/inbound/interaction_resolver_test.go
+++ b/server/internal/gateway/inbound/interaction_resolver_test.go
@@ -1,0 +1,143 @@
+package inbound
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/channel"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/interaction"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+type stubInteractionResolver struct {
+	requests []interaction.ResolveRequest
+	result   interaction.ResolveResult
+	err      error
+}
+
+func (s *stubInteractionResolver) Resolve(_ context.Context, request interaction.ResolveRequest) (interaction.ResolveResult, error) {
+	s.requests = append(s.requests, request)
+	return s.result, s.err
+}
+
+func TestIMPermissionUsesCanonicalResolver(t *testing.T) {
+	fs := newInboundFakeStore()
+	fs.cardsByPermReq["perm-canonical"] = store.ConversationInflightCards{
+		ConversationID: "conv-1", HasPermission: true,
+		Permission: store.PermissionInflightSlot{PermissionRequestID: "perm-canonical", AgentRunID: "run-1"},
+	}
+	legacy := &stubPermissionRouter{}
+	resolver := &stubInteractionResolver{result: interaction.ResolveResult{
+		Applied: true, Interaction: store.AgentInteractionRead{Status: store.AgentInteractionStatusApproved},
+	}}
+	mgr, err := NewManager(Options{
+		Store: fs, Secrets: inboundFakeDecrypter{}, PermissionRouter: legacy, InteractionResolver: resolver,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ack, err := mgr.cardActionRouter().RouteAction(context.Background(), channel.CardAction{
+		Kind: channel.CardActionPermissionAllow, Platform: channel.PlatformSlack, OperatorID: "U_operator",
+		Values: map[string]string{"permission_request_id": "perm-canonical"},
+	})
+	if err != nil {
+		t.Fatalf("RouteAction: %v", err)
+	}
+	if len(resolver.requests) != 1 {
+		t.Fatalf("resolver requests = %d, want 1", len(resolver.requests))
+	}
+	req := resolver.requests[0]
+	if req.RequestID != "perm-canonical" || req.AgentRunID != "run-1" || req.Actor.ActorID != "U_operator" || req.Actor.Source != store.AgentInteractionSourceSlack {
+		t.Fatalf("resolver request = %+v", req)
+	}
+	if req.Decision.Approved == nil || !*req.Decision.Approved {
+		t.Fatalf("decision = %+v", req.Decision)
+	}
+	if len(legacy.calls) != 0 {
+		t.Fatalf("legacy router calls = %+v", legacy.calls)
+	}
+	if len(fs.permissionClears) != 0 {
+		t.Fatalf("IM route duplicated canonical slot clear: %+v", fs.permissionClears)
+	}
+	if ack.ToastKind != "success" || ack.Result == nil || !ack.Result.Approved {
+		t.Fatalf("ack = %+v", ack)
+	}
+}
+
+func TestIMUserChoiceUsesStableQuestionIDsAndArrays(t *testing.T) {
+	fs := newInboundFakeStore()
+	fs.cardsByPromptForUserChoiceReq["ask-canonical"] = store.ConversationInflightCards{
+		ConversationID: "conv-1", HasPromptForUserChoice: true,
+		PromptForUserChoice: store.PromptForUserChoiceInflightSlot{
+			RequestID: "ask-canonical", AgentRunID: "run-1",
+			Questions: []store.PromptForUserChoiceQuestion{
+				{ID: "environment", Header: "Environment", MultiSelect: false},
+				{ID: "checks", Header: "Checks", MultiSelect: true},
+			},
+		},
+	}
+	legacy := &stubPromptForUserChoiceRouter{}
+	resolver := &stubInteractionResolver{result: interaction.ResolveResult{
+		Applied: true, Interaction: store.AgentInteractionRead{Status: store.AgentInteractionStatusAnswered},
+	}}
+	mgr, err := NewManager(Options{
+		Store: fs, Secrets: inboundFakeDecrypter{}, PromptForUserChoiceRouter: legacy, InteractionResolver: resolver,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ack, err := mgr.cardActionRouter().RouteAction(context.Background(), channel.CardAction{
+		Kind: channel.CardActionUserChoiceSubmit, Platform: channel.PlatformDiscord, OperatorID: "discord-user",
+		Values:     map[string]string{"request_id": "ask-canonical"},
+		FormValues: map[string]any{"q0": "staging", "q1": "unit, integration"},
+	})
+	if err != nil {
+		t.Fatalf("RouteAction: %v", err)
+	}
+	if len(resolver.requests) != 1 {
+		t.Fatalf("resolver requests = %d, want 1", len(resolver.requests))
+	}
+	req := resolver.requests[0]
+	if req.AgentRunID != "run-1" || req.Actor.Source != store.AgentInteractionSourceDiscord {
+		t.Fatalf("resolver request = %+v", req)
+	}
+	answers := map[string][]string{}
+	for _, answer := range req.Decision.QuestionAnswers {
+		answers[answer.QuestionID] = answer.Answers
+	}
+	if len(answers["environment"]) != 1 || answers["environment"][0] != "staging" {
+		t.Fatalf("environment answer = %+v", answers["environment"])
+	}
+	if len(answers["checks"]) != 2 || answers["checks"][0] != "unit" || answers["checks"][1] != "integration" {
+		t.Fatalf("checks answers = %+v", answers["checks"])
+	}
+	if len(legacy.calls) != 0 || len(fs.permissionClears) != 0 {
+		t.Fatalf("legacy side effects = calls:%+v clears:%+v", legacy.calls, fs.permissionClears)
+	}
+	if ack.ToastKind != "success" || ack.Result == nil {
+		t.Fatalf("ack = %+v", ack)
+	}
+}
+
+func TestIMResolverRaceLoserDoesNotPatchOrClear(t *testing.T) {
+	fs := newInboundFakeStore()
+	fs.cardsByPermReq["perm-race"] = store.ConversationInflightCards{
+		ConversationID: "conv-1", HasPermission: true,
+		Permission: store.PermissionInflightSlot{PermissionRequestID: "perm-race", AgentRunID: "run-1"},
+	}
+	resolver := &stubInteractionResolver{err: interaction.ErrAlreadyResolving}
+	mgr, err := NewManager(Options{Store: fs, Secrets: inboundFakeDecrypter{}, InteractionResolver: resolver})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ack, err := mgr.cardActionRouter().RouteAction(context.Background(), channel.CardAction{
+		Kind: channel.CardActionPermissionAllow, Platform: channel.PlatformSlack,
+		Values: map[string]string{"permission_request_id": "perm-race"},
+	})
+	if err != nil {
+		t.Fatalf("RouteAction: %v", err)
+	}
+	if ack.ToastKind != "info" || len(fs.permissionClears) != 0 {
+		t.Fatalf("ack/clears = %+v/%+v", ack, fs.permissionClears)
+	}
+}

--- a/server/internal/gateway/inbound/manager.go
+++ b/server/internal/gateway/inbound/manager.go
@@ -137,8 +137,9 @@ type InteractionResolver interface {
 // connector.PromptForUserChoiceQuestionAnswer; gateway-side so this
 // package stays free of the connector import.
 type PromptForUserChoiceQuestionAnswer struct {
-	Header string
-	Answer string
+	Header   string
+	Answer   string
+	IsSecret bool
 }
 
 // PromptForUserChoiceDecision mirrors connector.PromptForUserChoiceDecision;
@@ -1787,11 +1788,11 @@ func (m *Manager) patchPermissionResultCard(ctx context.Context, conv store.Conv
 // each answer joined by " / " with the header prefix where set.
 func summarizePromptForUserChoiceAnswers(answers []PromptForUserChoiceQuestionAnswer) string {
 	if len(answers) == 1 {
-		return strings.TrimSpace(answers[0].Answer)
+		return displayPromptForUserChoiceAnswer(answers[0])
 	}
 	parts := make([]string, 0, len(answers))
 	for _, a := range answers {
-		answer := strings.TrimSpace(a.Answer)
+		answer := displayPromptForUserChoiceAnswer(a)
 		if answer == "" {
 			continue
 		}
@@ -1805,17 +1806,34 @@ func summarizePromptForUserChoiceAnswers(answers []PromptForUserChoiceQuestionAn
 	return strings.Join(parts, " / ")
 }
 
+func displayPromptForUserChoiceAnswer(answer PromptForUserChoiceQuestionAnswer) string {
+	value := strings.TrimSpace(answer.Answer)
+	if value != "" && answer.IsSecret {
+		return "[REDACTED]"
+	}
+	return value
+}
+
 // extractPromptForUserChoiceFormAnswer reads field "q<idx>" out of the
 // form payload. select_static delivers a single string; multi_select_static
 // delivers []any; input delivers a string. Missing field → "".
-func extractPromptForUserChoiceFormAnswer(form map[string]any, idx int) string {
+func extractPromptForUserChoiceFormAnswer(form map[string]any, idx int, multi bool) string {
 	if form == nil {
 		return ""
 	}
-	raw, ok := form[fmt.Sprintf("q%d", idx)]
-	if !ok || raw == nil {
-		return ""
+	fieldName := fmt.Sprintf("q%d", idx)
+	selected := promptForUserChoiceFormValue(form[fieldName])
+	other := promptForUserChoiceFormValue(form[fieldName+"_other"])
+	if other == "" {
+		return selected
 	}
+	if !multi || selected == "" {
+		return other
+	}
+	return selected + "、" + other
+}
+
+func promptForUserChoiceFormValue(raw any) string {
 	switch v := raw.(type) {
 	case string:
 		return strings.TrimSpace(v)
@@ -1833,6 +1851,9 @@ func extractPromptForUserChoiceFormAnswer(form map[string]any, idx int) string {
 		}
 		return strings.Join(parts, "、")
 	default:
+		if raw == nil {
+			return ""
+		}
 		return strings.TrimSpace(fmt.Sprint(v))
 	}
 }
@@ -1851,8 +1872,9 @@ func (m *Manager) buildPromptForUserChoiceDoneCardMap(ctx context.Context, conv 
 	cardAnswers := make([]gateway.PromptForUserChoiceCardAnswer, 0, len(answers))
 	for _, a := range answers {
 		cardAnswers = append(cardAnswers, gateway.PromptForUserChoiceCardAnswer{
-			Header: a.Header,
-			Answer: a.Answer,
+			Header:   a.Header,
+			Answer:   a.Answer,
+			IsSecret: a.IsSecret,
 		})
 	}
 	return gateway.BuildPromptForUserChoiceDoneCard(title, cardAnswers)

--- a/server/internal/gateway/inbound/manager.go
+++ b/server/internal/gateway/inbound/manager.go
@@ -14,13 +14,14 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway"
+	sharedrouter "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/router"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/interaction"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	"github.com/larksuite/oapi-sdk-go/v3/ws"
-	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway"
-	sharedrouter "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/router"
-	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 )
 
 // Logger is the small logging surface Manager uses. *slog.Logger satisfies it.
@@ -128,6 +129,10 @@ type PromptForUserChoiceRouter interface {
 	SubmitPromptForUserChoice(ctx context.Context, decision PromptForUserChoiceDecision) error
 }
 
+type InteractionResolver interface {
+	Resolve(ctx context.Context, request interaction.ResolveRequest) (interaction.ResolveResult, error)
+}
+
 // PromptForUserChoiceQuestionAnswer mirrors
 // connector.PromptForUserChoiceQuestionAnswer; gateway-side so this
 // package stays free of the connector import.
@@ -210,6 +215,7 @@ type Options struct {
 	// PromptForUserChoiceRouter wires the AskUserQuestion card
 	// callback. Same nil-tolerance: missing router → toast.
 	PromptForUserChoiceRouter PromptForUserChoiceRouter
+	InteractionResolver       InteractionResolver
 
 	// JoinURLBuilder, when non-nil, mints the absolute URL the
 	// visibility=workspace rejection card surfaces as a "Request to join" link.
@@ -241,7 +247,8 @@ type Manager struct {
 	permRouter PermissionRouter
 
 	// pfucRouter is the ask-flow twin. Same nil-tolerance.
-	pfucRouter PromptForUserChoiceRouter
+	pfucRouter          PromptForUserChoiceRouter
+	interactionResolver InteractionResolver
 
 	joinURLBuilder func(workspaceID string) string
 
@@ -296,19 +303,20 @@ func NewManager(opts Options) (*Manager, error) {
 		return nil, errors.New("inbound: DefaultSharedBot requires both AppID and AppSecret")
 	}
 	return &Manager{
-		store:          opts.Store,
-		secrets:        opts.Secrets,
-		logger:         logger,
-		refresh:        refresh,
-		domain:         domain,
-		openAPIBaseURL: openAPIBaseURL,
-		secretKeys:     append([]string(nil), secretKeys...),
-		defaultBot:     defaultBot,
-		permRouter:     opts.PermissionRouter,
-		pfucRouter:     opts.PromptForUserChoiceRouter,
-		joinURLBuilder: opts.JoinURLBuilder,
-		connectors:     opts.Connectors,
-		clients:        make(map[string]*clientHandle),
+		store:               opts.Store,
+		secrets:             opts.Secrets,
+		logger:              logger,
+		refresh:             refresh,
+		domain:              domain,
+		openAPIBaseURL:      openAPIBaseURL,
+		secretKeys:          append([]string(nil), secretKeys...),
+		defaultBot:          defaultBot,
+		permRouter:          opts.PermissionRouter,
+		pfucRouter:          opts.PromptForUserChoiceRouter,
+		interactionResolver: opts.InteractionResolver,
+		joinURLBuilder:      opts.JoinURLBuilder,
+		connectors:          opts.Connectors,
+		clients:             make(map[string]*clientHandle),
 	}, nil
 }
 

--- a/server/internal/gateway/inbound/manager_test.go
+++ b/server/internal/gateway/inbound/manager_test.go
@@ -14,10 +14,31 @@ import (
 	"sync/atomic"
 	"testing"
 
-	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 )
+
+func TestPromptForUserChoiceSecretSummariesAndCustomAnswers(t *testing.T) {
+	answers := []PromptForUserChoiceQuestionAnswer{
+		{Header: "Token", Answer: "super-secret", IsSecret: true},
+		{Header: "Environment", Answer: "staging"},
+	}
+	summary := summarizePromptForUserChoiceAnswers(answers)
+	if strings.Contains(summary, "super-secret") || !strings.Contains(summary, "Token:[REDACTED]") {
+		t.Fatalf("secret summary = %q", summary)
+	}
+	if got := extractPromptForUserChoiceFormAnswer(map[string]any{
+		"q0": []any{"unit", "e2e"}, "q0_other": "smoke",
+	}, 0, true); got != "unit、e2e、smoke" {
+		t.Fatalf("multi-select custom answer = %q", got)
+	}
+	if got := extractPromptForUserChoiceFormAnswer(map[string]any{
+		"q0": "stored", "q0_other": "typed-secret",
+	}, 0, false); got != "typed-secret" {
+		t.Fatalf("single-select custom answer = %q", got)
+	}
+}
 
 func strptr(s string) *string { return &s }
 
@@ -277,12 +298,12 @@ type replaceUserCredentialsCall struct {
 
 func newInboundFakeStore() *inboundFakeStore {
 	return &inboundFakeStore{
-		agentsByAppID:  make(map[string]store.FeishuAgentRoute),
-		agentsByID:     make(map[string]store.FeishuAgentRoute),
-		selections:     make(map[string]string),
-		users:          make(map[string]string),
-		secrets:        make(map[string]store.SecretPayload),
-		cardsByPermReq: make(map[string]store.ConversationInflightCards),
+		agentsByAppID:                 make(map[string]store.FeishuAgentRoute),
+		agentsByID:                    make(map[string]store.FeishuAgentRoute),
+		selections:                    make(map[string]string),
+		users:                         make(map[string]string),
+		secrets:                       make(map[string]store.SecretPayload),
+		cardsByPermReq:                make(map[string]store.ConversationInflightCards),
 		cardsByPromptForUserChoiceReq: make(map[string]store.ConversationInflightCards),
 		inflightByConv:                make(map[string]store.ConversationInflightCards),
 		pendingAskByChat:              make(map[string]inboundFakeChatAsk),
@@ -1598,7 +1619,7 @@ func TestQuotedChainText_MergeForwardChatListFallback(t *testing.T) {
 				chatID:  "oc_chat",
 				// No inline subs — forces fallback.
 			},
-			"om_c1": {msgType: "text", content: `{"text":"fallback line"}`, upperID: "om_mf"},
+			"om_c1":        {msgType: "text", content: `{"text":"fallback line"}`, upperID: "om_mf"},
 			"om_unrelated": {msgType: "text", content: `{"text":"noise"}`, upperID: "om_other_mf"},
 		},
 		map[string][]string{

--- a/server/internal/gateway/inflight/inflight_driver.go
+++ b/server/internal/gateway/inflight/inflight_driver.go
@@ -623,6 +623,8 @@ func (w *Worker) maybeSendPromptForUserChoiceCard(
 			Header:      q.Header,
 			Question:    q.Question,
 			MultiSelect: q.MultiSelect,
+			IsOther:     q.IsOther,
+			IsSecret:    q.IsSecret,
 			Options:     opts,
 		})
 	}
@@ -1068,6 +1070,8 @@ func pendingAskFromPayload(payload map[string]any) (*pendingAsk, bool) {
 		q, _ := payload["question"].(string)
 		header, _ := payload["header"].(string)
 		multiSelect, _ := payload["multi_select"].(bool)
+		isOther, _ := payload["is_other"].(bool)
+		isSecret, _ := payload["is_secret"].(bool)
 		opts := decodePromptForUserChoiceOptionList(payload["options"])
 		if strings.TrimSpace(q) == "" && len(opts) == 0 {
 			return nil, false
@@ -1076,6 +1080,8 @@ func pendingAskFromPayload(payload map[string]any) (*pendingAsk, bool) {
 			Header:      strings.TrimSpace(header),
 			Question:    strings.TrimSpace(q),
 			MultiSelect: multiSelect,
+			IsOther:     isOther,
+			IsSecret:    isSecret,
 			Options:     opts,
 		}}
 	}
@@ -1104,6 +1110,8 @@ func decodePromptForUserChoiceQuestionList(raw any) []store.PromptForUserChoiceQ
 		id, _ := m["id"].(string)
 		header, _ := m["header"].(string)
 		multiSelect, _ := m["multi_select"].(bool)
+		isOther, _ := m["is_other"].(bool)
+		isSecret, _ := m["is_secret"].(bool)
 		opts := decodePromptForUserChoiceOptionList(m["options"])
 		if strings.TrimSpace(q) == "" && len(opts) == 0 {
 			continue
@@ -1113,6 +1121,8 @@ func decodePromptForUserChoiceQuestionList(raw any) []store.PromptForUserChoiceQ
 			Header:      strings.TrimSpace(header),
 			Question:    strings.TrimSpace(q),
 			MultiSelect: multiSelect,
+			IsOther:     isOther,
+			IsSecret:    isSecret,
 			Options:     opts,
 		})
 	}

--- a/server/internal/gateway/inflight/inflight_driver.go
+++ b/server/internal/gateway/inflight/inflight_driver.go
@@ -1101,6 +1101,7 @@ func decodePromptForUserChoiceQuestionList(raw any) []store.PromptForUserChoiceQ
 			continue
 		}
 		q, _ := m["question"].(string)
+		id, _ := m["id"].(string)
 		header, _ := m["header"].(string)
 		multiSelect, _ := m["multi_select"].(bool)
 		opts := decodePromptForUserChoiceOptionList(m["options"])
@@ -1108,6 +1109,7 @@ func decodePromptForUserChoiceQuestionList(raw any) []store.PromptForUserChoiceQ
 			continue
 		}
 		out = append(out, store.PromptForUserChoiceQuestion{
+			ID:          strings.TrimSpace(id),
 			Header:      strings.TrimSpace(header),
 			Question:    strings.TrimSpace(q),
 			MultiSelect: multiSelect,

--- a/server/internal/gateway/inflight/inflight_neutral.go
+++ b/server/internal/gateway/inflight/inflight_neutral.go
@@ -456,6 +456,8 @@ func (w *Worker) maybeSendNeutralChoiceCard(
 			Header:      q.Header,
 			Question:    q.Question,
 			MultiSelect: q.MultiSelect,
+			IsOther:     q.IsOther,
+			IsSecret:    q.IsSecret,
 			Options:     opts,
 		})
 	}

--- a/server/internal/interaction/delivery.go
+++ b/server/internal/interaction/delivery.go
@@ -1,0 +1,45 @@
+package interaction
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+type RunReader interface {
+	GetAgentRun(ctx context.Context, runID string) (store.AgentRunDetailRead, error)
+}
+
+type RegistryDelivery struct {
+	Runs     RunReader
+	Registry *connector.Registry
+}
+
+func (d RegistryDelivery) SubmitPermission(ctx context.Context, runID string, decision connector.PermissionDecision) error {
+	conn, err := d.connector(ctx, runID)
+	if err != nil {
+		return err
+	}
+	return conn.SubmitPermission(ctx, decision)
+}
+
+func (d RegistryDelivery) SubmitPromptForUserChoice(ctx context.Context, runID string, decision connector.PromptForUserChoiceDecision) error {
+	conn, err := d.connector(ctx, runID)
+	if err != nil {
+		return err
+	}
+	return conn.SubmitPromptForUserChoice(ctx, decision)
+}
+
+func (d RegistryDelivery) connector(ctx context.Context, runID string) (connector.AgentConnector, error) {
+	if d.Runs == nil || d.Registry == nil {
+		return nil, errors.New("interaction delivery is unavailable")
+	}
+	run, err := d.Runs.GetAgentRun(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	return d.Registry.Get(run.ConnectorType)
+}

--- a/server/internal/interaction/service.go
+++ b/server/internal/interaction/service.go
@@ -66,7 +66,7 @@ func (s *Service) Resolve(ctx context.Context, req ResolveRequest) (ResolveResul
 			latest, _ := s.store.GetAgentInteraction(ctx, claim.ID)
 			return ResolveResult{Interaction: latest, AlreadyResolved: true}, ErrRuntimeGone
 		}
-		_ = s.store.ReleaseAgentInteractionClaim(ctx, claim, s.now())
+		s.releaseClaim(ctx, claim)
 		return ResolveResult{}, fmt.Errorf("%w: %v", ErrRuntimeUnavailable, err)
 	}
 	if err := s.complete(ctx, claim, status, response, req.Actor); err != nil {
@@ -95,11 +95,19 @@ func (s *Service) Expire(ctx context.Context, interactionID string) error {
 	actor := Actor{ActorID: store.AgentInteractionSourceSystemTimeout, Source: store.AgentInteractionSourceSystemTimeout, ActorType: audit.ActorTypeSystem}
 	_, response, deliveryErr := s.deliver(ctx, claim, decision, actor)
 	if deliveryErr != nil && !errors.Is(deliveryErr, connector.ErrInteractionNoLongerPending) {
-		_ = s.store.ReleaseAgentInteractionClaim(ctx, claim, s.now())
+		s.releaseClaim(ctx, claim)
 		return deliveryErr
 	}
 	response["expired"] = true
 	return s.complete(ctx, claim, store.AgentInteractionStatusExpired, response, actor)
+}
+
+func (s *Service) releaseClaim(ctx context.Context, claim store.AgentInteractionClaim) {
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := s.store.ReleaseAgentInteractionClaim(writeCtx, claim, s.now()); err != nil {
+		s.warn("release interaction claim failed", "request_id", claim.RequestID, "error", err)
+	}
 }
 
 func (s *Service) load(ctx context.Context, req ResolveRequest) (store.AgentInteractionRead, error) {
@@ -142,7 +150,8 @@ func (s *Service) deliver(ctx context.Context, claim store.AgentInteractionClaim
 		approved := decision.Approved != nil && *decision.Approved
 		response := map[string]any{"approved": approved, "note": strings.TrimSpace(decision.Note)}
 		err := s.delivery.SubmitPermission(ctx, claim.AgentRunID, connector.PermissionDecision{
-			RequestID: claim.RequestID, DeviceID: claim.DeviceID, Approved: approved, Note: strings.TrimSpace(decision.Note), By: actor.ActorID,
+			RequestID: claim.RequestID, DeliveryID: claim.ID, DeviceID: claim.DeviceID,
+			Approved: approved, Note: strings.TrimSpace(decision.Note), By: actor.ActorID,
 		})
 		status := store.AgentInteractionStatusDenied
 		if approved {
@@ -151,15 +160,18 @@ func (s *Service) deliver(ctx context.Context, claim store.AgentInteractionClaim
 		return status, response, err
 	case store.AgentInteractionKindUserChoice:
 		answers := normalizeAnswers(decision.QuestionAnswers)
-		response := map[string]any{"answers": answers, "cancelled": decision.Cancelled, "reason": strings.TrimSpace(decision.Note)}
+		response := map[string]any{"answers": redactSecretAnswers(claim.Request, answers), "cancelled": decision.Cancelled, "reason": strings.TrimSpace(decision.Note)}
 		connectorAnswers := make([]connector.PromptForUserChoiceQuestionAnswer, 0, len(decision.QuestionAnswers))
 		for _, answer := range decision.QuestionAnswers {
+			questionID := strings.TrimSpace(answer.QuestionID)
+			values := answers[questionID]
 			connectorAnswers = append(connectorAnswers, connector.PromptForUserChoiceQuestionAnswer{
-				QuestionID: answer.QuestionID, Answers: append([]string(nil), answer.Answers...), Answer: strings.Join(answer.Answers, ", "),
+				QuestionID: questionID, Answers: append([]string(nil), values...), Answer: strings.Join(values, ", "),
 			})
 		}
 		err := s.delivery.SubmitPromptForUserChoice(ctx, claim.AgentRunID, connector.PromptForUserChoiceDecision{
-			RequestID: claim.RequestID, DeviceID: claim.DeviceID, QuestionAnswers: connectorAnswers, Cancelled: decision.Cancelled,
+			RequestID: claim.RequestID, DeliveryID: claim.ID, DeviceID: claim.DeviceID,
+			QuestionAnswers: connectorAnswers, Cancelled: decision.Cancelled,
 			Reason: strings.TrimSpace(decision.Note), By: actor.ActorID,
 		})
 		status := store.AgentInteractionStatusAnswered
@@ -173,7 +185,9 @@ func (s *Service) deliver(ctx context.Context, claim store.AgentInteractionClaim
 }
 
 func (s *Service) complete(ctx context.Context, claim store.AgentInteractionClaim, status string, response map[string]any, actor Actor) error {
-	if err := s.store.CompleteAgentInteraction(ctx, claim, status, response, s.now()); err != nil {
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := s.store.CompleteAgentInteraction(writeCtx, claim, status, response, s.now()); err != nil {
 		return err
 	}
 	slot := store.InflightSlotPermission
@@ -182,10 +196,10 @@ func (s *Service) complete(ctx context.Context, claim store.AgentInteractionClai
 		slot = store.InflightSlotPromptForUserChoice
 		eventKind = "prompt_for_user_choice.replied"
 	}
-	if err := s.store.ClearConversationInflightSlot(ctx, claim.ConversationID, slot, claim.AgentRunID); err != nil {
+	if err := s.store.ClearConversationInflightSlot(writeCtx, claim.ConversationID, slot, claim.AgentRunID); err != nil {
 		s.warn("clear interaction inflight slot failed", "request_id", claim.RequestID, "error", err)
 	}
-	if err := s.store.RecordAgentRunEvent(ctx, store.RecordAgentRunEventInput{
+	if err := s.store.RecordAgentRunEvent(writeCtx, store.RecordAgentRunEventInput{
 		RunID: claim.AgentRunID, EventKind: eventKind,
 		Payload: map[string]any{"request_id": claim.RequestID, "status": status, "response": response}, OccurredAt: s.now(),
 	}); err != nil {
@@ -267,6 +281,13 @@ func validateDecision(current store.AgentInteractionRead, decision Decision) err
 			if !question.multiSelect && len(values) != 1 {
 				return fmt.Errorf("%w: question %q accepts exactly one answer", ErrInvalidDecision, question.id)
 			}
+			if !question.isOther {
+				for _, value := range values {
+					if _, allowed := question.options[value]; !allowed {
+						return fmt.Errorf("%w: question %q does not allow a custom answer", ErrInvalidDecision, question.id)
+					}
+				}
+			}
 		}
 		return nil
 	default:
@@ -277,6 +298,9 @@ func validateDecision(current store.AgentInteractionRead, decision Decision) err
 type interactionQuestion struct {
 	id          string
 	multiSelect bool
+	isOther     bool
+	isSecret    bool
+	options     map[string]struct{}
 }
 
 func interactionQuestions(request map[string]any) []interactionQuestion {
@@ -285,11 +309,32 @@ func interactionQuestions(request map[string]any) []interactionQuestion {
 	for index, value := range raw {
 		question, _ := value.(map[string]any)
 		id, _ := question["id"].(string)
-		if strings.TrimSpace(id) == "" {
+		id = strings.TrimSpace(id)
+		if id == "" {
 			id = fmt.Sprintf("q%d", index)
 		}
 		multi, _ := question["multi_select"].(bool)
-		out = append(out, interactionQuestion{id: id, multiSelect: multi})
+		// Older durable rows predate is_other and the Web card has always
+		// treated an omitted flag as allowing free-form input. Only an
+		// explicit false closes the option set.
+		isOther := true
+		if value, ok := question["is_other"].(bool); ok {
+			isOther = value
+		}
+		isSecret, _ := question["is_secret"].(bool)
+		options := make(map[string]struct{})
+		if rawOptions, ok := question["options"].([]any); ok {
+			for _, rawOption := range rawOptions {
+				option, _ := rawOption.(map[string]any)
+				label, _ := option["label"].(string)
+				if label = strings.TrimSpace(label); label != "" {
+					options[label] = struct{}{}
+				}
+			}
+		}
+		out = append(out, interactionQuestion{
+			id: id, multiSelect: multi, isOther: isOther, isSecret: isSecret, options: options,
+		})
 	}
 	return out
 }
@@ -308,6 +353,22 @@ func normalizeAnswers(answers []QuestionAnswer) map[string][]string {
 	out := make(map[string][]string, len(answers))
 	for _, answer := range answers {
 		out[strings.TrimSpace(answer.QuestionID)] = cleanAnswers(answer.Answers)
+	}
+	return out
+}
+
+func redactSecretAnswers(request map[string]any, answers map[string][]string) map[string][]string {
+	secret := make(map[string]bool)
+	for _, question := range interactionQuestions(request) {
+		secret[question.id] = question.isSecret
+	}
+	out := make(map[string][]string, len(answers))
+	for questionID, values := range answers {
+		if secret[questionID] {
+			out[questionID] = []string{"[REDACTED]"}
+			continue
+		}
+		out[questionID] = append([]string(nil), values...)
 	}
 	return out
 }

--- a/server/internal/interaction/service.go
+++ b/server/internal/interaction/service.go
@@ -1,0 +1,313 @@
+package interaction
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/audit"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+type Service struct {
+	store    Store
+	delivery Delivery
+	logger   Logger
+	now      func() time.Time
+}
+
+func NewService(store Store, delivery Delivery, logger Logger) *Service {
+	return &Service{store: store, delivery: delivery, logger: logger, now: func() time.Time { return time.Now().UTC() }}
+}
+
+func (s *Service) Resolve(ctx context.Context, req ResolveRequest) (ResolveResult, error) {
+	current, err := s.load(ctx, req)
+	if err != nil {
+		return ResolveResult{}, err
+	}
+	if req.WorkspaceID != "" && current.WorkspaceID != req.WorkspaceID {
+		return ResolveResult{}, ErrNotFound
+	}
+	if result, done, err := classifyCurrent(current, s.now()); done {
+		return result, err
+	}
+	if err := validateDecision(current, req.Decision); err != nil {
+		return ResolveResult{}, err
+	}
+
+	claim, err := s.claim(ctx, req, s.now())
+	if err != nil {
+		if errors.Is(err, store.ErrAgentInteractionNotPending) {
+			latest, loadErr := s.load(ctx, req)
+			if loadErr != nil {
+				return ResolveResult{}, loadErr
+			}
+			result, done, classifyErr := classifyCurrent(latest, s.now())
+			if done {
+				return result, classifyErr
+			}
+			// A competing resolver can release a temporary failure between
+			// our failed claim and this reload. Do not return an empty success;
+			// tell the caller to retry through the normal conflict path.
+			return ResolveResult{Interaction: latest}, ErrAlreadyResolving
+		}
+		return ResolveResult{}, err
+	}
+	status, response, err := s.deliver(ctx, claim, req.Decision, req.Actor)
+	if err != nil {
+		if errors.Is(err, connector.ErrInteractionNoLongerPending) {
+			response = map[string]any{"reason": "runtime_request_gone"}
+			if completeErr := s.complete(ctx, claim, store.AgentInteractionStatusCancelled, response, req.Actor); completeErr != nil {
+				return ResolveResult{}, completeErr
+			}
+			latest, _ := s.store.GetAgentInteraction(ctx, claim.ID)
+			return ResolveResult{Interaction: latest, AlreadyResolved: true}, ErrRuntimeGone
+		}
+		_ = s.store.ReleaseAgentInteractionClaim(ctx, claim, s.now())
+		return ResolveResult{}, fmt.Errorf("%w: %v", ErrRuntimeUnavailable, err)
+	}
+	if err := s.complete(ctx, claim, status, response, req.Actor); err != nil {
+		return ResolveResult{}, err
+	}
+	latest, err := s.store.GetAgentInteraction(ctx, claim.ID)
+	if err != nil {
+		return ResolveResult{}, err
+	}
+	return ResolveResult{Interaction: latest, Applied: true}, nil
+}
+
+func (s *Service) Expire(ctx context.Context, interactionID string) error {
+	claim, err := s.store.ClaimExpiredAgentInteraction(ctx, interactionID, s.now())
+	if err != nil {
+		if errors.Is(err, store.ErrAgentInteractionNotPending) {
+			return nil
+		}
+		return err
+	}
+	decision := Decision{Cancelled: claim.Kind == store.AgentInteractionKindUserChoice}
+	if claim.Kind == store.AgentInteractionKindPermission {
+		approved := false
+		decision.Approved = &approved
+	}
+	actor := Actor{ActorID: store.AgentInteractionSourceSystemTimeout, Source: store.AgentInteractionSourceSystemTimeout, ActorType: audit.ActorTypeSystem}
+	_, response, deliveryErr := s.deliver(ctx, claim, decision, actor)
+	if deliveryErr != nil && !errors.Is(deliveryErr, connector.ErrInteractionNoLongerPending) {
+		_ = s.store.ReleaseAgentInteractionClaim(ctx, claim, s.now())
+		return deliveryErr
+	}
+	response["expired"] = true
+	return s.complete(ctx, claim, store.AgentInteractionStatusExpired, response, actor)
+}
+
+func (s *Service) load(ctx context.Context, req ResolveRequest) (store.AgentInteractionRead, error) {
+	var current store.AgentInteractionRead
+	var err error
+	if strings.TrimSpace(req.InteractionID) != "" {
+		current, err = s.store.GetAgentInteraction(ctx, req.InteractionID)
+	} else {
+		if strings.TrimSpace(req.AgentRunID) == "" {
+			return store.AgentInteractionRead{}, ErrNotFound
+		}
+		current, err = s.store.GetAgentInteractionByRequestID(ctx, req.Kind, req.RequestID, req.AgentRunID)
+	}
+	if err != nil {
+		if errors.Is(err, store.ErrUnknownAgentInteraction) {
+			return store.AgentInteractionRead{}, ErrNotFound
+		}
+		return store.AgentInteractionRead{}, err
+	}
+	return current, nil
+}
+
+func (s *Service) claim(ctx context.Context, req ResolveRequest, now time.Time) (store.AgentInteractionClaim, error) {
+	actorID := strings.TrimSpace(req.Actor.ActorID)
+	if actorID == "" {
+		actorID = strings.TrimSpace(req.Actor.UserID)
+	}
+	if strings.TrimSpace(req.InteractionID) != "" {
+		return s.store.ClaimAgentInteraction(ctx, req.WorkspaceID, req.InteractionID, req.Actor.UserID, actorID, req.Actor.Source, now)
+	}
+	return s.store.ClaimAgentInteractionByRequestID(ctx, req.Kind, req.RequestID, req.AgentRunID, req.Actor.UserID, actorID, req.Actor.Source, now)
+}
+
+func (s *Service) deliver(ctx context.Context, claim store.AgentInteractionClaim, decision Decision, actor Actor) (string, map[string]any, error) {
+	if s.delivery == nil {
+		return "", nil, errors.New("interaction delivery is unavailable")
+	}
+	switch claim.Kind {
+	case store.AgentInteractionKindPermission:
+		approved := decision.Approved != nil && *decision.Approved
+		response := map[string]any{"approved": approved, "note": strings.TrimSpace(decision.Note)}
+		err := s.delivery.SubmitPermission(ctx, claim.AgentRunID, connector.PermissionDecision{
+			RequestID: claim.RequestID, DeviceID: claim.DeviceID, Approved: approved, Note: strings.TrimSpace(decision.Note), By: actor.ActorID,
+		})
+		status := store.AgentInteractionStatusDenied
+		if approved {
+			status = store.AgentInteractionStatusApproved
+		}
+		return status, response, err
+	case store.AgentInteractionKindUserChoice:
+		answers := normalizeAnswers(decision.QuestionAnswers)
+		response := map[string]any{"answers": answers, "cancelled": decision.Cancelled, "reason": strings.TrimSpace(decision.Note)}
+		connectorAnswers := make([]connector.PromptForUserChoiceQuestionAnswer, 0, len(decision.QuestionAnswers))
+		for _, answer := range decision.QuestionAnswers {
+			connectorAnswers = append(connectorAnswers, connector.PromptForUserChoiceQuestionAnswer{
+				QuestionID: answer.QuestionID, Answers: append([]string(nil), answer.Answers...), Answer: strings.Join(answer.Answers, ", "),
+			})
+		}
+		err := s.delivery.SubmitPromptForUserChoice(ctx, claim.AgentRunID, connector.PromptForUserChoiceDecision{
+			RequestID: claim.RequestID, DeviceID: claim.DeviceID, QuestionAnswers: connectorAnswers, Cancelled: decision.Cancelled,
+			Reason: strings.TrimSpace(decision.Note), By: actor.ActorID,
+		})
+		status := store.AgentInteractionStatusAnswered
+		if decision.Cancelled {
+			status = store.AgentInteractionStatusCancelled
+		}
+		return status, response, err
+	default:
+		return "", nil, fmt.Errorf("%w: unsupported interaction kind", ErrInvalidDecision)
+	}
+}
+
+func (s *Service) complete(ctx context.Context, claim store.AgentInteractionClaim, status string, response map[string]any, actor Actor) error {
+	if err := s.store.CompleteAgentInteraction(ctx, claim, status, response, s.now()); err != nil {
+		return err
+	}
+	slot := store.InflightSlotPermission
+	eventKind := "permission.replied"
+	if claim.Kind == store.AgentInteractionKindUserChoice {
+		slot = store.InflightSlotPromptForUserChoice
+		eventKind = "prompt_for_user_choice.replied"
+	}
+	if err := s.store.ClearConversationInflightSlot(ctx, claim.ConversationID, slot, claim.AgentRunID); err != nil {
+		s.warn("clear interaction inflight slot failed", "request_id", claim.RequestID, "error", err)
+	}
+	if err := s.store.RecordAgentRunEvent(ctx, store.RecordAgentRunEventInput{
+		RunID: claim.AgentRunID, EventKind: eventKind,
+		Payload: map[string]any{"request_id": claim.RequestID, "status": status, "response": response}, OccurredAt: s.now(),
+	}); err != nil {
+		s.warn("record interaction resolution event failed", "request_id", claim.RequestID, "error", err)
+	}
+	actorID := strings.TrimSpace(actor.ActorID)
+	if actorID == "" {
+		actorID = strings.TrimSpace(actor.UserID)
+	}
+	s.store.RecordAgentInteractionResolutionAudit(store.AgentInteractionAuditInput{
+		InteractionID: claim.ID, WorkspaceID: claim.WorkspaceID, AgentRunID: claim.AgentRunID,
+		RequestID: claim.RequestID, Kind: claim.Kind, Status: status, Source: actor.Source,
+		ActorID: actorID, ActorType: actor.ActorType, Response: response,
+	})
+	return nil
+}
+
+func (s *Service) warn(msg string, args ...any) {
+	if s.logger != nil {
+		s.logger.Warn(msg, args...)
+	}
+}
+
+func classifyCurrent(current store.AgentInteractionRead, now time.Time) (ResolveResult, bool, error) {
+	switch current.Status {
+	case store.AgentInteractionStatusResolving:
+		return ResolveResult{Interaction: current}, true, ErrAlreadyResolving
+	case store.AgentInteractionStatusPending:
+		if !current.ExpiresAt.After(now) {
+			return ResolveResult{Interaction: current}, true, ErrExpired
+		}
+		return ResolveResult{}, false, nil
+	default:
+		return ResolveResult{Interaction: current, AlreadyResolved: true}, true, nil
+	}
+}
+
+func validateDecision(current store.AgentInteractionRead, decision Decision) error {
+	switch current.Kind {
+	case store.AgentInteractionKindPermission:
+		if decision.Approved == nil || decision.Cancelled || len(decision.QuestionAnswers) > 0 {
+			return fmt.Errorf("%w: approved is required for a permission request", ErrInvalidDecision)
+		}
+		return nil
+	case store.AgentInteractionKindUserChoice:
+		if decision.Approved != nil {
+			return fmt.Errorf("%w: approved is only valid for permission requests", ErrInvalidDecision)
+		}
+		if decision.Cancelled {
+			if len(decision.QuestionAnswers) > 0 {
+				return fmt.Errorf("%w: a cancelled request cannot include answers", ErrInvalidDecision)
+			}
+			return nil
+		}
+		questions := interactionQuestions(current.Request)
+		if len(questions) == 0 || len(decision.QuestionAnswers) != len(questions) {
+			return fmt.Errorf("%w: every question requires one answer", ErrInvalidDecision)
+		}
+		answers := make(map[string][]string, len(decision.QuestionAnswers))
+		for _, answer := range decision.QuestionAnswers {
+			id := strings.TrimSpace(answer.QuestionID)
+			if id == "" || len(answer.Answers) == 0 {
+				return fmt.Errorf("%w: every answer requires question_id and a non-empty answers array", ErrInvalidDecision)
+			}
+			if _, exists := answers[id]; exists {
+				return fmt.Errorf("%w: duplicate question_id %q", ErrInvalidDecision, id)
+			}
+			values := cleanAnswers(answer.Answers)
+			if len(values) == 0 {
+				return fmt.Errorf("%w: question %q has no non-empty answer", ErrInvalidDecision, id)
+			}
+			answers[id] = values
+		}
+		for _, question := range questions {
+			values, ok := answers[question.id]
+			if !ok {
+				return fmt.Errorf("%w: missing answer for question %q", ErrInvalidDecision, question.id)
+			}
+			if !question.multiSelect && len(values) != 1 {
+				return fmt.Errorf("%w: question %q accepts exactly one answer", ErrInvalidDecision, question.id)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: unsupported interaction kind", ErrInvalidDecision)
+	}
+}
+
+type interactionQuestion struct {
+	id          string
+	multiSelect bool
+}
+
+func interactionQuestions(request map[string]any) []interactionQuestion {
+	raw, _ := request["questions"].([]any)
+	out := make([]interactionQuestion, 0, len(raw))
+	for index, value := range raw {
+		question, _ := value.(map[string]any)
+		id, _ := question["id"].(string)
+		if strings.TrimSpace(id) == "" {
+			id = fmt.Sprintf("q%d", index)
+		}
+		multi, _ := question["multi_select"].(bool)
+		out = append(out, interactionQuestion{id: id, multiSelect: multi})
+	}
+	return out
+}
+
+func cleanAnswers(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func normalizeAnswers(answers []QuestionAnswer) map[string][]string {
+	out := make(map[string][]string, len(answers))
+	for _, answer := range answers {
+		out[strings.TrimSpace(answer.QuestionID)] = cleanAnswers(answer.Answers)
+	}
+	return out
+}

--- a/server/internal/interaction/service_test.go
+++ b/server/internal/interaction/service_test.go
@@ -19,6 +19,7 @@ type fakeStore struct {
 	claim         store.AgentInteractionClaim
 	claimCount    int
 	releaseCount  int
+	releaseCtxErr error
 	staleReleases int64
 	events        []store.RecordAgentRunEventInput
 	audits        []store.AgentInteractionAuditInput
@@ -110,9 +111,10 @@ func (s *fakeStore) CompleteAgentInteraction(_ context.Context, claim store.Agen
 	return nil
 }
 
-func (s *fakeStore) ReleaseAgentInteractionClaim(_ context.Context, claim store.AgentInteractionClaim, _ time.Time) error {
+func (s *fakeStore) ReleaseAgentInteractionClaim(ctx context.Context, claim store.AgentInteractionClaim, _ time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.releaseCtxErr = ctx.Err()
 	if claim.ClaimToken != s.claim.ClaimToken || s.interaction.Status != store.AgentInteractionStatusResolving {
 		return nil
 	}
@@ -228,6 +230,9 @@ func TestResolvePermissionIsDurableAndIdempotent(t *testing.T) {
 	if len(delivery.permissions) != 1 || !delivery.permissions[0].Approved || delivery.permissions[0].By != "user-1" || delivery.permissions[0].DeviceID != "device-1" {
 		t.Fatalf("permission deliveries = %+v", delivery.permissions)
 	}
+	if delivery.permissions[0].DeliveryID != "interaction-1" {
+		t.Fatalf("permission delivery id = %q", delivery.permissions[0].DeliveryID)
+	}
 	if fs.claimCount != 1 || len(fs.events) != 1 || len(fs.audits) != 1 || len(fs.cleared) != 1 {
 		t.Fatalf("side effects: claims=%d events=%d audits=%d cleared=%d", fs.claimCount, len(fs.events), len(fs.audits), len(fs.cleared))
 	}
@@ -239,8 +244,8 @@ func TestResolvePermissionIsDurableAndIdempotent(t *testing.T) {
 func TestResolveQuestionPreservesStableIDsAndAnswerArrays(t *testing.T) {
 	now := time.Now().UTC()
 	request := map[string]any{"questions": []any{
-		map[string]any{"id": "environment", "multi_select": false},
-		map[string]any{"id": "checks", "multi_select": true},
+		map[string]any{"id": "environment", "multi_select": false, "is_other": false, "options": []any{map[string]any{"label": "staging"}, map[string]any{"label": "prod"}}},
+		map[string]any{"id": "checks", "multi_select": true, "is_other": false, "options": []any{map[string]any{"label": "unit"}, map[string]any{"label": "integration"}}},
 	}}
 	fs := newFakeStore(store.AgentInteractionKindUserChoice, request, now)
 	delivery := &fakeDelivery{}
@@ -250,8 +255,8 @@ func TestResolveQuestionPreservesStableIDsAndAnswerArrays(t *testing.T) {
 		Kind: store.AgentInteractionKindUserChoice, RequestID: "request-1", AgentRunID: "run-1",
 		Actor: Actor{ActorID: "ou_1", Source: store.AgentInteractionSourceFeishu},
 		Decision: Decision{QuestionAnswers: []QuestionAnswer{
-			{QuestionID: "checks", Answers: []string{"unit", "integration"}},
-			{QuestionID: "environment", Answers: []string{"staging"}},
+			{QuestionID: " checks ", Answers: []string{" unit ", "integration  "}},
+			{QuestionID: " environment ", Answers: []string{" staging "}},
 		}},
 	})
 	if err != nil || !result.Applied || result.Interaction.Status != store.AgentInteractionStatusAnswered {
@@ -264,6 +269,9 @@ func TestResolveQuestionPreservesStableIDsAndAnswerArrays(t *testing.T) {
 	if delivery.choices[0].DeviceID != "device-1" {
 		t.Fatalf("choice device = %q", delivery.choices[0].DeviceID)
 	}
+	if delivery.choices[0].DeliveryID != "interaction-1" {
+		t.Fatalf("choice delivery id = %q", delivery.choices[0].DeliveryID)
+	}
 	want := []connector.PromptForUserChoiceQuestionAnswer{
 		{QuestionID: "checks", Answers: []string{"unit", "integration"}, Answer: "unit, integration"},
 		{QuestionID: "environment", Answers: []string{"staging"}, Answer: "staging"},
@@ -273,11 +281,51 @@ func TestResolveQuestionPreservesStableIDsAndAnswerArrays(t *testing.T) {
 	}
 }
 
+func TestResolveQuestionDeliversSecretButRedactsDurableRecords(t *testing.T) {
+	now := time.Now().UTC()
+	request := map[string]any{"questions": []any{
+		map[string]any{"id": "token", "is_secret": true, "is_other": true},
+		map[string]any{"id": "environment", "is_secret": false, "options": []any{map[string]any{"label": "staging"}}},
+	}}
+	fs := newFakeStore(store.AgentInteractionKindUserChoice, request, now)
+	delivery := &fakeDelivery{}
+	svc := NewService(fs, delivery, nil)
+	svc.now = func() time.Time { return now }
+	result, err := svc.Resolve(context.Background(), ResolveRequest{
+		WorkspaceID: "workspace-1", InteractionID: "interaction-1",
+		Actor: Actor{ActorID: "user-1", Source: store.AgentInteractionSourceWeb},
+		Decision: Decision{QuestionAnswers: []QuestionAnswer{
+			{QuestionID: "token", Answers: []string{"  super-secret  "}},
+			{QuestionID: "environment", Answers: []string{" staging "}},
+		}},
+	})
+	if err != nil || !result.Applied {
+		t.Fatalf("Resolve = %+v, %v", result, err)
+	}
+	if got := delivery.choices[0].QuestionAnswers[0].Answers; !reflect.DeepEqual(got, []string{"super-secret"}) {
+		t.Fatalf("runtime secret = %v", got)
+	}
+	assertRedacted := func(name string, response map[string]any) {
+		t.Helper()
+		answers, ok := response["answers"].(map[string][]string)
+		if !ok {
+			t.Fatalf("%s answers type = %T (%+v)", name, response["answers"], response)
+		}
+		if !reflect.DeepEqual(answers["token"], []string{"[REDACTED]"}) || !reflect.DeepEqual(answers["environment"], []string{"staging"}) {
+			t.Fatalf("%s answers = %+v", name, answers)
+		}
+	}
+	assertRedacted("interaction", fs.interaction.Response)
+	assertRedacted("audit", fs.audits[0].Response)
+	eventResponse, _ := fs.events[0].Payload["response"].(map[string]any)
+	assertRedacted("event", eventResponse)
+}
+
 func TestResolveQuestionRejectsInvalidStructuredAnswersBeforeClaim(t *testing.T) {
 	now := time.Now().UTC()
 	request := map[string]any{"questions": []any{
-		map[string]any{"id": "environment", "multi_select": false},
-		map[string]any{"id": "checks", "multi_select": true},
+		map[string]any{"id": "environment", "multi_select": false, "is_other": false, "options": []any{map[string]any{"label": "staging"}, map[string]any{"label": "prod"}}},
+		map[string]any{"id": "checks", "multi_select": true, "is_other": false, "options": []any{map[string]any{"label": "unit"}}},
 	}}
 	tests := []struct {
 		name    string
@@ -288,6 +336,7 @@ func TestResolveQuestionRejectsInvalidStructuredAnswersBeforeClaim(t *testing.T)
 		{name: "empty value", answers: []QuestionAnswer{{QuestionID: "environment", Answers: []string{" "}}, {QuestionID: "checks", Answers: []string{"unit"}}}},
 		{name: "multiple single select", answers: []QuestionAnswer{{QuestionID: "environment", Answers: []string{"staging", "prod"}}, {QuestionID: "checks", Answers: []string{"unit"}}}},
 		{name: "unknown id", answers: []QuestionAnswer{{QuestionID: "other", Answers: []string{"staging"}}, {QuestionID: "checks", Answers: []string{"unit"}}}},
+		{name: "custom answer disabled", answers: []QuestionAnswer{{QuestionID: "environment", Answers: []string{"qa"}}, {QuestionID: "checks", Answers: []string{"unit"}}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -306,6 +355,46 @@ func TestResolveQuestionRejectsInvalidStructuredAnswersBeforeClaim(t *testing.T)
 				t.Fatalf("invalid decision reached side effects: claims=%d choices=%d", fs.claimCount, len(delivery.choices))
 			}
 		})
+	}
+}
+
+func TestResolveQuestionLegacyMissingIsOtherAllowsCustomAnswer(t *testing.T) {
+	now := time.Now().UTC()
+	request := map[string]any{"questions": []any{
+		map[string]any{"id": " environment ", "options": []any{map[string]any{"label": "staging"}}},
+	}}
+	fs := newFakeStore(store.AgentInteractionKindUserChoice, request, now)
+	delivery := &fakeDelivery{}
+	svc := NewService(fs, delivery, nil)
+	svc.now = func() time.Time { return now }
+	result, err := svc.Resolve(context.Background(), ResolveRequest{
+		WorkspaceID: "workspace-1", InteractionID: "interaction-1",
+		Actor:    Actor{ActorID: "user-1", Source: store.AgentInteractionSourceWeb},
+		Decision: Decision{QuestionAnswers: []QuestionAnswer{{QuestionID: " environment ", Answers: []string{"qa"}}}},
+	})
+	if err != nil || !result.Applied {
+		t.Fatalf("Resolve = %+v, %v", result, err)
+	}
+	if got := delivery.choices[0].QuestionAnswers[0]; got.QuestionID != "environment" || !reflect.DeepEqual(got.Answers, []string{"qa"}) {
+		t.Fatalf("runtime answer = %+v", got)
+	}
+}
+
+func TestResolveQuestionExplicitlyClosedEmptyOptionsRejectsCustomAnswer(t *testing.T) {
+	now := time.Now().UTC()
+	request := map[string]any{"questions": []any{
+		map[string]any{"id": "q0", "is_other": false, "options": []any{}},
+	}}
+	fs := newFakeStore(store.AgentInteractionKindUserChoice, request, now)
+	svc := NewService(fs, &fakeDelivery{}, nil)
+	svc.now = func() time.Time { return now }
+	_, err := svc.Resolve(context.Background(), ResolveRequest{
+		WorkspaceID: "workspace-1", InteractionID: "interaction-1",
+		Actor:    Actor{ActorID: "user-1", Source: store.AgentInteractionSourceWeb},
+		Decision: Decision{QuestionAnswers: []QuestionAnswer{{QuestionID: "q0", Answers: []string{"custom"}}}},
+	})
+	if !errors.Is(err, ErrInvalidDecision) || fs.claimCount != 0 {
+		t.Fatalf("Resolve error/claims = %v/%d, want ErrInvalidDecision before claim", err, fs.claimCount)
 	}
 }
 
@@ -346,6 +435,9 @@ func TestConcurrentResolversHaveOneDeliveryWinner(t *testing.T) {
 		firstDone <- err
 	}()
 	<-delivery.entered
+	if fs.interaction.Status != store.AgentInteractionStatusResolving {
+		t.Fatalf("interaction became terminal before runtime delivery ack: %q", fs.interaction.Status)
+	}
 	_, secondErr := svc.Resolve(context.Background(), req)
 	if !errors.Is(secondErr, ErrAlreadyResolving) {
 		t.Fatalf("second error = %v, want ErrAlreadyResolving", secondErr)
@@ -376,6 +468,28 @@ func TestTemporaryDeliveryFailureReleasesClaimForRetry(t *testing.T) {
 	delivery.err = nil
 	if result, err := svc.Resolve(context.Background(), req); err != nil || !result.Applied {
 		t.Fatalf("retry = %+v, %v", result, err)
+	}
+}
+
+func TestCancelledResolveContextStillReleasesDeliveryClaim(t *testing.T) {
+	now := time.Now().UTC()
+	fs := newFakeStore(store.AgentInteractionKindPermission, nil, now)
+	delivery := &fakeDelivery{err: errors.New("runtime disconnected")}
+	svc := NewService(fs, delivery, nil)
+	svc.now = func() time.Time { return now }
+	approved := true
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := svc.Resolve(ctx, ResolveRequest{
+		WorkspaceID: "workspace-1", InteractionID: "interaction-1",
+		Actor:    Actor{ActorID: "user-1", Source: store.AgentInteractionSourceWeb},
+		Decision: Decision{Approved: &approved},
+	})
+	if !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("Resolve error = %v, want ErrRuntimeUnavailable", err)
+	}
+	if fs.releaseCount != 1 || fs.releaseCtxErr != nil || fs.interaction.Status != store.AgentInteractionStatusPending {
+		t.Fatalf("release state = count:%d ctx:%v status:%s", fs.releaseCount, fs.releaseCtxErr, fs.interaction.Status)
 	}
 }
 

--- a/server/internal/interaction/service_test.go
+++ b/server/internal/interaction/service_test.go
@@ -1,0 +1,453 @@
+package interaction
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+type fakeStore struct {
+	mu sync.Mutex
+
+	interaction   store.AgentInteractionRead
+	claim         store.AgentInteractionClaim
+	claimCount    int
+	releaseCount  int
+	staleReleases int64
+	events        []store.RecordAgentRunEventInput
+	audits        []store.AgentInteractionAuditInput
+	cleared       []store.InflightSlotKind
+}
+
+func newFakeStore(kind string, request map[string]any, now time.Time) *fakeStore {
+	return &fakeStore{
+		interaction: store.AgentInteractionRead{
+			ID: "interaction-1", WorkspaceID: "workspace-1", ConversationID: "conversation-1",
+			AgentRunID: "run-1", RequestID: "request-1", Kind: kind,
+			Status: store.AgentInteractionStatusPending, Request: request,
+			CreatedAt: now.Add(-time.Minute), ExpiresAt: now.Add(time.Minute), UpdatedAt: now.Add(-time.Minute),
+		},
+		claim: store.AgentInteractionClaim{
+			ID: "interaction-1", WorkspaceID: "workspace-1", ConversationID: "conversation-1",
+			AgentRunID: "run-1", RequestID: "request-1", Kind: kind,
+			DeviceID: "device-1", ClaimToken: "claim-1", Request: request,
+		},
+	}
+}
+
+func (s *fakeStore) GetAgentInteraction(_ context.Context, id string) (store.AgentInteractionRead, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if id != s.interaction.ID {
+		return store.AgentInteractionRead{}, store.ErrUnknownAgentInteraction
+	}
+	return s.interaction, nil
+}
+
+func (s *fakeStore) GetAgentInteractionByRequestID(_ context.Context, kind, requestID, runID string) (store.AgentInteractionRead, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if kind != s.interaction.Kind || requestID != s.interaction.RequestID || runID != s.interaction.AgentRunID {
+		return store.AgentInteractionRead{}, store.ErrUnknownAgentInteraction
+	}
+	return s.interaction, nil
+}
+
+func (s *fakeStore) ClaimAgentInteraction(_ context.Context, workspaceID, interactionID, userID, actorID, source string, now time.Time) (store.AgentInteractionClaim, error) {
+	if workspaceID != s.interaction.WorkspaceID || interactionID != s.interaction.ID {
+		return store.AgentInteractionClaim{}, store.ErrAgentInteractionNotPending
+	}
+	return s.claimPending(userID, actorID, source, now, false)
+}
+
+func (s *fakeStore) ClaimAgentInteractionByRequestID(_ context.Context, kind, requestID, runID, userID, actorID, source string, now time.Time) (store.AgentInteractionClaim, error) {
+	if kind != s.interaction.Kind || requestID != s.interaction.RequestID || runID != s.interaction.AgentRunID {
+		return store.AgentInteractionClaim{}, store.ErrAgentInteractionNotPending
+	}
+	return s.claimPending(userID, actorID, source, now, false)
+}
+
+func (s *fakeStore) ClaimExpiredAgentInteraction(_ context.Context, id string, now time.Time) (store.AgentInteractionClaim, error) {
+	if id != s.interaction.ID {
+		return store.AgentInteractionClaim{}, store.ErrAgentInteractionNotPending
+	}
+	return s.claimPending("", store.AgentInteractionSourceSystemTimeout, store.AgentInteractionSourceSystemTimeout, now, true)
+}
+
+func (s *fakeStore) claimPending(userID, actorID, source string, now time.Time, expired bool) (store.AgentInteractionClaim, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.interaction.Status != store.AgentInteractionStatusPending {
+		return store.AgentInteractionClaim{}, store.ErrAgentInteractionNotPending
+	}
+	if expired != !s.interaction.ExpiresAt.After(now) {
+		return store.AgentInteractionClaim{}, store.ErrAgentInteractionNotPending
+	}
+	s.interaction.Status = store.AgentInteractionStatusResolving
+	s.interaction.ResolvedBy = userID
+	s.interaction.ResolvedActor = actorID
+	s.interaction.ResolutionSource = source
+	s.claimCount++
+	return s.claim, nil
+}
+
+func (s *fakeStore) CompleteAgentInteraction(_ context.Context, claim store.AgentInteractionClaim, status string, response map[string]any, now time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if claim.ClaimToken != s.claim.ClaimToken || s.interaction.Status != store.AgentInteractionStatusResolving {
+		return store.ErrAgentInteractionNotPending
+	}
+	s.interaction.Status = status
+	s.interaction.Response = response
+	s.interaction.UpdatedAt = now
+	s.interaction.ResolvedAt = &now
+	return nil
+}
+
+func (s *fakeStore) ReleaseAgentInteractionClaim(_ context.Context, claim store.AgentInteractionClaim, _ time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if claim.ClaimToken != s.claim.ClaimToken || s.interaction.Status != store.AgentInteractionStatusResolving {
+		return nil
+	}
+	s.interaction.Status = store.AgentInteractionStatusPending
+	s.interaction.ResolvedBy = ""
+	s.interaction.ResolvedActor = ""
+	s.interaction.ResolutionSource = ""
+	s.releaseCount++
+	return nil
+}
+
+func (s *fakeStore) ListExpiredPendingAgentInteractionIDs(_ context.Context, now time.Time, _ int32) ([]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.interaction.Status == store.AgentInteractionStatusPending && !s.interaction.ExpiresAt.After(now) {
+		return []string{s.interaction.ID}, nil
+	}
+	return nil, nil
+}
+
+func (s *fakeStore) ReleaseStaleAgentInteractionClaims(_ context.Context, _, _ time.Time) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.staleReleases > 0 && s.interaction.Status == store.AgentInteractionStatusResolving {
+		s.interaction.Status = store.AgentInteractionStatusPending
+		s.interaction.ResolvedBy = ""
+		s.interaction.ResolvedActor = ""
+		s.interaction.ResolutionSource = ""
+	}
+	return s.staleReleases, nil
+}
+
+func (s *fakeStore) ClearConversationInflightSlot(_ context.Context, _ string, slot store.InflightSlotKind, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleared = append(s.cleared, slot)
+	return nil
+}
+
+func (s *fakeStore) RecordAgentRunEvent(_ context.Context, input store.RecordAgentRunEventInput) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, input)
+	return nil
+}
+
+func (s *fakeStore) RecordAgentInteractionResolutionAudit(input store.AgentInteractionAuditInput) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.audits = append(s.audits, input)
+}
+
+type fakeDelivery struct {
+	mu          sync.Mutex
+	permissions []connector.PermissionDecision
+	choices     []connector.PromptForUserChoiceDecision
+	err         error
+	entered     chan struct{}
+	release     chan struct{}
+}
+
+func (d *fakeDelivery) SubmitPermission(_ context.Context, _ string, decision connector.PermissionDecision) error {
+	d.wait()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.permissions = append(d.permissions, decision)
+	return d.err
+}
+
+func (d *fakeDelivery) SubmitPromptForUserChoice(_ context.Context, _ string, decision connector.PromptForUserChoiceDecision) error {
+	d.wait()
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.choices = append(d.choices, decision)
+	return d.err
+}
+
+func (d *fakeDelivery) wait() {
+	if d.entered != nil {
+		select {
+		case d.entered <- struct{}{}:
+		default:
+		}
+	}
+	if d.release != nil {
+		<-d.release
+	}
+}
+
+func TestResolvePermissionIsDurableAndIdempotent(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	fs := newFakeStore(store.AgentInteractionKindPermission, map[string]any{"title": "Run tests"}, now)
+	delivery := &fakeDelivery{}
+	svc := NewService(fs, delivery, nil)
+	svc.now = func() time.Time { return now }
+	approved := true
+	req := ResolveRequest{
+		WorkspaceID: "workspace-1", InteractionID: "interaction-1",
+		Actor:    Actor{UserID: "user-1", ActorID: "user-1", Source: store.AgentInteractionSourceWeb},
+		Decision: Decision{Approved: &approved, Note: "reviewed"},
+	}
+	result, err := svc.Resolve(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !result.Applied || result.Interaction.Status != store.AgentInteractionStatusApproved {
+		t.Fatalf("result = %+v", result)
+	}
+	second, err := svc.Resolve(context.Background(), req)
+	if err != nil || !second.AlreadyResolved || second.Applied {
+		t.Fatalf("second Resolve = %+v, %v", second, err)
+	}
+	if len(delivery.permissions) != 1 || !delivery.permissions[0].Approved || delivery.permissions[0].By != "user-1" || delivery.permissions[0].DeviceID != "device-1" {
+		t.Fatalf("permission deliveries = %+v", delivery.permissions)
+	}
+	if fs.claimCount != 1 || len(fs.events) != 1 || len(fs.audits) != 1 || len(fs.cleared) != 1 {
+		t.Fatalf("side effects: claims=%d events=%d audits=%d cleared=%d", fs.claimCount, len(fs.events), len(fs.audits), len(fs.cleared))
+	}
+	if fs.audits[0].Source != store.AgentInteractionSourceWeb || fs.audits[0].ActorID != "user-1" || fs.audits[0].Status != store.AgentInteractionStatusApproved {
+		t.Fatalf("audit = %+v", fs.audits[0])
+	}
+}
+
+func TestResolveQuestionPreservesStableIDsAndAnswerArrays(t *testing.T) {
+	now := time.Now().UTC()
+	request := map[string]any{"questions": []any{
+		map[string]any{"id": "environment", "multi_select": false},
+		map[string]any{"id": "checks", "multi_select": true},
+	}}
+	fs := newFakeStore(store.AgentInteractionKindUserChoice, request, now)
+	delivery := &fakeDelivery{}
+	svc := NewService(fs, delivery, nil)
+	svc.now = func() time.Time { return now }
+	result, err := svc.Resolve(context.Background(), ResolveRequest{
+		Kind: store.AgentInteractionKindUserChoice, RequestID: "request-1", AgentRunID: "run-1",
+		Actor: Actor{ActorID: "ou_1", Source: store.AgentInteractionSourceFeishu},
+		Decision: Decision{QuestionAnswers: []QuestionAnswer{
+			{QuestionID: "checks", Answers: []string{"unit", "integration"}},
+			{QuestionID: "environment", Answers: []string{"staging"}},
+		}},
+	})
+	if err != nil || !result.Applied || result.Interaction.Status != store.AgentInteractionStatusAnswered {
+		t.Fatalf("Resolve = %+v, %v", result, err)
+	}
+	if len(delivery.choices) != 1 {
+		t.Fatalf("choices = %+v", delivery.choices)
+	}
+	got := delivery.choices[0].QuestionAnswers
+	if delivery.choices[0].DeviceID != "device-1" {
+		t.Fatalf("choice device = %q", delivery.choices[0].DeviceID)
+	}
+	want := []connector.PromptForUserChoiceQuestionAnswer{
+		{QuestionID: "checks", Answers: []string{"unit", "integration"}, Answer: "unit, integration"},
+		{QuestionID: "environment", Answers: []string{"staging"}, Answer: "staging"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("answers = %+v, want %+v", got, want)
+	}
+}
+
+func TestResolveQuestionRejectsInvalidStructuredAnswersBeforeClaim(t *testing.T) {
+	now := time.Now().UTC()
+	request := map[string]any{"questions": []any{
+		map[string]any{"id": "environment", "multi_select": false},
+		map[string]any{"id": "checks", "multi_select": true},
+	}}
+	tests := []struct {
+		name    string
+		answers []QuestionAnswer
+	}{
+		{name: "missing question", answers: []QuestionAnswer{{QuestionID: "environment", Answers: []string{"staging"}}}},
+		{name: "duplicate id", answers: []QuestionAnswer{{QuestionID: "environment", Answers: []string{"staging"}}, {QuestionID: "environment", Answers: []string{"prod"}}}},
+		{name: "empty value", answers: []QuestionAnswer{{QuestionID: "environment", Answers: []string{" "}}, {QuestionID: "checks", Answers: []string{"unit"}}}},
+		{name: "multiple single select", answers: []QuestionAnswer{{QuestionID: "environment", Answers: []string{"staging", "prod"}}, {QuestionID: "checks", Answers: []string{"unit"}}}},
+		{name: "unknown id", answers: []QuestionAnswer{{QuestionID: "other", Answers: []string{"staging"}}, {QuestionID: "checks", Answers: []string{"unit"}}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := newFakeStore(store.AgentInteractionKindUserChoice, request, now)
+			delivery := &fakeDelivery{}
+			svc := NewService(fs, delivery, nil)
+			svc.now = func() time.Time { return now }
+			_, err := svc.Resolve(context.Background(), ResolveRequest{
+				WorkspaceID: "workspace-1", InteractionID: "interaction-1",
+				Decision: Decision{QuestionAnswers: tt.answers},
+			})
+			if !errors.Is(err, ErrInvalidDecision) {
+				t.Fatalf("error = %v, want ErrInvalidDecision", err)
+			}
+			if fs.claimCount != 0 || len(delivery.choices) != 0 {
+				t.Fatalf("invalid decision reached side effects: claims=%d choices=%d", fs.claimCount, len(delivery.choices))
+			}
+		})
+	}
+}
+
+func TestResolveQuestionRejectsContradictoryDecision(t *testing.T) {
+	now := time.Now().UTC()
+	request := map[string]any{"questions": []any{map[string]any{"id": "environment"}}}
+	approved := true
+	for _, decision := range []Decision{
+		{Approved: &approved, QuestionAnswers: []QuestionAnswer{{QuestionID: "environment", Answers: []string{"staging"}}}},
+		{Cancelled: true, QuestionAnswers: []QuestionAnswer{{QuestionID: "environment", Answers: []string{"staging"}}}},
+	} {
+		fs := newFakeStore(store.AgentInteractionKindUserChoice, request, now)
+		svc := NewService(fs, &fakeDelivery{}, nil)
+		svc.now = func() time.Time { return now }
+		if _, err := svc.Resolve(context.Background(), ResolveRequest{
+			WorkspaceID: "workspace-1", InteractionID: "interaction-1", Decision: decision,
+		}); !errors.Is(err, ErrInvalidDecision) {
+			t.Fatalf("decision %+v error = %v, want ErrInvalidDecision", decision, err)
+		}
+		if fs.claimCount != 0 {
+			t.Fatalf("contradictory decision reached claim: %+v", decision)
+		}
+	}
+}
+
+func TestConcurrentResolversHaveOneDeliveryWinner(t *testing.T) {
+	now := time.Now().UTC()
+	fs := newFakeStore(store.AgentInteractionKindPermission, nil, now)
+	delivery := &fakeDelivery{entered: make(chan struct{}, 1), release: make(chan struct{})}
+	svc := NewService(fs, delivery, nil)
+	svc.now = func() time.Time { return now }
+	approved := true
+	req := ResolveRequest{WorkspaceID: "workspace-1", InteractionID: "interaction-1", Decision: Decision{Approved: &approved}}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := svc.Resolve(context.Background(), req)
+		firstDone <- err
+	}()
+	<-delivery.entered
+	_, secondErr := svc.Resolve(context.Background(), req)
+	if !errors.Is(secondErr, ErrAlreadyResolving) {
+		t.Fatalf("second error = %v, want ErrAlreadyResolving", secondErr)
+	}
+	close(delivery.release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first Resolve: %v", err)
+	}
+	if fs.claimCount != 1 || len(delivery.permissions) != 1 {
+		t.Fatalf("claims/deliveries = %d/%d, want 1/1", fs.claimCount, len(delivery.permissions))
+	}
+}
+
+func TestTemporaryDeliveryFailureReleasesClaimForRetry(t *testing.T) {
+	now := time.Now().UTC()
+	fs := newFakeStore(store.AgentInteractionKindPermission, nil, now)
+	delivery := &fakeDelivery{err: errors.New("offline")}
+	svc := NewService(fs, delivery, nil)
+	svc.now = func() time.Time { return now }
+	approved := false
+	req := ResolveRequest{WorkspaceID: "workspace-1", InteractionID: "interaction-1", Decision: Decision{Approved: &approved}}
+	if _, err := svc.Resolve(context.Background(), req); !errors.Is(err, ErrRuntimeUnavailable) {
+		t.Fatalf("first error = %v, want ErrRuntimeUnavailable", err)
+	}
+	if fs.interaction.Status != store.AgentInteractionStatusPending || fs.releaseCount != 1 {
+		t.Fatalf("released state = %q, releases=%d", fs.interaction.Status, fs.releaseCount)
+	}
+	delivery.err = nil
+	if result, err := svc.Resolve(context.Background(), req); err != nil || !result.Applied {
+		t.Fatalf("retry = %+v, %v", result, err)
+	}
+}
+
+func TestRuntimeGoneClosesCanonicalInteraction(t *testing.T) {
+	now := time.Now().UTC()
+	fs := newFakeStore(store.AgentInteractionKindPermission, nil, now)
+	delivery := &fakeDelivery{err: connector.ErrInteractionNoLongerPending}
+	svc := NewService(fs, delivery, nil)
+	svc.now = func() time.Time { return now }
+	approved := true
+	result, err := svc.Resolve(context.Background(), ResolveRequest{
+		WorkspaceID: "workspace-1", InteractionID: "interaction-1", Decision: Decision{Approved: &approved},
+	})
+	if !errors.Is(err, ErrRuntimeGone) || !result.AlreadyResolved {
+		t.Fatalf("Resolve = %+v, %v", result, err)
+	}
+	if fs.interaction.Status != store.AgentInteractionStatusCancelled || fs.releaseCount != 0 {
+		t.Fatalf("state = %q, releases=%d", fs.interaction.Status, fs.releaseCount)
+	}
+}
+
+func TestWorkerExpiresPendingInteractionThroughRuntime(t *testing.T) {
+	now := time.Now().UTC()
+	fs := newFakeStore(store.AgentInteractionKindUserChoice, map[string]any{"questions": []any{map[string]any{"id": "q0"}}}, now)
+	fs.interaction.ExpiresAt = now.Add(-time.Second)
+	delivery := &fakeDelivery{}
+	svc := NewService(fs, delivery, nil)
+	svc.now = func() time.Time { return now }
+	worker := NewWorker(svc, fs, WorkerOptions{ClaimLease: time.Minute, BatchSize: 10})
+	if err := worker.Sweep(context.Background()); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if fs.interaction.Status != store.AgentInteractionStatusExpired {
+		t.Fatalf("status = %q, want expired", fs.interaction.Status)
+	}
+	if len(delivery.choices) != 1 || !delivery.choices[0].Cancelled {
+		t.Fatalf("expiry decisions = %+v", delivery.choices)
+	}
+	if expired, _ := fs.interaction.Response["expired"].(bool); !expired {
+		t.Fatalf("response = %+v", fs.interaction.Response)
+	}
+}
+
+func TestExpirePermissionExplicitlyDenies(t *testing.T) {
+	now := time.Now().UTC()
+	fs := newFakeStore(store.AgentInteractionKindPermission, nil, now)
+	fs.interaction.ExpiresAt = now.Add(-time.Second)
+	delivery := &fakeDelivery{}
+	svc := NewService(fs, delivery, nil)
+	svc.now = func() time.Time { return now }
+	if err := svc.Expire(context.Background(), fs.interaction.ID); err != nil {
+		t.Fatalf("Expire: %v", err)
+	}
+	if fs.interaction.Status != store.AgentInteractionStatusExpired || len(delivery.permissions) != 1 || delivery.permissions[0].Approved {
+		t.Fatalf("status/decisions = %q/%+v", fs.interaction.Status, delivery.permissions)
+	}
+}
+
+func TestWorkerRecoversStaleExpiredClaimAfterRestart(t *testing.T) {
+	now := time.Now().UTC()
+	fs := newFakeStore(store.AgentInteractionKindPermission, nil, now)
+	fs.interaction.Status = store.AgentInteractionStatusResolving
+	fs.interaction.ExpiresAt = now.Add(-time.Second)
+	fs.staleReleases = 1
+	delivery := &fakeDelivery{}
+	svc := NewService(fs, delivery, nil)
+	svc.now = func() time.Time { return now }
+	worker := NewWorker(svc, fs, WorkerOptions{ClaimLease: time.Minute, BatchSize: 10})
+	if err := worker.Sweep(context.Background()); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if fs.interaction.Status != store.AgentInteractionStatusExpired || len(delivery.permissions) != 1 {
+		t.Fatalf("recovered state = %q, deliveries=%+v", fs.interaction.Status, delivery.permissions)
+	}
+}

--- a/server/internal/interaction/types.go
+++ b/server/internal/interaction/types.go
@@ -1,0 +1,78 @@
+package interaction
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+var (
+	ErrInvalidDecision    = errors.New("invalid interaction decision")
+	ErrNotFound           = errors.New("interaction not found")
+	ErrAlreadyResolving   = errors.New("interaction is being resolved")
+	ErrExpired            = errors.New("interaction expired")
+	ErrRuntimeUnavailable = errors.New("interaction runtime unavailable")
+	ErrRuntimeGone        = errors.New("interaction runtime request is no longer pending")
+)
+
+type Actor struct {
+	UserID    string
+	ActorID   string
+	Source    string
+	ActorType string
+}
+
+type QuestionAnswer struct {
+	QuestionID string   `json:"question_id"`
+	Answers    []string `json:"answers"`
+}
+
+type Decision struct {
+	Approved        *bool
+	Note            string
+	QuestionAnswers []QuestionAnswer
+	Cancelled       bool
+}
+
+type ResolveRequest struct {
+	WorkspaceID   string
+	InteractionID string
+	Kind          string
+	RequestID     string
+	AgentRunID    string
+	Actor         Actor
+	Decision      Decision
+}
+
+type ResolveResult struct {
+	Interaction     store.AgentInteractionRead
+	Applied         bool
+	AlreadyResolved bool
+}
+
+type Store interface {
+	GetAgentInteraction(ctx context.Context, interactionID string) (store.AgentInteractionRead, error)
+	GetAgentInteractionByRequestID(ctx context.Context, kind, requestID, agentRunID string) (store.AgentInteractionRead, error)
+	ClaimAgentInteraction(ctx context.Context, workspaceID, interactionID, userID, actorID, source string, now time.Time) (store.AgentInteractionClaim, error)
+	ClaimAgentInteractionByRequestID(ctx context.Context, kind, requestID, agentRunID, userID, actorID, source string, now time.Time) (store.AgentInteractionClaim, error)
+	ClaimExpiredAgentInteraction(ctx context.Context, interactionID string, now time.Time) (store.AgentInteractionClaim, error)
+	CompleteAgentInteraction(ctx context.Context, claim store.AgentInteractionClaim, status string, response map[string]any, now time.Time) error
+	ReleaseAgentInteractionClaim(ctx context.Context, claim store.AgentInteractionClaim, now time.Time) error
+	ListExpiredPendingAgentInteractionIDs(ctx context.Context, now time.Time, limit int32) ([]string, error)
+	ReleaseStaleAgentInteractionClaims(ctx context.Context, staleBefore, now time.Time) (int64, error)
+	ClearConversationInflightSlot(ctx context.Context, conversationID string, slot store.InflightSlotKind, expectedAgentRunID string) error
+	RecordAgentRunEvent(ctx context.Context, input store.RecordAgentRunEventInput) error
+	RecordAgentInteractionResolutionAudit(input store.AgentInteractionAuditInput)
+}
+
+type Delivery interface {
+	SubmitPermission(ctx context.Context, runID string, decision connector.PermissionDecision) error
+	SubmitPromptForUserChoice(ctx context.Context, runID string, decision connector.PromptForUserChoiceDecision) error
+}
+
+type Logger interface {
+	Warn(msg string, args ...any)
+}

--- a/server/internal/interaction/worker.go
+++ b/server/internal/interaction/worker.go
@@ -1,0 +1,71 @@
+package interaction
+
+import (
+	"context"
+	"time"
+)
+
+type WorkerOptions struct {
+	Interval   time.Duration
+	ClaimLease time.Duration
+	BatchSize  int32
+}
+
+type Worker struct {
+	service    *Service
+	store      Store
+	interval   time.Duration
+	claimLease time.Duration
+	batchSize  int32
+}
+
+func NewWorker(service *Service, store Store, options WorkerOptions) *Worker {
+	interval := options.Interval
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	claimLease := options.ClaimLease
+	if claimLease <= 0 {
+		claimLease = time.Minute
+	}
+	batchSize := options.BatchSize
+	if batchSize <= 0 {
+		batchSize = 100
+	}
+	return &Worker{service: service, store: store, interval: interval, claimLease: claimLease, batchSize: batchSize}
+}
+
+func (w *Worker) Run(ctx context.Context) error {
+	if err := w.Sweep(ctx); err != nil {
+		w.service.warn("initial interaction expiry sweep failed", "error", err)
+	}
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := w.Sweep(ctx); err != nil {
+				w.service.warn("interaction expiry sweep failed", "error", err)
+			}
+		}
+	}
+}
+
+func (w *Worker) Sweep(ctx context.Context) error {
+	now := w.service.now()
+	if _, err := w.store.ReleaseStaleAgentInteractionClaims(ctx, now.Add(-w.claimLease), now); err != nil {
+		return err
+	}
+	ids, err := w.store.ListExpiredPendingAgentInteractionIDs(ctx, now, w.batchSize)
+	if err != nil {
+		return err
+	}
+	for _, id := range ids {
+		if err := w.service.Expire(ctx, id); err != nil {
+			w.service.warn("expire interaction failed", "interaction_id", id, "error", err)
+		}
+	}
+	return nil
+}

--- a/server/internal/store/agent_config.go
+++ b/server/internal/store/agent_config.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"fmt"
+	"strings"
+)
+
+func mergeAgentProfileOwnedConfig(current, requested map[string]any) (map[string]any, error) {
+	config := current
+	profileConfig := nonNilMap(requested)
+	previousAgentKind := stringFromMap(config, "agent_kind")
+
+	if raw, ok := profileConfig["profile"]; ok {
+		profile, ok := raw.(map[string]any)
+		if !ok || len(profile) == 0 {
+			delete(config, "profile")
+		} else {
+			config["profile"] = cloneAnyMap(profile)
+		}
+	}
+	for _, key := range []string{"agent_kind", "daemon_mode", "sandbox_size", "device_id"} {
+		raw, ok := profileConfig[key]
+		if !ok {
+			continue
+		}
+		value, _ := raw.(string)
+		if value = strings.TrimSpace(value); value == "" {
+			delete(config, key)
+		} else {
+			config[key] = value
+		}
+	}
+
+	var profileWorkdir any
+	var profileWorkdirSet bool
+	for _, key := range []string{"work_dir", "workdir", "working_directory"} {
+		if value, ok := profileConfig[key]; ok {
+			profileWorkdir = value
+			profileWorkdirSet = true
+			break
+		}
+	}
+	if profileWorkdirSet {
+		delete(config, "work_dir")
+		delete(config, "workdir")
+		delete(config, "working_directory")
+		if workdir, ok := profileWorkdir.(string); ok {
+			if workdir = strings.TrimSpace(workdir); workdir != "" {
+				config["work_dir"] = workdir
+			}
+		}
+	}
+
+	if raw, modeSet := profileConfig["mode"]; modeSet {
+		agentKind := stringFromMap(config, "agent_kind")
+		mode, keep, err := normalizeAgentMode(agentKind, raw)
+		if err != nil {
+			return nil, err
+		}
+		if !keep {
+			delete(config, "mode")
+		} else {
+			config["mode"] = mode
+		}
+	} else if previousAgentKind == "codex" && stringFromMap(config, "agent_kind") != "codex" {
+		// A Codex plan/default value is not a portable permission mode for
+		// another engine. Clear it when the engine changes even if an older
+		// client omitted the explicit null.
+		delete(config, "mode")
+	}
+
+	if _, daemonModeSet := profileConfig["daemon_mode"]; daemonModeSet {
+		switch stringFromMap(config, "daemon_mode") {
+		case "sandbox":
+			delete(config, "device_id")
+		case "local":
+			delete(config, "sandbox_size")
+		}
+	}
+	return config, nil
+}
+
+func foldAgentDaemonConfig(config, input map[string]any) error {
+	for _, key := range []string{"device_id", "daemon_mode", "agent_kind", "work_dir"} {
+		if value, ok := input[key].(string); ok {
+			if value = strings.TrimSpace(value); value != "" {
+				config[key] = value
+			}
+		}
+	}
+
+	rawMode, modeSet := input["mode"]
+	if !modeSet {
+		return nil
+	}
+	mode, keep, err := normalizeAgentMode(stringFromMap(config, "agent_kind"), rawMode)
+	if err != nil {
+		return err
+	}
+	if !keep {
+		return nil
+	}
+	config["mode"] = mode
+	return nil
+}
+
+func normalizeAgentMode(agentKind string, raw any) (mode string, keep bool, err error) {
+	if raw == nil {
+		return "", false, nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", false, fmt.Errorf("%w: agent mode must be a string", ErrInvalidInput)
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", false, nil
+	}
+	if agentKind == "codex" && value != "default" && value != "plan" {
+		return "", false, fmt.Errorf("%w: Codex collaboration mode must be default or plan", ErrInvalidInput)
+	}
+	return value, true, nil
+}

--- a/server/internal/store/agent_config_test.go
+++ b/server/internal/store/agent_config_test.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMergeAgentProfileOwnedConfigCodexMode(t *testing.T) {
+	t.Run("persists plan mode", func(t *testing.T) {
+		config, err := mergeAgentProfileOwnedConfig(
+			map[string]any{"agent_kind": "codex", "mode": "default"},
+			map[string]any{"mode": "plan"},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if config["mode"] != "plan" {
+			t.Fatalf("mode = %#v, want plan", config["mode"])
+		}
+	})
+
+	for _, badMode := range []any{"autopilot", true} {
+		t.Run("rejects invalid Codex mode", func(t *testing.T) {
+			_, err := mergeAgentProfileOwnedConfig(
+				map[string]any{"agent_kind": "codex", "mode": "default"},
+				map[string]any{"mode": badMode},
+			)
+			if !errors.Is(err, ErrInvalidInput) {
+				t.Fatalf("mode %#v returned %v, want ErrInvalidInput", badMode, err)
+			}
+		})
+	}
+
+	t.Run("clears Codex mode when engine changes", func(t *testing.T) {
+		config, err := mergeAgentProfileOwnedConfig(
+			map[string]any{"agent_kind": "codex", "mode": "plan"},
+			map[string]any{"agent_kind": "claude_code"},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := config["mode"]; ok {
+			t.Fatalf("Codex mode leaked into Claude config: %#v", config)
+		}
+	})
+
+	t.Run("preserves another engine mode when omitted", func(t *testing.T) {
+		config, err := mergeAgentProfileOwnedConfig(
+			map[string]any{"agent_kind": "claude_code", "mode": "acceptEdits"},
+			map[string]any{"agent_kind": "claude_code"},
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if config["mode"] != "acceptEdits" {
+			t.Fatalf("Claude mode was not preserved: %#v", config)
+		}
+	})
+}

--- a/server/internal/store/agent_interactions.go
+++ b/server/internal/store/agent_interactions.go
@@ -1,0 +1,353 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/audit"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+const (
+	AgentInteractionKindPermission = "permission"
+	AgentInteractionKindUserChoice = "user_choice"
+
+	AgentInteractionStatusPending   = "pending"
+	AgentInteractionStatusResolving = "resolving"
+	AgentInteractionStatusApproved  = "approved"
+	AgentInteractionStatusDenied    = "denied"
+	AgentInteractionStatusAnswered  = "answered"
+	AgentInteractionStatusCancelled = "cancelled"
+	AgentInteractionStatusExpired   = "expired"
+
+	AgentInteractionSourceWeb           = "web"
+	AgentInteractionSourceFeishu        = "feishu"
+	AgentInteractionSourceSlack         = "slack"
+	AgentInteractionSourceDiscord       = "discord"
+	AgentInteractionSourceTeams         = "teams"
+	AgentInteractionSourceSystemTimeout = "system_timeout"
+	AgentInteractionSourceRuntime       = "runtime"
+
+	// AgentInteractionTTL matches the daemon-side AskUserQuestion timeout.
+	// Permission requests use the same bounded lifetime so a disconnected
+	// browser cannot leave a run waiting forever.
+	AgentInteractionTTL = 10 * time.Minute
+)
+
+var (
+	ErrUnknownAgentInteraction    = errors.New("unknown agent interaction")
+	ErrAgentInteractionNotPending = errors.New("agent interaction is no longer pending")
+)
+
+type AgentInteractionRead struct {
+	ID                string         `json:"id"`
+	WorkspaceID       string         `json:"workspace_id"`
+	ConversationID    string         `json:"conversation_id"`
+	AgentRunID        string         `json:"agent_run_id"`
+	RequestID         string         `json:"request_id"`
+	Kind              string         `json:"kind"`
+	Status            string         `json:"status"`
+	Request           map[string]any `json:"request"`
+	Response          map[string]any `json:"response"`
+	ResolutionSource  string         `json:"resolution_source,omitempty"`
+	ResolvedActor     string         `json:"resolved_actor,omitempty"`
+	ResolvedBy        string         `json:"resolved_by,omitempty"`
+	CreatedAt         time.Time      `json:"created_at"`
+	ExpiresAt         time.Time      `json:"expires_at"`
+	ResolvedAt        *time.Time     `json:"resolved_at,omitempty"`
+	UpdatedAt         time.Time      `json:"updated_at"`
+	AgentName         string         `json:"agent_name"`
+	ConversationTitle string         `json:"conversation_title"`
+}
+
+type AgentInteractionClaim struct {
+	ID             string
+	WorkspaceID    string
+	RequestID      string
+	Kind           string
+	AgentRunID     string
+	ConversationID string
+	DeviceID       string
+	ClaimToken     string
+	Request        map[string]any
+}
+
+type AgentInteractionAuditInput struct {
+	InteractionID string
+	WorkspaceID   string
+	AgentRunID    string
+	RequestID     string
+	Kind          string
+	Status        string
+	Source        string
+	ActorID       string
+	ActorType     string
+	Response      map[string]any
+}
+
+func (s *Store) ListWorkspaceAgentInteractions(ctx context.Context, workspaceID, statusGroup string, limit int32) ([]AgentInteractionRead, error) {
+	workspaceUUID, err := uuid(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	statusGroup = strings.TrimSpace(statusGroup)
+	if statusGroup != "" && statusGroup != "pending" && statusGroup != "decided" && statusGroup != "expired" {
+		return nil, fmt.Errorf("invalid interaction status group %q", statusGroup)
+	}
+	if limit <= 0 || limit > 200 {
+		limit = 100
+	}
+	queries := sqlc.New(s.db)
+	rows, err := queries.ListWorkspaceAgentInteractions(ctx, sqlc.ListWorkspaceAgentInteractionsParams{
+		WorkspaceID: workspaceUUID, StatusGroup: statusGroup, ItemLimit: limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]AgentInteractionRead, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, interactionRead(
+			row.AiID, row.AiWorkspaceID, row.AiConversationID, row.AiAgentRunID,
+			row.RequestID, row.Kind, row.Status, row.Request, row.Response,
+			row.ResolutionSource, row.ResolvedActor, row.ResolvedBy,
+			row.CreatedAt, row.ExpiresAt, row.ResolvedAt, row.UpdatedAt,
+			row.AgentName, row.ConversationTitle,
+		))
+	}
+	return out, nil
+}
+
+func (s *Store) GetAgentInteraction(ctx context.Context, interactionID string) (AgentInteractionRead, error) {
+	id, err := uuid(interactionID)
+	if err != nil {
+		return AgentInteractionRead{}, err
+	}
+	row, err := sqlc.New(s.db).GetAgentInteraction(ctx, id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AgentInteractionRead{}, fmt.Errorf("%w: %s", ErrUnknownAgentInteraction, interactionID)
+		}
+		return AgentInteractionRead{}, err
+	}
+	return interactionRead(
+		row.AiID, row.AiWorkspaceID, row.AiConversationID, row.AiAgentRunID,
+		row.RequestID, row.Kind, row.Status, row.Request, row.Response,
+		row.ResolutionSource, row.ResolvedActor, row.ResolvedBy,
+		row.CreatedAt, row.ExpiresAt, row.ResolvedAt, row.UpdatedAt,
+		row.AgentName, row.ConversationTitle,
+	), nil
+}
+
+func (s *Store) GetAgentInteractionByRequestID(ctx context.Context, kind, requestID, agentRunID string) (AgentInteractionRead, error) {
+	runID, err := uuid(agentRunID)
+	if err != nil {
+		return AgentInteractionRead{}, err
+	}
+	row, err := sqlc.New(s.db).GetAgentInteractionByRequestID(ctx, sqlc.GetAgentInteractionByRequestIDParams{
+		Kind: strings.TrimSpace(kind), RequestID: strings.TrimSpace(requestID), AgentRunID: runID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AgentInteractionRead{}, fmt.Errorf("%w: %s", ErrUnknownAgentInteraction, requestID)
+		}
+		return AgentInteractionRead{}, err
+	}
+	return interactionRead(
+		row.AiID, row.AiWorkspaceID, row.AiConversationID, row.AiAgentRunID,
+		row.RequestID, row.Kind, row.Status, row.Request, row.Response,
+		row.ResolutionSource, row.ResolvedActor, row.ResolvedBy,
+		row.CreatedAt, row.ExpiresAt, row.ResolvedAt, row.UpdatedAt,
+		row.AgentName, row.ConversationTitle,
+	), nil
+}
+
+func (s *Store) ClaimAgentInteraction(ctx context.Context, workspaceID, interactionID, userID, actorID, source string, now time.Time) (AgentInteractionClaim, error) {
+	workspaceUUID, err := uuid(workspaceID)
+	if err != nil {
+		return AgentInteractionClaim{}, err
+	}
+	interactionUUID, err := uuid(interactionID)
+	if err != nil {
+		return AgentInteractionClaim{}, err
+	}
+	row, err := sqlc.New(s.db).ClaimAgentInteraction(ctx, sqlc.ClaimAgentInteractionParams{
+		ResolvedBy: strings.TrimSpace(userID), ResolvedActor: strings.TrimSpace(actorID),
+		ResolutionSource: textOrNull(source), Now: timestamptz(now.UTC()),
+		InteractionID: interactionUUID, WorkspaceID: workspaceUUID,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AgentInteractionClaim{}, ErrAgentInteractionNotPending
+		}
+		return AgentInteractionClaim{}, err
+	}
+	return interactionClaim(row.ID, row.WorkspaceID, row.RequestID, row.Kind, row.AgentRunID,
+		row.ConversationID, row.DeviceID, row.ClaimToken, row.Request), nil
+}
+
+func (s *Store) ClaimAgentInteractionByRequestID(ctx context.Context, kind, requestID, agentRunID, userID, actorID, source string, now time.Time) (AgentInteractionClaim, error) {
+	runID, err := uuid(agentRunID)
+	if err != nil {
+		return AgentInteractionClaim{}, err
+	}
+	row, err := sqlc.New(s.db).ClaimAgentInteractionByRequestID(ctx, sqlc.ClaimAgentInteractionByRequestIDParams{
+		Kind: strings.TrimSpace(kind), RequestID: strings.TrimSpace(requestID), AgentRunID: runID,
+		ResolvedBy: strings.TrimSpace(userID), ResolvedActor: strings.TrimSpace(actorID),
+		ResolutionSource: textOrNull(source), Now: timestamptz(now.UTC()),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AgentInteractionClaim{}, ErrAgentInteractionNotPending
+		}
+		return AgentInteractionClaim{}, err
+	}
+	return interactionClaim(row.ID, row.WorkspaceID, row.RequestID, row.Kind, row.AgentRunID,
+		row.ConversationID, row.DeviceID, row.ClaimToken, row.Request), nil
+}
+
+func (s *Store) ClaimExpiredAgentInteraction(ctx context.Context, interactionID string, now time.Time) (AgentInteractionClaim, error) {
+	id, err := uuid(interactionID)
+	if err != nil {
+		return AgentInteractionClaim{}, err
+	}
+	row, err := sqlc.New(s.db).ClaimExpiredAgentInteraction(ctx, sqlc.ClaimExpiredAgentInteractionParams{
+		Now: timestamptz(now.UTC()), InteractionID: id,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AgentInteractionClaim{}, ErrAgentInteractionNotPending
+		}
+		return AgentInteractionClaim{}, err
+	}
+	return interactionClaim(row.ID, row.WorkspaceID, row.RequestID, row.Kind, row.AgentRunID,
+		row.ConversationID, row.DeviceID, row.ClaimToken, row.Request), nil
+}
+
+func (s *Store) ListExpiredPendingAgentInteractionIDs(ctx context.Context, now time.Time, limit int32) ([]string, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 100
+	}
+	return sqlc.New(s.db).ListExpiredPendingAgentInteractionIDs(ctx, sqlc.ListExpiredPendingAgentInteractionIDsParams{
+		Now: timestamptz(now.UTC()), ItemLimit: limit,
+	})
+}
+
+func (s *Store) ReleaseStaleAgentInteractionClaims(ctx context.Context, staleBefore, now time.Time) (int64, error) {
+	return sqlc.New(s.db).ReleaseStaleResolvingAgentInteractions(ctx, sqlc.ReleaseStaleResolvingAgentInteractionsParams{
+		Now: timestamptz(now.UTC()), StaleBefore: timestamptz(staleBefore.UTC()),
+	})
+}
+
+func (s *Store) CompleteAgentInteraction(ctx context.Context, claim AgentInteractionClaim, status string, response map[string]any, now time.Time) error {
+	id, err := uuid(claim.ID)
+	if err != nil {
+		return err
+	}
+	claimToken, err := uuid(claim.ClaimToken)
+	if err != nil {
+		return err
+	}
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+	_, err = sqlc.New(s.db).CompleteAgentInteraction(ctx, sqlc.CompleteAgentInteractionParams{
+		Status: status, Response: encoded, Now: timestamptz(now.UTC()), InteractionID: id,
+		ClaimToken: claimToken,
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrAgentInteractionNotPending
+	}
+	return err
+}
+
+func (s *Store) ReleaseAgentInteractionClaim(ctx context.Context, claim AgentInteractionClaim, now time.Time) error {
+	id, err := uuid(claim.ID)
+	if err != nil {
+		return err
+	}
+	claimToken, err := uuid(claim.ClaimToken)
+	if err != nil {
+		return err
+	}
+	return sqlc.New(s.db).ReleaseAgentInteractionClaim(ctx, sqlc.ReleaseAgentInteractionClaimParams{
+		Now: timestamptz(now.UTC()), InteractionID: id, ClaimToken: claimToken,
+	})
+}
+
+// ResolveAgentInteractionByRequestID lets existing IM callbacks close the
+// canonical Web-visible record after the daemon accepts their response.
+func (s *Store) ResolveAgentInteractionByRequestID(ctx context.Context, kind, requestID, status string, response map[string]any) error {
+	encoded, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+	_, err = sqlc.New(s.db).ResolveAgentInteractionByRequestID(ctx, sqlc.ResolveAgentInteractionByRequestIDParams{
+		Status: status, Response: encoded, Now: timestamptz(time.Now().UTC()),
+		Kind: kind, RequestID: strings.TrimSpace(requestID),
+	})
+	return err
+}
+
+func (s *Store) interactionDeviceID(ctx context.Context, kind, requestID string) (string, error) {
+	return sqlc.New(s.db).GetAgentInteractionDeviceByRequestID(ctx, sqlc.GetAgentInteractionDeviceByRequestIDParams{
+		Kind: kind, RequestID: strings.TrimSpace(requestID),
+	})
+}
+
+func (s *Store) RecordAgentInteractionResolutionAudit(input AgentInteractionAuditInput) {
+	actorType := strings.TrimSpace(input.ActorType)
+	if actorType == "" {
+		actorType = audit.ActorTypeExternal
+	}
+	eventType := AuditPermissionResolved
+	if input.Kind == AgentInteractionKindUserChoice {
+		eventType = AuditUserChoiceResolved
+	}
+	s.emitAuditEvent(audit.Event{
+		OccurredAt: time.Now().UTC(), Source: audit.SourceApproval, EventType: eventType,
+		ActorType: actorType, ActorID: input.ActorID, TargetType: "agent_interaction",
+		TargetID: input.InteractionID, WorkspaceID: input.WorkspaceID,
+		Payload: map[string]any{
+			"request_id": input.RequestID, "agent_run_id": input.AgentRunID,
+			"kind": input.Kind, "status": input.Status, "source": input.Source,
+			"response": input.Response,
+		},
+	})
+}
+
+func interactionClaim(id, workspaceID, requestID, kind, runID, conversationID, deviceID, claimToken string, request []byte) AgentInteractionClaim {
+	return AgentInteractionClaim{
+		ID: id, WorkspaceID: workspaceID, RequestID: requestID, Kind: kind,
+		AgentRunID: runID, ConversationID: conversationID, DeviceID: deviceID,
+		ClaimToken: claimToken, Request: decodeJSONMap(request),
+	}
+}
+
+func interactionRead(
+	id, workspaceID, conversationID, agentRunID, requestID, kind, status string,
+	request, response []byte, resolutionSource, resolvedActor, resolvedBy string,
+	createdAt, expiresAt, resolvedAt, updatedAt pgtype.Timestamptz,
+	agentName, conversationTitle string,
+) AgentInteractionRead {
+	var resolvedAtPtr *time.Time
+	if resolvedAt.Valid {
+		value := resolvedAt.Time.UTC()
+		resolvedAtPtr = &value
+	}
+	return AgentInteractionRead{
+		ID: id, WorkspaceID: workspaceID, ConversationID: conversationID,
+		AgentRunID: agentRunID, RequestID: requestID, Kind: kind, Status: status,
+		Request: decodeJSONMap(request), Response: decodeJSONMap(response),
+		ResolutionSource: resolutionSource, ResolvedActor: resolvedActor, ResolvedBy: resolvedBy,
+		CreatedAt: pgTime(createdAt), ExpiresAt: pgTime(expiresAt),
+		ResolvedAt: resolvedAtPtr, UpdatedAt: pgTime(updatedAt), AgentName: agentName,
+		ConversationTitle: conversationTitle,
+	}
+}

--- a/server/internal/store/agent_interactions_test.go
+++ b/server/internal/store/agent_interactions_test.go
@@ -1,0 +1,132 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestAgentInteractionLifecycleIsDurableAndSingleWinner(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	store := New(db)
+	ids := mustSeedDevFixture(t, ctx, store)
+
+	sendResult, err := store.SendUserMessageToConversation(ctx, SendUserMessageToConversationInput{
+		ConversationID:    ids.ConversationID,
+		UserID:            ids.UserID,
+		Content:           "@product-agent interaction lifecycle",
+		MentionedAgentIDs: []string{ids.ProductAgentID},
+	})
+	if err != nil {
+		t.Fatalf("send user message: %v", err)
+	}
+	if len(sendResult.RunIDs) == 0 {
+		t.Fatal("expected an agent run")
+	}
+	runID := sendResult.RunIDs[0]
+	occurredAt := time.Now().UTC()
+	payload := map[string]any{
+		"request_id": "perm-lifecycle-test",
+		"device_id":  "device-web-owner",
+		"action":     "command_execution",
+		"resource":   "go test ./...",
+	}
+	if err := store.RecordAgentRunEvent(ctx, RecordAgentRunEventInput{
+		RunID: runID, EventKind: "permission.asked", Payload: payload, OccurredAt: occurredAt,
+	}); err != nil {
+		t.Fatalf("record permission request: %v", err)
+	}
+	// A retried stream event may be recorded twice, but the canonical request
+	// remains unique by kind and request_id.
+	if err := store.RecordAgentRunEvent(ctx, RecordAgentRunEventInput{
+		RunID: runID, EventKind: "permission.asked", Payload: payload, OccurredAt: occurredAt.Add(time.Millisecond),
+	}); err != nil {
+		t.Fatalf("record duplicate permission request: %v", err)
+	}
+
+	pending, err := store.ListWorkspaceAgentInteractions(ctx, ids.WorkspaceID, "pending", 100)
+	if err != nil {
+		t.Fatalf("list pending interactions: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("pending interactions = %d, want 1", len(pending))
+	}
+	interaction := pending[0]
+	if interaction.AgentRunID != runID || interaction.RequestID != "perm-lifecycle-test" || interaction.Kind != AgentInteractionKindPermission {
+		t.Fatalf("interaction = %+v", interaction)
+	}
+	if interaction.ExpiresAt.Sub(interaction.CreatedAt) != AgentInteractionTTL {
+		t.Fatalf("interaction lifetime = %s, want %s", interaction.ExpiresAt.Sub(interaction.CreatedAt), AgentInteractionTTL)
+	}
+	deviceID, err := store.DeviceIDForPermissionRequest(ctx, interaction.RequestID)
+	if err != nil {
+		t.Fatalf("resolve canonical device: %v", err)
+	}
+	if deviceID != "device-web-owner" {
+		t.Fatalf("device id = %q", deviceID)
+	}
+
+	claim, err := store.ClaimAgentInteraction(ctx, ids.WorkspaceID, interaction.ID, ids.UserID, "web-user", AgentInteractionSourceWeb, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("claim interaction: %v", err)
+	}
+	if claim.RequestID != interaction.RequestID || claim.AgentRunID != runID {
+		t.Fatalf("claim = %+v", claim)
+	}
+	if _, err := store.ClaimAgentInteraction(ctx, ids.WorkspaceID, interaction.ID, ids.UserID, "web-user", AgentInteractionSourceWeb, time.Now().UTC()); !errors.Is(err, ErrAgentInteractionNotPending) {
+		t.Fatalf("second claim error = %v, want ErrAgentInteractionNotPending", err)
+	}
+
+	response := map[string]any{"approved": true, "note": "approved in Web"}
+	if err := store.CompleteAgentInteraction(ctx, claim, AgentInteractionStatusApproved, response, time.Now().UTC()); err != nil {
+		t.Fatalf("complete interaction: %v", err)
+	}
+	decided, err := store.ListWorkspaceAgentInteractions(ctx, ids.WorkspaceID, "decided", 100)
+	if err != nil {
+		t.Fatalf("list decided interactions: %v", err)
+	}
+	if len(decided) != 1 || decided[0].Status != AgentInteractionStatusApproved || decided[0].ResolvedBy != ids.UserID {
+		t.Fatalf("decided interactions = %+v", decided)
+	}
+	if decided[0].ResolutionSource != AgentInteractionSourceWeb || decided[0].ResolvedActor != "web-user" {
+		t.Fatalf("resolution provenance = %q/%q", decided[0].ResolutionSource, decided[0].ResolvedActor)
+	}
+	if approved, _ := decided[0].Response["approved"].(bool); !approved {
+		t.Fatalf("response = %+v", decided[0].Response)
+	}
+
+	askPayload := map[string]any{
+		"request_id": "ask-terminal-test", "device_id": "device-web-owner",
+		"questions": []any{map[string]any{"id": "environment", "question": "Where?"}},
+	}
+	if err := store.RecordAgentRunEvent(ctx, RecordAgentRunEventInput{
+		RunID: runID, EventKind: "prompt_for_user_choice.asked", Payload: askPayload, OccurredAt: occurredAt.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("record user question: %v", err)
+	}
+	ask, err := store.GetAgentInteractionByRequestID(ctx, AgentInteractionKindUserChoice, "ask-terminal-test", runID)
+	if err != nil {
+		t.Fatalf("get question by run/request: %v", err)
+	}
+	questions, _ := ask.Request["questions"].([]any)
+	if len(questions) != 1 || questions[0].(map[string]any)["id"] != "environment" {
+		t.Fatalf("durable question snapshot = %+v", ask.Request)
+	}
+	if err := store.RecordAgentRunEvent(ctx, RecordAgentRunEventInput{
+		RunID: runID, EventKind: "run.cancelled", Payload: map[string]any{"reason": "operator_cancelled"}, OccurredAt: occurredAt.Add(2 * time.Second),
+	}); err != nil {
+		t.Fatalf("record terminal event: %v", err)
+	}
+	closed, err := store.ListWorkspaceAgentInteractions(ctx, ids.WorkspaceID, "expired", 100)
+	if err != nil {
+		t.Fatalf("list terminal interactions: %v", err)
+	}
+	if len(closed) != 1 || closed[0].ID != ask.ID || closed[0].Status != AgentInteractionStatusCancelled {
+		t.Fatalf("terminal interactions = %+v", closed)
+	}
+	if closed[0].ResolutionSource != AgentInteractionSourceRuntime || closed[0].Response["reason"] != "operator_cancelled" {
+		t.Fatalf("terminal provenance/response = %q/%+v", closed[0].ResolutionSource, closed[0].Response)
+	}
+}

--- a/server/internal/store/agent_interactions_test.go
+++ b/server/internal/store/agent_interactions_test.go
@@ -99,7 +99,8 @@ func TestAgentInteractionLifecycleIsDurableAndSingleWinner(t *testing.T) {
 
 	askPayload := map[string]any{
 		"request_id": "ask-terminal-test", "device_id": "device-web-owner",
-		"questions": []any{map[string]any{"id": "environment", "question": "Where?"}},
+		"auto_resolution_ms": uint64(120_000),
+		"questions":          []any{map[string]any{"id": "environment", "question": "Where?"}},
 	}
 	if err := store.RecordAgentRunEvent(ctx, RecordAgentRunEventInput{
 		RunID: runID, EventKind: "prompt_for_user_choice.asked", Payload: askPayload, OccurredAt: occurredAt.Add(time.Second),
@@ -113,6 +114,12 @@ func TestAgentInteractionLifecycleIsDurableAndSingleWinner(t *testing.T) {
 	questions, _ := ask.Request["questions"].([]any)
 	if len(questions) != 1 || questions[0].(map[string]any)["id"] != "environment" {
 		t.Fatalf("durable question snapshot = %+v", ask.Request)
+	}
+	if lifetime := ask.ExpiresAt.Sub(ask.CreatedAt); lifetime != 2*time.Minute {
+		t.Fatalf("question lifetime = %s, want 2m", lifetime)
+	}
+	if _, err := store.CancelAgentRun(ctx, runID, "operator_cancelled"); err != nil {
+		t.Fatalf("cancel run row: %v", err)
 	}
 	if err := store.RecordAgentRunEvent(ctx, RecordAgentRunEventInput{
 		RunID: runID, EventKind: "run.cancelled", Payload: map[string]any{"reason": "operator_cancelled"}, OccurredAt: occurredAt.Add(2 * time.Second),
@@ -128,5 +135,15 @@ func TestAgentInteractionLifecycleIsDurableAndSingleWinner(t *testing.T) {
 	}
 	if closed[0].ResolutionSource != AgentInteractionSourceRuntime || closed[0].Response["reason"] != "operator_cancelled" {
 		t.Fatalf("terminal provenance/response = %q/%+v", closed[0].ResolutionSource, closed[0].Response)
+	}
+	if err := store.RecordAgentRunEvent(ctx, RecordAgentRunEventInput{
+		RunID: runID, EventKind: "prompt_for_user_choice.asked",
+		Payload:    map[string]any{"request_id": "ask-after-terminal", "device_id": "device-web-owner"},
+		OccurredAt: occurredAt.Add(3 * time.Second),
+	}); err != nil {
+		t.Fatalf("record late question event: %v", err)
+	}
+	if _, err := store.GetAgentInteractionByRequestID(ctx, AgentInteractionKindUserChoice, "ask-after-terminal", runID); !errors.Is(err, ErrUnknownAgentInteraction) {
+		t.Fatalf("late terminal interaction error = %v, want ErrUnknownAgentInteraction", err)
 	}
 }

--- a/server/internal/store/agent_run_events.go
+++ b/server/internal/store/agent_run_events.go
@@ -78,14 +78,14 @@ func (s *Store) RecordAgentRunEvent(ctx context.Context, input RecordAgentRunEve
 		}
 		return err
 	}
-	if kind, requestID, deviceID, ok := interactionFromRunEvent(input.EventKind, payload); ok {
+	if kind, requestID, deviceID, ttl, ok := interactionFromRunEvent(input.EventKind, payload); ok {
 		if err := queries.InsertAgentInteractionFromRun(ctx, sqlc.InsertAgentInteractionFromRunParams{
 			RequestID:  requestID,
 			Kind:       kind,
 			Request:    encoded,
 			DeviceID:   deviceID,
 			CreatedAt:  timestamptz(occurredAt),
-			ExpiresAt:  timestamptz(occurredAt.Add(AgentInteractionTTL)),
+			ExpiresAt:  timestamptz(occurredAt.Add(ttl)),
 			AgentRunID: runID,
 		}); err != nil {
 			return err
@@ -101,19 +101,41 @@ func (s *Store) RecordAgentRunEvent(ctx context.Context, input RecordAgentRunEve
 	return tx.Commit(ctx)
 }
 
-func interactionFromRunEvent(eventKind string, payload map[string]any) (kind, requestID, deviceID string, ok bool) {
+func interactionFromRunEvent(eventKind string, payload map[string]any) (kind, requestID, deviceID string, ttl time.Duration, ok bool) {
 	switch eventKind {
 	case "permission.asked":
 		kind = AgentInteractionKindPermission
 	case "prompt_for_user_choice.asked":
 		kind = AgentInteractionKindUserChoice
 	default:
-		return "", "", "", false
+		return "", "", "", 0, false
 	}
 	requestID, _ = payload["request_id"].(string)
 	deviceID, _ = payload["device_id"].(string)
 	requestID = strings.TrimSpace(requestID)
-	return kind, requestID, strings.TrimSpace(deviceID), requestID != ""
+	ttl = AgentInteractionTTL
+	if millis, valid := positiveUint64(payload["auto_resolution_ms"]); valid {
+		const maxMillis = uint64(^uint64(0)>>1) / uint64(time.Millisecond)
+		if millis <= maxMillis {
+			ttl = time.Duration(millis) * time.Millisecond
+		}
+	}
+	return kind, requestID, strings.TrimSpace(deviceID), ttl, requestID != ""
+}
+
+func positiveUint64(value any) (uint64, bool) {
+	switch typed := value.(type) {
+	case uint64:
+		return typed, typed > 0
+	case int:
+		return uint64(typed), typed > 0
+	case int64:
+		return uint64(typed), typed > 0
+	case float64:
+		return uint64(typed), typed > 0 && typed == float64(uint64(typed))
+	default:
+		return 0, false
+	}
 }
 
 func terminalInteractionReason(eventKind string, payload map[string]any) (string, bool) {

--- a/server/internal/store/agent_run_events.go
+++ b/server/internal/store/agent_run_events.go
@@ -6,11 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"strings"
 	"time"
 
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
 )
 
 type AgentRunEventRead struct {
@@ -62,7 +63,8 @@ func (s *Store) RecordAgentRunEvent(ctx context.Context, input RecordAgentRunEve
 	if err := tx.QueryRow(ctx, `select coalesce(max(sequence), 0) + 1 from agent_run_events where agent_run_id = $1`, runID).Scan(&sequence); err != nil {
 		return err
 	}
-	_, err = sqlc.New(tx).InsertAgentRunEvent(ctx, sqlc.InsertAgentRunEventParams{
+	queries := sqlc.New(tx)
+	_, err = queries.InsertAgentRunEvent(ctx, sqlc.InsertAgentRunEventParams{
 		Sequence:   sequence,
 		EventKind:  input.EventKind,
 		Payload:    encoded,
@@ -76,7 +78,55 @@ func (s *Store) RecordAgentRunEvent(ctx context.Context, input RecordAgentRunEve
 		}
 		return err
 	}
+	if kind, requestID, deviceID, ok := interactionFromRunEvent(input.EventKind, payload); ok {
+		if err := queries.InsertAgentInteractionFromRun(ctx, sqlc.InsertAgentInteractionFromRunParams{
+			RequestID:  requestID,
+			Kind:       kind,
+			Request:    encoded,
+			DeviceID:   deviceID,
+			CreatedAt:  timestamptz(occurredAt),
+			ExpiresAt:  timestamptz(occurredAt.Add(AgentInteractionTTL)),
+			AgentRunID: runID,
+		}); err != nil {
+			return err
+		}
+	}
+	if reason, ok := terminalInteractionReason(input.EventKind, payload); ok {
+		if _, err := queries.CancelOpenAgentInteractionsByRunID(ctx, sqlc.CancelOpenAgentInteractionsByRunIDParams{
+			Reason: reason, Now: timestamptz(occurredAt), AgentRunID: runID,
+		}); err != nil {
+			return err
+		}
+	}
 	return tx.Commit(ctx)
+}
+
+func interactionFromRunEvent(eventKind string, payload map[string]any) (kind, requestID, deviceID string, ok bool) {
+	switch eventKind {
+	case "permission.asked":
+		kind = AgentInteractionKindPermission
+	case "prompt_for_user_choice.asked":
+		kind = AgentInteractionKindUserChoice
+	default:
+		return "", "", "", false
+	}
+	requestID, _ = payload["request_id"].(string)
+	deviceID, _ = payload["device_id"].(string)
+	requestID = strings.TrimSpace(requestID)
+	return kind, requestID, strings.TrimSpace(deviceID), requestID != ""
+}
+
+func terminalInteractionReason(eventKind string, payload map[string]any) (string, bool) {
+	switch eventKind {
+	case "run.completed", "run.failed", "run.cancelled":
+		reason, _ := payload["reason"].(string)
+		if strings.TrimSpace(reason) == "" {
+			reason = eventKind
+		}
+		return reason, true
+	default:
+		return "", false
+	}
 }
 
 func (s *Store) ListAgentRunEvents(ctx context.Context, runID string, afterSequence int64) ([]AgentRunEventRead, error) {

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -1988,6 +1988,8 @@ const (
 	auditAgentRunClaimed  = "agent_run.claimed"
 	// AuditAgentRunCancelled is exported so dev package emit calls share it.
 	AuditAgentRunCancelled           = "agent_run.cancelled"
+	AuditPermissionResolved          = "permission.resolved"
+	AuditUserChoiceResolved          = "user_choice.resolved"
 	auditAgentRunCompleted           = "agent_run.completed"
 	auditAgentRunFailed              = "agent_run.failed"
 	auditHTTPAgentCompleted          = "http_agent.completed"

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -2189,46 +2189,9 @@ func (s *Store) ConfigureAgentProfile(ctx context.Context, input ConfigureAgentP
 	// Agent edits call this endpoint after the main PATCH. Merge only fields
 	// owned by the profile request so its older snapshot cannot roll back model,
 	// capability, or credential changes already committed by UpdateAgent.
-	config := decodeJSONMap(current.Config)
-	profileConfig := nonNilMap(input.Config)
-	if raw, ok := profileConfig["profile"]; ok {
-		profile, ok := raw.(map[string]any)
-		if !ok || len(profile) == 0 {
-			delete(config, "profile")
-		} else {
-			config["profile"] = cloneAnyMap(profile)
-		}
-	}
-	for _, key := range []string{"agent_kind", "daemon_mode", "sandbox_size", "device_id"} {
-		raw, ok := profileConfig[key]
-		if !ok {
-			continue
-		}
-		value, _ := raw.(string)
-		if value = strings.TrimSpace(value); value == "" {
-			delete(config, key)
-		} else {
-			config[key] = value
-		}
-	}
-	var profileWorkdir any
-	var profileWorkdirSet bool
-	for _, key := range []string{"work_dir", "workdir", "working_directory"} {
-		if value, ok := profileConfig[key]; ok {
-			profileWorkdir = value
-			profileWorkdirSet = true
-			break
-		}
-	}
-	if profileWorkdirSet {
-		delete(config, "work_dir")
-		delete(config, "workdir")
-		delete(config, "working_directory")
-		if workdir, ok := profileWorkdir.(string); ok {
-			if workdir = strings.TrimSpace(workdir); workdir != "" {
-				config["work_dir"] = workdir
-			}
-		}
+	config, err := mergeAgentProfileOwnedConfig(decodeJSONMap(current.Config), input.Config)
+	if err != nil {
+		return ConfigureDevAgentConnectorResult{}, err
 	}
 	if modelID := strings.TrimSpace(input.ModelID); modelID != "" {
 		modelUUID, err := uuid(modelID)
@@ -2254,14 +2217,6 @@ func (s *Store) ConfigureAgentProfile(ctx context.Context, input ConfigureAgentP
 	}
 	if systemPrompt := strings.TrimSpace(input.SystemPrompt); systemPrompt != "" {
 		config["system_prompt"] = systemPrompt
-	}
-	if _, daemonModeSet := profileConfig["daemon_mode"]; daemonModeSet {
-		switch stringFromMap(config, "daemon_mode") {
-		case "sandbox":
-			delete(config, "device_id")
-		case "local":
-			delete(config, "sandbox_size")
-		}
 	}
 	encoded, err := json.Marshal(config)
 	if err != nil {
@@ -8039,14 +7994,8 @@ func agentConfigJSON(systemPrompt, defaultModelID string, capabilities []string,
 	// Fold agent_daemon identity/runtime keys (formerly carried on the
 	// agent config) into the merged agent config.
 	if connectorType == "agent_daemon" {
-		for _, key := range []string{"device_id", "daemon_mode", "agent_kind", "work_dir"} {
-			if v, ok := bindings[key]; ok {
-				if s, ok := v.(string); ok {
-					if trimmed := strings.TrimSpace(s); trimmed != "" {
-						config[key] = trimmed
-					}
-				}
-			}
+		if err := foldAgentDaemonConfig(config, bindings); err != nil {
+			return nil, err
 		}
 	}
 	return json.Marshal(config)

--- a/server/internal/store/store_inflight.go
+++ b/server/internal/store/store_inflight.go
@@ -102,6 +102,8 @@ type PromptForUserChoiceQuestion struct {
 	Header      string                      `json:"header,omitempty"`
 	Question    string                      `json:"question"`
 	MultiSelect bool                        `json:"multi_select,omitempty"`
+	IsOther     bool                        `json:"is_other,omitempty"`
+	IsSecret    bool                        `json:"is_secret,omitempty"`
 	Options     []PromptForUserChoiceOption `json:"options"`
 }
 

--- a/server/internal/store/store_inflight.go
+++ b/server/internal/store/store_inflight.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
+	sqlc "github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
-	sqlc "github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
 )
 
 // Wrappers around the inflight-card jsonb slots, keyed at
@@ -98,6 +98,7 @@ type PromptForUserChoiceOption struct {
 // — kept here so server callers don't have to import the daemon proto
 // package just to render a card.
 type PromptForUserChoiceQuestion struct {
+	ID          string                      `json:"id"`
 	Header      string                      `json:"header,omitempty"`
 	Question    string                      `json:"question"`
 	MultiSelect bool                        `json:"multi_select,omitempty"`
@@ -163,11 +164,11 @@ func (s PromptForUserChoiceInflightSlot) EffectiveQuestions() []PromptForUserCho
 // the full conversations.metadata jsonb; consume via the typed
 // WorkingInflightSlot / PermissionInflightSlot helpers.
 type FeishuInflightConversation struct {
-	ConversationID       string
-	WorkspaceID          string
-	ExternalChatID       string
-	ExternalThreadID     string
-	SourceAppID          string
+	ConversationID   string
+	WorkspaceID      string
+	ExternalChatID   string
+	ExternalThreadID string
+	SourceAppID      string
 	// Platform is the IM platform the conversation belongs to
 	// (conversations.platform: "feishu", "slack", ...). The outbound
 	// driver dispatches by this field — Feishu rows take the legacy
@@ -223,11 +224,11 @@ func (s *Store) ListActiveFeishuInflightConversations(ctx context.Context, cutof
 	out := make([]FeishuInflightConversation, 0, len(rows))
 	for _, row := range rows {
 		out = append(out, FeishuInflightConversation{
-			ConversationID:       row.ConversationID,
-			WorkspaceID:          row.WorkspaceID,
-			ExternalChatID:       row.ExternalChatID,
-			ExternalThreadID:     row.ExternalThreadID,
-			SourceAppID:          row.SourceAppID,
+			ConversationID:   row.ConversationID,
+			WorkspaceID:      row.WorkspaceID,
+			ExternalChatID:   row.ExternalChatID,
+			ExternalThreadID: row.ExternalThreadID,
+			SourceAppID:      row.SourceAppID,
 			// List query is not platform-parameterized (feishu-only debug
 			// path), so the row carries no platform column — literal here.
 			Platform:             "feishu",
@@ -655,6 +656,9 @@ func (s *Store) FindConversationByPermissionRequestID(ctx context.Context, permi
 // treats that as "single-pod / no owner routing". Returns
 // ErrUnknownConversation if no matching slot exists.
 func (s *Store) DeviceIDForPermissionRequest(ctx context.Context, requestID string) (string, error) {
+	if deviceID, err := s.interactionDeviceID(ctx, AgentInteractionKindPermission, requestID); err == nil {
+		return strings.TrimSpace(deviceID), nil
+	}
 	conv, err := s.FindConversationByPermissionRequestID(ctx, requestID)
 	if err != nil {
 		return "", err
@@ -665,6 +669,9 @@ func (s *Store) DeviceIDForPermissionRequest(ctx context.Context, requestID stri
 // DeviceIDForPromptForUserChoiceRequest mirrors DeviceIDForPermissionRequest
 // for AskUserQuestion slots.
 func (s *Store) DeviceIDForPromptForUserChoiceRequest(ctx context.Context, requestID string) (string, error) {
+	if deviceID, err := s.interactionDeviceID(ctx, AgentInteractionKindUserChoice, requestID); err == nil {
+		return strings.TrimSpace(deviceID), nil
+	}
 	conv, err := s.FindConversationByPromptForUserChoiceRequestID(ctx, requestID)
 	if err != nil {
 		return "", err

--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -2387,6 +2387,7 @@ func TestConfigureAgentProfilePreservesAgentPatchFields(t *testing.T) {
 				"skills":       []any{capability.Name},
 			},
 			"agent_kind":   "codex",
+			"mode":         "plan",
 			"daemon_mode":  "local",
 			"sandbox_size": "standard",
 			"device_id":    "00000000-0000-0000-0000-000000000401",
@@ -2413,7 +2414,7 @@ func TestConfigureAgentProfilePreservesAgentPatchFields(t *testing.T) {
 	if modelBinding["secret_id"] != "00000000-0000-0000-0000-000000000202" {
 		t.Fatalf("model credential binding was overwritten: %#v", config["model_credential_binding"])
 	}
-	if config["agent_kind"] != "codex" || config["daemon_mode"] != "local" || config["device_id"] != "00000000-0000-0000-0000-000000000401" {
+	if config["agent_kind"] != "codex" || config["mode"] != "plan" || config["daemon_mode"] != "local" || config["device_id"] != "00000000-0000-0000-0000-000000000401" {
 		t.Fatalf("profile-owned daemon fields were not updated: %#v", config)
 	}
 	if config["system_prompt"] != "updated prompt" {
@@ -3767,6 +3768,22 @@ func TestCreateAgentDaemonRejectsRuntimeValue(t *testing.T) {
 			t.Fatalf("CreateAgent(agent_daemon, runtime=%q) = %v, want ErrInvalidInput", badRuntime, err)
 		}
 	}
+	for index, badMode := range []any{"autopilot", true} {
+		_, err := st.CreateAgent(ctx, CreateAgentInput{
+			WorkspaceID:   ids.WorkspaceID,
+			Name:          fmt.Sprintf("daemon-bad-codex-mode-%d", index),
+			Slug:          fmt.Sprintf("daemon-bad-codex-mode-%d", index),
+			ConnectorType: "agent_daemon",
+			AgentConfig: map[string]any{
+				"agent_kind": "codex",
+				"mode":       badMode,
+			},
+			CreatedBy: ids.UserID,
+		})
+		if !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("CreateAgent(agent_daemon, Codex mode=%#v) = %v, want ErrInvalidInput", badMode, err)
+		}
+	}
 
 	created, err := st.CreateAgent(ctx, CreateAgentInput{
 		WorkspaceID:   ids.WorkspaceID,
@@ -3776,7 +3793,8 @@ func TestCreateAgentDaemonRejectsRuntimeValue(t *testing.T) {
 		AgentConfig: map[string]any{
 			"device_id":   "00000000-0000-0000-0000-00000000d001",
 			"daemon_mode": "local",
-			"agent_kind":  "claude_code",
+			"agent_kind":  "codex",
+			"mode":        "plan",
 			"ignored":     "not-persisted",
 		},
 		CreatedBy: ids.UserID,
@@ -3792,6 +3810,9 @@ func TestCreateAgentDaemonRejectsRuntimeValue(t *testing.T) {
 	}
 	if got := created.Agent.Config["daemon_mode"]; got != "local" {
 		t.Fatalf("agent.config daemon_mode mismatch: got %#v", got)
+	}
+	if got := created.Agent.Config["mode"]; got != "plan" {
+		t.Fatalf("agent.config Codex mode mismatch: got %#v", got)
 	}
 	if _, ok := created.Agent.Config["ignored"]; ok {
 		t.Fatalf("agent.config must not persist unknown daemon key: %#v", created.Agent.Config)
@@ -3810,7 +3831,7 @@ func TestCreateAgentDaemonRejectsRuntimeValue(t *testing.T) {
 	if err := db.QueryRow(ctx, `select config::text from agents where id = $1::uuid`, created.Agent.ID).Scan(&rawPAConfig); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(rawPAConfig, `"device_id": "00000000-0000-0000-0000-00000000d001"`) || strings.Contains(rawPAConfig, `"ignored"`) {
+	if !strings.Contains(rawPAConfig, `"device_id": "00000000-0000-0000-0000-00000000d001"`) || !strings.Contains(rawPAConfig, `"mode": "plan"`) || strings.Contains(rawPAConfig, `"ignored"`) {
 		t.Fatalf("agents.config did not persist only daemon keys, got %s", rawPAConfig)
 	}
 }

--- a/server/migrations/000009_agent_interactions.sql
+++ b/server/migrations/000009_agent_interactions.sql
@@ -42,7 +42,7 @@ COMMENT ON TABLE agent_interactions IS 'Durable human interaction requests share
 COMMENT ON COLUMN agent_interactions.kind IS 'permission = approve or deny a tool action; user_choice = answer an AskUserQuestion request';
 COMMENT ON COLUMN agent_interactions.status IS 'Lifecycle: pending, transient resolving, or terminal approved/denied/answered/cancelled/expired';
 COMMENT ON COLUMN agent_interactions.request IS 'Immutable request snapshot rendered by Web and IM clients';
-COMMENT ON COLUMN agent_interactions.response IS 'Human decision snapshot, populated only after resolution';
+COMMENT ON COLUMN agent_interactions.response IS 'Human decision snapshot populated only after runtime ack; secret answer values are redacted';
 COMMENT ON COLUMN agent_interactions.device_id IS 'Agent-daemon device used to route a response to the pod owning the runtime WebSocket';
 COMMENT ON COLUMN agent_interactions.claim_token IS 'CAS token held by the single resolver currently delivering a decision';
 COMMENT ON COLUMN agent_interactions.resolution_source IS 'web, IM platform, system_timeout, or runtime';

--- a/server/migrations/000009_agent_interactions.sql
+++ b/server/migrations/000009_agent_interactions.sql
@@ -1,0 +1,53 @@
+-- +goose Up
+
+CREATE TABLE agent_interactions (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id    uuid NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  conversation_id uuid NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  agent_run_id    uuid NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+  request_id      text NOT NULL,
+  kind            text NOT NULL CHECK (kind IN ('permission', 'user_choice')),
+  status          text NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending', 'resolving', 'approved', 'denied', 'answered', 'cancelled', 'expired')),
+  request         jsonb NOT NULL DEFAULT '{}'::jsonb,
+  response        jsonb NOT NULL DEFAULT '{}'::jsonb,
+  device_id       text NOT NULL DEFAULT '',
+  claim_token     uuid,
+  claimed_at      timestamptz,
+  resolution_source text,
+  resolved_actor  text,
+  resolved_by     uuid REFERENCES users(id) ON DELETE SET NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  expires_at      timestamptz NOT NULL,
+  resolved_at     timestamptz,
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT uk_agent_interactions_request UNIQUE (workspace_id, device_id, kind, request_id)
+);
+
+CREATE INDEX idx_agent_interactions_workspace_status_time
+  ON agent_interactions(workspace_id, status, created_at DESC);
+
+CREATE INDEX idx_agent_interactions_run_time
+  ON agent_interactions(agent_run_id, created_at DESC);
+
+CREATE INDEX idx_agent_interactions_expiry
+  ON agent_interactions(expires_at)
+  WHERE status = 'pending';
+
+CREATE INDEX idx_agent_interactions_stale_claim
+  ON agent_interactions(claimed_at)
+  WHERE status = 'resolving';
+
+COMMENT ON TABLE agent_interactions IS 'Durable human interaction requests shared by Web and IM surfaces';
+COMMENT ON COLUMN agent_interactions.kind IS 'permission = approve or deny a tool action; user_choice = answer an AskUserQuestion request';
+COMMENT ON COLUMN agent_interactions.status IS 'Lifecycle: pending, transient resolving, or terminal approved/denied/answered/cancelled/expired';
+COMMENT ON COLUMN agent_interactions.request IS 'Immutable request snapshot rendered by Web and IM clients';
+COMMENT ON COLUMN agent_interactions.response IS 'Human decision snapshot, populated only after resolution';
+COMMENT ON COLUMN agent_interactions.device_id IS 'Agent-daemon device used to route a response to the pod owning the runtime WebSocket';
+COMMENT ON COLUMN agent_interactions.claim_token IS 'CAS token held by the single resolver currently delivering a decision';
+COMMENT ON COLUMN agent_interactions.resolution_source IS 'web, IM platform, system_timeout, or runtime';
+COMMENT ON COLUMN agent_interactions.resolved_actor IS 'User UUID or external platform subject that submitted the decision';
+
+-- +goose Down
+
+DROP TABLE IF EXISTS agent_interactions;

--- a/tests/e2e/fixtures/interaction-cards.sql
+++ b/tests/e2e/fixtures/interaction-cards.sql
@@ -1,0 +1,212 @@
+BEGIN;
+
+-- Keep this browser fixture runnable against a freshly migrated database.
+-- These IDs mirror store.DefaultDevFixtureIDs, but the setup is intentionally
+-- SQL-only so Playwright does not depend on a Go test side effect or a
+-- developer having manually seeded the database first.
+INSERT INTO users (id, email, name, status, created_at, updated_at)
+VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  'admin@example.com', 'Dev Admin', 'active', now(), now()
+)
+ON CONFLICT (id) DO UPDATE SET status = 'active', updated_at = now();
+
+INSERT INTO workspaces (id, name, slug, created_by, created_at, updated_at)
+VALUES (
+  '00000000-0000-0000-0000-000000000002',
+  'Demo Workspace', 'demo',
+  '00000000-0000-0000-0000-000000000001', now(), now()
+)
+ON CONFLICT (id) DO UPDATE SET updated_at = now();
+
+INSERT INTO workspace_members (
+  id, workspace_id, user_id, role, status, created_at, updated_at
+)
+VALUES (
+  '00000000-0000-0000-0000-000000000003',
+  '00000000-0000-0000-0000-000000000002',
+  '00000000-0000-0000-0000-000000000001',
+  'owner', 'active', now(), now()
+)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO agents (
+  id, workspace_id, name, slug, description, connector_type,
+  status, config, created_by, created_at, updated_at
+)
+VALUES
+  (
+    '00000000-0000-0000-0000-000000000006',
+    '00000000-0000-0000-0000-000000000002',
+    'Product Agent', 'product-agent', 'Interaction card fixture',
+    'agent_daemon', 'active',
+    '{"daemon_mode":"local","agent_kind":"codex"}'::jsonb,
+    '00000000-0000-0000-0000-000000000001', now(), now()
+  ),
+  (
+    '00000000-0000-0000-0000-000000000007',
+    '00000000-0000-0000-0000-000000000002',
+    'Backend Agent', 'backend-agent', 'Interaction card fixture',
+    'agent_daemon', 'active',
+    '{"daemon_mode":"local","agent_kind":"codex"}'::jsonb,
+    '00000000-0000-0000-0000-000000000001', now(), now()
+  )
+ON CONFLICT (id) DO UPDATE SET
+  status = 'active', config = EXCLUDED.config, updated_at = now();
+
+INSERT INTO conversations (
+  id, workspace_id, surface, form, title, status, metadata,
+  created_at, updated_at
+)
+VALUES (
+  '00000000-0000-0000-0000-000000000012',
+  '00000000-0000-0000-0000-000000000002',
+  'web', 'group', 'Interaction Cards', 'active', '{}'::jsonb,
+  now(), now()
+)
+ON CONFLICT (id) DO UPDATE SET status = 'active', updated_at = now();
+
+INSERT INTO agent_runs (
+  id, workspace_id, conversation_id, trigger_source, trigger_channel,
+  requested_by_type, requested_by_id, agent_id, connector_type,
+  status, visibility, metadata, created_at, started_at, updated_at
+) VALUES
+  (
+    '11111111-1111-4111-8111-111111111111',
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000012',
+    'manual', 'web', 'user',
+    '00000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000007',
+    'agent_daemon', 'running', 'workspace',
+    '{"preview":true}'::jsonb, now(), now(), now()
+  ),
+  (
+    '22222222-2222-4222-8222-222222222222',
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000012',
+    'manual', 'web', 'user',
+    '00000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000006',
+    'agent_daemon', 'running', 'workspace',
+    '{"preview":true}'::jsonb, now(), now(), now()
+  ),
+  (
+    '33333333-3333-4333-8333-333333333333',
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000012',
+    'manual', 'web', 'user',
+    '00000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000006',
+    'agent_daemon', 'running', 'workspace',
+    '{"preview":true}'::jsonb, now(), now(), now()
+  )
+ON CONFLICT (id) DO UPDATE SET
+  status = 'running',
+  finished_at = NULL,
+  started_at = now(),
+  updated_at = now();
+
+INSERT INTO agent_interactions (
+  id, workspace_id, conversation_id, agent_run_id, request_id,
+  kind, status, request, response, device_id,
+  created_at, expires_at, updated_at
+) VALUES
+  (
+    'aaaaaaaa-1111-4111-8111-111111111111',
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000012',
+    '11111111-1111-4111-8111-111111111111',
+    'preview-permission-001', 'permission', 'pending',
+    '{
+      "request_id":"preview-permission-001",
+      "device_id":"preview-device",
+      "resource":"Write production configuration",
+      "action":"Modify files",
+      "detail":"Agent wants to update deploy/production.yaml and restart the service.",
+      "payload":{
+        "command":"apply deployment configuration",
+        "paths":["deploy/production.yaml"],
+        "risk":"high"
+      }
+    }'::jsonb,
+    '{}'::jsonb, 'preview-device', now(), now() + interval '10 minutes', now()
+  ),
+  (
+    'aaaaaaaa-2222-4222-8222-222222222222',
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000012',
+    '22222222-2222-4222-8222-222222222222',
+    'preview-question-001', 'user_choice', 'pending',
+    '{
+      "request_id":"preview-question-001",
+      "device_id":"preview-device",
+      "questions":[
+        {
+          "id":"q0",
+          "header":"Deployment target",
+          "question":"Which environment should the Agent deploy to?",
+          "options":[
+            {"label":"Staging","description":"Deploy to the shared test environment."},
+            {"label":"Production","description":"Deploy to the live customer environment."}
+          ],
+          "multi_select":false,
+          "is_other":false,
+          "is_secret":false
+        },
+        {
+          "id":"verification_steps",
+          "header":"Verification",
+          "question":"Which checks should run after deployment?",
+          "options":[
+            {"label":"Smoke tests","description":"Run the critical user journey checks."},
+            {"label":"Full regression","description":"Run the complete test suite."}
+          ],
+          "multi_select":true,
+          "is_other":false,
+          "is_secret":false
+        }
+      ]
+    }'::jsonb,
+    '{}'::jsonb, 'preview-device', now(), now() + interval '10 minutes', now()
+  ),
+  (
+    'aaaaaaaa-3333-4333-8333-333333333333',
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000012',
+    '33333333-3333-4333-8333-333333333333',
+    'preview-secret-001', 'user_choice', 'pending',
+    '{
+      "request_id":"preview-secret-001",
+      "device_id":"preview-device",
+      "questions":[
+        {
+          "id":"q0",
+          "header":"Deployment token",
+          "question":"Which credential should the Agent use?",
+          "options":[
+            {"label":"Use stored token","description":"Use the token already available to the runtime."}
+          ],
+          "multi_select":false,
+          "is_other":true,
+          "is_secret":true
+        }
+      ]
+    }'::jsonb,
+    '{}'::jsonb, 'preview-device', now(), now() + interval '10 minutes', now()
+  )
+ON CONFLICT (id) DO UPDATE SET
+  status = 'pending',
+  request = EXCLUDED.request,
+  response = '{}'::jsonb,
+  claim_token = NULL,
+  claimed_at = NULL,
+  resolution_source = NULL,
+  resolved_actor = NULL,
+  resolved_by = NULL,
+  created_at = now(),
+  expires_at = now() + interval '10 minutes',
+  resolved_at = NULL,
+  updated_at = now();
+
+COMMIT;

--- a/tests/e2e/interaction-cards.spec.ts
+++ b/tests/e2e/interaction-cards.spec.ts
@@ -1,18 +1,34 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+
 import { expect, test } from "@playwright/test";
 
-// Opt-in: requires the local stack and the deterministic interaction preview
-// fixture. The test drives the real API and verifies both inline card types,
-// answer state, refresh recovery, and the workspace-wide Inbox surface.
+// Requires the local stack. The committed deterministic fixture lets the test
+// drive the real API and verify inline cards, isolation
+// between repeated question ids, secret/custom input semantics, resolve error
+// recovery, refresh recovery, and the workspace-wide Inbox surface.
 //
-//   psql "$DATABASE_URL" -f /private/tmp/parsar_preview_interactions.sql
-//   PARSAR_E2E_INTERACTIONS=1 pnpm exec playwright test \
+//   pnpm exec playwright test \
 //     --config tests/e2e/playwright.config.ts tests/e2e/interaction-cards.spec.ts
-const ENABLED = process.env.PARSAR_E2E_INTERACTIONS === "1";
 const INTERACTIONS_URL =
   process.env.PARSAR_E2E_INTERACTIONS_URL ??
   "/?admin=conversations&id=00000000-0000-0000-0000-000000000012&ws=00000000-0000-0000-0000-000000000002";
 
-test.skip(!ENABLED, "set PARSAR_E2E_INTERACTIONS=1 to run");
+const REPO_ROOT = resolve(__dirname, "..", "..");
+
+test.beforeAll(() => {
+  execFileSync(
+    resolve(REPO_ROOT, "scripts", "with-dev-env.sh"),
+    [
+      "bash",
+      "-c",
+      'psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$1"',
+      "parsar-interaction-fixture",
+      resolve(REPO_ROOT, "tests", "e2e", "fixtures", "interaction-cards.sql"),
+    ],
+    { cwd: REPO_ROOT, stdio: "inherit" },
+  );
+});
 
 test.use({
   extraHTTPHeaders: {
@@ -26,7 +42,7 @@ test("inline approval and question cards survive refresh and remain available in
   await page.goto(INTERACTIONS_URL);
 
   const cards = page.getByTestId("interaction-card");
-  await expect(cards).toHaveCount(2);
+  await expect(cards).toHaveCount(3);
 
   const permission = page.locator('[data-request-id="preview-permission-001"]');
   await expect(permission).toContainText("Write production configuration");
@@ -44,9 +60,25 @@ test("inline approval and question cards survive refresh and remain available in
   await question.getByRole("radio", { name: /Staging/ }).check();
   await question.getByRole("checkbox", { name: /Smoke tests/ }).check();
   await expect(submit).toBeEnabled();
+  await expect(question.getByPlaceholder("Custom answer")).toHaveCount(0);
+
+  const secret = page.locator('[data-request-id="preview-secret-001"]');
+  await secret.getByRole("radio", { name: /Use stored token/ }).check();
+  await expect(question.getByRole("radio", { name: /Staging/ })).toBeChecked();
+  const secretInput = secret.getByPlaceholder("Custom answer");
+  await expect(secretInput).toHaveAttribute("type", "password");
+  await secretInput.fill("not-persisted-test-secret");
+  await expect(
+    secret.getByRole("button", { name: "Submit answers" }),
+  ).toBeEnabled();
+
+  // The fixture intentionally has no live daemon. A real resolve POST must
+  // surface a retryable runtime error and leave the durable card pending.
+  await permission.getByRole("button", { name: "Deny" }).click();
+  await expect(permission).toContainText(/runtime|unavailable|pending/i);
 
   await page.reload();
-  await expect(page.getByTestId("interaction-card")).toHaveCount(2);
+  await expect(page.getByTestId("interaction-card")).toHaveCount(3);
 
   await page.getByRole("button", { name: "View all in Inbox" }).click();
   await expect(

--- a/tests/e2e/interaction-cards.spec.ts
+++ b/tests/e2e/interaction-cards.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+// Opt-in: requires the local stack and the deterministic interaction preview
+// fixture. The test drives the real API and verifies both inline card types,
+// answer state, refresh recovery, and the workspace-wide Inbox surface.
+//
+//   psql "$DATABASE_URL" -f /private/tmp/parsar_preview_interactions.sql
+//   PARSAR_E2E_INTERACTIONS=1 pnpm exec playwright test \
+//     --config tests/e2e/playwright.config.ts tests/e2e/interaction-cards.spec.ts
+const ENABLED = process.env.PARSAR_E2E_INTERACTIONS === "1";
+const INTERACTIONS_URL =
+  process.env.PARSAR_E2E_INTERACTIONS_URL ??
+  "/?admin=conversations&id=00000000-0000-0000-0000-000000000012&ws=00000000-0000-0000-0000-000000000002";
+
+test.skip(!ENABLED, "set PARSAR_E2E_INTERACTIONS=1 to run");
+
+test.use({
+  extraHTTPHeaders: {
+    "X-Parsar-Dev-User-ID": "00000000-0000-0000-0000-000000000001",
+  },
+});
+
+test("inline approval and question cards survive refresh and remain available in Inbox", async ({
+  page,
+}) => {
+  await page.goto(INTERACTIONS_URL);
+
+  const cards = page.getByTestId("interaction-card");
+  await expect(cards).toHaveCount(2);
+
+  const permission = page.locator('[data-request-id="preview-permission-001"]');
+  await expect(permission).toContainText("Write production configuration");
+  await expect(
+    permission.getByRole("button", { name: "Allow once" }),
+  ).toBeEnabled();
+  await expect(permission.getByRole("button", { name: "Deny" })).toBeEnabled();
+
+  const question = page.locator('[data-request-id="preview-question-001"]');
+  const submit = question.getByRole("button", { name: "Submit answers" });
+  await expect(question).toContainText(
+    "Which environment should the Agent deploy to?",
+  );
+  await expect(submit).toBeDisabled();
+  await question.getByRole("radio", { name: /Staging/ }).check();
+  await question.getByRole("checkbox", { name: /Smoke tests/ }).check();
+  await expect(submit).toBeEnabled();
+
+  await page.reload();
+  await expect(page.getByTestId("interaction-card")).toHaveCount(2);
+
+  await page.getByRole("button", { name: "View all in Inbox" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Inbox / Approvals" }),
+  ).toBeVisible();
+  await expect(page.getByTestId("interaction-card")).toHaveCount(1);
+  await expect(page.getByTestId("interaction-card")).toContainText(
+    /Write production configuration|Which environment should the Agent deploy to\?/,
+  );
+});


### PR DESCRIPTION
## Summary

This PR makes Approval and AskUserQuestion first-class, durable interactions across Parsar's daemon, server, API, IM paths, and Web UI.

- Runtime replies are deferred until a user actually approves, denies, answers, cancels, or times out.
- Pending interactions are persisted so refreshes, server restarts, and multi-pod routing do not lose the decision point.
- Web conversations render the full decision card inline; Inbox / Approvals provides the same flow across conversations.
- Resolution uses a database claim plus daemon ACK, so concurrent responders cannot resume the same runtime request twice.
- The current Codex app-server protocol is supported, including real sandbox escalation and plan-mode `request_user_input`.

## Why

Previously, a human-in-the-loop event could be observable without being actionable in the Web conversation. Transient connector state also meant a refresh, restart, concurrent browser tab, daemon timeout, or runtime disconnect could strand or double-resolve a request.

The new boundary is explicit:

1. Persist the immutable request and pending lifecycle.
2. Publish an actionable card to Web / IM surfaces.
3. Claim one submitted decision with compare-and-swap.
4. Deliver it to the daemon that owns the original request and wait for its ACK.
5. Commit the terminal interaction state and let the original runtime continue.

`gateway_inflight` remains presentation/delivery state; `agent_interactions` is the durable lifecycle source of truth.

## What changed

### Runtime adapters and daemon protocol

- Claude Code defers permission and AskUserQuestion responses, tracks pending requests atomically, and prevents submit/timeout double completion.
- Codex handles command execution approval, file change approval, permissions approval, and `item/tool/requestUserInput` with the response schema expected by each app-server request.
- Codex approval policy now uses the current `on-request` policy, which permits a sandboxed command to request `require_escalated` instead of rejecting the escalation before Parsar can render it.
- Codex `config.mode=plan` is forwarded as `turn/start.collaborationMode`, including the resolved model and developer instructions. Default and plan modes are validated against the current app-server schema.
- Permission envelopes keep the run ID in `Envelope.ID`, so the server's active run subscriber receives the card. The daemon-minted permission handle is carried separately as `payload.request_id` for decision routing. Readers retain legacy fallback behavior.
- Claude Code emits the same run-correlated permission shape, and all permission timers use the payload request ID.

### Durable lifecycle and routing

- Adds migration `000009_agent_interactions.sql` and generated sqlc contracts.
- Stores workspace, conversation, run, request ID, interaction kind, immutable request payload, response payload, owning device, actor/source, expiration, and claim metadata.
- Enforces request idempotency with `(workspace_id, device_id, kind, request_id)` uniqueness.
- Supports `pending`, `resolving`, `approved`, `denied`, `answered`, `cancelled`, and `expired` states.
- Claims a pending interaction before daemon delivery; transient delivery failures release the claim for retry, while permanent missing-runtime failures become terminal.
- Uses application-level daemon ACKs and routes decisions by the device/session that owns the original request.
- Reconciles expiration and stale claims, and closes outstanding interactions when the run terminates.

### API and Web UI

- `GET /api/v1/workspaces/{workspaceID}/interactions?status=pending|decided|expired`
- `POST /api/v1/workspaces/{workspaceID}/interactions/{interactionID}/resolve`
- Maps validation, authorization, conflict, expiration, and runtime availability failures to explicit HTTP responses.
- Reuses `InteractionDecisionCard` in the active conversation and the global Inbox / Approvals queue.
- Supports permission allow/deny, single-select, multi-select, custom answers, secret answers, cancellation, expiration, and delivery failure states.
- Restores pending cards from the durable API after reload, including conversations with no ordinary message row yet.
- Adds English and Chinese UI copy.

### Codex Plan configuration

- Agent create/edit now exposes **Codex collaboration mode: Default / Plan**.
- The normal Agent profile API persists and validates the value; direct database edits are no longer required.
- Switching away from Codex clears a stale Codex mode instead of leaking it into another engine's permission-mode semantics.
- Agent Config details show the effective Codex collaboration mode.

## Safety and concurrency guarantees

- Only one resolver can win the database claim.
- Runtime submission and timeout removal use atomic take semantics.
- A transient delivery error does not strand a `resolving` record.
- Expiration and run termination produce explicit terminal decisions.
- Permission responses and structured question answers are validated independently.
- Stable protocol IDs, not presentation labels or array positions, identify requests and questions.
- Secret answers are accepted through password inputs and redacted from persisted/runtime/audit output.

## Real MiniMax / Codex validation

Latest-head validation used a real local Parsar server, PostgreSQL, a connected Parsar daemon, the current Codex app-server, and MiniMax's international Responses endpoint with `MiniMax-M3`.

### AskUserQuestion closed loop

1. Set Backend Agent to **Plan** through the normal Web edit dialog.
2. Sent a prompt that required `request_user_input` with Unit only / Integration only / Both.
3. The structured question card appeared inline while the conversation remained visible.
4. Selected **Both** and submitted the card.
5. The original Codex turn resumed and returned `Both`.

### Approval closed loop

1. Asked Codex to execute `curl -I https://example.com` in the sandbox.
2. Sandbox DNS failed, so Codex requested `require_escalated`.
3. Parsar rendered the inline permission card with **Allow once** / **Deny**.
4. Selected **Allow once**.
5. The original Codex turn resumed and returned the real `HTTP/2 200` response headers.

The provider connection follows MiniMax's international [Responses API](https://platform.minimax.io/docs/api-reference/responses-create). The credential is stored through Parsar's encrypted secret reference and is not committed to Git.

## Screenshots

### Inline permission and AskUserQuestion cards

Both pending interaction types render inside the active AI conversation, so the user can respond without leaving the transcript.

<img width="1100" alt="Permission and AskUserQuestion cards rendered inline in the Parsar conversation" src="https://github.com/user-attachments/assets/b6a8e6b8-b42a-4415-9c16-0e443fce2b95" />

### Structured answer selection

Single-select and multi-select values are represented independently; after the required answers are selected, the submit action becomes available.

<img width="1100" alt="AskUserQuestion card with radio and checkbox answers selected" src="https://github.com/user-attachments/assets/9ac13b15-6b0e-44f7-8407-2bb725eed812" />

### Durable restoration after refresh

After a full browser reload, pending cards are restored from the durable interaction API instead of relying on a transient SSE event.

<img width="1100" alt="Pending interaction cards restored after a full page refresh" src="https://github.com/user-attachments/assets/083f5100-a7a5-4b1d-afbe-cc220828ce68" />


### Real runtime — Plan mode enabled from the Agent UI

**Setup:** The Backend Agent uses Codex with `MiniMax-M3 Responses (International)`, and the newly exposed collaboration-mode setting was saved as **Plan**.

**What this shows:** The effective Agent configuration reports `Plan (enables questions)`. This is the runtime prerequisite for Codex to expose `request_user_input`; prompt wording alone cannot enable the tool while the Agent remains in Default mode.

<img width="1920" height="992" alt="Backend Agent configuration showing Codex Plan collaboration mode with MiniMax-M3 Responses International" src="https://github.com/user-attachments/assets/03507d1b-420c-44d9-a26b-57e7ef88ee09" />

### Real runtime — AskUserQuestion pauses the original turn

**Trigger:** A real MiniMax/Codex turn was instructed to ask one structured test-scope question through `request_user_input`, with **Unit only**, **Integration only**, and **Both** as choices.

**What this shows:** Parsar renders the pending question inline while the full conversation remains visible. The `Thinking...` state confirms that the originating turn is still waiting; the user can select a predefined option, enter a custom answer, submit, or cancel. In the completed flow, choosing **Both** resumed that same turn and produced the final `Both` response.

<img width="1920" height="992" alt="Real MiniMax Codex AskUserQuestion request waiting inline with test scope options" src="https://github.com/user-attachments/assets/e09d2ee2-c614-419f-a9ff-bb8e32edee31" />

### Real runtime — sandbox escalation requests approval

**Trigger:** Codex ran `curl -I https://example.com` in the sandbox. After sandbox network access failed, it requested `require_escalated` with the exact command and available decisions shown on the card.

**What this shows:** The permission request is an inline card rather than a full-page overlay, so the surrounding transcript stays readable. The original turn remains paused until **Allow once** or **Deny** is submitted. In the completed flow, **Allow once** resumed that same turn and returned the real `HTTP/2 200` response headers.

<img width="1920" height="992" alt="Real Codex sandbox escalation approval card shown inline with Allow once and Deny actions" src="https://github.com/user-attachments/assets/4cdf1808-8396-4000-a28f-e6f6a995a7af" />

### Global Inbox / Approvals queue

The queue provides a cross-conversation operational view while reusing the exact same decision component and resolution API as the inline cards.

<img width="1100" alt="Global Inbox and Approvals queue showing pending interactions" src="https://github.com/user-attachments/assets/cf51744d-e991-4c36-8963-7491412fba6d" />

> **Evidence boundary:** The three screenshots labeled **Real runtime** were captured from the latest-head MiniMax/Codex run. They show the saved Plan configuration and the two real pending decision states; the completed wait/decide/resume results are documented in the validation steps above. The other four screenshots in this section are deterministic Chrome fixtures for dense pending/restored UI states. Unit and integration tests cover protocol schemas, durable claims, daemon ACK/retry, timeout/cancel, refresh restoration, and delivery errors.

## Verification

Latest head: `3d6e6a5`

- `make check`
  - server Go packages
  - sqlc drift check
  - Docker PostgreSQL migration and store integration smoke test
  - Web, CLI, and OpenCode plugin type checks
- Full Codex adapter package tests.
- Focused Claude permission parser/session round-trip and timeout tests.
- Focused daemon dispatch, gateway, connector, profile persistence, and route validation tests.
- `pnpm --dir apps/web typecheck`.
- Targeted ESLint is still blocked by the pre-existing `react-hooks/set-state-in-effect` violations in `CreateAgentDialog.tsx`; the other changed Web files produce no findings.
- Real Chrome flows for Plan configuration, inline AskUserQuestion resolution, and inline permission approval.

## Generated and documented contracts

- Adds the migration and regenerated sqlc model/query files required by the durable interaction store.
- Regenerates `docs/openapi/openapi.yaml` for the list and resolve endpoints.
- The latest protocol/Plan follow-up does not change SQL queries or the OpenAPI request shape, so it adds no further generated diff.
- Documents the human-interaction lifecycle, run/request correlation rule, and Codex Plan ownership in `CONTRIBUTING.md`.

## Review guide

1. `apps/parsar-daemon/internal/agent/{claudecode,codex}` and `internal/agentdaemon/proto` — deferred runtime requests and wire contracts.
2. `apps/parsar-daemon/internal/dispatch`, `server/internal/agentdaemon/gateway`, and `server/internal/connector/agentdaemon` — run delivery and request-ID routing.
3. `server/migrations/000009_agent_interactions.sql`, generated sqlc output, and `server/internal/interaction` — durable lifecycle, claim, ACK/retry, expiration.
4. Interaction routes, `InteractionDecisionCard`, conversation integration, and `ApprovalsPage` — shared Web/IM resolution surface.
5. Agent profile configuration and `CreateAgentDialog` — user-facing Codex Default/Plan configuration.
