### PR TITLE
fix: block incompatible agent capabilities

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1398,6 +1398,16 @@
             "switchAction": "Switch to an available version"
           }
         },
+        "compatibility": {
+          "badge": "Not supported",
+          "unsupported": "{{engine}} does not support {{type}} capabilities. Supported engines: {{engines}}.",
+          "types": {
+            "mcp": "MCP",
+            "skill": "Skill",
+            "plugin": "Plugin",
+            "system_prompt": "System Prompt"
+          }
+        },
         "builtin": {
           "badge": "Built-in",
           "on": "On",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1398,6 +1398,16 @@
             "switchAction": "请切到可用版本"
           }
         },
+        "compatibility": {
+          "badge": "不支持",
+          "unsupported": "{{engine}} 不支持 {{type}} 能力。支持的 Agent 引擎：{{engines}}。",
+          "types": {
+            "mcp": "MCP",
+            "skill": "Skill",
+            "plugin": "Plugin",
+            "system_prompt": "System Prompt"
+          }
+        },
         "builtin": {
           "badge": "系统内置",
           "on": "已开启",

--- a/apps/web/src/lib/agent-view-model.ts
+++ b/apps/web/src/lib/agent-view-model.ts
@@ -1,4 +1,4 @@
-import type { Agent, AgentDetail, Model } from "./api-types"
+import type { Agent, AgentDetail, CapabilityType, Model } from "./api-types"
 
 export type AgentEngine = "claude_code" | "codex" | "pi" | "opencode"
 
@@ -84,6 +84,24 @@ export function agentEngineLabel(engine: AgentEngine): AgentEngineLabelKey {
     case "opencode":
       return "agents.engine.opencode.title"
   }
+}
+
+export function agentEngineSupportsCapability(engine: AgentEngine, capabilityType: CapabilityType): boolean {
+  switch (engine) {
+    case "claude_code":
+      return true
+    case "codex":
+    case "opencode":
+      return capabilityType === "mcp" || capabilityType === "system_prompt"
+    case "pi":
+      return capabilityType === "skill" || capabilityType === "system_prompt"
+  }
+}
+
+export function agentEnginesSupportingCapability(capabilityType: CapabilityType): AgentEngine[] {
+  return (["claude_code", "codex", "pi", "opencode"] as const).filter((engine) =>
+    agentEngineSupportsCapability(engine, capabilityType),
+  )
 }
 
 export function agentCodexModeOf(agent: AgentSource): CodexCollaborationMode {

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -38,6 +38,7 @@ import {
 import { useMyCredentials } from "../../../lib/api-credentials"
 import { useSecrets } from "../../../lib/api-secrets"
 import { agentExecutionPlacement } from "../../../lib/agent-runtime"
+import { agentEngineLabel, agentEngineOf, agentEngineSupportsCapability, agentEnginesSupportingCapability } from "../../../lib/agent-view-model"
 import { credentialBinding, hasCredentialKind, sharedSecretsForKind } from "../../../lib/credential-bindings"
 import type { Agent, AgentCapability, AgentDetail, Capability, CapabilityVersion, Secret, UserCredential } from "../../../lib/api-types"
 import { CredentialBindingSelect } from "../../../components/admin/CredentialBindingSelect"
@@ -227,6 +228,16 @@ function CapabilityCard({
   }
   if (!capability) return null
 
+  const agentEngine = agentEngineOf(agent)
+  const incompatible = !agentEngineSupportsCapability(agentEngine, capability.type)
+  const compatibilityMessage = incompatible
+    ? t("agents.detail.capabilities.compatibility.unsupported", {
+        engine: t(agentEngineLabel(agentEngine)),
+        type: t(`agents.detail.capabilities.compatibility.types.${capability.type}`),
+        engines: agentEnginesSupportingCapability(capability.type).map((engine) => t(agentEngineLabel(engine))).join(", "),
+      })
+    : ""
+
   return (
     <div className={`rounded-md border ${border} p-3`}>
       <div className="flex items-start justify-between gap-3">
@@ -235,6 +246,7 @@ function CapabilityCard({
             <span className="text-sm font-medium text-fg">{capability.name}</span>
             <CapabilityTypeBadge type={capability.type} />
             {fromMarketplace && <Badge variant="primary">{t("agents.detail.capabilities.marketplace.badge")}</Badge>}
+            {incompatible && <Badge variant="destructive">{t("agents.detail.capabilities.compatibility.badge")}</Badge>}
             {missingCredential && <Badge variant="destructive">{t("agents.detail.capabilities.credential.missingBadge")}</Badge>}
             {versionDeleted && <Badge variant="destructive">{t("agents.detail.capabilities.bindings.versionDeleted.warning")}</Badge>}
             {versionDeleted && versions.length > 0 && binding && (
@@ -258,6 +270,12 @@ function CapabilityCard({
       {mode === "enabled" && deprecated && (
         <div className="mt-3 rounded-md border border-danger-border bg-danger-subtle px-3 py-2 text-sm leading-5 text-danger-emphasis">
           {t("agents.detail.capabilities.marketplace.deprecatedBanner", { version: boundVersion?.version ?? capability.pinned_version ?? "—" })}
+        </div>
+      )}
+
+      {incompatible && (
+        <div className="mt-3 rounded-md border border-warning-border bg-warning-subtle px-3 py-2 text-sm leading-5 text-warning-emphasis">
+          {compatibilityMessage}
         </div>
       )}
 
@@ -292,6 +310,7 @@ function CapabilityCard({
               credentials={credentials}
               sharedSecrets={sharedSecrets}
               workspaceID={workspaceID}
+              disabled={incompatible}
               onToast={onToast}
             />
           ) : binding ? (
@@ -472,6 +491,7 @@ function CapabilityVersionDialog({
   binding,
   triggerLabel,
   triggerVariant = "ghost",
+  disabled = false,
   onToast,
 }: {
   mode: "enable" | "switch"
@@ -483,6 +503,7 @@ function CapabilityVersionDialog({
   binding?: AgentCapability
   triggerLabel?: string
   triggerVariant?: "ghost" | "link"
+  disabled?: boolean
   onToast: (message: string) => void
 }) {
   const { t } = useTranslation("admin")
@@ -519,6 +540,7 @@ function CapabilityVersionDialog({
   })
   const canSubmit = !!selectedVersion
     && !mut.isPending
+    && !disabled
     && (mode === "enable" ? !missingRequiredCredential : selectedVersion.id !== binding?.capability_version_id)
 
   const submit = () => {
@@ -558,6 +580,7 @@ function CapabilityVersionDialog({
         variant={isSwitch ? triggerVariant : "default"}
         size="sm"
         className={isSwitch && triggerVariant === "link" ? "h-auto px-1 py-0 text-sm text-danger-emphasis" : undefined}
+        disabled={disabled}
         onClick={() => setOpen(true)}
       >
         {triggerLabel ?? t(isSwitch ? "agents.detail.capabilities.actions.switchVersion" : "agents.detail.capabilities.actions.enable")}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -4984,6 +4984,13 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "422":
+          description: Capability is incompatible with the Agent engine or its credentials
+            are invalid
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "503":
           description: Database-backed capability APIs are disabled
           schema:

--- a/server/internal/capability/render/claudecode.go
+++ b/server/internal/capability/render/claudecode.go
@@ -52,6 +52,15 @@ type claudeCodePluginDocument struct {
 	SHA256  string `json:"sha256"`
 }
 
+func (claudeCodeRenderer) Supports(kind canonical.Kind) bool {
+	switch kind {
+	case canonical.KindMCP, canonical.KindSkill, canonical.KindPlugin, canonical.KindSystemPrompt:
+		return true
+	default:
+		return false
+	}
+}
+
 func (claudeCodeRenderer) Render(_ context.Context, spec canonical.Spec) (Output, error) {
 	if err := spec.Validate(); err != nil {
 		return Output{}, fmt.Errorf("claudecode render: invalid spec: %w", err)

--- a/server/internal/capability/render/codex.go
+++ b/server/internal/capability/render/codex.go
@@ -44,6 +44,10 @@ type codexMCPServer struct {
 	Env     map[string]string `json:"env,omitempty"`
 }
 
+func (codexRenderer) Supports(kind canonical.Kind) bool {
+	return kind == canonical.KindMCP || kind == canonical.KindSystemPrompt
+}
+
 func (codexRenderer) Render(_ context.Context, spec canonical.Spec) (Output, error) {
 	if err := spec.Validate(); err != nil {
 		return Output{}, fmt.Errorf("codex render: invalid spec: %w", err)

--- a/server/internal/capability/render/opencode.go
+++ b/server/internal/capability/render/opencode.go
@@ -34,6 +34,10 @@ type openCodeMCPServer struct {
 	Enabled bool              `json:"enabled"`
 }
 
+func (openCodeRenderer) Supports(kind canonical.Kind) bool {
+	return kind == canonical.KindMCP || kind == canonical.KindSystemPrompt
+}
+
 func (openCodeRenderer) Render(_ context.Context, spec canonical.Spec) (Output, error) {
 	if err := spec.Validate(); err != nil {
 		return Output{}, fmt.Errorf("opencode render: invalid spec: %w", err)

--- a/server/internal/capability/render/pi.go
+++ b/server/internal/capability/render/pi.go
@@ -21,6 +21,10 @@ type piRenderer struct{}
 
 func (piRenderer) Target() Target { return TargetPi }
 
+func (piRenderer) Supports(kind canonical.Kind) bool {
+	return kind == canonical.KindSkill || kind == canonical.KindSystemPrompt
+}
+
 func (piRenderer) Render(_ context.Context, spec canonical.Spec) (Output, error) {
 	if err := spec.Validate(); err != nil {
 		return Output{}, fmt.Errorf("pi render: invalid spec: %w", err)

--- a/server/internal/capability/render/renderer.go
+++ b/server/internal/capability/render/renderer.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
 )
@@ -47,7 +48,29 @@ var ErrUnsupported = errors.New("render: spec kind unsupported for target")
 // Renderer implementations must be pure and side-effect free.
 type Renderer interface {
 	Target() Target
+	Supports(kind canonical.Kind) bool
 	Render(ctx context.Context, spec canonical.Spec) (Output, error)
+}
+
+// TargetForAgentKind maps the daemon agent_kind value to its capability
+// renderer. Unknown and legacy empty values retain the Claude Code fallback.
+func TargetForAgentKind(agentKind string) Target {
+	switch strings.TrimSpace(agentKind) {
+	case "opencode":
+		return TargetOpenCode
+	case "codex":
+		return TargetCodex
+	case "pi":
+		return TargetPi
+	default:
+		return TargetClaudeCode
+	}
+}
+
+// Supports reports whether target can render the capability kind.
+func Supports(target Target, kind canonical.Kind) bool {
+	renderer, err := For(target)
+	return err == nil && renderer.Supports(kind)
 }
 
 func For(target Target) (Renderer, error) {

--- a/server/internal/capability/render/renderer_test.go
+++ b/server/internal/capability/render/renderer_test.go
@@ -76,6 +76,30 @@ func TestFor_UnknownTarget(t *testing.T) {
 	}
 }
 
+func TestSupports(t *testing.T) {
+	cases := []struct {
+		target Target
+		kind   canonical.Kind
+		want   bool
+	}{
+		{TargetClaudeCode, canonical.KindMCP, true},
+		{TargetClaudeCode, canonical.KindSkill, true},
+		{TargetCodex, canonical.KindMCP, true},
+		{TargetCodex, canonical.KindSkill, false},
+		{TargetOpenCode, canonical.KindMCP, true},
+		{TargetOpenCode, canonical.KindSkill, false},
+		{TargetPi, canonical.KindMCP, false},
+		{TargetPi, canonical.KindSkill, true},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.target)+"/"+string(tc.kind), func(t *testing.T) {
+			if got := Supports(tc.target, tc.kind); got != tc.want {
+				t.Fatalf("Supports(%q, %q) = %t, want %t", tc.target, tc.kind, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestOpenCodeRenderer_MCPGolden locks in the wire shape the OpenCode
 // connector reads back. Changes here must coordinate with capability_runtime.go.
 func TestOpenCodeRenderer_MCPGolden(t *testing.T) {

--- a/server/internal/connector/agentdaemon/capability_runtime.go
+++ b/server/internal/connector/agentdaemon/capability_runtime.go
@@ -179,23 +179,6 @@ const CapabilityVersionUnavailable = "capability_version_unavailable"
 // rows.
 var errCapabilityVersionUnavailable = errors.New("agent_daemon: capability version unavailable (empty oss_key)")
 
-// agentKindToRenderTarget maps the daemon-side agent_kind discriminant
-// onto the render.Target the capability serializer should produce. Unknown
-// kinds fall back to TargetClaudeCode so legacy rows (empty agent_kind)
-// keep working.
-func agentKindToRenderTarget(agentKind string) render.Target {
-	switch strings.TrimSpace(agentKind) {
-	case "opencode":
-		return render.TargetOpenCode
-	case "codex":
-		return render.TargetCodex
-	case "pi":
-		return render.TargetPi
-	default:
-		return render.TargetClaudeCode
-	}
-}
-
 // disabledForUnsupportedCapability builds the DisabledCapability surfaced
 // when a renderer returns render.ErrUnsupported — e.g. an opencode/codex
 // agent enabling a skill or plugin capability. MissingCredentials is left
@@ -284,7 +267,7 @@ func (c *Connector) resolveCapabilityAdditions(ctx context.Context, in connector
 		c.log.Info("agent_daemon: no enabled capabilities for agent", "agent_id", in.AgentID)
 		return result, nil
 	}
-	target := agentKindToRenderTarget(agentKind)
+	target := render.TargetForAgentKind(agentKind)
 	renderer, err := render.For(target)
 	if err != nil {
 		return result, fmt.Errorf("agent_daemon: render lookup: %w", err)

--- a/server/internal/connector/agentdaemon/capability_runtime_dispatch_test.go
+++ b/server/internal/connector/agentdaemon/capability_runtime_dispatch_test.go
@@ -16,7 +16,7 @@ import (
 //
 // Unknown / empty kinds must fall back to TargetClaudeCode so legacy rows
 // keep rendering as before.
-func TestAgentKindToRenderTarget(t *testing.T) {
+func TestTargetForAgentKind(t *testing.T) {
 	cases := []struct {
 		agentKind string
 		want      render.Target
@@ -31,8 +31,8 @@ func TestAgentKindToRenderTarget(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.agentKind, func(t *testing.T) {
-			if got := agentKindToRenderTarget(tc.agentKind); got != tc.want {
-				t.Fatalf("agentKindToRenderTarget(%q) = %q, want %q", tc.agentKind, got, tc.want)
+			if got := render.TargetForAgentKind(tc.agentKind); got != tc.want {
+				t.Fatalf("render.TargetForAgentKind(%q) = %q, want %q", tc.agentKind, got, tc.want)
 			}
 		})
 	}

--- a/server/internal/connector/agentdaemon/capability_runtime_test.go
+++ b/server/internal/connector/agentdaemon/capability_runtime_test.go
@@ -206,6 +206,17 @@ func TestResolveCapabilityAdditions_NilStoreNoOp(t *testing.T) {
 	}
 }
 
+func TestBuildAgentOptions_DefaultClaudeCodeUsesBypassPermissions(t *testing.T) {
+	c := &Connector{log: discardLogger()}
+	opts, err := c.buildAgentOptions(context.Background(), defaultPromptInput())
+	if err != nil {
+		t.Fatalf("buildAgentOptions: %v", err)
+	}
+	if got := opts["mode"]; got != "bypassPermissions" {
+		t.Fatalf("opts[mode] = %v, want bypassPermissions", got)
+	}
+}
+
 func TestResolveCapabilityAdditions_SkillKindMismatchErrors(t *testing.T) {
 	mismatched := canonical.Spec{
 		SchemaVersion: canonical.SchemaVersionCurrent,

--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -91,13 +91,13 @@ func (c *Connector) buildAgentOptions(ctx context.Context, in connector.PromptIn
 		c.log.Error("agent_daemon: injectManagedModel failed", "run_id", in.RunID, "err", err)
 		return nil, err
 	}
-	// Web and IM now share a durable permission loop, so Claude Code must
-	// surface tool approval requests instead of silently bypassing them.
+	// Claude Code defaults to bypassPermissions so already-bound MCPs and
+	// other trusted tool calls do not stop on repeated approvals.
 	// Explicit agent configuration still wins for operators that choose a
 	// different Claude permission mode.
 	if agentKind == "claude_code" {
 		if _, ok := opts["mode"]; !ok {
-			opts["mode"] = "default"
+			opts["mode"] = "bypassPermissions"
 		}
 	}
 

--- a/server/internal/dev/capability_routes.go
+++ b/server/internal/dev/capability_routes.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/render"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 	"github.com/go-chi/chi/v5"
@@ -1382,6 +1383,7 @@ func listAgentCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 //	@Failure		400 {object} map[string]string "Invalid UUID or malformed body"
 //	@Failure		403 {object} map[string]string "Not agent creator, or marketplace capability unavailable"
 //	@Failure		404 {object} map[string]string "Agent, capability, or version not found"
+//	@Failure		422 {object} map[string]string "Capability is incompatible with the Agent engine or its credentials are invalid"
 //	@Failure		503 {object} map[string]string "Database-backed capability APIs are disabled"
 //	@Router			/api/v1/workspaces/{workspaceID}/agents/{agentID}/capabilities/{capabilityVersionID}/enable [post]
 func enableAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
@@ -1420,6 +1422,18 @@ func enableAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 		agentRecord, err := runtimeStore.GetAgent(r.Context(), agentID)
 		if err != nil {
 			writeCapabilityError(w, err, "failed to get agent")
+			return
+		}
+		agentKind, _ := agentRecord.Config["agent_kind"].(string)
+		agentKind = strings.TrimSpace(agentKind)
+		target := render.TargetForAgentKind(agentKind)
+		if !render.Supports(target, canonical.Kind(capability.Type)) {
+			if agentKind == "" {
+				agentKind = "claude_code"
+			}
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+				"error": fmt.Sprintf("agent kind %q does not support %s capabilities", agentKind, capability.Type),
+			})
 			return
 		}
 		if err := validateCapabilityCredentialBindings(r.Context(), runtimeStore, capabilityCredentialBindingValidationInput{

--- a/server/internal/dev/routes_capability_test.go
+++ b/server/internal/dev/routes_capability_test.go
@@ -264,6 +264,29 @@ func TestCapabilityEnableRejectsOAuthSecretFromDifferentCatalogConnector(t *test
 	}
 }
 
+func TestCapabilityEnableRejectsUnsupportedAgentKind(t *testing.T) {
+	r, db := capabilityTestRouter(t, map[string]string{testUserAID: "member"}, nil)
+	capID, versionID, _ := insertCapabilityVersions(t, db, store.DefaultDevFixtureIDs().WorkspaceID, "Pi Incompatible MCP")
+	agentID := insertAgentForOwner(t, db, testUserAID, "pi-incompatible-mcp")
+	if _, err := db.Exec(context.Background(), `update agents set config = jsonb_set(config, '{agent_kind}', '"pi"'::jsonb) where id = $1`, agentID); err != nil {
+		t.Fatalf("set pi agent kind: %v", err)
+	}
+
+	res := serveCapabilityRoute(t, r, http.MethodPost,
+		"/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/agents/"+agentID+"/capabilities/"+versionID+"/enable",
+		`{}`, testUserAID)
+	if res.Code != http.StatusUnprocessableEntity || !strings.Contains(res.Body.String(), `agent kind \"pi\" does not support mcp capabilities`) {
+		t.Fatalf("enable incompatible MCP expected 422, got %d: %s", res.Code, res.Body.String())
+	}
+	var count int
+	if err := db.QueryRow(context.Background(), `select count(*) from agent_capabilities where agent_id = $1 and capability_id = $2`, agentID, capID).Scan(&count); err != nil {
+		t.Fatalf("count agent capabilities: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("incompatible capability was enabled")
+	}
+}
+
 func TestCapabilityUpgradeValidatesNewVersionCredentials(t *testing.T) {
 	r, db := capabilityTestRouter(t, map[string]string{testUserAID: "admin"}, nil)
 	capID, v1, v2 := insertCapabilityVersions(t, db, store.DefaultDevFixtureIDs().WorkspaceID, "Credential Upgrade MCP")


### PR DESCRIPTION
## Summary

- centralize the Agent engine/capability support matrix in the existing renderer layer
- reject unsupported capability enable requests with HTTP 422 before persisting the binding
- mark incompatible capabilities in the Agent configuration UI and disable the Enable action
- keep existing incompatible bindings visible so users can remove them
- add English and Chinese compatibility guidance

## Problem

A Pi Agent could be configured with an MCP capability and the UI reported success, but the runtime intentionally skipped MCP for Pi. This left a valid database binding that never reached the Agent. The same mismatch also applies to Skill capabilities on Codex and OpenCode.

This behavior predates the MCP Directory stack. The PR is separate and is based on #230 only because it updates the capability picker introduced there.

## Testing

- `PATH="$PATH:$HOME/go/bin" make check`
- database-backed `TestCapabilityEnableRejectsUnsupportedAgentKind`
- renderer and Agent Daemon compatibility tests
- `pnpm --filter @parsar/web typecheck`

## Compatibility

- no database migrations
- no Store or OAuth changes
- existing incompatible bindings remain readable and removable
- runtime soft-degrade behavior remains as a fallback for legacy data