### PR TITLE
fix(web): restore Add Model endpoint fields

### DIFF
--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -535,7 +535,7 @@ export function CreateModelDialog({
             </span>
           </div>
 
-          {/* --- Protocol row ---
+          {/* --- Protocol row --- */}
           <Field
             id="model-base-url"
             label={t("models.createProvider.fields.baseURL")}


### PR DESCRIPTION
## What & why

The Add Model dialog had an unterminated JSX section comment, which caused the Base URL and Model Key controls to be treated as comment content and hidden from users.

## How

Close the JSX section comment before rendering the endpoint fields. The fix is a single-line change.

## Verification

- [x] `pnpm --filter @parsar/web typecheck`
- [x] `pnpm --filter @parsar/web build`
- [x] `git diff --check`
- [ ] `pnpm --filter @parsar/web lint` (latest `main` currently has unrelated existing lint failures)
- [ ] `pnpm --filter @parsar/web format:check` (latest `main` currently has unrelated existing formatting failures)

## Notes for reviewers

This PR intentionally contains only the JSX comment fix.