### PR TITLE
feat: add OAuth for hosted MCP connectors

### DIFF
--- a/apps/parsar-daemon/internal/agent/codex/mcp_config.go
+++ b/apps/parsar-daemon/internal/agent/codex/mcp_config.go
@@ -15,6 +15,7 @@ import (
 type mcpServerConfig struct {
 	Name    string
 	URL     string
+	Headers map[string]string
 	Command string
 	Args    []string
 	Env     map[string]string
@@ -53,7 +54,25 @@ func writeCodexMCPConfig(codexHome string, servers map[string]mcpServerConfig) e
 		if srv.URL != "" {
 			b.WriteString(`url = `)
 			b.WriteString(tomlQuoteString(srv.URL))
-			b.WriteString("\n\n")
+			b.WriteByte('\n')
+			if len(srv.Headers) > 0 {
+				headerKeys := make([]string, 0, len(srv.Headers))
+				for key := range srv.Headers {
+					headerKeys = append(headerKeys, key)
+				}
+				sort.Strings(headerKeys)
+				b.WriteString("http_headers = {")
+				for index, key := range headerKeys {
+					if index > 0 {
+						b.WriteString(", ")
+					}
+					b.WriteString(tomlQuoteString(key))
+					b.WriteString(" = ")
+					b.WriteString(tomlQuoteString(srv.Headers[key]))
+				}
+				b.WriteString("}\n")
+			}
+			b.WriteByte('\n')
 			continue
 		}
 		b.WriteString(`command = `)

--- a/apps/parsar-daemon/internal/agent/codex/mcp_config_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/mcp_config_test.go
@@ -64,7 +64,11 @@ func TestWriteCodexMCPConfig_EmitsCommandArgsEnv(t *testing.T) {
 func TestWriteCodexMCPConfig_EmitsStreamableHTTPURL(t *testing.T) {
 	dir := t.TempDir()
 	servers := map[string]mcpServerConfig{
-		"docs": {Name: "docs", URL: "https://docs.example.com/mcp"},
+		"docs": {
+			Name:    "docs",
+			URL:     "https://docs.example.com/mcp",
+			Headers: map[string]string{"Authorization": "Bearer token"},
+		},
 	}
 	if err := writeCodexMCPConfig(dir, servers); err != nil {
 		t.Fatalf("write: %v", err)
@@ -72,6 +76,9 @@ func TestWriteCodexMCPConfig_EmitsStreamableHTTPURL(t *testing.T) {
 	body, _ := os.ReadFile(filepath.Join(dir, "config.toml"))
 	if !strings.Contains(string(body), `url = "https://docs.example.com/mcp"`) || strings.Contains(string(body), "command =") {
 		t.Fatalf("remote config: %s", body)
+	}
+	if !strings.Contains(string(body), `http_headers = {"Authorization" = "Bearer token"}`) {
+		t.Fatalf("remote headers: %s", body)
 	}
 }
 

--- a/apps/parsar-daemon/internal/agent/codex/options.go
+++ b/apps/parsar-daemon/internal/agent/codex/options.go
@@ -363,6 +363,16 @@ func normaliseMCPServers(raw any) (map[string]mcpServerConfig, error) {
 				}
 			}
 		}
+		if headers, ok := entry["headers"].(map[string]any); ok {
+			srv.Headers = make(map[string]string, len(headers))
+			for key, value := range headers {
+				if text, ok := value.(string); ok {
+					srv.Headers[key] = text
+				}
+			}
+		} else if headers, ok := entry["headers"].(map[string]string); ok {
+			srv.Headers = headers
+		}
 		if srv.Command == "" && srv.URL == "" {
 			return nil, fmt.Errorf("codex: mcp_servers[%q] missing command or url", name)
 		}

--- a/apps/parsar-daemon/internal/agent/opencode/options.go
+++ b/apps/parsar-daemon/internal/agent/opencode/options.go
@@ -103,11 +103,15 @@ func mergeMCPConfig(rawConfig string, rawServers any) (string, error) {
 			enabled = value
 		}
 		if remoteURL, ok := entry["url"].(string); ok && strings.TrimSpace(remoteURL) != "" {
-			mcp[name] = map[string]any{
+			remote := map[string]any{
 				"type":    "remote",
 				"url":     strings.TrimSpace(remoteURL),
 				"enabled": enabled,
 			}
+			if headers := stringMap(entry["headers"]); len(headers) > 0 {
+				remote["headers"] = headers
+			}
+			mcp[name] = remote
 			continue
 		}
 		command, ok := entry["command"].(string)
@@ -140,6 +144,23 @@ func mergeMCPConfig(rawConfig string, rawServers any) (string, error) {
 		return "", fmt.Errorf("opencode: marshal merged MCP config: %w", err)
 	}
 	return string(encoded), nil
+}
+
+func stringMap(value any) map[string]string {
+	switch typed := value.(type) {
+	case map[string]string:
+		return typed
+	case map[string]any:
+		result := make(map[string]string, len(typed))
+		for key, raw := range typed {
+			if text, ok := raw.(string); ok {
+				result[key] = text
+			}
+		}
+		return result
+	default:
+		return nil
+	}
 }
 
 func resolveWorkDir(input string) (string, error) {

--- a/apps/parsar-daemon/internal/agent/opencode/options_test.go
+++ b/apps/parsar-daemon/internal/agent/opencode/options_test.go
@@ -100,7 +100,10 @@ func TestBuildArgsMergesLocalAndRemoteMCPServers(t *testing.T) {
 		"opencode_json": `{"provider":{}}`,
 		"mcp_servers": map[string]any{
 			"local": map[string]any{"command": "npx", "args": []any{"-y", "pkg"}},
-			"docs":  map[string]any{"url": "https://docs.example.com/mcp"},
+			"docs": map[string]any{
+				"url":     "https://docs.example.com/mcp",
+				"headers": map[string]any{"Authorization": "Bearer token"},
+			},
 		},
 	})
 	if err != nil {
@@ -120,6 +123,10 @@ func TestBuildArgsMergesLocalAndRemoteMCPServers(t *testing.T) {
 	remote := mcp["docs"].(map[string]any)
 	if remote["type"] != "remote" || remote["url"] != "https://docs.example.com/mcp" {
 		t.Fatalf("remote = %+v", remote)
+	}
+	headers := remote["headers"].(map[string]any)
+	if headers["Authorization"] != "Bearer token" {
+		t.Fatalf("headers = %+v", headers)
 	}
 	local := mcp["local"].(map[string]any)
 	if local["type"] != "local" {

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -912,6 +912,12 @@
         "back": "Back to connectors",
         "viewCapability": "View Capability"
       },
+	  "oauth": {
+		"connect": "Connect",
+		"connected": "Connected",
+		"required": "OAuth required",
+		"failed": "Authorization did not complete. Please try again."
+	  },
       "loadError": {
         "title": "Couldn't load the connectors directory",
         "description": "Couldn't load the connectors directory. Some connector details may be missing. Retry without leaving the Capability Marketplace."
@@ -935,7 +941,7 @@
       },
       "import": {
         "title": "Import {{name}}?",
-        "description": "Review the connector configuration. No token is required during import, and nothing will run or bind to an Agent.",
+		"description": "Review the connector configuration. OAuth connectors must be connected first; importing does not run the MCP or bind it to an Agent.",
         "success": "{{name}} was imported as a workspace MCP Capability.",
         "failed": "The connector could not be imported.",
         "importing": "Importing...",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -912,6 +912,12 @@
         "back": "返回连接器列表",
         "viewCapability": "查看 Capability"
       },
+	  "oauth": {
+		"connect": "连接",
+		"connected": "已连接",
+		"required": "需要 OAuth 授权",
+		"failed": "授权未完成，请重试。"
+	  },
       "loadError": {
         "title": "无法加载连接器目录",
         "description": "无法加载连接器目录，部分连接器信息可能缺失。你可以直接重试，不会影响 Skill 市场和工作区 Capability。"
@@ -935,7 +941,7 @@
       },
       "import": {
         "title": "导入 {{name}}？",
-        "description": "请检查连接器配置。导入时不需要 Token，也不会运行 MCP 或绑定 Agent。",
+		"description": "请检查连接器配置。OAuth 连接器需要先完成授权；导入不会运行 MCP 或绑定 Agent。",
         "success": "已将 {{name}} 导入为工作区 MCP Capability。",
         "failed": "无法导入该连接器。",
         "importing": "正在导入...",

--- a/apps/web/src/lib/api-marketplace.ts
+++ b/apps/web/src/lib/api-marketplace.ts
@@ -102,9 +102,11 @@ export interface MCPDirectoryItem {
   verified: boolean
   categories: string[]
   featured_rank: number
-  version: string
-  transport: "streamable-http"
-  url?: string
+	version: string
+	transport: "streamable-http"
+	authentication: "none" | "oauth2"
+	connected: boolean
+	url?: string
   installed: boolean
   installed_capability_id: string | null
 }
@@ -218,6 +220,10 @@ async function getMCPDirectoryItem(workspaceID: string | null, catalogID: string
 
 async function importMCPDirectoryItem(workspaceID: string, catalogID: string): Promise<MCPDirectoryImportResponse> {
   return apiRequest(`/api/v1/workspaces/${encodeURIComponent(workspaceID)}/mcp-directory/${encodeURIComponent(catalogID)}/import`, { method: "POST" })
+}
+
+export function mcpDirectoryOAuthStartURL(workspaceID: string, catalogID: string): string {
+	return `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/mcp-directory/${encodeURIComponent(catalogID)}/oauth/start`
 }
 
 function normalizeMarketplaceCapability(item: MarketplaceCapability): MarketplaceCapability {

--- a/apps/web/src/pages/admin/capabilities/mcp-directory/ImportMCPDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/mcp-directory/ImportMCPDialog.tsx
@@ -70,7 +70,11 @@ export function ImportMCPDialog({
                 {t("capabilities.mcpDirectory.detail.authentication")}
               </p>
               <p className="mt-1.5 font-mono text-xs text-fg">
-                {t("capabilities.mcpDirectory.detail.noAuthentication")}
+				{item.authentication === "oauth2"
+				  ? item.connected
+					? t("capabilities.mcpDirectory.oauth.connected")
+					: t("capabilities.mcpDirectory.oauth.required")
+				  : t("capabilities.mcpDirectory.detail.noAuthentication")}
               </p>
             </div>
             <p className="rounded-md border border-line bg-surface-muted/25 p-3 text-xs leading-5 text-fg-muted">
@@ -91,7 +95,7 @@ export function ImportMCPDialog({
           </Button>
           <Button
             onClick={onConfirm}
-            disabled={!item || loading || !!error || pending || item.installed}
+			disabled={!item || loading || !!error || pending || item.installed || (item.authentication === "oauth2" && !item.connected)}
           >
             {pending
               ? t("capabilities.mcpDirectory.import.importing")

--- a/apps/web/src/pages/admin/capabilities/mcp-directory/MCPDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/mcp-directory/MCPDirectory.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Check, PackageCheck, Server } from "lucide-react"
 
@@ -11,6 +11,7 @@ import {
   useImportMCPDirectoryItem,
   useMCPDirectory,
   useMCPDirectoryDetail,
+  mcpDirectoryOAuthStartURL,
 } from "../../../../lib/api-marketplace"
 import { useWorkspaceId } from "../../../../lib/workspace"
 import { DirectoryCard } from "./MCPDirectoryCard"
@@ -40,7 +41,8 @@ export function MCPDirectory({
   const [category, setCategory] = useState("")
   const [verifiedOnly, setVerifiedOnly] = useState(false)
   const [sort, setSort] = useState<DirectorySort>("featured")
-  const [confirmID, setConfirmID] = useState<string | null>(null)
+	const [confirmID, setConfirmID] = useState<string | null>(null)
+	const [oauthError, setOAuthError] = useState(false)
   const [success, setSuccess] = useState<{ name: string; capabilityID: string } | null>(null)
   const detailID = confirmID ?? itemID
   const detailQ = useMCPDirectoryDetail(workspaceID, detailID)
@@ -56,10 +58,47 @@ export function MCPDirectory({
   )
   const selectedSummary = items.find((item) => item.id === itemID) ?? null
   const selected = detailQ.data?.id === itemID ? detailQ.data : selectedSummary
-  const confirmItem = detailQ.data?.id === confirmID ? detailQ.data : items.find((item) => item.id === confirmID) ?? null
+	const confirmItem = detailQ.data?.id === confirmID ? detailQ.data : items.find((item) => item.id === confirmID) ?? null
+
+	useEffect(() => {
+		const onMessage = (event: MessageEvent) => {
+			if (event.origin !== window.location.origin || event.data?.type !== "parsar:mcp-oauth") return
+			setOAuthError(Boolean(event.data.error))
+			if (!event.data.error) {
+				void directoryQ.refetch()
+				void detailQ.refetch()
+			}
+		}
+		window.addEventListener("message", onMessage)
+		return () => window.removeEventListener("message", onMessage)
+	}, [detailQ, directoryQ])
+
+	const connectOAuth = (id: string) => {
+		if (!workspaceID) return
+		setOAuthError(false)
+		const width = 620
+		const height = 760
+		const left = Math.max(0, Math.round(window.screenX + (window.outerWidth - width) / 2))
+		const top = Math.max(0, Math.round(window.screenY + (window.outerHeight - height) / 2))
+		const popup = window.open(
+			mcpDirectoryOAuthStartURL(workspaceID, id),
+			`parsar-mcp-oauth-${id}`,
+			`popup=yes,width=${width},height=${height},left=${left},top=${top}`,
+		)
+		if (!popup) {
+			setOAuthError(true)
+			return
+		}
+		popup.focus()
+	}
 
   const requestImport = (id: string) => {
     if (!canImport) return
+		const item = items.find((candidate) => candidate.id === id)
+		if (item?.authentication === "oauth2" && !item.connected) {
+			connectOAuth(id)
+			return
+		}
     importMut.reset()
     setConfirmID(id)
   }
@@ -95,6 +134,7 @@ export function MCPDirectory({
     return (
       <>
         {success ? <SuccessBanner success={success} onViewCapability={onViewCapability} /> : null}
+		{oauthError ? <p className="mb-3 rounded-lg border border-line bg-surface px-4 py-3 text-sm text-danger">{t("capabilities.mcpDirectory.oauth.failed")}</p> : null}
         <DirectoryDetail
           item={selected}
           loading={detailQ.isLoading}
@@ -103,6 +143,7 @@ export function MCPDirectory({
           onBack={() => onSelectItem(null)}
           onRetry={() => void detailQ.refetch()}
           onImport={() => requestImport(itemID)}
+		  onConnect={() => connectOAuth(itemID)}
           onViewCapability={onViewCapability}
         />
         {importDialog}
@@ -140,6 +181,7 @@ export function MCPDirectory({
       </div>
 
       {success ? <SuccessBanner success={success} onViewCapability={onViewCapability} /> : null}
+	  {oauthError ? <p className="rounded-lg border border-line bg-surface px-4 py-3 text-sm text-danger">{t("capabilities.mcpDirectory.oauth.failed")}</p> : null}
       {directoryQ.isLoading ? (
         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3" data-testid="mcp-directory-loading">
           {Array.from({ length: 6 }).map((_, index) => <Skeleton key={index} className="h-52 w-full" />)}
@@ -150,7 +192,7 @@ export function MCPDirectory({
         <EmptyState icon={PackageCheck} title={t("capabilities.mcpDirectory.empty.title")} description={t("capabilities.mcpDirectory.empty.description")} />
       ) : (
         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-          {filtered.map((item) => <DirectoryCard key={item.id} item={item} canImport={canImport} onOpen={() => onSelectItem(item.id)} onImport={() => requestImport(item.id)} onViewCapability={onViewCapability} />)}
+		  {filtered.map((item) => <DirectoryCard key={item.id} item={item} canImport={canImport} onOpen={() => onSelectItem(item.id)} onImport={() => requestImport(item.id)} onConnect={() => connectOAuth(item.id)} onViewCapability={onViewCapability} />)}
         </div>
       )}
       {importDialog}

--- a/apps/web/src/pages/admin/capabilities/mcp-directory/MCPDirectoryCard.tsx
+++ b/apps/web/src/pages/admin/capabilities/mcp-directory/MCPDirectoryCard.tsx
@@ -6,11 +6,12 @@ import { Button } from "../../../../components/ui/button"
 import type { MCPDirectoryItem } from "../../../../lib/api-marketplace"
 import { ConnectorIcon, VerifiedBadge } from "./shared"
 
-export function DirectoryCard({ item, canImport, onOpen, onImport, onViewCapability }: {
+export function DirectoryCard({ item, canImport, onOpen, onImport, onConnect, onViewCapability }: {
   item: MCPDirectoryItem
   canImport: boolean
   onOpen: () => void
   onImport: () => void
+	onConnect: () => void
   onViewCapability: (capabilityID: string) => void
 }) {
   const { t } = useTranslation("admin")
@@ -27,6 +28,7 @@ export function DirectoryCard({ item, canImport, onOpen, onImport, onViewCapabil
             <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-fg-subtle">
               <span className="truncate">{item.publisher.name}</span>
               {item.verified ? <VerifiedBadge /> : null}
+			  {item.connected ? <Badge variant="success">{t("capabilities.mcpDirectory.oauth.connected")}</Badge> : null}
             </div>
           </div>
         </div>
@@ -40,7 +42,11 @@ export function DirectoryCard({ item, canImport, onOpen, onImport, onViewCapabil
           <Button className="w-full" variant="outline" size="sm" onClick={() => onViewCapability(item.installed_capability_id!)}>
             <Check className="h-3.5 w-3.5" /> {t("capabilities.mcpDirectory.actions.installed")}
           </Button>
-        ) : (
+        ) : item.authentication === "oauth2" && !item.connected ? (
+		  <Button className="w-full" size="sm" onClick={onConnect}>
+			{t("capabilities.mcpDirectory.oauth.connect")}
+		  </Button>
+		) : (
           <Button className="w-full" size="sm" disabled={!canImport} title={!canImport ? t("capabilities.permission.adminOnly") : undefined} onClick={onImport}>
             {canImport ? t("capabilities.mcpDirectory.actions.import") : t("capabilities.permission.adminOnly")}
           </Button>

--- a/apps/web/src/pages/admin/capabilities/mcp-directory/MCPDirectoryDetail.tsx
+++ b/apps/web/src/pages/admin/capabilities/mcp-directory/MCPDirectoryDetail.tsx
@@ -17,6 +17,7 @@ export function DirectoryDetail({
   onBack,
   onRetry,
   onImport,
+	onConnect,
   onViewCapability,
 }: {
   item: MCPDirectoryItem | null
@@ -26,6 +27,7 @@ export function DirectoryDetail({
   onBack: () => void
   onRetry: () => void
   onImport: () => void
+	onConnect: () => void
   onViewCapability: (capabilityID: string) => void
 }) {
   const { t } = useTranslation("admin")
@@ -71,6 +73,7 @@ export function DirectoryDetail({
               {item.installed ? (
                 <Badge variant="success">{t("capabilities.mcpDirectory.actions.installed")}</Badge>
               ) : null}
+			  {item.connected ? <Badge variant="success">{t("capabilities.mcpDirectory.oauth.connected")}</Badge> : null}
             </div>
             <p className="mt-1 text-sm text-fg-subtle">{item.publisher.name}</p>
             <p className="mt-4 max-w-3xl text-sm leading-6 text-fg-muted">{item.description}</p>
@@ -89,7 +92,11 @@ export function DirectoryDetail({
           />
           <Metadata
             label={t("capabilities.mcpDirectory.detail.authentication")}
-            value={t("capabilities.mcpDirectory.detail.noAuthentication")}
+			value={item.authentication === "oauth2"
+			  ? item.connected
+				? t("capabilities.mcpDirectory.oauth.connected")
+				: t("capabilities.mcpDirectory.oauth.required")
+			  : t("capabilities.mcpDirectory.detail.noAuthentication")}
           />
         </div>
         <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px]">
@@ -128,7 +135,11 @@ export function DirectoryDetail({
           </aside>
         </div>
         <div className="mt-5 flex flex-wrap justify-end gap-2 border-t border-line pt-4">
-          {item.installed && item.installed_capability_id ? (
+		  {item.authentication === "oauth2" && !item.connected ? (
+			<Button size="sm" onClick={onConnect}>
+			  {t("capabilities.mcpDirectory.oauth.connect")}
+			</Button>
+		  ) : item.installed && item.installed_capability_id ? (
             <Button
               variant="outline"
               size="sm"

--- a/catalog/mcp/README.md
+++ b/catalog/mcp/README.md
@@ -1,8 +1,8 @@
 # MCP Connector Directory Catalog
 
 `catalog.json` is the repository-maintained source for Parsar's built-in MCP
-Connector Directory. It contains metadata plus credential-free Streamable HTTP
-endpoints. Importing an item saves a workspace capability and never executes it.
+Connector Directory. It contains metadata plus hosted Streamable HTTP endpoints.
+Importing an item saves a workspace capability and never executes it.
 
 ## Updating the catalog
 
@@ -10,9 +10,10 @@ endpoints. Importing an item saves a workspace capability and never executes it.
   official MCP Registry.
 - Keep `id` stable and unique. Renaming an item does not require changing its
   ID.
-- Entries use an HTTPS `url` only. Built-in entries must
-  complete an MCP initialize request without headers, API keys, OAuth, or other
-  user credentials before they are added.
+- Entries use an HTTPS `url` only.
+- OAuth entries must support MCP OAuth discovery, PKCE, and dynamic client
+  registration. Tokens are stored in the existing encrypted workspace secret
+  flow and are never included in the catalog.
 - Use only HTTPS URLs without embedded credentials.
 - Update `updated_at` whenever catalog content changes.
 

--- a/catalog/mcp/catalog.json
+++ b/catalog/mcp/catalog.json
@@ -64,6 +64,30 @@
         "name": "firecrawl",
         "url": "https://mcp.firecrawl.dev/v2/mcp"
       }
+    },
+    {
+      "id": "notion",
+      "name": "Notion",
+      "description": "Search, read, create, and update pages and databases in the Notion workspaces you authorize.",
+      "publisher": {
+        "name": "Notion",
+        "url": "https://www.notion.so"
+      },
+      "icon_url": "https://github.com/makenotion.png?size=128",
+      "homepage_url": "https://developers.notion.com/guides/mcp/get-started-with-mcp",
+      "verified": true,
+      "categories": ["Productivity", "Knowledge"],
+      "featured_rank": 4,
+      "version": "1.0.0",
+      "transport": "streamable-http",
+      "authentication": {
+        "type": "oauth2",
+        "credential_kind": "notion_integration"
+      },
+      "server": {
+        "name": "notion",
+        "url": "https://mcp.notion.com/mcp"
+      }
     }
   ]
 }

--- a/catalog/mcp/catalog.schema.json
+++ b/catalog/mcp/catalog.schema.json
@@ -37,6 +37,22 @@
         "url": { "$ref": "#/$defs/httpUrl" }
       }
     },
+    "authentication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type"],
+      "properties": {
+        "type": { "enum": ["none", "oauth2"] },
+        "credential_kind": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$"
+        }
+      },
+      "if": {
+        "properties": { "type": { "const": "oauth2" } }
+      },
+      "then": { "required": ["credential_kind"] }
+    },
     "item": {
       "type": "object",
       "additionalProperties": false,
@@ -69,6 +85,7 @@
         "featured_rank": { "type": "integer", "minimum": 1 },
         "version": { "type": "string", "minLength": 1 },
         "transport": { "const": "streamable-http" },
+        "authentication": { "$ref": "#/$defs/authentication" },
         "server": { "$ref": "#/$defs/server" }
       }
     }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1152,10 +1152,14 @@ definitions:
     type: object
   mcpdirectory.itemResponse:
     properties:
+      authentication:
+        type: string
       categories:
         items:
           type: string
         type: array
+      connected:
+        type: boolean
       description:
         type: string
       featured_rank:
@@ -7147,6 +7151,84 @@ paths:
               type: string
             type: object
       summary: Import an MCP Connector Directory item
+      tags:
+      - mcp-directory
+  /api/v1/workspaces/{workspaceID}/mcp-directory/{catalogID}/oauth/callback:
+    get:
+      parameters:
+      - description: workspace id
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: catalog item id
+        in: path
+        name: catalogID
+        required: true
+        type: string
+      - description: OAuth state
+        in: query
+        name: state
+        required: true
+        type: string
+      - description: OAuth authorization code
+        in: query
+        name: code
+        required: true
+        type: string
+      responses:
+        "200":
+          description: Closes the OAuth popup
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "502":
+          description: Bad Gateway
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Complete an MCP connector OAuth flow
+      tags:
+      - mcp-directory
+  /api/v1/workspaces/{workspaceID}/mcp-directory/{catalogID}/oauth/start:
+    get:
+      parameters:
+      - description: workspace id
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: catalog item id
+        in: path
+        name: catalogID
+        required: true
+        type: string
+      responses:
+        "302":
+          description: Redirect to the provider authorization page
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Service Unavailable
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Start an MCP connector OAuth flow
       tags:
       - mcp-directory
   /api/v1/workspaces/{workspaceID}/members:

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -47,6 +47,7 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/feishu"
 	authgithub "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/github"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/mcpoauth"
 	authpassword "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/password"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/bootstrap"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/config"
@@ -707,13 +708,26 @@ func main() {
 			SharedRuntimeToken: strings.TrimSpace(envLookup("PARSAR_SHARED_RUNTIME_TOKEN")),
 		}
 		mcpCatalog := mcpcatalog.New(mcpcatalog.Options{})
+		mcpOAuthSecrets, mcpOAuthSecretsErr := secrets.New(cfg.Secret.MasterKey)
+		if mcpOAuthSecretsErr != nil {
+			log.Bg().Warn("MCP connector OAuth disabled", "error", mcpOAuthSecretsErr)
+		}
+		publicURL := strings.TrimSpace(cfg.Server.PublicURL)
+		if publicURL == "" {
+			publicURL = "http://localhost" + cfg.Server.Addr
+		}
 		sessionStore := auth.NewPostgresSessionStore(sqlc.New(pool))
 		authMw := auth.NewMiddleware(sessionStore).WithDevAuth(cfg.Auth.DevAuth)
 		r.Group(func(r chi.Router) {
 			r.Use(authMw.Require)
 			mcpdirectoryapi.RegisterRoutes(r, mcpdirectoryapi.Deps{
-				Catalog: mcpCatalog,
-				Store:   dbStore,
+				Catalog:              mcpCatalog,
+				Store:                dbStore,
+				WorkspaceCredentials: dbStore,
+				OAuth:                mcpoauth.New(nil),
+				Secrets:              mcpOAuthSecrets,
+				PublicURL:            publicURL,
+				CookieSecure:         cfg.Auth.Cookie.Secure,
 			})
 			runtimeapi.RegisterAdminRoutes(r, runtimeDeps)
 		})

--- a/server/internal/api/mcpdirectory/handler.go
+++ b/server/internal/api/mcpdirectory/handler.go
@@ -14,7 +14,9 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/mcpoauth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/mcpcatalog"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 )
 
@@ -28,9 +30,20 @@ type directoryStore interface {
 	ImportCapability(ctx context.Context, input store.ImportCapabilityInput) (store.ImportCapabilityResult, error)
 }
 
+type workspaceCredentialStore interface {
+	ListSecrets(ctx context.Context, workspaceID string, limit int32) ([]store.SecretRead, error)
+	CreateSecret(ctx context.Context, input store.CreateSecretInput, encryptedPayload []byte) (store.SecretRead, error)
+	UpdateSecretPayload(ctx context.Context, workspaceID, secretID string, encryptedPayload []byte) (store.SecretPayload, error)
+}
+
 type Deps struct {
-	Catalog catalogLoader
-	Store   directoryStore
+	Catalog              catalogLoader
+	Store                directoryStore
+	WorkspaceCredentials workspaceCredentialStore
+	OAuth                *mcpoauth.Client
+	Secrets              *secrets.Service
+	PublicURL            string
+	CookieSecure         bool
 }
 
 type handler struct {
@@ -50,6 +63,8 @@ type itemResponse struct {
 	FeaturedRank          int                  `json:"featured_rank"`
 	Version               string               `json:"version"`
 	Transport             string               `json:"transport"`
+	Authentication        string               `json:"authentication"`
+	Connected             bool                 `json:"connected"`
 	URL                   string               `json:"url,omitempty"`
 	Installed             bool                 `json:"installed"`
 	InstalledCapabilityID *string              `json:"installed_capability_id"`
@@ -80,6 +95,8 @@ func RegisterRoutes(r chi.Router, deps Deps) {
 	r.Get("/api/v1/workspaces/{workspaceID}/mcp-directory", h.list)
 	r.Get("/api/v1/workspaces/{workspaceID}/mcp-directory/{catalogID}", h.get)
 	r.Post("/api/v1/workspaces/{workspaceID}/mcp-directory/{catalogID}/import", h.importItem)
+	r.Get("/api/v1/workspaces/{workspaceID}/mcp-directory/{catalogID}/oauth/start", h.oauthStart)
+	r.Get("/api/v1/workspaces/{workspaceID}/mcp-directory/{catalogID}/oauth/callback", h.oauthCallback)
 }
 
 // list godoc
@@ -104,9 +121,13 @@ func (h *handler) list(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	byCatalog := installMap(installs)
+	connected, ok := h.connectedCatalogIDs(w, r, workspaceID)
+	if !ok {
+		return
+	}
 	items := make([]itemResponse, 0, len(snapshot.Catalog.Items))
 	for _, item := range snapshot.Catalog.Items {
-		items = append(items, summarizeItem(item, byCatalog[item.ID]))
+		items = append(items, summarizeItem(item, byCatalog[item.ID], connected[item.ID]))
 	}
 	writeJSON(w, http.StatusOK, listResponse{
 		Items:     items,
@@ -140,7 +161,11 @@ func (h *handler) get(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "connector_not_found")
 		return
 	}
-	response := summarizeItem(item, installMap(installs)[item.ID])
+	connected, ok := h.connectedCatalogIDs(w, r, workspaceID)
+	if !ok {
+		return
+	}
+	response := summarizeItem(item, installMap(installs)[item.ID], connected[item.ID])
 	response.URL = item.Server.URL
 	writeJSON(w, http.StatusOK, response)
 }
@@ -177,6 +202,16 @@ func (h *handler) importItem(w http.ResponseWriter, r *http.Request) {
 	if existing, installed := installMap(installs)[item.ID]; installed {
 		writeJSON(w, http.StatusOK, importResponse{Installed: true, CapabilityID: existing.CapabilityID})
 		return
+	}
+	if item.Authentication.EffectiveType() == "oauth2" {
+		connected, ok := h.connectedCatalogIDs(w, r, workspaceID)
+		if !ok {
+			return
+		}
+		if !connected[item.ID] {
+			writeError(w, http.StatusConflict, "connector_oauth_required")
+			return
+		}
 	}
 
 	payload, err := json.Marshal(sourcePayload{
@@ -225,6 +260,14 @@ func (h *handler) importItem(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) authorize(w http.ResponseWriter, r *http.Request, admin bool) (string, bool) {
+	allowed := []string{"owner", "admin", "member", "viewer"}
+	if admin {
+		allowed = []string{"owner", "admin"}
+	}
+	return h.authorizeRoles(w, r, allowed...)
+}
+
+func (h *handler) authorizeRoles(w http.ResponseWriter, r *http.Request, allowed ...string) (string, bool) {
 	if h.deps.Catalog == nil || h.deps.Store == nil {
 		writeError(w, http.StatusServiceUnavailable, "mcp_directory_unavailable")
 		return "", false
@@ -233,10 +276,6 @@ func (h *handler) authorize(w http.ResponseWriter, r *http.Request, admin bool) 
 	if _, err := uuid.Parse(workspaceID); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_workspace_id")
 		return "", false
-	}
-	allowed := []string{"owner", "admin", "member", "viewer"}
-	if admin {
-		allowed = []string{"owner", "admin"}
 	}
 	if err := auth.RequireWorkspaceRole(r.Context(), h.deps.Store, workspaceID, allowed...); err != nil {
 		switch {
@@ -274,7 +313,7 @@ func installMap(installs []store.MCPDirectoryInstall) map[string]store.MCPDirect
 	return result
 }
 
-func summarizeItem(item mcpcatalog.Item, install store.MCPDirectoryInstall) itemResponse {
+func summarizeItem(item mcpcatalog.Item, install store.MCPDirectoryInstall, connected bool) itemResponse {
 	var installedCapabilityID *string
 	if install.CapabilityID != "" {
 		id := install.CapabilityID
@@ -293,9 +332,40 @@ func summarizeItem(item mcpcatalog.Item, install store.MCPDirectoryInstall) item
 		FeaturedRank:          item.FeaturedRank,
 		Version:               item.Version,
 		Transport:             item.Transport,
+		Authentication:        item.Authentication.EffectiveType(),
+		Connected:             connected,
 		Installed:             install.CapabilityID != "",
 		InstalledCapabilityID: installedCapabilityID,
 	}
+}
+
+func (h *handler) connectedCatalogIDs(w http.ResponseWriter, r *http.Request, workspaceID string) (map[string]bool, bool) {
+	result := map[string]bool{}
+	if h.deps.WorkspaceCredentials == nil {
+		return result, true
+	}
+	workspaceSecrets, err := h.deps.WorkspaceCredentials.ListSecrets(r.Context(), workspaceID, 1000)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "connector_connection_state_failed")
+		return nil, false
+	}
+	for _, candidate := range workspaceSecrets {
+		if candidate.Kind != "capability_inline" ||
+			candidate.AuthType != "oauth2" ||
+			candidate.Status != "active" ||
+			metadataString(candidate.Metadata, "workspace_id") != strings.TrimSpace(workspaceID) {
+			continue
+		}
+		if catalogID := metadataString(candidate.Metadata, "catalog_id"); catalogID != "" {
+			result[catalogID] = true
+		}
+	}
+	return result, true
+}
+
+func metadataString(metadata map[string]any, key string) string {
+	value, _ := metadata[key].(string)
+	return strings.TrimSpace(value)
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {

--- a/server/internal/api/mcpdirectory/handler_test.go
+++ b/server/internal/api/mcpdirectory/handler_test.go
@@ -37,6 +37,22 @@ type fakeDirectoryStore struct {
 	imported          *store.ImportCapabilityInput
 }
 
+type fakeWorkspaceCredentialStore struct {
+	secrets []store.SecretRead
+}
+
+func (f *fakeWorkspaceCredentialStore) ListSecrets(context.Context, string, int32) ([]store.SecretRead, error) {
+	return append([]store.SecretRead(nil), f.secrets...), nil
+}
+
+func (f *fakeWorkspaceCredentialStore) CreateSecret(context.Context, store.CreateSecretInput, []byte) (store.SecretRead, error) {
+	return store.SecretRead{}, nil
+}
+
+func (f *fakeWorkspaceCredentialStore) UpdateSecretPayload(context.Context, string, string, []byte) (store.SecretPayload, error) {
+	return store.SecretPayload{}, nil
+}
+
 func (f *fakeDirectoryStore) GetWorkspaceMemberRole(context.Context, string, string) (string, error) {
 	if f.roleErr != nil {
 		return "", f.roleErr
@@ -127,6 +143,37 @@ func TestDirectoryImportIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestOAuthDirectoryItemRequiresWorkspaceConnectionBeforeImport(t *testing.T) {
+	snapshot := testSnapshot()
+	snapshot.Catalog.Items = []mcpcatalog.Item{{
+		ID: "notion", Name: "Notion", Description: "Search Notion.",
+		Publisher: mcpcatalog.Publisher{Name: "Notion", URL: "https://www.notion.so"},
+		Verified:  true, Categories: []string{"Productivity"}, FeaturedRank: 1,
+		Version: "1.0.0", Transport: "streamable-http",
+		Authentication: mcpcatalog.Authentication{Type: "oauth2", CredentialKind: "notion_integration"},
+		Server:         mcpcatalog.Server{Name: "notion", URL: "https://mcp.notion.com/mcp"},
+	}}
+	fs := &fakeDirectoryStore{role: "admin"}
+	credentials := &fakeWorkspaceCredentialStore{}
+	rec := requestWithDeps(t, fs, credentials, snapshot, http.MethodPost, "/api/v1/workspaces/"+testWorkspaceID+"/mcp-directory/notion/import")
+	if rec.Code != http.StatusConflict || fs.imported != nil {
+		t.Fatalf("status=%d imported=%v body=%s", rec.Code, fs.imported != nil, rec.Body.String())
+	}
+
+	credentials.secrets = []store.SecretRead{{
+		ID: "secret-1", Kind: "capability_inline", AuthType: "oauth2", Status: "active",
+		Metadata: map[string]any{"workspace_id": testWorkspaceID, "catalog_id": "notion"},
+	}}
+	rec = requestWithDeps(t, fs, credentials, snapshot, http.MethodPost, "/api/v1/workspaces/"+testWorkspaceID+"/mcp-directory/notion/import")
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	header := fs.imported.Spec.MCP.Servers[0].Headers["Authorization"]
+	if header.Prefix != "Bearer " || header.CredentialKindCode != "notion_integration" {
+		t.Fatalf("authorization header = %+v", header)
+	}
+}
+
 func TestDirectoryImportRecoversConcurrentIdenticalImport(t *testing.T) {
 	fs := &fakeDirectoryStore{role: "admin", importErr: store.ErrCapabilityNameTaken, concurrentInstall: true}
 	rec := request(t, fs, http.MethodPost, "/api/v1/workspaces/"+testWorkspaceID+"/mcp-directory/context7/import")
@@ -185,6 +232,10 @@ func request(t *testing.T, fs *fakeDirectoryStore, method, path string) *httptes
 }
 
 func requestWithSnapshot(t *testing.T, fs *fakeDirectoryStore, snapshot mcpcatalog.Snapshot, method, path string) *httptest.ResponseRecorder {
+	return requestWithDeps(t, fs, nil, snapshot, method, path)
+}
+
+func requestWithDeps(t *testing.T, fs *fakeDirectoryStore, credentials workspaceCredentialStore, snapshot mcpcatalog.Snapshot, method, path string) *httptest.ResponseRecorder {
 	t.Helper()
 	router := chi.NewRouter()
 	router.Use(func(next http.Handler) http.Handler {
@@ -192,7 +243,7 @@ func requestWithSnapshot(t *testing.T, fs *fakeDirectoryStore, snapshot mcpcatal
 			next.ServeHTTP(w, r.WithContext(auth.WithUserID(r.Context(), testUserID)))
 		})
 	})
-	RegisterRoutes(router, Deps{Catalog: fakeCatalog{snapshot: snapshot}, Store: fs})
+	RegisterRoutes(router, Deps{Catalog: fakeCatalog{snapshot: snapshot}, Store: fs, WorkspaceCredentials: credentials})
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, httptest.NewRequest(method, path, nil))
 	return rec

--- a/server/internal/api/mcpdirectory/oauth.go
+++ b/server/internal/api/mcpdirectory/oauth.go
@@ -1,0 +1,288 @@
+package mcpdirectory
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/mcpoauth"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/mcpcatalog"
+)
+
+const (
+	oauthCookieName = "parsar_mcp_oauth"
+	oauthCookieTTL  = 10 * time.Minute
+)
+
+type oauthCookie struct {
+	WorkspaceID string               `json:"workspace_id"`
+	CatalogID   string               `json:"catalog_id"`
+	UserID      string               `json:"user_id"`
+	Transaction mcpoauth.Transaction `json:"transaction"`
+}
+
+// oauthStart godoc
+//
+//	@Summary Start an MCP connector OAuth flow
+//	@Tags mcp-directory
+//	@Param workspaceID path string true "workspace id"
+//	@Param catalogID path string true "catalog item id"
+//	@Success 302 "Redirect to the provider authorization page"
+//	@Failure 400 {object} map[string]string
+//	@Failure 404 {object} map[string]string
+//	@Failure 503 {object} map[string]string
+//	@Router /api/v1/workspaces/{workspaceID}/mcp-directory/{catalogID}/oauth/start [get]
+func (h *handler) oauthStart(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := h.authorizeRoles(w, r, "owner", "admin", "member")
+	if !ok {
+		return
+	}
+	item, ok := h.oauthItem(w, r)
+	if !ok {
+		return
+	}
+	if h.deps.OAuth == nil || h.deps.Secrets == nil || h.deps.WorkspaceCredentials == nil {
+		writeError(w, http.StatusServiceUnavailable, "connector_oauth_unavailable")
+		return
+	}
+	baseURL, err := h.oauthBaseURL(r)
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "connector_oauth_public_url_invalid")
+		return
+	}
+	callbackURL, err := publicURLFor(baseURL, oauthCookiePath(workspaceID, item.ID)+"/callback")
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "connector_oauth_public_url_invalid")
+		return
+	}
+	transaction, authorizeURL, err := h.deps.OAuth.Begin(r.Context(), item.Server.URL, callbackURL)
+	if err != nil {
+		log.Warn(r.Context(), "mcp oauth start failed", "catalog_id", item.ID, "error", err)
+		writeError(w, http.StatusBadGateway, "connector_oauth_discovery_failed")
+		return
+	}
+	cookieValue, err := h.encryptOAuthCookie(oauthCookie{
+		WorkspaceID: workspaceID,
+		CatalogID:   item.ID,
+		UserID:      auth.UserIDFromContext(r.Context()),
+		Transaction: transaction,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "connector_oauth_state_failed")
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthCookieName,
+		Value:    cookieValue,
+		Path:     oauthCookiePath(workspaceID, item.ID),
+		HttpOnly: true,
+		Secure:   h.deps.CookieSecure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   int(oauthCookieTTL.Seconds()),
+	})
+	http.Redirect(w, r, authorizeURL, http.StatusFound)
+}
+
+// oauthCallback godoc
+//
+//	@Summary Complete an MCP connector OAuth flow
+//	@Tags mcp-directory
+//	@Param workspaceID path string true "workspace id"
+//	@Param catalogID path string true "catalog item id"
+//	@Param state query string true "OAuth state"
+//	@Param code query string true "OAuth authorization code"
+//	@Success 200 "Closes the OAuth popup"
+//	@Failure 400 {object} map[string]string
+//	@Failure 502 {object} map[string]string
+//	@Router /api/v1/workspaces/{workspaceID}/mcp-directory/{catalogID}/oauth/callback [get]
+func (h *handler) oauthCallback(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := h.authorizeRoles(w, r, "owner", "admin", "member")
+	if !ok {
+		return
+	}
+	item, ok := h.oauthItem(w, r)
+	if !ok {
+		return
+	}
+	if providerError := strings.TrimSpace(r.URL.Query().Get("error")); providerError != "" {
+		h.writeOAuthCompletion(w, item.ID, providerError)
+		return
+	}
+	code := strings.TrimSpace(r.URL.Query().Get("code"))
+	state := strings.TrimSpace(r.URL.Query().Get("state"))
+	if code == "" || state == "" {
+		writeError(w, http.StatusBadRequest, "connector_oauth_missing_code_or_state")
+		return
+	}
+	cookie, err := r.Cookie(oauthCookieName)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "connector_oauth_state_missing")
+		return
+	}
+	oauthState, err := h.decryptOAuthCookie(cookie.Value)
+	if err != nil ||
+		oauthState.WorkspaceID != workspaceID ||
+		oauthState.CatalogID != item.ID ||
+		oauthState.UserID != auth.UserIDFromContext(r.Context()) ||
+		oauthState.Transaction.State != state {
+		writeError(w, http.StatusBadRequest, "connector_oauth_state_mismatch")
+		return
+	}
+	if time.Since(time.Unix(oauthState.Transaction.IssuedAt, 0)) > oauthCookieTTL {
+		writeError(w, http.StatusBadRequest, "connector_oauth_state_expired")
+		return
+	}
+	if h.deps.OAuth == nil || h.deps.Secrets == nil || h.deps.WorkspaceCredentials == nil {
+		writeError(w, http.StatusServiceUnavailable, "connector_oauth_unavailable")
+		return
+	}
+	h.clearOAuthCookie(w, workspaceID, item.ID)
+	credential, err := h.deps.OAuth.Exchange(r.Context(), oauthState.Transaction, code)
+	if err != nil {
+		log.Warn(r.Context(), "mcp oauth token exchange failed", "catalog_id", item.ID, "error", err)
+		writeError(w, http.StatusBadGateway, "connector_oauth_exchange_failed")
+		return
+	}
+	if err := h.saveWorkspaceOAuthCredential(r.Context(), workspaceID, item, credential, auth.UserIDFromContext(r.Context())); err != nil {
+		log.Error(r.Context(), "mcp oauth credential persist failed", "catalog_id", item.ID, "error", err)
+		writeError(w, http.StatusInternalServerError, "connector_oauth_persist_failed")
+		return
+	}
+	h.writeOAuthCompletion(w, item.ID, "")
+}
+
+func (h *handler) oauthItem(w http.ResponseWriter, r *http.Request) (mcpcatalog.Item, bool) {
+	snapshot, err := h.deps.Catalog.Load(r.Context())
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "mcp_catalog_unavailable")
+		return mcpcatalog.Item{}, false
+	}
+	item, found := snapshot.Find(chi.URLParam(r, "catalogID"))
+	if !found {
+		writeError(w, http.StatusNotFound, "connector_not_found")
+		return mcpcatalog.Item{}, false
+	}
+	if item.Authentication.EffectiveType() != "oauth2" {
+		writeError(w, http.StatusBadRequest, "connector_does_not_use_oauth")
+		return mcpcatalog.Item{}, false
+	}
+	return item, true
+}
+
+func (h *handler) encryptOAuthCookie(value oauthCookie) (string, error) {
+	transactionJSON, err := json.Marshal(value.Transaction)
+	if err != nil {
+		return "", err
+	}
+	encrypted, err := h.deps.Secrets.Encrypt(map[string]any{
+		"workspace_id": value.WorkspaceID,
+		"catalog_id":   value.CatalogID,
+		"user_id":      value.UserID,
+		"transaction":  string(transactionJSON),
+	})
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(encrypted), nil
+}
+
+func (h *handler) decryptOAuthCookie(encoded string) (oauthCookie, error) {
+	encrypted, err := base64.RawURLEncoding.DecodeString(encoded)
+	if err != nil {
+		return oauthCookie{}, err
+	}
+	payload, err := h.deps.Secrets.Decrypt(encrypted)
+	if err != nil {
+		return oauthCookie{}, err
+	}
+	result := oauthCookie{
+		WorkspaceID: stringField(payload, "workspace_id"),
+		CatalogID:   stringField(payload, "catalog_id"),
+		UserID:      stringField(payload, "user_id"),
+	}
+	if err := json.Unmarshal([]byte(stringField(payload, "transaction")), &result.Transaction); err != nil {
+		return oauthCookie{}, err
+	}
+	return result, nil
+}
+
+func (h *handler) writeOAuthCompletion(w http.ResponseWriter, catalogID, errorCode string) {
+	payload, _ := json.Marshal(map[string]string{
+		"type":       "parsar:mcp-oauth",
+		"catalog_id": catalogID,
+		"error":      errorCode,
+	})
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintf(w, `<!doctype html><meta charset="utf-8"><title>Parsar OAuth</title><script>if(window.opener){window.opener.postMessage(%s,window.location.origin)}window.close()</script>`, payload)
+}
+
+func publicURLFor(baseURL, path string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return "", fmt.Errorf("invalid public url")
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + path
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func (h *handler) oauthBaseURL(r *http.Request) (string, error) {
+	configured, err := url.Parse(strings.TrimSpace(h.deps.PublicURL))
+	if err != nil || configured.Host == "" || (configured.Scheme != "http" && configured.Scheme != "https") {
+		return "", fmt.Errorf("invalid public url")
+	}
+	if !isLoopbackHost(configured.Hostname()) {
+		return strings.TrimRight(configured.String(), "/"), nil
+	}
+	requestURL, err := url.Parse("http://" + strings.TrimSpace(r.Host))
+	if err != nil || requestURL.Host == "" || !isLoopbackHost(requestURL.Hostname()) {
+		return strings.TrimRight(configured.String(), "/"), nil
+	}
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	} else if forwarded := strings.TrimSpace(strings.Split(r.Header.Get("X-Forwarded-Proto"), ",")[0]); forwarded == "http" || forwarded == "https" {
+		scheme = forwarded
+	}
+	return (&url.URL{Scheme: scheme, Host: requestURL.Host, Path: strings.TrimRight(configured.Path, "/")}).String(), nil
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(strings.TrimSpace(host), "localhost") {
+		return true
+	}
+	ip := net.ParseIP(strings.TrimSpace(host))
+	return ip != nil && ip.IsLoopback()
+}
+
+func (h *handler) clearOAuthCookie(w http.ResponseWriter, workspaceID, catalogID string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     oauthCookieName,
+		Value:    "",
+		Path:     oauthCookiePath(workspaceID, catalogID),
+		HttpOnly: true,
+		Secure:   h.deps.CookieSecure,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   -1,
+	})
+}
+
+func oauthCookiePath(workspaceID, catalogID string) string {
+	return "/api/v1/workspaces/" + url.PathEscape(workspaceID) + "/mcp-directory/" + url.PathEscape(catalogID) + "/oauth"
+}
+
+func stringField(payload map[string]any, key string) string {
+	value, _ := payload[key].(string)
+	return strings.TrimSpace(value)
+}

--- a/server/internal/api/mcpdirectory/oauth_scope.go
+++ b/server/internal/api/mcpdirectory/oauth_scope.go
@@ -1,0 +1,73 @@
+package mcpdirectory
+
+import (
+	"context"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/mcpoauth"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/mcpcatalog"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func (h *handler) saveWorkspaceOAuthCredential(
+	ctx context.Context,
+	workspaceID string,
+	item mcpcatalog.Item,
+	credential mcpoauth.Credential,
+	createdBy string,
+) error {
+	payload := credential.Payload()
+	payload["catalog_id"] = item.ID
+	encrypted, err := h.deps.Secrets.Encrypt(payload)
+	if err != nil {
+		return err
+	}
+	existing, found, err := h.workspaceOAuthCredentialRead(ctx, workspaceID, item, false)
+	if err != nil {
+		return err
+	}
+	if found {
+		_, err = h.deps.WorkspaceCredentials.UpdateSecretPayload(ctx, workspaceID, existing.ID, encrypted)
+		return err
+	}
+	_, err = h.deps.WorkspaceCredentials.CreateSecret(ctx, store.CreateSecretInput{
+		WorkspaceID:        workspaceID,
+		Name:               item.Name + " OAuth",
+		Kind:               "capability_inline",
+		Provider:           item.ID,
+		AuthType:           "oauth2",
+		Masked:             secrets.MaskPayload(payload),
+		CreatedBy:          createdBy,
+		CredentialKindCode: item.Authentication.CredentialKind,
+		Metadata: map[string]any{
+			"catalog_id": item.ID,
+		},
+	}, encrypted)
+	return err
+}
+
+func (h *handler) workspaceOAuthCredentialRead(
+	ctx context.Context,
+	workspaceID string,
+	item mcpcatalog.Item,
+	activeOnly bool,
+) (store.SecretRead, bool, error) {
+	workspaceSecrets, err := h.deps.WorkspaceCredentials.ListSecrets(ctx, workspaceID, 1000)
+	if err != nil {
+		return store.SecretRead{}, false, err
+	}
+	for _, candidate := range workspaceSecrets {
+		if activeOnly && candidate.Status != "active" {
+			continue
+		}
+		if candidate.Kind != "capability_inline" ||
+			candidate.AuthType != "oauth2" ||
+			metadataString(candidate.Metadata, "workspace_id") != strings.TrimSpace(workspaceID) ||
+			metadataString(candidate.Metadata, "catalog_id") != item.ID {
+			continue
+		}
+		return candidate, true, nil
+	}
+	return store.SecretRead{}, false, nil
+}

--- a/server/internal/auth/mcpoauth/client.go
+++ b/server/internal/auth/mcpoauth/client.go
@@ -1,0 +1,429 @@
+package mcpoauth
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	maxMetadataBytes = 1 << 20
+)
+
+type Doer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type Client struct {
+	http Doer
+	now  func() time.Time
+}
+
+type Transaction struct {
+	State                   string `json:"state"`
+	CodeVerifier            string `json:"code_verifier"`
+	ClientID                string `json:"client_id"`
+	ClientSecret            string `json:"client_secret,omitempty"`
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
+	AuthorizationEndpoint   string `json:"authorization_endpoint"`
+	TokenEndpoint           string `json:"token_endpoint"`
+	RedirectURI             string `json:"redirect_uri"`
+	Resource                string `json:"resource"`
+	Scope                   string `json:"scope,omitempty"`
+	IssuedAt                int64  `json:"issued_at"`
+}
+
+type Credential struct {
+	AccessToken             string
+	RefreshToken            string
+	TokenType               string
+	Scope                   string
+	ExpiresAt               time.Time
+	ClientID                string
+	ClientSecret            string
+	TokenEndpointAuthMethod string
+	TokenEndpoint           string
+	Resource                string
+}
+
+type protectedResourceMetadata struct {
+	Resource             string   `json:"resource"`
+	AuthorizationServers []string `json:"authorization_servers"`
+	ScopesSupported      []string `json:"scopes_supported"`
+}
+
+type authorizationServerMetadata struct {
+	Issuer                        string   `json:"issuer"`
+	AuthorizationEndpoint         string   `json:"authorization_endpoint"`
+	TokenEndpoint                 string   `json:"token_endpoint"`
+	RegistrationEndpoint          string   `json:"registration_endpoint"`
+	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported"`
+	TokenEndpointMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+}
+
+type registrationResponse struct {
+	ClientID                string `json:"client_id"`
+	ClientSecret            string `json:"client_secret"`
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
+}
+
+type tokenResponse struct {
+	AccessToken  string          `json:"access_token"`
+	RefreshToken string          `json:"refresh_token"`
+	TokenType    string          `json:"token_type"`
+	Scope        string          `json:"scope"`
+	ExpiresIn    json.RawMessage `json:"expires_in"`
+}
+
+func New(httpClient Doer) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 10 * time.Second}
+	}
+	return &Client{http: httpClient, now: time.Now}
+}
+
+func (c *Client) Begin(ctx context.Context, resource, redirectURI string) (Transaction, string, error) {
+	resourceURL, err := requireHTTPSURL(resource)
+	if err != nil {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: resource: %w", err)
+	}
+	if _, err := requireHTTPURL(redirectURI); err != nil {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: redirect_uri: %w", err)
+	}
+
+	var protected protectedResourceMetadata
+	if err := c.getJSON(ctx, protectedResourceMetadataURL(resourceURL), &protected); err != nil {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: protected resource discovery: %w", err)
+	}
+	if strings.TrimSpace(protected.Resource) != resourceURL.String() {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: protected resource metadata returned resource %q", protected.Resource)
+	}
+	if len(protected.AuthorizationServers) == 0 {
+		return Transaction{}, "", errors.New("mcp oauth: protected resource metadata has no authorization server")
+	}
+	issuer, err := requireHTTPSURL(protected.AuthorizationServers[0])
+	if err != nil {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: authorization server: %w", err)
+	}
+
+	metadata, err := c.discoverAuthorizationServer(ctx, issuer)
+	if err != nil {
+		return Transaction{}, "", err
+	}
+	if strings.TrimRight(metadata.Issuer, "/") != strings.TrimRight(issuer.String(), "/") {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: authorization server issuer mismatch: %q", metadata.Issuer)
+	}
+	if !contains(metadata.CodeChallengeMethodsSupported, "S256") {
+		return Transaction{}, "", errors.New("mcp oauth: authorization server does not support PKCE S256")
+	}
+	if _, err := requireHTTPSURL(metadata.AuthorizationEndpoint); err != nil {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: authorization endpoint: %w", err)
+	}
+	if _, err := requireHTTPSURL(metadata.TokenEndpoint); err != nil {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: token endpoint: %w", err)
+	}
+	if _, err := requireHTTPSURL(metadata.RegistrationEndpoint); err != nil {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: registration endpoint: %w", err)
+	}
+
+	registration, err := c.register(ctx, metadata.RegistrationEndpoint, redirectURI)
+	if err != nil {
+		return Transaction{}, "", err
+	}
+	state, err := randomURLToken(24)
+	if err != nil {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: state: %w", err)
+	}
+	verifier, err := randomURLToken(48)
+	if err != nil {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: code verifier: %w", err)
+	}
+	challengeBytes := sha256.Sum256([]byte(verifier))
+	challenge := base64.RawURLEncoding.EncodeToString(challengeBytes[:])
+
+	authorizeURL, err := url.Parse(metadata.AuthorizationEndpoint)
+	if err != nil {
+		return Transaction{}, "", fmt.Errorf("mcp oauth: parse authorization endpoint: %w", err)
+	}
+	query := authorizeURL.Query()
+	query.Set("response_type", "code")
+	query.Set("client_id", registration.ClientID)
+	query.Set("redirect_uri", redirectURI)
+	query.Set("state", state)
+	query.Set("code_challenge", challenge)
+	query.Set("code_challenge_method", "S256")
+	query.Set("resource", resourceURL.String())
+	scope := strings.Join(protected.ScopesSupported, " ")
+	if scope != "" {
+		query.Set("scope", scope)
+	}
+	authorizeURL.RawQuery = query.Encode()
+
+	return Transaction{
+		State:                   state,
+		CodeVerifier:            verifier,
+		ClientID:                registration.ClientID,
+		ClientSecret:            registration.ClientSecret,
+		TokenEndpointAuthMethod: registration.TokenEndpointAuthMethod,
+		AuthorizationEndpoint:   metadata.AuthorizationEndpoint,
+		TokenEndpoint:           metadata.TokenEndpoint,
+		RedirectURI:             redirectURI,
+		Resource:                resourceURL.String(),
+		Scope:                   scope,
+		IssuedAt:                c.now().UTC().Unix(),
+	}, authorizeURL.String(), nil
+}
+
+func (c *Client) discoverAuthorizationServer(ctx context.Context, issuer *url.URL) (authorizationServerMetadata, error) {
+	var metadata authorizationServerMetadata
+	oauthURL := authorizationServerMetadataURL(issuer)
+	if err := c.getJSON(ctx, oauthURL, &metadata); err == nil {
+		return metadata, nil
+	} else {
+		var openIDMetadata authorizationServerMetadata
+		openIDURL := openIDConfigurationURL(issuer)
+		if openIDErr := c.getJSON(ctx, openIDURL, &openIDMetadata); openIDErr != nil {
+			return authorizationServerMetadata{}, fmt.Errorf(
+				"mcp oauth: authorization server discovery: oauth metadata: %v; openid metadata: %w",
+				err,
+				openIDErr,
+			)
+		}
+		return openIDMetadata, nil
+	}
+}
+
+func (c *Client) Exchange(ctx context.Context, transaction Transaction, code string) (Credential, error) {
+	values := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {strings.TrimSpace(code)},
+		"redirect_uri":  {transaction.RedirectURI},
+		"client_id":     {transaction.ClientID},
+		"code_verifier": {transaction.CodeVerifier},
+		"resource":      {transaction.Resource},
+	}
+	return c.tokenRequest(ctx, transaction.TokenEndpoint, transaction.TokenEndpointAuthMethod, transaction.ClientID, transaction.ClientSecret, values, "")
+}
+
+func (c *Client) Refresh(ctx context.Context, credential Credential) (Credential, error) {
+	if strings.TrimSpace(credential.RefreshToken) == "" {
+		return Credential{}, errors.New("mcp oauth: refresh token is empty")
+	}
+	values := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {credential.RefreshToken},
+		"client_id":     {credential.ClientID},
+		"resource":      {credential.Resource},
+	}
+	return c.tokenRequest(ctx, credential.TokenEndpoint, credential.TokenEndpointAuthMethod, credential.ClientID, credential.ClientSecret, values, credential.RefreshToken)
+}
+
+func (c *Client) register(ctx context.Context, endpoint, redirectURI string) (registrationResponse, error) {
+	body := map[string]any{
+		"client_name":                "Parsar",
+		"redirect_uris":              []string{redirectURI},
+		"grant_types":                []string{"authorization_code", "refresh_token"},
+		"response_types":             []string{"code"},
+		"token_endpoint_auth_method": "none",
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return registrationResponse{}, fmt.Errorf("mcp oauth: encode registration: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(string(encoded)))
+	if err != nil {
+		return registrationResponse{}, fmt.Errorf("mcp oauth: create registration request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	var response registrationResponse
+	if err := c.doJSON(req, http.StatusCreated, &response); err != nil {
+		return registrationResponse{}, fmt.Errorf("mcp oauth: dynamic client registration: %w", err)
+	}
+	if strings.TrimSpace(response.ClientID) == "" {
+		return registrationResponse{}, errors.New("mcp oauth: dynamic client registration returned no client_id")
+	}
+	if strings.TrimSpace(response.TokenEndpointAuthMethod) == "" {
+		response.TokenEndpointAuthMethod = "none"
+	}
+	switch response.TokenEndpointAuthMethod {
+	case "none", "client_secret_basic", "client_secret_post":
+	default:
+		return registrationResponse{}, fmt.Errorf("mcp oauth: unsupported token endpoint auth method %q", response.TokenEndpointAuthMethod)
+	}
+	return response, nil
+}
+
+func (c *Client) tokenRequest(ctx context.Context, endpoint, authMethod, clientID, clientSecret string, values url.Values, fallbackRefreshToken string) (Credential, error) {
+	if _, err := requireHTTPSURL(endpoint); err != nil {
+		return Credential{}, fmt.Errorf("mcp oauth: token endpoint: %w", err)
+	}
+	if authMethod == "client_secret_post" {
+		values.Set("client_secret", clientSecret)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(values.Encode()))
+	if err != nil {
+		return Credential{}, fmt.Errorf("mcp oauth: create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if authMethod == "client_secret_basic" {
+		req.SetBasicAuth(clientID, clientSecret)
+	}
+	var response tokenResponse
+	if err := c.doJSON(req, http.StatusOK, &response); err != nil {
+		return Credential{}, fmt.Errorf("mcp oauth: token exchange: %w", err)
+	}
+	if strings.TrimSpace(response.AccessToken) == "" {
+		return Credential{}, errors.New("mcp oauth: token response has no access_token")
+	}
+	refreshToken := strings.TrimSpace(response.RefreshToken)
+	if refreshToken == "" {
+		refreshToken = fallbackRefreshToken
+	}
+	expiresIn := parseExpiresIn(response.ExpiresIn)
+	var expiresAt time.Time
+	if expiresIn > 0 {
+		expiresAt = c.now().UTC().Add(expiresIn)
+	}
+	return Credential{
+		AccessToken:             response.AccessToken,
+		RefreshToken:            refreshToken,
+		TokenType:               response.TokenType,
+		Scope:                   response.Scope,
+		ExpiresAt:               expiresAt,
+		ClientID:                clientID,
+		ClientSecret:            clientSecret,
+		TokenEndpointAuthMethod: authMethod,
+		TokenEndpoint:           endpoint,
+		Resource:                values.Get("resource"),
+	}, nil
+}
+
+func (c *Client) getJSON(ctx context.Context, endpoint string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	return c.doJSON(req, http.StatusOK, out)
+}
+
+func (c *Client) doJSON(req *http.Request, expectedStatus int, out any) error {
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxMetadataBytes+1))
+	if err != nil {
+		return err
+	}
+	if len(body) > maxMetadataBytes {
+		return errors.New("response exceeds 1 MiB")
+	}
+	if resp.StatusCode != expectedStatus {
+		return fmt.Errorf("unexpected HTTP status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode json: %w", err)
+	}
+	return nil
+}
+
+func protectedResourceMetadataURL(resource *url.URL) string {
+	copyURL := *resource
+	copyURL.RawQuery = ""
+	copyURL.Fragment = ""
+	path := strings.TrimPrefix(copyURL.EscapedPath(), "/")
+	copyURL.Path = "/.well-known/oauth-protected-resource"
+	copyURL.RawPath = ""
+	if path != "" {
+		copyURL.Path += "/" + path
+	}
+	return copyURL.String()
+}
+
+func authorizationServerMetadataURL(issuer *url.URL) string {
+	copyURL := *issuer
+	copyURL.RawQuery = ""
+	copyURL.Fragment = ""
+	issuerPath := strings.TrimPrefix(copyURL.EscapedPath(), "/")
+	copyURL.Path = "/.well-known/oauth-authorization-server"
+	copyURL.RawPath = ""
+	if issuerPath != "" {
+		copyURL.Path += "/" + issuerPath
+	}
+	return copyURL.String()
+}
+
+func openIDConfigurationURL(issuer *url.URL) string {
+	copyURL := *issuer
+	copyURL.RawQuery = ""
+	copyURL.Fragment = ""
+	issuerPath := strings.TrimPrefix(copyURL.EscapedPath(), "/")
+	copyURL.Path = "/.well-known/openid-configuration"
+	copyURL.RawPath = ""
+	if issuerPath != "" {
+		copyURL.Path += "/" + issuerPath
+	}
+	return copyURL.String()
+}
+
+func requireHTTPSURL(raw string) (*url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Host == "" || parsed.Scheme != "https" || parsed.User != nil {
+		return nil, errors.New("must be an https URL without embedded credentials")
+	}
+	return parsed, nil
+}
+
+func requireHTTPURL(raw string) (*url.URL, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.User != nil {
+		return nil, errors.New("must be an http or https URL without embedded credentials")
+	}
+	return parsed, nil
+}
+
+func randomURLToken(size int) (string, error) {
+	buffer := make([]byte, size)
+	if _, err := rand.Read(buffer); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buffer), nil
+}
+
+func contains(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func parseExpiresIn(raw json.RawMessage) time.Duration {
+	if len(raw) == 0 {
+		return 0
+	}
+	var seconds int64
+	if err := json.Unmarshal(raw, &seconds); err == nil && seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+	var value string
+	if err := json.Unmarshal(raw, &value); err == nil {
+		seconds, _ = strconv.ParseInt(value, 10, 64)
+		if seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	return 0
+}

--- a/server/internal/auth/mcpoauth/client_test.go
+++ b/server/internal/auth/mcpoauth/client_test.go
@@ -1,0 +1,192 @@
+package mcpoauth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOAuthDiscoveryRegistrationExchangeAndRefresh(t *testing.T) {
+	var server *httptest.Server
+	var tokenGrantTypes []string
+	handler := http.NewServeMux()
+	handler.HandleFunc("/.well-known/oauth-protected-resource/mcp", func(w http.ResponseWriter, _ *http.Request) {
+		writeTestJSON(t, w, http.StatusOK, map[string]any{
+			"resource":              server.URL + "/mcp",
+			"authorization_servers": []string{server.URL},
+			"scopes_supported":      []string{"openid", "offline_access"},
+		})
+	})
+	handler.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		writeTestJSON(t, w, http.StatusOK, map[string]any{
+			"issuer":                           server.URL,
+			"authorization_endpoint":           server.URL + "/authorize",
+			"token_endpoint":                   server.URL + "/token",
+			"registration_endpoint":            server.URL + "/register",
+			"code_challenge_methods_supported": []string{"S256"},
+		})
+	})
+	handler.HandleFunc("/register", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body["token_endpoint_auth_method"] != "none" {
+			t.Fatalf("registration auth method = %v", body["token_endpoint_auth_method"])
+		}
+		writeTestJSON(t, w, http.StatusCreated, map[string]any{
+			"client_id":                  "client-1",
+			"token_endpoint_auth_method": "none",
+		})
+	})
+	handler.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatal(err)
+		}
+		tokenGrantTypes = append(tokenGrantTypes, r.Form.Get("grant_type"))
+		if r.Form.Get("client_id") != "client-1" || r.Form.Get("resource") != server.URL+"/mcp" {
+			t.Fatalf("unexpected token form: %v", r.Form)
+		}
+		if r.Form.Get("grant_type") == "authorization_code" {
+			if r.Form.Get("code_verifier") == "" || r.Form.Get("code") != "code-1" {
+				t.Fatalf("missing PKCE exchange values: %v", r.Form)
+			}
+			writeTestJSON(t, w, http.StatusOK, map[string]any{
+				"access_token":  "access-1",
+				"refresh_token": "refresh-1",
+				"token_type":    "Bearer",
+				"expires_in":    3600,
+			})
+			return
+		}
+		writeTestJSON(t, w, http.StatusOK, map[string]any{
+			"access_token": "access-2",
+			"token_type":   "Bearer",
+			"expires_in":   "7200",
+		})
+	})
+	server = httptest.NewTLSServer(handler)
+	defer server.Close()
+
+	client := New(server.Client())
+	now := time.Date(2026, 7, 22, 10, 0, 0, 0, time.UTC)
+	client.now = func() time.Time { return now }
+	redirectURI := "http://127.0.0.1:18080/oauth/callback"
+	transaction, authorizeURL, err := client.Begin(t.Context(), server.URL+"/mcp", redirectURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsedAuthorizeURL, err := url.Parse(authorizeURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := parsedAuthorizeURL.Query()
+	if query.Get("client_id") != "client-1" || query.Get("redirect_uri") != redirectURI || query.Get("resource") != server.URL+"/mcp" || query.Get("scope") != "openid offline_access" {
+		t.Fatalf("unexpected authorize query: %v", query)
+	}
+	if query.Get("code_challenge_method") != "S256" || query.Get("code_challenge") == "" || query.Get("state") == "" {
+		t.Fatalf("missing PKCE authorize query: %v", query)
+	}
+
+	credential, err := client.Exchange(t.Context(), transaction, "code-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credential.AccessToken != "access-1" || credential.RefreshToken != "refresh-1" || !credential.ExpiresAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("unexpected credential: %+v", credential)
+	}
+
+	refreshed, err := client.Refresh(t.Context(), credential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refreshed.AccessToken != "access-2" || refreshed.RefreshToken != "refresh-1" || !refreshed.ExpiresAt.Equal(now.Add(2*time.Hour)) {
+		t.Fatalf("unexpected refreshed credential: %+v", refreshed)
+	}
+	if strings.Join(tokenGrantTypes, ",") != "authorization_code,refresh_token" {
+		t.Fatalf("grant types = %v", tokenGrantTypes)
+	}
+}
+
+func TestOAuthDiscoveryFallsBackToOpenIDConfiguration(t *testing.T) {
+	var server *httptest.Server
+	handler := http.NewServeMux()
+	handler.HandleFunc("/.well-known/oauth-protected-resource", func(w http.ResponseWriter, _ *http.Request) {
+		writeTestJSON(t, w, http.StatusOK, map[string]any{
+			"resource":              server.URL,
+			"authorization_servers": []string{server.URL},
+		})
+	})
+	handler.HandleFunc("/.well-known/oauth-authorization-server", func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, nil)
+	})
+	handler.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		writeTestJSON(t, w, http.StatusOK, map[string]any{
+			"issuer":                           server.URL,
+			"authorization_endpoint":           server.URL + "/authorize",
+			"token_endpoint":                   server.URL + "/token",
+			"registration_endpoint":            server.URL + "/register",
+			"code_challenge_methods_supported": []string{"S256"},
+		})
+	})
+	handler.HandleFunc("/register", func(w http.ResponseWriter, _ *http.Request) {
+		writeTestJSON(t, w, http.StatusCreated, map[string]any{
+			"client_id":                  "openid-client",
+			"token_endpoint_auth_method": "none",
+		})
+	})
+	server = httptest.NewTLSServer(handler)
+	defer server.Close()
+
+	transaction, authorizeURL, err := New(server.Client()).Begin(
+		t.Context(),
+		server.URL,
+		"http://127.0.0.1:18080/oauth/callback",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transaction.ClientID != "openid-client" || !strings.HasPrefix(authorizeURL, server.URL+"/authorize?") {
+		t.Fatalf("transaction=%+v authorizeURL=%q", transaction, authorizeURL)
+	}
+}
+
+func TestBeginRejectsNonHTTPSResource(t *testing.T) {
+	_, _, err := New(nil).Begin(t.Context(), "http://example.com/mcp", "http://127.0.0.1/callback")
+	if err == nil || !strings.Contains(err.Error(), "https") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCredentialPayloadRoundTrip(t *testing.T) {
+	want := Credential{
+		AccessToken:             "access",
+		RefreshToken:            "refresh",
+		TokenType:               "Bearer",
+		ExpiresAt:               time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+		ClientID:                "client",
+		TokenEndpointAuthMethod: "none",
+		TokenEndpoint:           "https://example.com/token",
+		Resource:                "https://example.com/mcp",
+	}
+	got, ok, err := CredentialFromPayload(want.Payload())
+	if err != nil || !ok {
+		t.Fatalf("ok=%v err=%v", ok, err)
+	}
+	if got.AccessToken != want.AccessToken || got.RefreshToken != want.RefreshToken || !got.ExpiresAt.Equal(want.ExpiresAt) {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+}
+
+func writeTestJSON(t *testing.T, w http.ResponseWriter, status int, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/server/internal/auth/mcpoauth/credential.go
+++ b/server/internal/auth/mcpoauth/credential.go
@@ -1,0 +1,71 @@
+package mcpoauth
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const CredentialProvider = "mcp_oauth"
+
+func (c Credential) Payload() map[string]any {
+	payload := map[string]any{
+		"provider":                   CredentialProvider,
+		"access_token":               c.AccessToken,
+		"refresh_token":              c.RefreshToken,
+		"token_type":                 c.TokenType,
+		"scope":                      c.Scope,
+		"client_id":                  c.ClientID,
+		"client_secret":              c.ClientSecret,
+		"token_endpoint_auth_method": c.TokenEndpointAuthMethod,
+		"token_endpoint":             c.TokenEndpoint,
+		"resource":                   c.Resource,
+	}
+	if !c.ExpiresAt.IsZero() {
+		payload["expires_at"] = c.ExpiresAt.UTC().Format(time.RFC3339)
+	}
+	return payload
+}
+
+func CredentialFromPayload(payload map[string]any) (Credential, bool, error) {
+	if stringValue(payload, "provider") != CredentialProvider {
+		return Credential{}, false, nil
+	}
+	credential := Credential{
+		AccessToken:             stringValue(payload, "access_token"),
+		RefreshToken:            stringValue(payload, "refresh_token"),
+		TokenType:               stringValue(payload, "token_type"),
+		Scope:                   stringValue(payload, "scope"),
+		ClientID:                stringValue(payload, "client_id"),
+		ClientSecret:            stringValue(payload, "client_secret"),
+		TokenEndpointAuthMethod: stringValue(payload, "token_endpoint_auth_method"),
+		TokenEndpoint:           stringValue(payload, "token_endpoint"),
+		Resource:                stringValue(payload, "resource"),
+	}
+	if raw := stringValue(payload, "expires_at"); raw != "" {
+		expiresAt, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			return Credential{}, true, fmt.Errorf("mcp oauth: parse expires_at: %w", err)
+		}
+		credential.ExpiresAt = expiresAt
+	}
+	if credential.AccessToken == "" || credential.ClientID == "" || credential.TokenEndpoint == "" || credential.Resource == "" {
+		return Credential{}, true, fmt.Errorf("mcp oauth: stored credential is incomplete")
+	}
+	return credential, true, nil
+}
+
+func (c Credential) NeedsRefresh(now time.Time) bool {
+	return !c.ExpiresAt.IsZero() && !c.ExpiresAt.After(now.UTC().Add(time.Minute))
+}
+
+func PreserveMetadata(source, target map[string]any) {
+	if value, ok := source["catalog_id"]; ok {
+		target["catalog_id"] = value
+	}
+}
+
+func stringValue(payload map[string]any, key string) string {
+	value, _ := payload[key].(string)
+	return strings.TrimSpace(value)
+}

--- a/server/internal/capability/canonical/mcp.go
+++ b/server/internal/capability/canonical/mcp.go
@@ -26,6 +26,7 @@ type MCPServer struct {
 	Name              string              `json:"name"`
 	Transport         string              `json:"transport,omitempty"`
 	URL               string              `json:"url,omitempty"`
+	Headers           map[string]EnvValue `json:"headers,omitempty"`
 	Command           string              `json:"command,omitempty"`
 	Args              []string            `json:"args,omitempty"`
 	Env               map[string]EnvValue `json:"env,omitempty"`
@@ -74,6 +75,9 @@ func (s MCPServer) Validate() error {
 		if strings.TrimSpace(s.URL) != "" {
 			return fmt.Errorf("%w: server %q: stdio transport must not set url", ErrInvalidMCP, s.Name)
 		}
+		if len(s.Headers) > 0 {
+			return fmt.Errorf("%w: server %q: stdio transport must not set headers", ErrInvalidMCP, s.Name)
+		}
 	case MCPTransportStreamableHTTP:
 		parsed, err := url.Parse(strings.TrimSpace(s.URL))
 		if err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.User != nil {
@@ -91,6 +95,17 @@ func (s MCPServer) Validate() error {
 		}
 		if err := value.Validate(); err != nil {
 			return fmt.Errorf("server %q env %q: %w", s.Name, name, err)
+		}
+	}
+	for name, value := range s.Headers {
+		if strings.TrimSpace(name) == "" || strings.ContainsAny(name, "\r\n") {
+			return fmt.Errorf("%w: server %q: invalid header name", ErrInvalidMCP, s.Name)
+		}
+		if value.Mode == EnvModeInlineSecret {
+			return fmt.Errorf("%w: server %q header %q: inline_secret is not supported", ErrInvalidMCP, s.Name, name)
+		}
+		if err := value.Validate(); err != nil {
+			return fmt.Errorf("server %q header %q: %w", s.Name, name, err)
 		}
 	}
 	return nil

--- a/server/internal/capability/canonical/spec.go
+++ b/server/internal/capability/canonical/spec.go
@@ -176,6 +176,8 @@ const (
 type EnvValue struct {
 	Mode EnvMode `json:"mode"`
 
+	Prefix string `json:"prefix,omitempty"`
+
 	// Literal is set iff Mode == EnvModeLiteral.
 	Literal string `json:"literal,omitempty"`
 
@@ -191,8 +193,8 @@ type EnvValue struct {
 func (v EnvValue) Validate() error {
 	switch v.Mode {
 	case EnvModeLiteral:
-		if v.SecretID != "" || v.CredentialKindCode != "" {
-			return fmt.Errorf("%w: literal mode must not set secret_id/credential_kind_code", ErrInvalidEnvValue)
+		if v.SecretID != "" || v.CredentialKindCode != "" || v.Prefix != "" {
+			return fmt.Errorf("%w: literal mode must not set secret_id/credential_kind_code/prefix", ErrInvalidEnvValue)
 		}
 	case EnvModeInlineSecret:
 		if strings.TrimSpace(v.SecretID) == "" {

--- a/server/internal/capability/render/claudecode.go
+++ b/server/internal/capability/render/claudecode.go
@@ -30,6 +30,7 @@ type claudeCodeMCPDocument struct {
 type claudeCodeMCPServer struct {
 	Type    string            `json:"type,omitempty"`
 	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
 	Command string            `json:"command"`
 	Args    []string          `json:"args,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`
@@ -76,7 +77,11 @@ func renderClaudeCodeMCP(s *canonical.MCPSpec) (Output, error) {
 	doc := claudeCodeMCPDocument{MCPServers: make(map[string]claudeCodeMCPServer, len(s.Servers))}
 	for _, srv := range s.Servers {
 		if srv.EffectiveTransport() == canonical.MCPTransportStreamableHTTP {
-			doc.MCPServers[srv.Name] = claudeCodeMCPServer{Type: "http", URL: srv.URL}
+			headers, err := renderEnvMap(srv.Headers)
+			if err != nil {
+				return Output{}, fmt.Errorf("claudecode render: server %q headers: %w", srv.Name, err)
+			}
+			doc.MCPServers[srv.Name] = claudeCodeMCPServer{Type: "http", URL: srv.URL, Headers: headers}
 			continue
 		}
 		env, err := renderEnvMap(srv.Env)

--- a/server/internal/capability/render/codex.go
+++ b/server/internal/capability/render/codex.go
@@ -38,6 +38,7 @@ type codexMCPDocument struct {
 type codexMCPServer struct {
 	Type    string            `json:"type,omitempty"`
 	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
 	Command string            `json:"command"`
 	Args    []string          `json:"args,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`
@@ -72,7 +73,11 @@ func renderCodexMCP(s *canonical.MCPSpec) (Output, error) {
 	doc := codexMCPDocument{MCPServers: make(map[string]codexMCPServer, len(s.Servers))}
 	for _, srv := range s.Servers {
 		if srv.EffectiveTransport() == canonical.MCPTransportStreamableHTTP {
-			doc.MCPServers[srv.Name] = codexMCPServer{Type: "http", URL: srv.URL}
+			headers, err := renderEnvMap(srv.Headers)
+			if err != nil {
+				return Output{}, fmt.Errorf("codex render: server %q headers: %w", srv.Name, err)
+			}
+			doc.MCPServers[srv.Name] = codexMCPServer{Type: "http", URL: srv.URL, Headers: headers}
 			continue
 		}
 		env, err := renderEnvMap(srv.Env)

--- a/server/internal/capability/render/opencode.go
+++ b/server/internal/capability/render/opencode.go
@@ -27,6 +27,7 @@ type openCodeMCPDocument struct {
 type openCodeMCPServer struct {
 	Type    string            `json:"type,omitempty"`
 	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
 	Command string            `json:"command"`
 	Args    []string          `json:"args,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`
@@ -61,7 +62,11 @@ func renderOpenCodeMCP(s *canonical.MCPSpec) (Output, error) {
 	doc := openCodeMCPDocument{MCPServers: make(map[string]openCodeMCPServer, len(s.Servers))}
 	for _, srv := range s.Servers {
 		if srv.EffectiveTransport() == canonical.MCPTransportStreamableHTTP {
-			doc.MCPServers[srv.Name] = openCodeMCPServer{Type: "remote", URL: srv.URL, Enabled: true}
+			headers, err := renderEnvMap(srv.Headers)
+			if err != nil {
+				return Output{}, fmt.Errorf("opencode render: server %q headers: %w", srv.Name, err)
+			}
+			doc.MCPServers[srv.Name] = openCodeMCPServer{Type: "remote", URL: srv.URL, Headers: headers, Enabled: true}
 			continue
 		}
 		env, err := renderEnvMap(srv.Env)

--- a/server/internal/capability/render/placeholders.go
+++ b/server/internal/capability/render/placeholders.go
@@ -15,9 +15,9 @@ func envValueToString(v canonical.EnvValue) (string, error) {
 	case canonical.EnvModeLiteral:
 		return v.Literal, nil
 	case canonical.EnvModeInlineSecret:
-		return fmt.Sprintf("${PARSAR_SECRET:%s}", v.SecretID), nil
+		return v.Prefix + fmt.Sprintf("${PARSAR_SECRET:%s}", v.SecretID), nil
 	case canonical.EnvModeCredentialRef:
-		return fmt.Sprintf("${PARSAR_CREDENTIAL:%s}", v.CredentialKindCode), nil
+		return v.Prefix + fmt.Sprintf("${PARSAR_CREDENTIAL:%s}", v.CredentialKindCode), nil
 	default:
 		return "", fmt.Errorf("render: unknown env mode %q", v.Mode)
 	}

--- a/server/internal/connector/agentdaemon/capability_runtime.go
+++ b/server/internal/connector/agentdaemon/capability_runtime.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/mcpoauth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/render"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
@@ -73,8 +74,7 @@ type ResolvedSkill struct {
 	SHA256      string `json:"sha256"`
 }
 
-// credentialPlaceholderRe matches ${PARSAR_CREDENTIAL:<kind>}.
-var credentialPlaceholderRe = regexp.MustCompile(`^\$\{PARSAR_CREDENTIAL:([a-zA-Z0-9_]+)\}$`)
+var credentialPlaceholderRe = regexp.MustCompile(`\$\{PARSAR_CREDENTIAL:([a-zA-Z0-9_]+)\}`)
 
 // capabilityAdditions holds the results of resolveCapabilityAdditions.
 type capabilityAdditions struct {
@@ -602,6 +602,17 @@ func (c *Connector) resolveMCPCapability(
 	for name, server := range parsed.MCPServers {
 		if server.URL != "" {
 			entry := map[string]any{"url": server.URL}
+			headers := make(map[string]string, len(server.Headers))
+			for headerName, value := range server.Headers {
+				resolved, err := substituteCredentialPlaceholders(value, credentialValues)
+				if err != nil {
+					return nil, nil, nil, fmt.Errorf("agent_daemon: capability %s mcp server %q header %s: %w", cap.CapabilityID, name, headerName, err)
+				}
+				headers[headerName] = resolved
+			}
+			if len(headers) > 0 {
+				entry["headers"] = headers
+			}
 			if server.Type != "" {
 				entry["type"] = server.Type
 			}
@@ -613,17 +624,11 @@ func (c *Connector) resolveMCPCapability(
 		}
 		env := map[string]string{}
 		for key, value := range server.Env {
-			if match := credentialPlaceholderRe.FindStringSubmatch(value); match != nil {
-				kind := match[1]
-				credValue, ok := credentialValues[kind]
-				if !ok {
-					return nil, nil, nil, fmt.Errorf("agent_daemon: capability %s mcp server %q env %s references unresolved credential kind %q",
-						cap.CapabilityID, name, key, kind)
-				}
-				env[key] = credValue
-				continue
+			resolved, err := substituteCredentialPlaceholders(value, credentialValues)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("agent_daemon: capability %s mcp server %q env %s: %w", cap.CapabilityID, name, key, err)
 			}
-			env[key] = value
+			env[key] = resolved
 		}
 		entry := map[string]any{
 			"command": server.Command,
@@ -708,7 +713,6 @@ func (c *Connector) resolveCredentialValues(
 	if c.secrets == nil {
 		return nil, nil, nil, fmt.Errorf("agent_daemon: capability %s requires credentials but secrets service is not configured", cap.CapabilityID)
 	}
-
 	// First pass: split required kinds into personal vs shared.
 	type sharedTarget struct {
 		Kind     string
@@ -754,6 +758,10 @@ func (c *Connector) resolveCredentialValues(
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("agent_daemon: decrypt shared credential kind=%s secret_id=%s: %w", st.Kind, st.SecretID, err)
 			}
+			payload, err = c.refreshSharedOAuthCredentialIfNeeded(ctx, in.WorkspaceID, st.SecretID, payload)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("agent_daemon: refresh shared credential kind=%s secret_id=%s: %w", st.Kind, st.SecretID, err)
+			}
 			value := credentialPayloadValue(payload)
 			if value == "" {
 				return nil, nil, nil, fmt.Errorf("agent_daemon: shared credential kind=%s secret_id=%s decrypted payload has no token/api_key value", st.Kind, st.SecretID)
@@ -793,6 +801,53 @@ func (c *Connector) resolveCredentialValues(
 	}
 
 	return values, sharedSecretIDs, missing, nil
+}
+
+type sharedOAuthCredentialStore interface {
+	UpdateSecretPayload(ctx context.Context, workspaceID, secretID string, encryptedPayload []byte) (store.SecretPayload, error)
+}
+
+func (c *Connector) refreshSharedOAuthCredentialIfNeeded(
+	ctx context.Context,
+	workspaceID string,
+	secretID string,
+	payload map[string]any,
+) (map[string]any, error) {
+	credential, isOAuth, err := mcpoauth.CredentialFromPayload(payload)
+	if err != nil || !isOAuth || !credential.NeedsRefresh(time.Now()) {
+		return payload, err
+	}
+	credentialStore, ok := c.modelResolver.(sharedOAuthCredentialStore)
+	if !ok {
+		return nil, errors.New("shared credential store does not support OAuth token rotation")
+	}
+	refreshed, err := mcpoauth.New(nil).Refresh(ctx, credential)
+	if err != nil {
+		return nil, err
+	}
+	refreshedPayload := refreshed.Payload()
+	mcpoauth.PreserveMetadata(payload, refreshedPayload)
+	encrypted, err := c.secrets.Encrypt(refreshedPayload)
+	if err != nil {
+		return nil, fmt.Errorf("encrypt refreshed token: %w", err)
+	}
+	if _, err := credentialStore.UpdateSecretPayload(ctx, workspaceID, secretID, encrypted); err != nil {
+		return nil, fmt.Errorf("persist refreshed token: %w", err)
+	}
+	return refreshedPayload, nil
+}
+
+func substituteCredentialPlaceholders(value string, credentials map[string]string) (string, error) {
+	matches := credentialPlaceholderRe.FindAllStringSubmatch(value, -1)
+	resolved := value
+	for _, match := range matches {
+		credential, ok := credentials[match[1]]
+		if !ok {
+			return "", fmt.Errorf("references unresolved credential kind %q", match[1])
+		}
+		resolved = strings.ReplaceAll(resolved, match[0], credential)
+	}
+	return resolved, nil
 }
 
 // lookupCredential fetches a user credential by kind, using a cache to
@@ -861,6 +916,7 @@ type claudeCodeMCPDocument struct {
 type claudeCodeMCPServerEntry struct {
 	Type    string            `json:"type,omitempty"`
 	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
 	Command string            `json:"command"`
 	Args    []string          `json:"args,omitempty"`
 	Env     map[string]string `json:"env,omitempty"`

--- a/server/internal/connector/agentdaemon/capability_runtime_test.go
+++ b/server/internal/connector/agentdaemon/capability_runtime_test.go
@@ -7,7 +7,9 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth/mcpoauth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
@@ -444,6 +446,58 @@ func TestResolveCapabilityAdditions_MCPStreamableHTTP(t *testing.T) {
 	server := got.MCPServers["docs"].(map[string]any)
 	if server["type"] != "http" || server["url"] != "https://docs.example.com/mcp" {
 		t.Fatalf("server = %+v", server)
+	}
+}
+
+func TestResolveCapabilityAdditions_UsesWorkspaceOAuthHeader(t *testing.T) {
+	svc := testSecretsService(t)
+	credential := mcpoauth.Credential{
+		AccessToken:             "workspace-notion-token",
+		RefreshToken:            "workspace-notion-refresh",
+		ExpiresAt:               time.Now().Add(time.Hour),
+		ClientID:                "client-1",
+		TokenEndpointAuthMethod: "none",
+		TokenEndpoint:           "https://mcp.notion.com/token",
+		Resource:                "https://mcp.notion.com/mcp",
+	}
+	row := newMCPRow(t, "mcp-notion", "Notion", []canonical.MCPServer{{
+		Name:      "notion",
+		Transport: canonical.MCPTransportStreamableHTTP,
+		URL:       "https://mcp.notion.com/mcp",
+		Headers: map[string]canonical.EnvValue{
+			"Authorization": {
+				Mode:               canonical.EnvModeCredentialRef,
+				Prefix:             "Bearer ",
+				CredentialKindCode: "notion_integration",
+			},
+		},
+	}}, []store.RequiredCredential{{Kind: "notion_integration", Required: true}})
+	c := &Connector{
+		capabilities: stubCapabilityStore{rows: []store.EnabledCapabilityRead{row}},
+		modelResolver: &fakeModelResolver{secret: store.SecretPayload{
+			SecretRead:       store.SecretRead{ID: "secret-1", Status: "active"},
+			EncryptedPayload: encryptPayload(t, svc, credential.Payload()),
+		}},
+		secrets: svc,
+		log:     discardLogger(),
+	}
+	in := defaultPromptInput()
+	in.ConversationInitiatorID = ""
+	in.AgentConfig = map[string]any{
+		"credential_bindings": map[string]any{
+			"notion_integration": map[string]any{
+				"source":    "shared",
+				"secret_id": "secret-1",
+			},
+		},
+	}
+	got, err := c.resolveCapabilityAdditions(context.Background(), in, "claude_code")
+	if err != nil {
+		t.Fatalf("resolveCapabilityAdditions: %v", err)
+	}
+	headers := got.MCPServers["notion"].(map[string]any)["headers"].(map[string]string)
+	if headers["Authorization"] != "Bearer workspace-notion-token" {
+		t.Fatalf("Authorization = %q", headers["Authorization"])
 	}
 }
 

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -1984,11 +1984,29 @@ where (@kind_filter::text = '' or kind = @kind_filter::text)
 order by created_at desc, id desc
 limit @item_limit;
 
+-- name: ListSecretsForWorkspace :many
+select id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, created_at, updated_at
+from secrets
+where (coalesce(metadata->>'workspace_id', '') = '' or metadata->>'workspace_id' = @workspace_id::text)
+  and deleted_at is null
+order by created_at desc, id desc
+limit @item_limit;
+
 -- name: GetSecretPayload :one
 select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_at, updated_at
 from secrets
 where id = @id::uuid
   and deleted_at is null;
+
+-- name: UpdateSecretPayload :one
+update secrets
+set encrypted_payload = @encrypted_payload::jsonb,
+    key_version = @key_version,
+    status = 'active',
+    updated_at = @now
+where id = @id::uuid
+  and deleted_at is null
+returning id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_at, updated_at;
 
 -- name: ResolveSlackBotSecretByTeam :one
 -- Resolve the active Slack bot-token secret for a workspace, keyed by the

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -9025,6 +9025,66 @@ func (q *Queries) ListSecrets(ctx context.Context, arg ListSecretsParams) ([]Lis
 	return items, nil
 }
 
+const listSecretsForWorkspace = `-- name: ListSecretsForWorkspace :many
+select id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, created_at, updated_at
+from secrets
+where (coalesce(metadata->>'workspace_id', '') = '' or metadata->>'workspace_id' = $1::text)
+  and deleted_at is null
+order by created_at desc, id desc
+limit $2
+`
+
+type ListSecretsForWorkspaceParams struct {
+	WorkspaceID string `json:"workspace_id"`
+	ItemLimit   int32  `json:"item_limit"`
+}
+
+type ListSecretsForWorkspaceRow struct {
+	ID         string             `json:"id"`
+	Slug       string             `json:"slug"`
+	Name       string             `json:"name"`
+	Kind       string             `json:"kind"`
+	Provider   string             `json:"provider"`
+	AuthType   string             `json:"auth_type"`
+	KeyVersion string             `json:"key_version"`
+	Status     string             `json:"status"`
+	Metadata   []byte             `json:"metadata"`
+	CreatedAt  pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+}
+
+func (q *Queries) ListSecretsForWorkspace(ctx context.Context, arg ListSecretsForWorkspaceParams) ([]ListSecretsForWorkspaceRow, error) {
+	rows, err := q.db.Query(ctx, listSecretsForWorkspace, arg.WorkspaceID, arg.ItemLimit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListSecretsForWorkspaceRow{}
+	for rows.Next() {
+		var i ListSecretsForWorkspaceRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Slug,
+			&i.Name,
+			&i.Kind,
+			&i.Provider,
+			&i.AuthType,
+			&i.KeyVersion,
+			&i.Status,
+			&i.Metadata,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listStaleFeishuPermissionInflightCards = `-- name: ListStaleFeishuPermissionInflightCards :many
 select id::text                  as conversation_id,
        workspace_id::text        as workspace_id,
@@ -12414,6 +12474,64 @@ func (q *Queries) UpdateScheduledTask(ctx context.Context, arg UpdateScheduledTa
 		&i.LastStatus,
 		&i.ConsecutiveFailures,
 		&i.CreatedBy,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const updateSecretPayload = `-- name: UpdateSecretPayload :one
+update secrets
+set encrypted_payload = $1::jsonb,
+    key_version = $2,
+    status = 'active',
+    updated_at = $3
+where id = $4::uuid
+  and deleted_at is null
+returning id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_at, updated_at
+`
+
+type UpdateSecretPayloadParams struct {
+	EncryptedPayload []byte             `json:"encrypted_payload"`
+	KeyVersion       string             `json:"key_version"`
+	Now              pgtype.Timestamptz `json:"now"`
+	ID               pgtype.UUID        `json:"id"`
+}
+
+type UpdateSecretPayloadRow struct {
+	ID               string             `json:"id"`
+	Slug             string             `json:"slug"`
+	Name             string             `json:"name"`
+	Kind             string             `json:"kind"`
+	Provider         string             `json:"provider"`
+	AuthType         string             `json:"auth_type"`
+	EncryptedPayload []byte             `json:"encrypted_payload"`
+	KeyVersion       string             `json:"key_version"`
+	Status           string             `json:"status"`
+	Metadata         []byte             `json:"metadata"`
+	CreatedAt        pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+}
+
+func (q *Queries) UpdateSecretPayload(ctx context.Context, arg UpdateSecretPayloadParams) (UpdateSecretPayloadRow, error) {
+	row := q.db.QueryRow(ctx, updateSecretPayload,
+		arg.EncryptedPayload,
+		arg.KeyVersion,
+		arg.Now,
+		arg.ID,
+	)
+	var i UpdateSecretPayloadRow
+	err := row.Scan(
+		&i.ID,
+		&i.Slug,
+		&i.Name,
+		&i.Kind,
+		&i.Provider,
+		&i.AuthType,
+		&i.EncryptedPayload,
+		&i.KeyVersion,
+		&i.Status,
+		&i.Metadata,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/internal/mcpcatalog/catalog_test.go
+++ b/server/internal/mcpcatalog/catalog_test.go
@@ -15,7 +15,7 @@ func TestBuiltinCatalogLoads(t *testing.T) {
 	if snapshot.Source != SourceBuiltin {
 		t.Fatalf("source = %q", snapshot.Source)
 	}
-	want := []string{"context7", "exa", "firecrawl"}
+	want := []string{"context7", "exa", "firecrawl", "notion"}
 	if len(snapshot.Catalog.Items) != len(want) {
 		t.Fatalf("items = %d, want %d", len(snapshot.Catalog.Items), len(want))
 	}
@@ -26,6 +26,12 @@ func TestBuiltinCatalogLoads(t *testing.T) {
 		}
 		if err := item.CanonicalSpec().Validate(); err != nil {
 			t.Fatalf("item %q canonical spec: %v", item.ID, err)
+		}
+		if item.ID == "notion" {
+			header := item.CanonicalSpec().MCP.Servers[0].Headers["Authorization"]
+			if header.Prefix != "Bearer " || header.CredentialKindCode != "notion_integration" {
+				t.Fatalf("notion authorization header = %+v", header)
+			}
 		}
 	}
 }
@@ -42,6 +48,9 @@ func TestCatalogValidationRejectsInvalidContent(t *testing.T) {
 		{"insecure URL", func(c *Catalog) { c.Items[0].Server.URL = "http://example.com/mcp" }, "https URL"},
 		{"embedded credentials", func(c *Catalog) { c.Items[0].Server.URL = "https://token@example.com/mcp" }, "embedded credentials"},
 		{"featured rank", func(c *Catalog) { c.Items[0].FeaturedRank = 0 }, "featured_rank"},
+		{"oauth credential kind", func(c *Catalog) {
+			c.Items[0].Authentication = Authentication{Type: "oauth2", CredentialKind: "Not Valid"}
+		}, "credential_kind"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/mcpcatalog/types.go
+++ b/server/internal/mcpcatalog/types.go
@@ -13,19 +13,32 @@ type Catalog struct {
 }
 
 type Item struct {
-	ID            string    `json:"id"`
-	Name          string    `json:"name"`
-	Description   string    `json:"description"`
-	Publisher     Publisher `json:"publisher"`
-	IconURL       string    `json:"icon_url,omitempty"`
-	HomepageURL   string    `json:"homepage_url,omitempty"`
-	RepositoryURL string    `json:"repository_url,omitempty"`
-	Verified      bool      `json:"verified"`
-	Categories    []string  `json:"categories"`
-	FeaturedRank  int       `json:"featured_rank"`
-	Version       string    `json:"version"`
-	Transport     string    `json:"transport"`
-	Server        Server    `json:"server"`
+	ID             string         `json:"id"`
+	Name           string         `json:"name"`
+	Description    string         `json:"description"`
+	Publisher      Publisher      `json:"publisher"`
+	IconURL        string         `json:"icon_url,omitempty"`
+	HomepageURL    string         `json:"homepage_url,omitempty"`
+	RepositoryURL  string         `json:"repository_url,omitempty"`
+	Verified       bool           `json:"verified"`
+	Categories     []string       `json:"categories"`
+	FeaturedRank   int            `json:"featured_rank"`
+	Version        string         `json:"version"`
+	Transport      string         `json:"transport"`
+	Authentication Authentication `json:"authentication,omitempty"`
+	Server         Server         `json:"server"`
+}
+
+type Authentication struct {
+	Type           string `json:"type,omitempty"`
+	CredentialKind string `json:"credential_kind,omitempty"`
+}
+
+func (a Authentication) EffectiveType() string {
+	if a.Type == "" {
+		return "none"
+	}
+	return a.Type
 }
 
 type Publisher struct {
@@ -39,13 +52,23 @@ type Server struct {
 }
 
 func (i Item) CanonicalSpec() canonical.Spec {
+	server := canonical.MCPServer{
+		Name:      i.Server.Name,
+		Transport: i.Transport,
+		URL:       i.Server.URL,
+	}
+	if i.Authentication.EffectiveType() == "oauth2" {
+		server.Headers = map[string]canonical.EnvValue{
+			"Authorization": {
+				Mode:               canonical.EnvModeCredentialRef,
+				Prefix:             "Bearer ",
+				CredentialKindCode: i.Authentication.CredentialKind,
+			},
+		}
+	}
 	return canonical.Spec{
 		SchemaVersion: canonical.SchemaVersionCurrent,
 		Kind:          canonical.KindMCP,
-		MCP: &canonical.MCPSpec{Servers: []canonical.MCPServer{{
-			Name:      i.Server.Name,
-			Transport: i.Transport,
-			URL:       i.Server.URL,
-		}}},
+		MCP:           &canonical.MCPSpec{Servers: []canonical.MCPServer{server}},
 	}
 }

--- a/server/internal/mcpcatalog/validate.go
+++ b/server/internal/mcpcatalog/validate.go
@@ -14,7 +14,10 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
 )
 
-var idPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+var (
+	idPattern         = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+	credentialPattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+)
 
 func Decode(data []byte) (Catalog, error) {
 	decoder := json.NewDecoder(bytes.NewReader(data))
@@ -87,6 +90,18 @@ func (i Item) Validate() error {
 	}
 	if i.Transport != canonical.MCPTransportStreamableHTTP {
 		return fmt.Errorf("item %q transport %q is unsupported", i.ID, i.Transport)
+	}
+	switch i.Authentication.EffectiveType() {
+	case "none":
+		if strings.TrimSpace(i.Authentication.CredentialKind) != "" {
+			return fmt.Errorf("item %q authentication credential_kind requires oauth2", i.ID)
+		}
+	case "oauth2":
+		if !credentialPattern.MatchString(i.Authentication.CredentialKind) {
+			return fmt.Errorf("item %q authentication credential_kind %q is invalid", i.ID, i.Authentication.CredentialKind)
+		}
+	default:
+		return fmt.Errorf("item %q authentication type %q is unsupported", i.ID, i.Authentication.Type)
 	}
 	if strings.TrimSpace(i.Server.Name) == "" {
 		return fmt.Errorf("item %q server name is required", i.ID)

--- a/server/internal/store/capability_import.go
+++ b/server/internal/store/capability_import.go
@@ -460,6 +460,7 @@ func commitCapabilityVersionInTx(ctx context.Context, q *sqlc.Queries, p commitV
 		metaJSON, err := json.Marshal(map[string]any{
 			"origin":        "capability_import",
 			"capability_id": p.CapabilityName,
+			"workspace_id":  pgUUIDString(p.WorkspaceID),
 			"server":        secret.ServerName,
 			"env_key":       secret.EnvKey,
 		})
@@ -587,6 +588,23 @@ func (s *Store) collectAndValidateCredentialRefs(ctx context.Context, spec canon
 			seen[code] = struct{}{}
 			out = append(out, RequiredCredential{Kind: code, Required: true})
 		}
+		for headerName, value := range srv.Headers {
+			if value.Mode != canonical.EnvModeCredentialRef {
+				continue
+			}
+			code := strings.ToLower(strings.TrimSpace(value.CredentialKindCode))
+			if code == "" {
+				return nil, fmt.Errorf("import_capability: server %q header %q: credential_ref missing credential_kind_code", srv.Name, headerName)
+			}
+			if _, dup := seen[code]; dup {
+				continue
+			}
+			if _, err := s.GetCredentialKindByCode(ctx, code); err != nil {
+				return nil, fmt.Errorf("import_capability: server %q header %q references unknown credential_kind %q: %w", srv.Name, headerName, code, err)
+			}
+			seen[code] = struct{}{}
+			out = append(out, RequiredCredential{Kind: code, Required: true})
+		}
 	}
 	return out, nil
 }
@@ -706,8 +724,8 @@ func validateMCPSpecPreCommit(m canonical.MCPSpec) error {
 			}
 			switch value.Mode {
 			case canonical.EnvModeLiteral:
-				if value.SecretID != "" || value.CredentialKindCode != "" {
-					return fmt.Errorf("server %q env %q: literal mode must not set secret_id/credential_kind_code", srv.Name, name)
+				if value.SecretID != "" || value.CredentialKindCode != "" || value.Prefix != "" {
+					return fmt.Errorf("server %q env %q: literal mode must not set secret_id/credential_kind_code/prefix", srv.Name, name)
 				}
 			case canonical.EnvModeInlineSecret:
 				// Empty SecretID is intentional here — the import tx fills it
@@ -724,6 +742,17 @@ func validateMCPSpecPreCommit(m canonical.MCPSpec) error {
 				}
 			default:
 				return fmt.Errorf("server %q env %q: unknown env mode %q", srv.Name, name, value.Mode)
+			}
+		}
+		for name, value := range srv.Headers {
+			if strings.TrimSpace(name) == "" || strings.ContainsAny(name, "\r\n") {
+				return fmt.Errorf("server %q: invalid header name", srv.Name)
+			}
+			if value.Mode == canonical.EnvModeInlineSecret {
+				return fmt.Errorf("server %q header %q: inline_secret is not supported", srv.Name, name)
+			}
+			if err := value.Validate(); err != nil {
+				return fmt.Errorf("server %q header %q: %w", srv.Name, name, err)
 			}
 		}
 		if _, dup := seen[srv.Name]; dup {

--- a/server/internal/store/oauth_secret_test.go
+++ b/server/internal/store/oauth_secret_test.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestCapabilitySecretIsScopedToWorkspaceAndCanRotate(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	st := New(db)
+	ids := mustSeedDevFixture(t, ctx, st)
+
+	created, err := st.CreateSecret(ctx, CreateSecretInput{
+		WorkspaceID:        ids.WorkspaceID,
+		Name:               "Notion OAuth",
+		Kind:               "capability_inline",
+		Provider:           "notion",
+		AuthType:           "oauth2",
+		Masked:             "configured",
+		CreatedBy:          ids.UserID,
+		CredentialKindCode: "notion_integration",
+		Metadata:           map[string]any{"catalog_id": "notion"},
+	}, []byte(`{"token":"first"}`))
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+	if created.Metadata["workspace_id"] != ids.WorkspaceID || created.Metadata["catalog_id"] != "notion" {
+		t.Fatalf("metadata = %+v", created.Metadata)
+	}
+
+	otherWorkspaceID := "00000000-0000-0000-0000-000000000099"
+	visible, err := st.ListSecrets(ctx, otherWorkspaceID, 100)
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	for _, secret := range visible {
+		if secret.ID == created.ID {
+			t.Fatalf("workspace-scoped secret leaked into another workspace")
+		}
+	}
+	if _, err := st.GetSecretPayload(ctx, otherWorkspaceID, created.ID); !errors.Is(err, ErrUnknownSecret) {
+		t.Fatalf("cross-workspace GetSecretPayload error = %v", err)
+	}
+
+	updated, err := st.UpdateSecretPayload(ctx, ids.WorkspaceID, created.ID, []byte(`{"token":"second"}`))
+	if err != nil {
+		t.Fatalf("UpdateSecretPayload: %v", err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(updated.EncryptedPayload, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload["token"] != "second" {
+		t.Fatalf("updated payload = %+v", payload)
+	}
+}

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -699,7 +699,7 @@ type UsageLogRead struct {
 }
 
 type CreateSecretInput struct {
-	WorkspaceID string // accepted for caller-compat; secrets are org-global
+	WorkspaceID string
 	Name        string
 	Kind        string
 	Provider    string
@@ -711,6 +711,7 @@ type CreateSecretInput struct {
 	// secret to a single credential_kinds.code. Used by the agent-creation
 	// shared-binding picker to filter secrets by the kind they hold.
 	CredentialKindCode string
+	Metadata           map[string]any
 }
 
 type SecretRead struct {
@@ -5709,12 +5710,17 @@ func (s *Store) ListWorkspaceUsageLogs(ctx context.Context, workspaceID string, 
 
 func (s *Store) CreateSecret(ctx context.Context, input CreateSecretInput, encryptedPayload []byte) (SecretRead, error) {
 	now := time.Now().UTC()
-	// Secrets are org-global; WorkspaceID accepted for caller-compat only.
-	_ = input.WorkspaceID
 	createdBy := nullableUUID(input.CreatedBy)
-	metaPayload := map[string]any{"masked": strings.TrimSpace(input.Masked)}
+	metaPayload := make(map[string]any, len(input.Metadata)+3)
+	for key, value := range input.Metadata {
+		metaPayload[key] = value
+	}
+	metaPayload["masked"] = strings.TrimSpace(input.Masked)
 	if code := strings.TrimSpace(input.CredentialKindCode); code != "" {
 		metaPayload["credential_kind_code"] = code
+	}
+	if strings.TrimSpace(input.Kind) == "capability_inline" {
+		metaPayload["workspace_id"] = strings.TrimSpace(input.WorkspaceID)
 	}
 	metadata, err := json.Marshal(metaPayload)
 	if err != nil {
@@ -5759,10 +5765,22 @@ func (s *Store) CreateSecret(ctx context.Context, input CreateSecretInput, encry
 	return read, nil
 }
 
-// ListSecrets returns active secrets in the org-global catalog.
-// workspaceID is accepted for caller-compat only and ignored.
 func (s *Store) ListSecrets(ctx context.Context, workspaceID string, limit int32) ([]SecretRead, error) {
-	return s.ListSecretsByKind(ctx, "", limit)
+	if limit <= 0 {
+		limit = defaultReadLimit
+	}
+	rows, err := sqlc.New(s.db).ListSecretsForWorkspace(ctx, sqlc.ListSecretsForWorkspaceParams{
+		WorkspaceID: strings.TrimSpace(workspaceID),
+		ItemLimit:   limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := make([]SecretRead, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, secretReadFromWorkspaceListRow(row))
+	}
+	return result, nil
 }
 
 func (s *Store) ListSecretsByKind(ctx context.Context, kindFilter string, limit int32) ([]SecretRead, error) {
@@ -5782,7 +5800,9 @@ func (s *Store) ListSecretsByKind(ctx context.Context, kindFilter string, limit 
 
 func (s *Store) DisableSecret(ctx context.Context, workspaceID string, secretID string) (SecretRead, error) {
 	now := time.Now().UTC()
-	_ = workspaceID
+	if _, err := s.GetSecretPayload(ctx, workspaceID, secretID); err != nil {
+		return SecretRead{}, err
+	}
 	secretUUID, err := uuid(secretID)
 	if err != nil {
 		return SecretRead{}, err
@@ -5815,7 +5835,6 @@ func (s *Store) DisableSecret(ctx context.Context, workspaceID string, secretID 
 }
 
 func (s *Store) GetSecretPayload(ctx context.Context, workspaceID string, secretID string) (SecretPayload, error) {
-	_ = workspaceID
 	secretUUID, err := uuid(secretID)
 	if err != nil {
 		return SecretPayload{}, err
@@ -5828,7 +5847,44 @@ func (s *Store) GetSecretPayload(ctx context.Context, workspaceID string, secret
 		return SecretPayload{}, err
 	}
 	read := secretReadFromSecretRow(row)
+	if scopedWorkspaceID := secretWorkspaceID(read.Metadata); scopedWorkspaceID != "" && scopedWorkspaceID != strings.TrimSpace(workspaceID) {
+		return SecretPayload{}, fmt.Errorf("%w: %s", ErrUnknownSecret, secretID)
+	}
 	return SecretPayload{SecretRead: read, EncryptedPayload: row.EncryptedPayload}, nil
+}
+
+func (s *Store) UpdateSecretPayload(ctx context.Context, workspaceID, secretID string, encryptedPayload []byte) (SecretPayload, error) {
+	current, err := s.GetSecretPayload(ctx, workspaceID, secretID)
+	if err != nil {
+		return SecretPayload{}, err
+	}
+	secretUUID, err := uuid(secretID)
+	if err != nil {
+		return SecretPayload{}, err
+	}
+	keyVersion := strings.TrimSpace(current.KeyVersion)
+	if keyVersion == "" {
+		keyVersion = "v1"
+	}
+	row, err := sqlc.New(s.db).UpdateSecretPayload(ctx, sqlc.UpdateSecretPayloadParams{
+		ID:               secretUUID,
+		EncryptedPayload: encryptedPayload,
+		KeyVersion:       keyVersion,
+		Now:              timestamptz(time.Now().UTC()),
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return SecretPayload{}, fmt.Errorf("%w: %s", ErrUnknownSecret, secretID)
+		}
+		return SecretPayload{}, err
+	}
+	read := secretReadFromUpdatePayloadRow(row)
+	return SecretPayload{SecretRead: read, EncryptedPayload: row.EncryptedPayload}, nil
+}
+
+func secretWorkspaceID(metadata map[string]any) string {
+	workspaceID, _ := metadata["workspace_id"].(string)
+	return strings.TrimSpace(workspaceID)
 }
 
 // SlackBotSecret is a decrypt-ready Slack bot-token secret resolved by Slack
@@ -8282,11 +8338,19 @@ func secretReadFromListRow(row sqlc.ListSecretsRow) SecretRead {
 	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.CreatedAt, row.UpdatedAt)
 }
 
+func secretReadFromWorkspaceListRow(row sqlc.ListSecretsForWorkspaceRow) SecretRead {
+	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.CreatedAt, row.UpdatedAt)
+}
+
 func secretReadFromDisableRow(row sqlc.DisableSecretRow) SecretRead {
 	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.CreatedAt, row.UpdatedAt)
 }
 
 func secretReadFromSecretRow(row sqlc.GetSecretPayloadRow) SecretRead {
+	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.CreatedAt, row.UpdatedAt)
+}
+
+func secretReadFromUpdatePayloadRow(row sqlc.UpdateSecretPayloadRow) SecretRead {
 	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.CreatedAt, row.UpdatedAt)
 }
 


### PR DESCRIPTION
## Summary

- add MCP OAuth discovery, dynamic client registration, PKCE, popup callback, and token refresh for hosted connectors
- add Notion as the first OAuth-enabled connector using the official `https://mcp.notion.com/mcp` endpoint
- reuse the existing `secrets` table, `notion_integration` credential kind, and Agent shared credential bindings
- inject authenticated HTTP headers into Claude Code, Codex, and OpenCode MCP configurations
- require OAuth connection before importing an authenticated connector

## Scope

- stacked on #223
- no new database tables or migrations
- no `npx` proxy, automatic Agent binding, or remote catalog URL
- OAuth tokens remain encrypted with the existing `PARSAR_MASTER_KEY` secret service

## Testing

- `make check`
- `pnpm --filter @parsar/web build`
- rebuilt the local Docker image and verified `/healthz`
