### PR TITLE
fix: show published marketplace capabilities by default

### DIFF
--- a/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
@@ -24,7 +24,7 @@ export function MarketplaceTab({ itemID, query, typeFilter, onSelectItem, onInst
   const { t, i18n } = useTranslation("admin")
   const workspaceID = useWorkspaceId()
   const marketplaceQ = useMarketplaceList(workspaceID)
-  const [hideInstalled, setHideInstalled] = useState(true)
+  const [hideInstalled, setHideInstalled] = useState(false)
 
   const items = useMemo(() => marketplaceQ.data ?? [], [marketplaceQ.data])
   const selected = items.find((item) => item.id === itemID) ?? null


### PR DESCRIPTION
## What & why

The Marketplace enabled “Hide added capabilities” by default. Because capabilities published by the current workspace are marked as `self_published`, they disappeared immediately after a successful publish and appeared not to have been published.

## How

Default the filter to disabled. Users can still enable it manually when they want to hide capabilities already available in the workspace.

## Verification

- [x] `make check`
- [x] `pnpm --filter @parsar/web build`
- [x] Targeted ESLint for `MarketplaceTab.tsx`
- [ ] Relevant E2E target: not applicable
- [x] Manual smoke: confirmed the Marketplace API returns the published Skills as `self_published`