### PR TITLE
Allow workspace members to manage agent capabilities

### DIFF
--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -589,7 +589,9 @@ export function AgentConfigTab({
       }
     })
   const installable = availableCapabilities.filter((cap) => !installedIDs.has(cap.id))
-  const isAdmin = workspaceRole === "owner" || workspaceRole === "admin"
+  const canManageCapabilities = workspaceRole === "owner"
+    || workspaceRole === "admin"
+    || workspaceRole === "member"
 
   return (
     <div className="space-y-4">
@@ -602,7 +604,7 @@ export function AgentConfigTab({
       <ConfigCapabilitiesSection
         agent={agent}
         workspaceID={workspaceID}
-        isAdmin={isAdmin}
+        isAdmin={canManageCapabilities}
         enabledCaps={enabledCaps}
         installable={installable}
         credentials={credentials}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -114,6 +114,9 @@ definitions:
         description: user id
         type: string
       deliveryID:
+        description: |-
+          DeliveryID is the caller's stable idempotency base. The agent-daemon
+          connector adds a unique suffix for each wire attempt before awaiting ack.
         type: string
       deviceID:
         type: string
@@ -133,6 +136,7 @@ definitions:
       cancelled:
         type: boolean
       deliveryID:
+        description: DeliveryID follows PermissionDecision's stable-base semantics.
         type: string
       deviceID:
         type: string
@@ -4624,8 +4628,8 @@ paths:
     put:
       consumes:
       - application/json
-      description: Toggles a runtime-injected built-in on/off for one agent. Only
-        the agent creator may change it. The key must be a known built-in.
+      description: Toggles a runtime-injected built-in on/off for one agent. Workspace
+        owners, admins, and members may change it. The key must be a known built-in.
       operationId: setDevAgentBuiltinCapability
       parameters:
       - description: Workspace UUID
@@ -4664,7 +4668,7 @@ paths:
               type: string
             type: object
         "403":
-          description: Not agent creator
+          description: Caller is a viewer or non-member
           schema:
             additionalProperties:
               type: string
@@ -4741,7 +4745,8 @@ paths:
       consumes:
       - application/json
       description: Swaps the agent's binding to a new version of the same capability,
-        optionally flipping the pinning mode at the same time. Agent creator only.
+        optionally flipping the pinning mode at the same time. Workspace owner, admin,
+        or member only.
       operationId: upgradeDevAgentCapability
       parameters:
       - description: Workspace UUID
@@ -4780,7 +4785,7 @@ paths:
               type: string
             type: object
         "403":
-          description: Not agent creator
+          description: Caller is a viewer or non-member
           schema:
             additionalProperties:
               type: string
@@ -4802,8 +4807,8 @@ paths:
       - capabilities
   /api/v1/workspaces/{workspaceID}/agents/{agentID}/capabilities/{capabilityVersionID}:
     delete:
-      description: Removes the given capability version from the agent. Agent creator
-        only.
+      description: Removes the given capability version from the agent. Workspace
+        owner, admin, or member only.
       operationId: deleteDevAgentCapability
       parameters:
       - description: Workspace UUID
@@ -4833,7 +4838,7 @@ paths:
               type: string
             type: object
         "403":
-          description: Not agent creator
+          description: Caller is a viewer or non-member
           schema:
             additionalProperties:
               type: string
@@ -4858,8 +4863,8 @@ paths:
       consumes:
       - application/json
       description: Enables (installs) a capability version on the agent. Cross-workspace
-        enable requires the source capability to be public and non-deprecated. Agent
-        creator only.
+        enable requires the source capability to be public and non-deprecated. Workspace
+        owner, admin, or member only.
       operationId: enableDevAgentCapability
       parameters:
       - description: Workspace UUID
@@ -4898,7 +4903,8 @@ paths:
               type: string
             type: object
         "403":
-          description: Not agent creator, or marketplace capability unavailable
+          description: Caller is a viewer/non-member, or marketplace capability is
+            unavailable
           schema:
             additionalProperties:
               type: string

--- a/server/internal/dev/capability_routes.go
+++ b/server/internal/dev/capability_routes.go
@@ -1369,7 +1369,7 @@ func listAgentCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 // Cross-workspace requires the source capability to be public + non-deprecated.
 //
 //	@Summary		Enable a capability on an agent
-//	@Description	Enables (installs) a capability version on the agent. Cross-workspace enable requires the source capability to be public and non-deprecated. Agent creator only.
+//	@Description	Enables (installs) a capability version on the agent. Cross-workspace enable requires the source capability to be public and non-deprecated. Workspace owner, admin, or member only.
 //	@Tags			capabilities
 //	@ID				enableDevAgentCapability
 //	@Accept			json
@@ -1380,13 +1380,13 @@ func listAgentCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 //	@Param			body				body	agentCapabilityBody		true	"Configuration + pinning mode"
 //	@Success		200 {object} map[string]interface{} "Enabled agent_capability row"
 //	@Failure		400 {object} map[string]string "Invalid UUID or malformed body"
-//	@Failure		403 {object} map[string]string "Not agent creator, or marketplace capability unavailable"
+//	@Failure		403 {object} map[string]string "Caller is a viewer/non-member, or marketplace capability is unavailable"
 //	@Failure		404 {object} map[string]string "Agent, capability, or version not found"
 //	@Failure		503 {object} map[string]string "Database-backed capability APIs are disabled"
 //	@Router			/api/v1/workspaces/{workspaceID}/agents/{agentID}/capabilities/{capabilityVersionID}/enable [post]
 func enableAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_, agentID, agent, ok := requireAgentOwnerMember(w, r, runtimeStore)
+		_, agentID, agent, ok := requireAgentWritableMember(w, r, runtimeStore)
 		if !ok {
 			return
 		}
@@ -1429,7 +1429,7 @@ func enableAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 // deleteAgentCapability uninstalls a capability version from the agent.
 //
 //	@Summary		Uninstall a capability from an agent
-//	@Description	Removes the given capability version from the agent. Agent creator only.
+//	@Description	Removes the given capability version from the agent. Workspace owner, admin, or member only.
 //	@Tags			capabilities
 //	@ID				deleteDevAgentCapability
 //	@Produce		json
@@ -1438,13 +1438,13 @@ func enableAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 //	@Param			capabilityVersionID	path	string	true	"Capability version UUID"
 //	@Success		204 "Uninstalled"
 //	@Failure		400 {object} map[string]string "Invalid UUID"
-//	@Failure		403 {object} map[string]string "Not agent creator"
+//	@Failure		403 {object} map[string]string "Caller is a viewer or non-member"
 //	@Failure		404 {object} map[string]string "Agent capability not found"
 //	@Failure		503 {object} map[string]string "Database-backed capability APIs are disabled"
 //	@Router			/api/v1/workspaces/{workspaceID}/agents/{agentID}/capabilities/{capabilityVersionID} [delete]
 func deleteAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_, agentID, _, ok := requireAgentOwnerMember(w, r, runtimeStore)
+		_, agentID, _, ok := requireAgentWritableMember(w, r, runtimeStore)
 		if !ok {
 			return
 		}
@@ -1462,14 +1462,11 @@ func deleteAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 }
 
 // setBuiltinCapability toggles a runtime-injected built-in on/off for one agent.
-// Only the agent owner may change it; the key is validated against the built-in
-// registry so callers can't create arbitrary rows.
-// setBuiltinCapability toggles a runtime-injected built-in on/off for one agent.
-// Only the agent owner may change it; the key is validated against the built-in
+// Any non-viewer workspace member may change it; the key is validated against the built-in
 // registry so callers can't create arbitrary rows.
 //
 //	@Summary		Toggle a built-in capability on an agent
-//	@Description	Toggles a runtime-injected built-in on/off for one agent. Only the agent creator may change it. The key must be a known built-in.
+//	@Description	Toggles a runtime-injected built-in on/off for one agent. Workspace owners, admins, and members may change it. The key must be a known built-in.
 //	@Tags			capabilities
 //	@ID				setDevAgentBuiltinCapability
 //	@Accept			json
@@ -1480,13 +1477,13 @@ func deleteAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 //	@Param			body		body	builtinCapabilityBody	true	"Enabled flag"
 //	@Success		200 {object} map[string]interface{} "agent_id, builtin_key, enabled"
 //	@Failure		400 {object} map[string]string "Invalid UUID or malformed body"
-//	@Failure		403 {object} map[string]string "Not agent creator"
+//	@Failure		403 {object} map[string]string "Caller is a viewer or non-member"
 //	@Failure		404 {object} map[string]string "Unknown builtin key or agent not found"
 //	@Failure		503 {object} map[string]string "Database-backed capability APIs are disabled"
 //	@Router			/api/v1/workspaces/{workspaceID}/agents/{agentID}/builtin-capabilities/{key} [put]
 func setBuiltinCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_, agentID, _, ok := requireAgentOwnerMember(w, r, runtimeStore)
+		_, agentID, _, ok := requireAgentWritableMember(w, r, runtimeStore)
 		if !ok {
 			return
 		}
@@ -1512,7 +1509,7 @@ func setBuiltinCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 // same capability, optionally flipping the pinning mode at the same time.
 //
 //	@Summary		Upgrade an agent's capability version
-//	@Description	Swaps the agent's binding to a new version of the same capability, optionally flipping the pinning mode at the same time. Agent creator only.
+//	@Description	Swaps the agent's binding to a new version of the same capability, optionally flipping the pinning mode at the same time. Workspace owner, admin, or member only.
 //	@Tags			capabilities
 //	@ID				upgradeDevAgentCapability
 //	@Accept			json
@@ -1523,13 +1520,13 @@ func setBuiltinCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 //	@Param			body			body	upgradeAgentCapabilityBody		true	"new_version_id and optional pinning_mode"
 //	@Success		200 {object} map[string]interface{} "Updated agent_capability row"
 //	@Failure		400 {object} map[string]string "Invalid UUID or malformed body"
-//	@Failure		403 {object} map[string]string "Not agent creator"
+//	@Failure		403 {object} map[string]string "Caller is a viewer or non-member"
 //	@Failure		404 {object} map[string]string "Agent, capability, or version not found"
 //	@Failure		503 {object} map[string]string "Database-backed capability APIs are disabled"
 //	@Router			/api/v1/workspaces/{workspaceID}/agents/{agentID}/capabilities/{capabilityID}/upgrade [post]
 func upgradeAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_, agentID, _, ok := requireAgentOwnerMember(w, r, runtimeStore)
+		_, agentID, _, ok := requireAgentWritableMember(w, r, runtimeStore)
 		if !ok {
 			return
 		}
@@ -1636,6 +1633,14 @@ func requireAuthenticatedUser(w http.ResponseWriter, r *http.Request, runtimeSto
 }
 
 func requireAgentMember(w http.ResponseWriter, r *http.Request, runtimeStore RuntimeStore) (string, string, store.AgentStatusRead, bool) {
+	return requireAgentRoles(w, r, runtimeStore, "owner", "admin", "member", "viewer")
+}
+
+func requireAgentWritableMember(w http.ResponseWriter, r *http.Request, runtimeStore RuntimeStore) (string, string, store.AgentStatusRead, bool) {
+	return requireAgentRoles(w, r, runtimeStore, "owner", "admin", "member")
+}
+
+func requireAgentRoles(w http.ResponseWriter, r *http.Request, runtimeStore RuntimeStore, roles ...string) (string, string, store.AgentStatusRead, bool) {
 	if runtimeStore == nil {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "database-backed capability APIs are disabled"})
 		return "", "", store.AgentStatusRead{}, false
@@ -1653,21 +1658,8 @@ func requireAgentMember(w http.ResponseWriter, r *http.Request, runtimeStore Run
 		writeJSON(w, http.StatusNotFound, map[string]string{"error": "agent not found"})
 		return "", "", store.AgentStatusRead{}, false
 	}
-	if err := requireWorkspaceMember(r, runtimeStore, workspaceID); err != nil {
+	if err := auth.RequireWorkspaceRole(requestContextForRBAC(r), runtimeStore, workspaceID, roles...); err != nil {
 		writeRBACError(w, err)
-		return "", "", store.AgentStatusRead{}, false
-	}
-	return workspaceID, agentID, agent, true
-}
-
-func requireAgentOwnerMember(w http.ResponseWriter, r *http.Request, runtimeStore RuntimeStore) (string, string, store.AgentStatusRead, bool) {
-	workspaceID, agentID, agent, ok := requireAgentMember(w, r, runtimeStore)
-	if !ok {
-		return "", "", store.AgentStatusRead{}, false
-	}
-	userID := strings.TrimSpace(auth.UserIDFromContext(requestContextForRBAC(r)))
-	if strings.TrimSpace(agent.CreatedBy) != "" && agent.CreatedBy != userID {
-		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
 		return "", "", store.AgentStatusRead{}, false
 	}
 	return workspaceID, agentID, agent, true

--- a/server/internal/dev/routes_capability_test.go
+++ b/server/internal/dev/routes_capability_test.go
@@ -168,9 +168,9 @@ func TestCapabilityUserCredentialsOwnScopeAndNoSecretLeak(t *testing.T) {
 	}
 }
 
-func TestCapabilityAgentEnableRBACWorkspaceAndUniqueUpdate(t *testing.T) {
+func TestCapabilityAgentWriteRBACWorkspaceAndUniqueUpdate(t *testing.T) {
 	foreignWorkspaceID := "00000000-0000-0000-0000-000000000099"
-	r, db := capabilityTestRouter(t, map[string]string{store.DefaultDevFixtureIDs().UserID: "admin", testUserBID: "admin"}, map[string]string{testUserAID: "member", testUserBID: "member"})
+	r, db := capabilityTestRouter(t, map[string]string{testUserAID: "member", testUserBID: "viewer"}, nil)
 	insertForeignWorkspace(t, db, foreignWorkspaceID)
 	capID, v1, v2 := insertCapabilityVersions(t, db, store.DefaultDevFixtureIDs().WorkspaceID, "GitHub MCP")
 	_ = capID
@@ -183,9 +183,25 @@ func TestCapabilityAgentEnableRBACWorkspaceAndUniqueUpdate(t *testing.T) {
 	if enabled.Code != http.StatusOK {
 		t.Fatalf("enable own agent expected 200, got %d: %s", enabled.Code, enabled.Body.String())
 	}
-	forbidden := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/agents/"+otherPA+"/capabilities/"+v1+"/enable", `{}`, testUserAID)
-	if forbidden.Code != http.StatusForbidden {
-		t.Fatalf("enable other agent expected 403, got %d: %s", forbidden.Code, forbidden.Body.String())
+	enabledOther := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/agents/"+otherPA+"/capabilities/"+v1+"/enable", `{}`, testUserAID)
+	if enabledOther.Code != http.StatusOK {
+		t.Fatalf("member enable another workspace agent expected 200, got %d: %s", enabledOther.Code, enabledOther.Body.String())
+	}
+	upgradedOther := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/agents/"+otherPA+"/capabilities/"+capID+"/upgrade", `{"new_version_id":"`+v2+`"}`, testUserAID)
+	if upgradedOther.Code != http.StatusOK {
+		t.Fatalf("member upgrade another workspace agent expected 200, got %d: %s", upgradedOther.Code, upgradedOther.Body.String())
+	}
+	toggledOther := serveCapabilityRoute(t, r, http.MethodPut, "/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/agents/"+otherPA+"/builtin-capabilities/parsar_chat_history", `{"enabled":false}`, testUserAID)
+	if toggledOther.Code != http.StatusOK {
+		t.Fatalf("member toggle another workspace agent builtin expected 200, got %d: %s", toggledOther.Code, toggledOther.Body.String())
+	}
+	removedOther := serveCapabilityRoute(t, r, http.MethodDelete, "/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/agents/"+otherPA+"/capabilities/"+v2, ``, testUserAID)
+	if removedOther.Code != http.StatusNoContent {
+		t.Fatalf("member remove another workspace agent capability expected 204, got %d: %s", removedOther.Code, removedOther.Body.String())
+	}
+	viewer := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/agents/"+ownedPA+"/capabilities/"+v1+"/enable", `{}`, testUserBID)
+	if viewer.Code != http.StatusForbidden {
+		t.Fatalf("viewer enable expected 403, got %d: %s", viewer.Code, viewer.Body.String())
 	}
 	foreign := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/agents/"+ownedPA+"/capabilities/"+foreignV1+"/enable", `{}`, testUserAID)
 	if foreign.Code != http.StatusForbidden {


### PR DESCRIPTION
## Summary
- allow workspace members to bind, remove, upgrade, and toggle built-in agent capabilities
- keep viewers and non-members read-only
- expose capability controls to members in the agent configuration UI
- update OpenAPI descriptions and RBAC regression coverage

## Verification
- `go test ./server/internal/dev ./server/internal/auth`
- `pnpm --filter @parsar/web build`
- `make openapi`