### PR TITLE
feat: add curated Skill Directory

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -945,6 +945,58 @@
         "cancel": "Cancel"
       }
     },
+    "skillDirectory": {
+      "title": "Skills",
+      "description": "Browse reviewed Skills and workspace-published Skills in one place.",
+      "verified": "Verified",
+      "securityNotice": "Import only stores the reviewed Skill package. It is not executed or bound to an Agent until you enable it.",
+      "filters": {
+        "category": "Skill categories",
+        "allCategories": "All categories",
+        "verified": "Verified only",
+        "sort": "Sort Skills"
+      },
+      "sort": {
+        "featured": "Featured",
+        "name": "Name",
+        "newest": "Newest"
+      },
+      "actions": {
+        "import": "Import",
+        "installed": "Installed",
+        "back": "Back to Skills",
+        "viewCapability": "View Capability"
+      },
+      "loadError": {
+        "title": "Couldn't load the Skill directory",
+        "description": "Couldn't load the reviewed Skill directory. Retry without leaving the Capability Marketplace."
+      },
+      "empty": {
+        "title": "No Skills match these filters",
+        "description": "Try another search term or clear the category and Verified filters."
+      },
+      "detail": {
+        "loadError": "Failed to load Skill details",
+        "notFound": "Skill not found",
+        "version": "Version",
+        "license": "License",
+        "files": "Files",
+        "supportingFiles": "supporting files",
+        "publisher": "Publisher",
+        "homepage": "Homepage",
+        "repository": "Repository",
+        "sourceCommit": "Source commit",
+        "openLink": "Open link"
+      },
+      "import": {
+        "title": "Import {{name}}?",
+        "description": "Review the Skill package before importing. Importing does not execute scripts or bind the Skill to an Agent.",
+        "success": "{{name}} was imported as a workspace Skill Capability.",
+        "failed": "The Skill could not be imported.",
+        "importing": "Importing...",
+        "cancel": "Cancel"
+      }
+    },
     "marketplaceDetail": {
       "badge": "From market",
       "notFound": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -945,6 +945,58 @@
         "cancel": "取消"
       }
     },
+    "skillDirectory": {
+      "title": "Skills",
+      "description": "在同一个页面浏览经过审核的 Skill 和工作区发布的 Skill。",
+      "verified": "已验证",
+      "securityNotice": "导入只会保存经过审核的 Skill 文件包。启用前不会执行，也不会绑定到 Agent。",
+      "filters": {
+        "category": "Skill 分类",
+        "allCategories": "全部分类",
+        "verified": "仅已验证",
+        "sort": "Skill 排序"
+      },
+      "sort": {
+        "featured": "精选优先",
+        "name": "名称",
+        "newest": "最新"
+      },
+      "actions": {
+        "import": "导入",
+        "installed": "已安装",
+        "back": "返回 Skills",
+        "viewCapability": "查看 Capability"
+      },
+      "loadError": {
+        "title": "无法加载 Skill 目录",
+        "description": "无法加载经过审核的 Skill 目录。你可以直接重试，不会离开能力市场。"
+      },
+      "empty": {
+        "title": "没有符合筛选条件的 Skill",
+        "description": "请更换搜索词，或清除分类和已验证筛选。"
+      },
+      "detail": {
+        "loadError": "无法加载 Skill 详情",
+        "notFound": "未找到该 Skill",
+        "version": "版本",
+        "license": "许可证",
+        "files": "文件",
+        "supportingFiles": "个辅助文件",
+        "publisher": "发布者",
+        "homepage": "主页",
+        "repository": "代码仓库",
+        "sourceCommit": "来源提交",
+        "openLink": "打开链接"
+      },
+      "import": {
+        "title": "导入「{{name}}」？",
+        "description": "导入前请检查 Skill 文件。导入不会执行脚本，也不会绑定到 Agent。",
+        "success": "已将「{{name}}」导入为工作区 Skill Capability。",
+        "failed": "Skill 导入失败。",
+        "importing": "正在导入...",
+        "cancel": "取消"
+      }
+    },
     "marketplaceDetail": {
       "badge": "来自市场",
       "notFound": {

--- a/apps/web/src/lib/api-marketplace.ts
+++ b/apps/web/src/lib/api-marketplace.ts
@@ -120,6 +120,45 @@ export interface MCPDirectoryImportResponse {
   capability_id: string
 }
 
+export interface SkillDirectoryFile {
+  path: string
+  content: string
+  kind: "markdown" | "script" | "asset"
+}
+
+export interface SkillDirectoryItem {
+  id: string
+  name: string
+  description: string
+  publisher: { name: string; url: string }
+  icon_url?: string
+  homepage_url?: string
+  repository_url?: string
+  verified: boolean
+  categories: string[]
+  featured_rank: number
+  version: string
+  license: string
+  source_ref?: string
+  source_path?: string
+  slug?: string
+  title?: string
+  instruction?: string
+  trigger?: string
+  files?: SkillDirectoryFile[]
+  installed: boolean
+  installed_capability_id: string | null
+}
+
+export interface SkillDirectoryListResponse {
+  items: SkillDirectoryItem[]
+}
+
+export interface SkillDirectoryImportResponse {
+  installed: boolean
+  capability_id: string
+}
+
 interface MarketplaceListResponse {
   capabilities?: MarketplaceCapability[]
   marketplace?: MarketplaceCapability[]
@@ -155,6 +194,8 @@ export const KEY_INSTALL_COUNT = (workspaceID: string, capabilityID: string) => 
 export const KEY_MARKETPLACE_ENABLED_AGENTS = (workspaceID: string, capabilityID: string) => ["admin", "marketplaceEnabledAgents", workspaceID, capabilityID] as const
 export const KEY_MCP_DIRECTORY = (workspaceID: string) => ["admin", "mcpDirectory", workspaceID] as const
 export const KEY_MCP_DIRECTORY_DETAIL = (workspaceID: string, catalogID: string) => ["admin", "mcpDirectoryDetail", workspaceID, catalogID] as const
+export const KEY_SKILL_DIRECTORY = (workspaceID: string) => ["admin", "skillDirectory", workspaceID] as const
+export const KEY_SKILL_DIRECTORY_DETAIL = (workspaceID: string, catalogID: string) => ["admin", "skillDirectoryDetail", workspaceID, catalogID] as const
 
 async function listMarketplace(workspaceID: string | null): Promise<MarketplaceCapability[]> {
   if (!workspaceID) return []
@@ -216,6 +257,20 @@ async function getMCPDirectoryItem(workspaceID: string | null, catalogID: string
 
 async function importMCPDirectoryItem(workspaceID: string, catalogID: string): Promise<MCPDirectoryImportResponse> {
   return apiRequest(`/api/v1/workspaces/${encodeURIComponent(workspaceID)}/mcp-directory/${encodeURIComponent(catalogID)}/import`, { method: "POST" })
+}
+
+async function listSkillDirectory(workspaceID: string | null): Promise<SkillDirectoryListResponse> {
+  if (!workspaceID) return { items: [] }
+  return apiRequest(`/api/v1/workspaces/${encodeURIComponent(workspaceID)}/skill-directory`)
+}
+
+async function getSkillDirectoryItem(workspaceID: string | null, catalogID: string | null): Promise<SkillDirectoryItem> {
+  if (!workspaceID || !catalogID) throw new Error("workspace and skill catalog item are required")
+  return apiRequest(`/api/v1/workspaces/${encodeURIComponent(workspaceID)}/skill-directory/${encodeURIComponent(catalogID)}`)
+}
+
+async function importSkillDirectoryItem(workspaceID: string, catalogID: string): Promise<SkillDirectoryImportResponse> {
+  return apiRequest(`/api/v1/workspaces/${encodeURIComponent(workspaceID)}/skill-directory/${encodeURIComponent(catalogID)}/import`, { method: "POST" })
 }
 
 export function mcpDirectoryOAuthStartURL(workspaceID: string, catalogID: string): string {
@@ -347,6 +402,50 @@ export function useImportMCPDirectoryItem(workspaceID: string | null) {
           : item),
       } : current)
       qc.setQueryData<MCPDirectoryItem>(KEY_MCP_DIRECTORY_DETAIL(workspaceID, catalogID), (current) => current
+        ? { ...current, installed: true, installed_capability_id: result.capability_id }
+        : current)
+      void qc.invalidateQueries({ queryKey: KEY_CAPABILITIES_WORKSPACE(workspaceID) })
+      void qc.invalidateQueries({ queryKey: ["admin", "capability"] })
+    },
+  })
+}
+
+export function useSkillDirectory(workspaceID: string | null) {
+  return useQuery({
+    queryKey: KEY_SKILL_DIRECTORY(workspaceID ?? "_none"),
+    queryFn: () => listSkillDirectory(workspaceID),
+    retry: noUnreachableRetry,
+    staleTime: 30_000,
+  })
+}
+
+export function useSkillDirectoryDetail(workspaceID: string | null, catalogID: string | null) {
+  return useQuery({
+    queryKey: KEY_SKILL_DIRECTORY_DETAIL(workspaceID ?? "_none", catalogID ?? "_none"),
+    queryFn: () => getSkillDirectoryItem(workspaceID, catalogID),
+    enabled: !!workspaceID && !!catalogID,
+    retry: noUnreachableRetry,
+    staleTime: 30_000,
+  })
+}
+
+export function useImportSkillDirectoryItem(workspaceID: string | null) {
+  const qc = useQueryClient()
+  return useMutation({
+    mutationFn: (catalogID: string) => {
+      if (!workspaceID) throw new Error("workspace is required")
+      return importSkillDirectoryItem(workspaceID, catalogID)
+    },
+    retry: noUnreachableRetry,
+    onSuccess: (result, catalogID) => {
+      if (!workspaceID) return
+      qc.setQueryData<SkillDirectoryListResponse>(KEY_SKILL_DIRECTORY(workspaceID), (current) => current ? {
+        ...current,
+        items: current.items.map((item) => item.id === catalogID
+          ? { ...item, installed: true, installed_capability_id: result.capability_id }
+          : item),
+      } : current)
+      qc.setQueryData<SkillDirectoryItem>(KEY_SKILL_DIRECTORY_DETAIL(workspaceID, catalogID), (current) => current
         ? { ...current, installed: true, installed_capability_id: result.capability_id }
         : current)
       void qc.invalidateQueries({ queryKey: KEY_CAPABILITIES_WORKSPACE(workspaceID) })

--- a/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
@@ -12,6 +12,7 @@ import { useWorkspaceId } from "../../../lib/workspace"
 import { requiredCredentialsLabel } from "../capability-ui"
 import type { Capability } from "../../../lib/api-types"
 import { MCPDirectory } from "./mcp-directory/MCPDirectory"
+import { SkillDirectory } from "./skill-directory/SkillDirectory"
 
 interface MarketplaceTabProps {
   itemID: string | null
@@ -27,6 +28,7 @@ interface MarketplaceTabProps {
 
 export function MarketplaceTab(props: MarketplaceTabProps) {
   const mcpItemID = props.itemID?.startsWith("mcp:") ? props.itemID.slice(4) : null
+  const skillItemID = props.itemID?.startsWith("skill:") ? props.itemID.slice(6) : null
   if (mcpItemID !== null) {
     return <MCPDirectory
       itemID={mcpItemID}
@@ -41,7 +43,35 @@ export function MarketplaceTab(props: MarketplaceTabProps) {
     />
   }
 
-  if (props.itemID || props.typeFilter === "skill") {
+  if (skillItemID !== null) {
+    return <SkillDirectory
+      itemID={skillItemID}
+      query={props.query}
+      canImport={props.canImport}
+      onSelectItem={(id) => props.onSelectItem(id ? `skill:${id}` : null)}
+      onSelectMarketplaceItem={props.onSelectItem}
+      onInstallMarketplace={props.onInstall}
+      canManageMarketplace={props.canManage}
+      onDeleteMarketplace={props.onDelete}
+      onViewCapability={props.onViewCapability}
+    />
+  }
+
+  if (props.typeFilter === "skill") {
+    return <SkillDirectory
+      itemID={null}
+      query={props.query}
+      canImport={props.canImport}
+      onSelectItem={(id) => props.onSelectItem(id ? `skill:${id}` : null)}
+      onSelectMarketplaceItem={props.onSelectItem}
+      onInstallMarketplace={props.onInstall}
+      canManageMarketplace={props.canManage}
+      onDeleteMarketplace={props.onDelete}
+      onViewCapability={props.onViewCapability}
+    />
+  }
+
+  if (props.itemID) {
     return <PublishedMarketplaceTab {...props} />
   }
 

--- a/apps/web/src/pages/admin/capabilities/skill-directory/ImportSkillDirectoryDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/skill-directory/ImportSkillDirectoryDialog.tsx
@@ -1,0 +1,78 @@
+import { useTranslation } from "react-i18next"
+
+import { Button } from "../../../../components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../../../../components/ui/dialog"
+import { ErrorState } from "../../../../components/ui/error-state"
+import { Skeleton } from "../../../../components/ui/skeleton"
+import type { SkillDirectoryItem } from "../../../../lib/api-marketplace"
+
+export function ImportSkillDirectoryDialog({
+  open,
+  item,
+  loading,
+  error,
+  pending,
+  mutationError,
+  onRetry,
+  onOpenChange,
+  onConfirm,
+}: {
+  open: boolean
+  item: SkillDirectoryItem | null
+  loading: boolean
+  error: unknown
+  pending: boolean
+  mutationError: unknown
+  onRetry: () => void
+  onOpenChange: (open: boolean) => void
+  onConfirm: () => void
+}) {
+  const { t } = useTranslation("admin")
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("capabilities.skillDirectory.import.title", { name: item?.name ?? "" })}</DialogTitle>
+          <DialogDescription>{t("capabilities.skillDirectory.import.description")}</DialogDescription>
+        </DialogHeader>
+        {loading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-20 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+        ) : error ? (
+          <ErrorState title={t("capabilities.skillDirectory.detail.loadError")} description={error instanceof Error ? error.message : ""} onRetry={onRetry} />
+        ) : item ? (
+          <div className="space-y-3 text-sm">
+            <div className="grid grid-cols-2 gap-2">
+              <Meta label={t("capabilities.skillDirectory.detail.version")} value={item.version} />
+              <Meta label={t("capabilities.skillDirectory.detail.license")} value={item.license} />
+            </div>
+            <div className="rounded-md border border-line bg-surface-muted/25 p-3">
+              <p className="text-xs leading-5 text-fg-muted">{t("capabilities.skillDirectory.securityNotice")}</p>
+              <p className="mt-2 text-xs text-fg-subtle">{item.files?.length ?? 0} {t("capabilities.skillDirectory.detail.supportingFiles")}</p>
+            </div>
+          </div>
+        ) : null}
+        {mutationError ? <p className="text-sm text-destructive">{mutationError instanceof Error ? mutationError.message : t("capabilities.skillDirectory.import.failed")}</p> : null}
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={pending}>{t("capabilities.skillDirectory.import.cancel")}</Button>
+          <Button onClick={onConfirm} disabled={!item || loading || !!error || pending || item.installed}>
+            {pending ? t("capabilities.skillDirectory.import.importing") : t("capabilities.skillDirectory.actions.import")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return <div className="rounded-md border border-line p-2.5"><p className="text-xs text-fg-subtle">{label}</p><p className="mt-1 text-sm text-fg">{value}</p></div>
+}

--- a/apps/web/src/pages/admin/capabilities/skill-directory/SkillDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/skill-directory/SkillDirectory.tsx
@@ -1,0 +1,208 @@
+import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Check, PackageCheck, Sparkles } from "lucide-react"
+
+import { Button } from "../../../../components/ui/button"
+import { EmptyState } from "../../../../components/ui/empty-state"
+import { ErrorState } from "../../../../components/ui/error-state"
+import { Skeleton } from "../../../../components/ui/skeleton"
+import {
+  marketplaceSourceName,
+  type MarketplaceCapability,
+  useImportSkillDirectoryItem,
+  useMarketplaceList,
+  useSkillDirectory,
+  useSkillDirectoryDetail,
+  type SkillDirectoryItem,
+} from "../../../../lib/api-marketplace"
+import { useWorkspaceId } from "../../../../lib/workspace"
+import { DirectorySkillCard, PublishedSkillCard } from "./SkillDirectoryCard"
+import { ImportSkillDirectoryDialog } from "./ImportSkillDirectoryDialog"
+import { SkillDirectoryDetail } from "./SkillDirectoryDetail"
+
+type DirectorySort = "featured" | "name" | "newest"
+
+interface SkillDirectoryProps {
+  itemID: string | null
+  query: string
+  canImport: boolean
+  onSelectItem: (id: string | null) => void
+  onSelectMarketplaceItem: (id: string | null) => void
+  onInstallMarketplace: (capability: MarketplaceCapability) => void
+  canManageMarketplace: boolean
+  onDeleteMarketplace: (capability: MarketplaceCapability) => void
+  onViewCapability: (capabilityID: string) => void
+}
+
+export function SkillDirectory({
+  itemID,
+  query,
+  canImport,
+  onSelectItem,
+  onSelectMarketplaceItem,
+  onInstallMarketplace,
+  canManageMarketplace,
+  onDeleteMarketplace,
+  onViewCapability,
+}: SkillDirectoryProps) {
+  const { t } = useTranslation("admin")
+  const workspaceID = useWorkspaceId()
+  const directoryQ = useSkillDirectory(workspaceID)
+  const marketplaceQ = useMarketplaceList(itemID ? null : workspaceID)
+  const importMut = useImportSkillDirectoryItem(workspaceID)
+  const [category, setCategory] = useState("")
+  const [verifiedOnly, setVerifiedOnly] = useState(false)
+  const [sort, setSort] = useState<DirectorySort>("featured")
+  const [confirmID, setConfirmID] = useState<string | null>(null)
+  const [success, setSuccess] = useState<{ name: string; capabilityID: string } | null>(null)
+
+  const detailID = confirmID ?? itemID
+  const detailQ = useSkillDirectoryDetail(workspaceID, detailID)
+  const items = useMemo(() => directoryQ.data?.items ?? [], [directoryQ.data?.items])
+  const categories = useMemo(
+    () => Array.from(new Set(items.flatMap((item) => item.categories))).sort((left, right) => left.localeCompare(right)),
+    [items],
+  )
+  const filtered = useMemo(() => filterItems(items, query, category, verifiedOnly, sort), [items, query, category, verifiedOnly, sort])
+  const publishedSkills = useMemo(() => {
+    if (category || verifiedOnly) return []
+    const installedIDs = new Set(items.flatMap((item) => item.installed_capability_id ? [item.installed_capability_id] : []))
+    const needle = query.trim().toLocaleLowerCase()
+    return (marketplaceQ.data ?? [])
+      .filter((item) => {
+        if (item.type !== "skill" || installedIDs.has(item.id)) return false
+        if (!needle) return true
+        return [item.name, item.description ?? "", marketplaceSourceName(item)].join(" ").toLocaleLowerCase().includes(needle)
+      })
+      .sort((left, right) => left.name.localeCompare(right.name))
+  }, [category, items, marketplaceQ.data, query, verifiedOnly])
+  const cards = useMemo(() => [
+    ...filtered.map((item) => ({ kind: "directory" as const, item })),
+    ...publishedSkills.map((item) => ({ kind: "marketplace" as const, item })),
+  ], [filtered, publishedSkills])
+  const selectedSummary = items.find((item) => item.id === itemID) ?? null
+  const selected = detailQ.data?.id === itemID ? detailQ.data : selectedSummary
+  const confirmItem = detailQ.data?.id === confirmID ? detailQ.data : items.find((item) => item.id === confirmID) ?? null
+
+  const requestImport = (id: string) => {
+    if (!canImport) return
+    importMut.reset()
+    setConfirmID(id)
+  }
+  const closeImportDialog = () => {
+    importMut.reset()
+    setConfirmID(null)
+  }
+  const confirmImport = () => {
+    if (!confirmID || !confirmItem || confirmItem.installed) return
+    importMut.mutate(confirmID, {
+      onSuccess: (result) => {
+        setSuccess({ name: confirmItem.name, capabilityID: result.capability_id })
+        closeImportDialog()
+      },
+    })
+  }
+
+  const importDialog = (
+    <ImportSkillDirectoryDialog
+      open={confirmID !== null}
+      item={confirmItem}
+      loading={detailQ.isLoading}
+      error={detailQ.error}
+      pending={importMut.isPending}
+      mutationError={importMut.error}
+      onRetry={() => void detailQ.refetch()}
+      onOpenChange={(open) => !open && closeImportDialog()}
+      onConfirm={confirmImport}
+    />
+  )
+
+  if (itemID) {
+    return (
+      <>
+        {success ? <SuccessBanner success={success} onViewCapability={onViewCapability} /> : null}
+        <SkillDirectoryDetail
+          item={selected}
+          loading={detailQ.isLoading}
+          error={detailQ.error}
+          canImport={canImport}
+          onBack={() => onSelectItem(null)}
+          onRetry={() => void detailQ.refetch()}
+          onImport={() => requestImport(itemID)}
+          onViewCapability={onViewCapability}
+        />
+        {importDialog}
+      </>
+    )
+  }
+
+  return (
+    <div className="space-y-4" data-testid="skill-directory">
+      <div className="rounded-xl border border-line bg-surface px-5 py-4">
+        <div className="flex items-start gap-3">
+          <div>
+            <div className="flex items-center gap-2"><Sparkles className="h-4 w-4 text-fg-subtle" /><h2 className="text-lg font-semibold text-fg">{t("capabilities.skillDirectory.title")}</h2></div>
+            <p className="mt-1 max-w-2xl text-sm leading-5 text-fg-muted">{t("capabilities.skillDirectory.description")}</p>
+          </div>
+        </div>
+        <div className="mt-4 flex flex-wrap items-center gap-2 border-t border-line pt-4">
+          <div className="flex min-w-0 flex-1 flex-wrap gap-1.5" aria-label={t("capabilities.skillDirectory.filters.category")}>
+            <FilterChip active={!category} onClick={() => setCategory("")}>{t("capabilities.skillDirectory.filters.allCategories")}</FilterChip>
+            {categories.map((value) => <FilterChip key={value} active={category === value} onClick={() => setCategory(value)}>{value}</FilterChip>)}
+          </div>
+          <label className="inline-flex h-8 select-none items-center gap-2 rounded-md border border-line bg-surface px-2.5 text-sm text-fg-muted">
+            <input type="checkbox" checked={verifiedOnly} onChange={(event) => setVerifiedOnly(event.target.checked)} className="h-3.5 w-3.5 rounded border-line-strong" />
+            {t("capabilities.skillDirectory.filters.verified")}
+          </label>
+          <select aria-label={t("capabilities.skillDirectory.filters.sort")} value={sort} onChange={(event) => setSort(event.target.value as DirectorySort)} className="h-8 rounded-md border border-line bg-surface px-2.5 text-sm text-fg-muted outline-none focus:border-line-strong">
+            <option value="featured">{t("capabilities.skillDirectory.sort.featured")}</option>
+            <option value="name">{t("capabilities.skillDirectory.sort.name")}</option>
+            <option value="newest">{t("capabilities.skillDirectory.sort.newest")}</option>
+          </select>
+        </div>
+      </div>
+
+      {success ? <SuccessBanner success={success} onViewCapability={onViewCapability} /> : null}
+      {directoryQ.error ? <ErrorState title={t("capabilities.skillDirectory.loadError.title")} description={t("capabilities.skillDirectory.loadError.description")} onRetry={() => void directoryQ.refetch()} /> : null}
+      {marketplaceQ.error ? <ErrorState title={t("capabilities.marketplace.loadError.title")} description={marketplaceQ.error instanceof Error ? marketplaceQ.error.message : t("capabilities.marketplace.loadError.description")} onRetry={() => void marketplaceQ.refetch()} /> : null}
+      {cards.length === 0 && (directoryQ.isLoading || marketplaceQ.isLoading) ? (
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3" data-testid="skill-directory-loading">{Array.from({ length: 6 }).map((_, index) => <Skeleton key={index} className="h-52 w-full" />)}</div>
+      ) : cards.length === 0 && !directoryQ.error && !marketplaceQ.error ? (
+        <EmptyState icon={PackageCheck} title={t("capabilities.skillDirectory.empty.title")} description={t("capabilities.skillDirectory.empty.description")} />
+      ) : cards.length > 0 ? (
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3" data-testid="skill-marketplace-grid">
+          {cards.map((card) => card.kind === "directory" ? (
+            <DirectorySkillCard key={`directory:${card.item.id}`} item={card.item} canImport={canImport} onOpen={() => onSelectItem(card.item.id)} onImport={() => requestImport(card.item.id)} onViewCapability={onViewCapability} />
+          ) : (
+            <PublishedSkillCard key={`marketplace:${card.item.id}`} capability={card.item} canManage={canManageMarketplace} onOpen={() => onSelectMarketplaceItem(card.item.id)} onInstall={() => onInstallMarketplace(card.item)} onDelete={() => onDeleteMarketplace(card.item)} onViewCapability={() => onViewCapability(card.item.id)} />
+          ))}
+        </div>
+      ) : null}
+      {importDialog}
+    </div>
+  )
+}
+
+function filterItems(items: SkillDirectoryItem[], query: string, category: string, verifiedOnly: boolean, sort: DirectorySort) {
+  const needle = query.trim().toLocaleLowerCase()
+  const filtered = items.filter((item) => {
+    if (category && !item.categories.includes(category)) return false
+    if (verifiedOnly && !item.verified) return false
+    if (!needle) return true
+    return [item.name, item.description, item.publisher.name, ...item.categories].join(" ").toLocaleLowerCase().includes(needle)
+  })
+  return filtered.sort((left, right) => {
+    if (sort === "name") return left.name.localeCompare(right.name)
+    if (sort === "newest") return right.version.localeCompare(left.version) || left.featured_rank - right.featured_rank
+    return left.featured_rank - right.featured_rank || left.name.localeCompare(right.name)
+  })
+}
+
+function SuccessBanner({ success, onViewCapability }: { success: { name: string; capabilityID: string }; onViewCapability: (capabilityID: string) => void }) {
+  const { t } = useTranslation("admin")
+  return <div className="mb-3 flex flex-wrap items-center gap-3 rounded-lg border border-line bg-surface px-4 py-3" role="status"><span className="flex h-7 w-7 items-center justify-center rounded-full bg-surface-muted text-fg"><Check className="h-4 w-4" /></span><p className="min-w-0 flex-1 text-sm text-fg">{t("capabilities.skillDirectory.import.success", { name: success.name })}</p><Button variant="outline" size="sm" onClick={() => onViewCapability(success.capabilityID)}>{t("capabilities.skillDirectory.actions.viewCapability")}</Button></div>
+}
+
+function FilterChip({ active, onClick, children }: { active: boolean; onClick: () => void; children: string }) {
+  return <button type="button" aria-pressed={active} onClick={onClick} className={`h-8 rounded-md border px-2.5 text-sm transition-colors ${active ? "border-line-strong bg-surface-muted text-fg" : "border-line bg-surface text-fg-muted hover:border-line-strong hover:text-fg"}`}>{children}</button>
+}

--- a/apps/web/src/pages/admin/capabilities/skill-directory/SkillDirectoryCard.tsx
+++ b/apps/web/src/pages/admin/capabilities/skill-directory/SkillDirectoryCard.tsx
@@ -1,0 +1,108 @@
+import { ArrowRight, Check, Sparkles, X } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "../../../../components/ui/badge"
+import { Button } from "../../../../components/ui/button"
+import { marketplaceSourceName, type MarketplaceCapability, type SkillDirectoryItem } from "../../../../lib/api-marketplace"
+
+export function SkillDirectoryIcon({ item, large = false }: { item: Pick<SkillDirectoryItem, "icon_url">; large?: boolean }) {
+  const size = large ? "h-14 w-14 rounded-xl" : "h-11 w-11 rounded-lg"
+  return (
+    <span className={`flex shrink-0 items-center justify-center overflow-hidden border border-line bg-surface-muted ${size}`}>
+      {item.icon_url ? <img src={item.icon_url} alt="" referrerPolicy="no-referrer" className="h-full w-full object-cover" /> : <Sparkles className={large ? "h-6 w-6 text-fg-subtle" : "h-5 w-5 text-fg-subtle"} />}
+    </span>
+  )
+}
+
+export function DirectorySkillCard({ item, canImport, onOpen, onImport, onViewCapability }: {
+  item: SkillDirectoryItem
+  canImport: boolean
+  onOpen: () => void
+  onImport: () => void
+  onViewCapability: (capabilityID: string) => void
+}) {
+  const { t } = useTranslation("admin")
+  return (
+    <article className="flex min-h-52 flex-col rounded-xl border border-line bg-surface p-4 transition hover:border-line-strong hover:shadow-sm" data-testid="skill-directory-card" data-catalog-id={item.id}>
+      <button type="button" className="flex flex-1 flex-col text-left" onClick={onOpen}>
+        <div className="flex items-start gap-3">
+          <SkillDirectoryIcon item={item} />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-start justify-between gap-2">
+              <h3 className="truncate text-base font-semibold text-fg">{item.name}</h3>
+              <ArrowRight className="mt-1 h-3.5 w-3.5 shrink-0 text-fg-faint" />
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-fg-subtle">
+              <span className="truncate">{item.publisher.name}</span>
+              {item.verified ? <Badge variant="primary">{t("capabilities.skillDirectory.verified")}</Badge> : null}
+            </div>
+          </div>
+        </div>
+        <p className="mt-3 line-clamp-3 text-sm leading-5 text-fg-muted">{item.description}</p>
+        <div className="mt-auto flex flex-wrap items-center gap-1.5 pt-4">
+          {item.categories.slice(0, 2).map((category) => <Badge key={category} variant="neutral">{category}</Badge>)}
+          <Badge variant="neutral">v{item.version}</Badge>
+        </div>
+      </button>
+      <div className="mt-3 border-t border-line pt-3">
+        {item.installed && item.installed_capability_id ? (
+          <Button className="w-full" variant="outline" size="sm" onClick={() => onViewCapability(item.installed_capability_id!)}>
+            <Check className="h-3.5 w-3.5" /> {t("capabilities.skillDirectory.actions.installed")}
+          </Button>
+        ) : (
+          <Button className="w-full" size="sm" disabled={!canImport} title={!canImport ? t("capabilities.permission.adminOnly") : undefined} onClick={onImport}>
+            {canImport ? t("capabilities.skillDirectory.actions.import") : t("capabilities.permission.adminOnly")}
+          </Button>
+        )}
+      </div>
+    </article>
+  )
+}
+
+export function PublishedSkillCard({ capability, canManage, onOpen, onInstall, onDelete, onViewCapability }: {
+  capability: MarketplaceCapability
+  canManage: boolean
+  onOpen: () => void
+  onInstall: () => void
+  onDelete: () => void
+  onViewCapability: () => void
+}) {
+  const { t } = useTranslation("admin")
+  const source = marketplaceSourceName(capability)
+  const count = capability.installed_agent_count ?? capability.enabled_agent_count ?? capability.install_count ?? 0
+  return (
+    <article className="flex min-h-52 flex-col rounded-xl border border-line bg-surface p-4 transition hover:border-line-strong hover:shadow-sm" data-testid="marketplace-skill-card">
+      <button type="button" className="flex flex-1 flex-col text-left" onClick={onOpen}>
+        <div className="flex items-start gap-3">
+          <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg border border-line bg-surface-muted text-fg-subtle"><Sparkles className="h-5 w-5" /></span>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-start justify-between gap-2">
+              <h3 className="truncate text-base font-semibold text-fg">{capability.name}</h3>
+              <ArrowRight className="mt-1 h-3.5 w-3.5 shrink-0 text-fg-faint" />
+            </div>
+            {source ? <p className="mt-1 truncate text-xs text-fg-subtle">{source}</p> : null}
+          </div>
+        </div>
+        {capability.description ? <p className="mt-3 line-clamp-3 text-sm leading-5 text-fg-muted">{capability.description}</p> : null}
+        <div className="mt-auto flex flex-wrap items-center gap-1.5 pt-4">
+          <Badge variant="neutral">Skill</Badge>
+          {capability.self_published ? <Badge variant="neutral">{t("capabilities.marketplace.card.selfPublished")}</Badge> : null}
+          {!capability.self_published && capability.installed ? <Badge variant="success">{t("capabilities.marketplace.card.installedBadge")}</Badge> : null}
+          <Badge variant="neutral">v{capability.latest_version ?? "—"}</Badge>
+        </div>
+      </button>
+      <div className="mt-3 border-t border-line pt-3">
+        {capability.self_published ? (
+          <div className="flex gap-2">
+            <Button className="min-w-0 flex-1" variant="outline" size="sm" onClick={onViewCapability}>{t("capabilities.skillDirectory.actions.viewCapability")}</Button>
+            {canManage ? <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0 text-fg-faint hover:bg-transparent hover:text-fg-muted" aria-label={t("capabilities.rowActions.delete")} title={t("capabilities.rowActions.delete")} onClick={onDelete}><X className="h-4 w-4" /></Button> : null}
+          </div>
+        ) : (
+          <Button className="w-full" size="sm" onClick={onInstall}>
+            {capability.installed ? t("capabilities.marketplace.card.installed", { count }) : t("capabilities.marketplace.card.install")}
+          </Button>
+        )}
+      </div>
+    </article>
+  )
+}

--- a/apps/web/src/pages/admin/capabilities/skill-directory/SkillDirectoryDetail.tsx
+++ b/apps/web/src/pages/admin/capabilities/skill-directory/SkillDirectoryDetail.tsx
@@ -1,0 +1,112 @@
+import { ArrowLeft, ExternalLink, ShieldCheck, Sparkles } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "../../../../components/ui/badge"
+import { Button } from "../../../../components/ui/button"
+import { EmptyState } from "../../../../components/ui/empty-state"
+import { ErrorState } from "../../../../components/ui/error-state"
+import { Skeleton } from "../../../../components/ui/skeleton"
+import type { SkillDirectoryItem } from "../../../../lib/api-marketplace"
+import { SkillFileTree } from "../SkillFileTree"
+import type { CanonicalSkillSpec } from "../types"
+import { SkillDirectoryIcon } from "./SkillDirectoryCard"
+
+export function SkillDirectoryDetail({
+  item,
+  loading,
+  error,
+  canImport,
+  onBack,
+  onRetry,
+  onImport,
+  onViewCapability,
+}: {
+  item: SkillDirectoryItem | null
+  loading: boolean
+  error: unknown
+  canImport: boolean
+  onBack: () => void
+  onRetry: () => void
+  onImport: () => void
+  onViewCapability: (capabilityID: string) => void
+}) {
+  const { t } = useTranslation("admin")
+  if (loading && !item) {
+    return <div className="space-y-3"><Skeleton className="h-9 w-40" /><Skeleton className="h-[560px] w-full" /></div>
+  }
+  if (error) {
+    return <ErrorState title={t("capabilities.skillDirectory.detail.loadError")} description={error instanceof Error ? error.message : ""} onRetry={onRetry} />
+  }
+  if (!item) {
+    return <EmptyState icon={Sparkles} title={t("capabilities.skillDirectory.detail.notFound")} action={<Button variant="outline" size="sm" onClick={onBack}>{t("capabilities.skillDirectory.actions.back")}</Button>} />
+  }
+
+  const skill: CanonicalSkillSpec = {
+    slug: item.slug ?? item.id,
+    title: item.title ?? item.name,
+    description: item.description,
+    instruction: item.instruction ?? "",
+    trigger: item.trigger,
+    files: item.files,
+  }
+
+  return (
+    <div className="space-y-3" data-testid="skill-directory-detail">
+      <Button variant="ghost" size="sm" onClick={onBack}><ArrowLeft className="h-3.5 w-3.5" /> {t("capabilities.skillDirectory.actions.back")}</Button>
+      <article className="rounded-xl border border-line bg-surface p-5">
+        <div className="flex flex-wrap items-start gap-4">
+          <SkillDirectoryIcon item={item} large />
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="text-xl font-semibold text-fg">{item.name}</h2>
+              {item.verified ? <Badge variant="primary"><ShieldCheck className="h-3 w-3" /> {t("capabilities.skillDirectory.verified")}</Badge> : null}
+              {item.installed ? <Badge variant="success">{t("capabilities.skillDirectory.actions.installed")}</Badge> : null}
+            </div>
+            <p className="mt-1 text-sm text-fg-subtle">{item.publisher.name}</p>
+            <p className="mt-4 max-w-3xl text-sm leading-6 text-fg-muted">{item.description}</p>
+          </div>
+        </div>
+        <div className="mt-5 grid gap-3 sm:grid-cols-3">
+          <Meta label={t("capabilities.skillDirectory.detail.version")} value={item.version} mono />
+          <Meta label={t("capabilities.skillDirectory.detail.license")} value={item.license} />
+          <Meta label={t("capabilities.skillDirectory.detail.files")} value={String((item.files?.length ?? 0) + 1)} />
+        </div>
+        <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_240px]">
+          <div className="min-w-0"><SkillFileTree skill={skill} /></div>
+          <aside className="space-y-3 rounded-lg border border-line bg-surface-muted/20 p-4">
+            <ExternalLinkRow label={t("capabilities.skillDirectory.detail.publisher")} value={item.publisher.name} href={item.publisher.url} />
+            <ExternalLinkRow label={t("capabilities.skillDirectory.detail.homepage")} value={t("capabilities.skillDirectory.detail.openLink")} href={item.homepage_url} />
+            <ExternalLinkRow label={t("capabilities.skillDirectory.detail.repository")} value={t("capabilities.skillDirectory.detail.openLink")} href={item.repository_url} />
+            <Meta label={t("capabilities.skillDirectory.detail.sourceCommit")} value={item.source_ref ?? "—"} mono />
+          </aside>
+        </div>
+        <div className="mt-5 flex flex-wrap justify-end gap-2 border-t border-line pt-4">
+          {item.installed && item.installed_capability_id ? (
+            <Button variant="outline" size="sm" onClick={() => onViewCapability(item.installed_capability_id!)}>{t("capabilities.skillDirectory.actions.viewCapability")}</Button>
+          ) : (
+            <Button size="sm" disabled={!canImport} title={!canImport ? t("capabilities.permission.adminOnly") : undefined} onClick={onImport}>
+              {canImport ? t("capabilities.skillDirectory.actions.import") : t("capabilities.permission.adminOnly")}
+            </Button>
+          )}
+        </div>
+      </article>
+    </div>
+  )
+}
+
+function Meta({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return <div className="rounded-lg border border-line p-3"><p className="text-xs text-fg-subtle">{label}</p><p className={`mt-1 text-sm text-fg ${mono ? "font-mono break-all" : ""}`}>{value}</p></div>
+}
+
+function ExternalLinkRow({ label, value, href }: { label: string; value: string; href?: string }) {
+  let safeHref: string | undefined
+  try {
+    if (href) {
+      const parsed = new URL(href)
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") safeHref = parsed.toString()
+    }
+  } catch {
+    safeHref = undefined
+  }
+  return <div><p className="text-xs text-fg-subtle">{label}</p>{safeHref ? <a href={safeHref} target="_blank" rel="noreferrer" className="mt-1 inline-flex items-center gap-1 text-sm text-fg underline decoration-line-strong underline-offset-2"><span>{value}</span><ExternalLink className="h-3 w-3" /></a> : <p className="mt-1 text-sm text-fg-faint">—</p>}</div>
+}

--- a/catalog/skills/README.md
+++ b/catalog/skills/README.md
@@ -1,0 +1,29 @@
+# Built-in Skill Directory
+
+`catalog.json` is the reviewed, embedded Skill directory shipped with Parsar.
+Each item points at a pinned upstream commit and a vendored package under
+`items/<id>/`. Importing an item uses the embedded files, not a user-supplied
+URL or a live Git checkout.
+
+## Included Sources
+
+| Skill | Source | License | Pinned commit |
+| --- | --- | --- | --- |
+| Frontend Design | `https://github.com/anthropics/skills/tree/main/skills/frontend-design` | Apache-2.0 | `b29e7cf65e5cb78a5ac33d582270551bc74a14eb` |
+| Webapp Testing | `https://github.com/anthropics/skills/tree/main/skills/webapp-testing` | Apache-2.0 | `b29e7cf65e5cb78a5ac33d582270551bc74a14eb` |
+| React Composition Patterns | `https://github.com/vercel-labs/agent-skills/tree/main/skills/composition-patterns` | MIT | `7c180d9044c9ae2b442b567aad4e42a28dd5ed62` |
+
+The original license files are kept inside the vendored packages where the
+upstream source provides them. Vercel's skill declares MIT in its `SKILL.md`.
+
+## Updating an Item
+
+1. Review the upstream package and its license.
+2. Copy the complete Skill directory, including `SKILL.md`, references, rules,
+   scripts, examples, and license files.
+3. Pin `source_ref` to the exact 40-character commit SHA.
+4. Update `version` and `updated_at` in `catalog.json`.
+5. Run the Skill catalog tests and `make check`.
+
+Catalog packages must not contain API keys, tokens, passwords, or executable
+install hooks. Import stores the package and does not run its scripts.

--- a/catalog/skills/catalog.json
+++ b/catalog/skills/catalog.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "updated_at": "2026-08-03T00:00:00Z",
+  "items": [
+    {
+      "id": "frontend-design",
+      "name": "Frontend Design",
+      "description": "Create distinctive, production-quality frontend interfaces with deliberate visual direction and strong interaction design.",
+      "publisher": {
+        "name": "Anthropic",
+        "url": "https://github.com/anthropics/skills"
+      },
+      "icon_url": "https://github.com/anthropics.png?size=128",
+      "homepage_url": "https://github.com/anthropics/skills/tree/main/skills/frontend-design",
+      "repository_url": "https://github.com/anthropics/skills",
+      "verified": true,
+      "categories": ["Design", "Frontend"],
+      "featured_rank": 1,
+      "version": "b29e7cf",
+      "license": "Apache-2.0",
+      "source_ref": "b29e7cf65e5cb78a5ac33d582270551bc74a14eb",
+      "source_path": "skills/frontend-design",
+      "content_path": "items/frontend-design"
+    },
+    {
+      "id": "webapp-testing",
+      "name": "Webapp Testing",
+      "description": "Test local web applications with browser automation, inspect behavior, and diagnose frontend issues with repeatable workflows.",
+      "publisher": {
+        "name": "Anthropic",
+        "url": "https://github.com/anthropics/skills"
+      },
+      "icon_url": "https://github.com/anthropics.png?size=128",
+      "homepage_url": "https://github.com/anthropics/skills/tree/main/skills/webapp-testing",
+      "repository_url": "https://github.com/anthropics/skills",
+      "verified": true,
+      "categories": ["Developer Tools", "Testing", "Web"],
+      "featured_rank": 2,
+      "version": "b29e7cf",
+      "license": "Apache-2.0",
+      "source_ref": "b29e7cf65e5cb78a5ac33d582270551bc74a14eb",
+      "source_path": "skills/webapp-testing",
+      "content_path": "items/webapp-testing"
+    },
+    {
+      "id": "composition-patterns",
+      "name": "React Composition Patterns",
+      "description": "Design flexible React components with composition, compound components, and scalable state boundaries instead of prop-heavy APIs.",
+      "publisher": {
+        "name": "Vercel Engineering",
+        "url": "https://github.com/vercel-labs/agent-skills"
+      },
+      "icon_url": "https://github.com/vercel.png?size=128",
+      "homepage_url": "https://github.com/vercel-labs/agent-skills/tree/main/skills/composition-patterns",
+      "repository_url": "https://github.com/vercel-labs/agent-skills",
+      "verified": true,
+      "categories": ["Developer Tools", "React", "Architecture"],
+      "featured_rank": 3,
+      "version": "7c180d9",
+      "license": "MIT",
+      "source_ref": "7c180d9044c9ae2b442b567aad4e42a28dd5ed62",
+      "source_path": "skills/composition-patterns",
+      "content_path": "items/composition-patterns"
+    }
+  ]
+}

--- a/catalog/skills/catalog.schema.json
+++ b/catalog/skills/catalog.schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/MiniMax-AI-Dev/parsar/catalog/skills/catalog.schema.json",
+  "title": "Parsar Skill Directory Catalog",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "updated_at", "items"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "updated_at": { "type": "string", "format": "date-time" },
+    "items": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/item" }
+    }
+  },
+  "$defs": {
+    "httpsUrl": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^https://"
+    },
+    "publisher": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "url"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "url": { "$ref": "#/$defs/httpsUrl" }
+      }
+    },
+    "item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "description",
+        "publisher",
+        "verified",
+        "categories",
+        "featured_rank",
+        "version",
+        "license",
+        "source_ref",
+        "source_path",
+        "content_path"
+      ],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "publisher": { "$ref": "#/$defs/publisher" },
+        "icon_url": { "$ref": "#/$defs/httpsUrl" },
+        "homepage_url": { "$ref": "#/$defs/httpsUrl" },
+        "repository_url": { "$ref": "#/$defs/httpsUrl" },
+        "verified": { "type": "boolean" },
+        "categories": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "featured_rank": { "type": "integer", "minimum": 1 },
+        "version": { "type": "string", "minLength": 1 },
+        "license": { "type": "string", "minLength": 1 },
+        "source_ref": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+        "source_path": { "type": "string", "pattern": "^(?!/)(?!.*\\.\\.)[a-zA-Z0-9._/-]+$" },
+        "content_path": { "type": "string", "pattern": "^items/[a-z0-9][a-z0-9._-]*$" }
+      }
+    }
+  }
+}

--- a/catalog/skills/embed.go
+++ b/catalog/skills/embed.go
@@ -1,0 +1,12 @@
+package skillcatalogdata
+
+import "embed"
+
+// FS contains the catalog metadata and the pinned, reviewed Skill packages.
+// The server never fetches arbitrary source URLs during an import.
+//
+//go:embed catalog.json items
+var FS embed.FS
+
+//go:embed catalog.json
+var CatalogJSON []byte

--- a/catalog/skills/items/composition-patterns/AGENTS.md
+++ b/catalog/skills/items/composition-patterns/AGENTS.md
@@ -1,0 +1,946 @@
+# React Composition Patterns
+
+**Version 1.0.0**
+Engineering
+January 2026
+
+> **Note:**
+> This document is mainly for agents and LLMs to follow when maintaining,
+> generating, or refactoring React codebases using composition. Humans
+> may also find it useful, but guidance here is optimized for automation
+> and consistency by AI-assisted workflows.
+
+---
+
+## Abstract
+
+Composition patterns for building flexible, maintainable React components. Avoid boolean prop proliferation by using compound components, lifting state, and composing internals. These patterns make codebases easier for both humans and AI agents to work with as they scale.
+
+---
+
+## Table of Contents
+
+1. [Component Architecture](#1-component-architecture) — **HIGH**
+   - 1.1 [Avoid Boolean Prop Proliferation](#11-avoid-boolean-prop-proliferation)
+   - 1.2 [Use Compound Components](#12-use-compound-components)
+2. [State Management](#2-state-management) — **MEDIUM**
+   - 2.1 [Decouple State Management from UI](#21-decouple-state-management-from-ui)
+   - 2.2 [Define Generic Context Interfaces for Dependency Injection](#22-define-generic-context-interfaces-for-dependency-injection)
+   - 2.3 [Lift State into Provider Components](#23-lift-state-into-provider-components)
+3. [Implementation Patterns](#3-implementation-patterns) — **MEDIUM**
+   - 3.1 [Create Explicit Component Variants](#31-create-explicit-component-variants)
+   - 3.2 [Prefer Composing Children Over Render Props](#32-prefer-composing-children-over-render-props)
+4. [React 19 APIs](#4-react-19-apis) — **MEDIUM**
+   - 4.1 [React 19 API Changes](#41-react-19-api-changes)
+
+---
+
+## 1. Component Architecture
+
+**Impact: HIGH**
+
+Fundamental patterns for structuring components to avoid prop
+proliferation and enable flexible composition.
+
+### 1.1 Avoid Boolean Prop Proliferation
+
+**Impact: CRITICAL (prevents unmaintainable component variants)**
+
+Don't add boolean props like `isThread`, `isEditing`, `isDMThread` to customize
+
+component behavior. Each boolean doubles possible states and creates
+
+unmaintainable conditional logic. Use composition instead.
+
+**Incorrect: boolean props create exponential complexity**
+
+```tsx
+function Composer({
+  onSubmit,
+  isThread,
+  channelId,
+  isDMThread,
+  dmId,
+  isEditing,
+  isForwarding,
+}: Props) {
+  return (
+    <form>
+      <Header />
+      <Input />
+      {isDMThread ? (
+        <AlsoSendToDMField id={dmId} />
+      ) : isThread ? (
+        <AlsoSendToChannelField id={channelId} />
+      ) : null}
+      {isEditing ? (
+        <EditActions />
+      ) : isForwarding ? (
+        <ForwardActions />
+      ) : (
+        <DefaultActions />
+      )}
+      <Footer onSubmit={onSubmit} />
+    </form>
+  )
+}
+```
+
+**Correct: composition eliminates conditionals**
+
+```tsx
+// Channel composer
+function ChannelComposer() {
+  return (
+    <Composer.Frame>
+      <Composer.Header />
+      <Composer.Input />
+      <Composer.Footer>
+        <Composer.Attachments />
+        <Composer.Formatting />
+        <Composer.Emojis />
+        <Composer.Submit />
+      </Composer.Footer>
+    </Composer.Frame>
+  )
+}
+
+// Thread composer - adds "also send to channel" field
+function ThreadComposer({ channelId }: { channelId: string }) {
+  return (
+    <Composer.Frame>
+      <Composer.Header />
+      <Composer.Input />
+      <AlsoSendToChannelField id={channelId} />
+      <Composer.Footer>
+        <Composer.Formatting />
+        <Composer.Emojis />
+        <Composer.Submit />
+      </Composer.Footer>
+    </Composer.Frame>
+  )
+}
+
+// Edit composer - different footer actions
+function EditComposer() {
+  return (
+    <Composer.Frame>
+      <Composer.Input />
+      <Composer.Footer>
+        <Composer.Formatting />
+        <Composer.Emojis />
+        <Composer.CancelEdit />
+        <Composer.SaveEdit />
+      </Composer.Footer>
+    </Composer.Frame>
+  )
+}
+```
+
+Each variant is explicit about what it renders. We can share internals without
+
+sharing a single monolithic parent.
+
+### 1.2 Use Compound Components
+
+**Impact: HIGH (enables flexible composition without prop drilling)**
+
+Structure complex components as compound components with a shared context. Each
+
+subcomponent accesses shared state via context, not props. Consumers compose the
+
+pieces they need.
+
+**Incorrect: monolithic component with render props**
+
+```tsx
+function Composer({
+  renderHeader,
+  renderFooter,
+  renderActions,
+  showAttachments,
+  showFormatting,
+  showEmojis,
+}: Props) {
+  return (
+    <form>
+      {renderHeader?.()}
+      <Input />
+      {showAttachments && <Attachments />}
+      {renderFooter ? (
+        renderFooter()
+      ) : (
+        <Footer>
+          {showFormatting && <Formatting />}
+          {showEmojis && <Emojis />}
+          {renderActions?.()}
+        </Footer>
+      )}
+    </form>
+  )
+}
+```
+
+**Correct: compound components with shared context**
+
+```tsx
+const ComposerContext = createContext<ComposerContextValue | null>(null)
+
+function ComposerProvider({ children, state, actions, meta }: ProviderProps) {
+  return (
+    <ComposerContext value={{ state, actions, meta }}>
+      {children}
+    </ComposerContext>
+  )
+}
+
+function ComposerFrame({ children }: { children: React.ReactNode }) {
+  return <form>{children}</form>
+}
+
+function ComposerInput() {
+  const {
+    state,
+    actions: { update },
+    meta: { inputRef },
+  } = use(ComposerContext)
+  return (
+    <TextInput
+      ref={inputRef}
+      value={state.input}
+      onChangeText={(text) => update((s) => ({ ...s, input: text }))}
+    />
+  )
+}
+
+function ComposerSubmit() {
+  const {
+    actions: { submit },
+  } = use(ComposerContext)
+  return <Button onPress={submit}>Send</Button>
+}
+
+// Export as compound component
+const Composer = {
+  Provider: ComposerProvider,
+  Frame: ComposerFrame,
+  Input: ComposerInput,
+  Submit: ComposerSubmit,
+  Header: ComposerHeader,
+  Footer: ComposerFooter,
+  Attachments: ComposerAttachments,
+  Formatting: ComposerFormatting,
+  Emojis: ComposerEmojis,
+}
+```
+
+**Usage:**
+
+```tsx
+<Composer.Provider state={state} actions={actions} meta={meta}>
+  <Composer.Frame>
+    <Composer.Header />
+    <Composer.Input />
+    <Composer.Footer>
+      <Composer.Formatting />
+      <Composer.Submit />
+    </Composer.Footer>
+  </Composer.Frame>
+</Composer.Provider>
+```
+
+Consumers explicitly compose exactly what they need. No hidden conditionals. And the state, actions and meta are dependency-injected by a parent provider, allowing multiple usages of the same component structure.
+
+---
+
+## 2. State Management
+
+**Impact: MEDIUM**
+
+Patterns for lifting state and managing shared context across
+composed components.
+
+### 2.1 Decouple State Management from UI
+
+**Impact: MEDIUM (enables swapping state implementations without changing UI)**
+
+The provider component should be the only place that knows how state is managed.
+
+UI components consume the context interface—they don't know if state comes from
+
+useState, Zustand, or a server sync.
+
+**Incorrect: UI coupled to state implementation**
+
+```tsx
+function ChannelComposer({ channelId }: { channelId: string }) {
+  // UI component knows about global state implementation
+  const state = useGlobalChannelState(channelId)
+  const { submit, updateInput } = useChannelSync(channelId)
+
+  return (
+    <Composer.Frame>
+      <Composer.Input
+        value={state.input}
+        onChange={(text) => sync.updateInput(text)}
+      />
+      <Composer.Submit onPress={() => sync.submit()} />
+    </Composer.Frame>
+  )
+}
+```
+
+**Correct: state management isolated in provider**
+
+```tsx
+// Provider handles all state management details
+function ChannelProvider({
+  channelId,
+  children,
+}: {
+  channelId: string
+  children: React.ReactNode
+}) {
+  const { state, update, submit } = useGlobalChannel(channelId)
+  const inputRef = useRef(null)
+
+  return (
+    <Composer.Provider
+      state={state}
+      actions={{ update, submit }}
+      meta={{ inputRef }}
+    >
+      {children}
+    </Composer.Provider>
+  )
+}
+
+// UI component only knows about the context interface
+function ChannelComposer() {
+  return (
+    <Composer.Frame>
+      <Composer.Header />
+      <Composer.Input />
+      <Composer.Footer>
+        <Composer.Submit />
+      </Composer.Footer>
+    </Composer.Frame>
+  )
+}
+
+// Usage
+function Channel({ channelId }: { channelId: string }) {
+  return (
+    <ChannelProvider channelId={channelId}>
+      <ChannelComposer />
+    </ChannelProvider>
+  )
+}
+```
+
+**Different providers, same UI:**
+
+```tsx
+// Local state for ephemeral forms
+function ForwardMessageProvider({ children }) {
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
+
+  return (
+    <Composer.Provider
+      state={state}
+      actions={{ update: setState, submit: forwardMessage }}
+    >
+      {children}
+    </Composer.Provider>
+  )
+}
+
+// Global synced state for channels
+function ChannelProvider({ channelId, children }) {
+  const { state, update, submit } = useGlobalChannel(channelId)
+
+  return (
+    <Composer.Provider state={state} actions={{ update, submit }}>
+      {children}
+    </Composer.Provider>
+  )
+}
+```
+
+The same `Composer.Input` component works with both providers because it only
+
+depends on the context interface, not the implementation.
+
+### 2.2 Define Generic Context Interfaces for Dependency Injection
+
+**Impact: HIGH (enables dependency-injectable state across use-cases)**
+
+Define a **generic interface** for your component context with three parts:
+
+`state`, `actions`, and `meta`. This interface is a contract that any provider
+
+can implement—enabling the same UI components to work with completely different
+
+state implementations.
+
+**Core principle:** Lift state, compose internals, make state
+
+dependency-injectable.
+
+**Incorrect: UI coupled to specific state implementation**
+
+```tsx
+function ComposerInput() {
+  // Tightly coupled to a specific hook
+  const { input, setInput } = useChannelComposerState()
+  return <TextInput value={input} onChangeText={setInput} />
+}
+```
+
+**Correct: generic interface enables dependency injection**
+
+```tsx
+// Define a GENERIC interface that any provider can implement
+interface ComposerState {
+  input: string
+  attachments: Attachment[]
+  isSubmitting: boolean
+}
+
+interface ComposerActions {
+  update: (updater: (state: ComposerState) => ComposerState) => void
+  submit: () => void
+}
+
+interface ComposerMeta {
+  inputRef: React.RefObject<TextInput>
+}
+
+interface ComposerContextValue {
+  state: ComposerState
+  actions: ComposerActions
+  meta: ComposerMeta
+}
+
+const ComposerContext = createContext<ComposerContextValue | null>(null)
+```
+
+**UI components consume the interface, not the implementation:**
+
+```tsx
+function ComposerInput() {
+  const {
+    state,
+    actions: { update },
+    meta,
+  } = use(ComposerContext)
+
+  // This component works with ANY provider that implements the interface
+  return (
+    <TextInput
+      ref={meta.inputRef}
+      value={state.input}
+      onChangeText={(text) => update((s) => ({ ...s, input: text }))}
+    />
+  )
+}
+```
+
+**Different providers implement the same interface:**
+
+```tsx
+// Provider A: Local state for ephemeral forms
+function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState(initialState)
+  const inputRef = useRef(null)
+  const submit = useForwardMessage()
+
+  return (
+    <ComposerContext
+      value={{
+        state,
+        actions: { update: setState, submit },
+        meta: { inputRef },
+      }}
+    >
+      {children}
+    </ComposerContext>
+  )
+}
+
+// Provider B: Global synced state for channels
+function ChannelProvider({ channelId, children }: Props) {
+  const { state, update, submit } = useGlobalChannel(channelId)
+  const inputRef = useRef(null)
+
+  return (
+    <ComposerContext
+      value={{
+        state,
+        actions: { update, submit },
+        meta: { inputRef },
+      }}
+    >
+      {children}
+    </ComposerContext>
+  )
+}
+```
+
+**The same composed UI works with both:**
+
+```tsx
+// Works with ForwardMessageProvider (local state)
+<ForwardMessageProvider>
+  <Composer.Frame>
+    <Composer.Input />
+    <Composer.Submit />
+  </Composer.Frame>
+</ForwardMessageProvider>
+
+// Works with ChannelProvider (global synced state)
+<ChannelProvider channelId="abc">
+  <Composer.Frame>
+    <Composer.Input />
+    <Composer.Submit />
+  </Composer.Frame>
+</ChannelProvider>
+```
+
+**Custom UI outside the component can access state and actions:**
+
+```tsx
+function ForwardMessageDialog() {
+  return (
+    <ForwardMessageProvider>
+      <Dialog>
+        {/* The composer UI */}
+        <Composer.Frame>
+          <Composer.Input placeholder="Add a message, if you'd like." />
+          <Composer.Footer>
+            <Composer.Formatting />
+            <Composer.Emojis />
+          </Composer.Footer>
+        </Composer.Frame>
+
+        {/* Custom UI OUTSIDE the composer, but INSIDE the provider */}
+        <MessagePreview />
+
+        {/* Actions at the bottom of the dialog */}
+        <DialogActions>
+          <CancelButton />
+          <ForwardButton />
+        </DialogActions>
+      </Dialog>
+    </ForwardMessageProvider>
+  )
+}
+
+// This button lives OUTSIDE Composer.Frame but can still submit based on its context!
+function ForwardButton() {
+  const {
+    actions: { submit },
+  } = use(ComposerContext)
+  return <Button onPress={submit}>Forward</Button>
+}
+
+// This preview lives OUTSIDE Composer.Frame but can read composer's state!
+function MessagePreview() {
+  const { state } = use(ComposerContext)
+  return <Preview message={state.input} attachments={state.attachments} />
+}
+```
+
+The provider boundary is what matters—not the visual nesting. Components that
+
+need shared state don't have to be inside the `Composer.Frame`. They just need
+
+to be within the provider.
+
+The `ForwardButton` and `MessagePreview` are not visually inside the composer
+
+box, but they can still access its state and actions. This is the power of
+
+lifting state into providers.
+
+The UI is reusable bits you compose together. The state is dependency-injected
+
+by the provider. Swap the provider, keep the UI.
+
+### 2.3 Lift State into Provider Components
+
+**Impact: HIGH (enables state sharing outside component boundaries)**
+
+Move state management into dedicated provider components. This allows sibling
+
+components outside the main UI to access and modify state without prop drilling
+
+or awkward refs.
+
+**Incorrect: state trapped inside component**
+
+```tsx
+function ForwardMessageComposer() {
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
+
+  return (
+    <Composer.Frame>
+      <Composer.Input />
+      <Composer.Footer />
+    </Composer.Frame>
+  )
+}
+
+// Problem: How does this button access composer state?
+function ForwardMessageDialog() {
+  return (
+    <Dialog>
+      <ForwardMessageComposer />
+      <MessagePreview /> {/* Needs composer state */}
+      <DialogActions>
+        <CancelButton />
+        <ForwardButton /> {/* Needs to call submit */}
+      </DialogActions>
+    </Dialog>
+  )
+}
+```
+
+**Incorrect: useEffect to sync state up**
+
+```tsx
+function ForwardMessageDialog() {
+  const [input, setInput] = useState('')
+  return (
+    <Dialog>
+      <ForwardMessageComposer onInputChange={setInput} />
+      <MessagePreview input={input} />
+    </Dialog>
+  )
+}
+
+function ForwardMessageComposer({ onInputChange }) {
+  const [state, setState] = useState(initialState)
+  useEffect(() => {
+    onInputChange(state.input) // Sync on every change 😬
+  }, [state.input])
+}
+```
+
+**Incorrect: reading state from ref on submit**
+
+```tsx
+function ForwardMessageDialog() {
+  const stateRef = useRef(null)
+  return (
+    <Dialog>
+      <ForwardMessageComposer stateRef={stateRef} />
+      <ForwardButton onPress={() => submit(stateRef.current)} />
+    </Dialog>
+  )
+}
+```
+
+**Correct: state lifted to provider**
+
+```tsx
+function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
+  const inputRef = useRef(null)
+
+  return (
+    <Composer.Provider
+      state={state}
+      actions={{ update: setState, submit: forwardMessage }}
+      meta={{ inputRef }}
+    >
+      {children}
+    </Composer.Provider>
+  )
+}
+
+function ForwardMessageDialog() {
+  return (
+    <ForwardMessageProvider>
+      <Dialog>
+        <ForwardMessageComposer />
+        <MessagePreview /> {/* Custom components can access state and actions */}
+        <DialogActions>
+          <CancelButton />
+          <ForwardButton /> {/* Custom components can access state and actions */}
+        </DialogActions>
+      </Dialog>
+    </ForwardMessageProvider>
+  )
+}
+
+function ForwardButton() {
+  const { actions } = use(Composer.Context)
+  return <Button onPress={actions.submit}>Forward</Button>
+}
+```
+
+The ForwardButton lives outside the Composer.Frame but still has access to the
+
+submit action because it's within the provider. Even though it's a one-off
+
+component, it can still access the composer's state and actions from outside the
+
+UI itself.
+
+**Key insight:** Components that need shared state don't have to be visually
+
+nested inside each other—they just need to be within the same provider.
+
+---
+
+## 3. Implementation Patterns
+
+**Impact: MEDIUM**
+
+Specific techniques for implementing compound components and
+context providers.
+
+### 3.1 Create Explicit Component Variants
+
+**Impact: MEDIUM (self-documenting code, no hidden conditionals)**
+
+Instead of one component with many boolean props, create explicit variant
+
+components. Each variant composes the pieces it needs. The code documents
+
+itself.
+
+**Incorrect: one component, many modes**
+
+```tsx
+// What does this component actually render?
+<Composer
+  isThread
+  isEditing={false}
+  channelId='abc'
+  showAttachments
+  showFormatting={false}
+/>
+```
+
+**Correct: explicit variants**
+
+```tsx
+// Immediately clear what this renders
+<ThreadComposer channelId="abc" />
+
+// Or
+<EditMessageComposer messageId="xyz" />
+
+// Or
+<ForwardMessageComposer messageId="123" />
+```
+
+Each implementation is unique, explicit and self-contained. Yet they can each
+
+use shared parts.
+
+**Implementation:**
+
+```tsx
+function ThreadComposer({ channelId }: { channelId: string }) {
+  return (
+    <ThreadProvider channelId={channelId}>
+      <Composer.Frame>
+        <Composer.Input />
+        <AlsoSendToChannelField channelId={channelId} />
+        <Composer.Footer>
+          <Composer.Formatting />
+          <Composer.Emojis />
+          <Composer.Submit />
+        </Composer.Footer>
+      </Composer.Frame>
+    </ThreadProvider>
+  )
+}
+
+function EditMessageComposer({ messageId }: { messageId: string }) {
+  return (
+    <EditMessageProvider messageId={messageId}>
+      <Composer.Frame>
+        <Composer.Input />
+        <Composer.Footer>
+          <Composer.Formatting />
+          <Composer.Emojis />
+          <Composer.CancelEdit />
+          <Composer.SaveEdit />
+        </Composer.Footer>
+      </Composer.Frame>
+    </EditMessageProvider>
+  )
+}
+
+function ForwardMessageComposer({ messageId }: { messageId: string }) {
+  return (
+    <ForwardMessageProvider messageId={messageId}>
+      <Composer.Frame>
+        <Composer.Input placeholder="Add a message, if you'd like." />
+        <Composer.Footer>
+          <Composer.Formatting />
+          <Composer.Emojis />
+          <Composer.Mentions />
+        </Composer.Footer>
+      </Composer.Frame>
+    </ForwardMessageProvider>
+  )
+}
+```
+
+Each variant is explicit about:
+
+- What provider/state it uses
+
+- What UI elements it includes
+
+- What actions are available
+
+No boolean prop combinations to reason about. No impossible states.
+
+### 3.2 Prefer Composing Children Over Render Props
+
+**Impact: MEDIUM (cleaner composition, better readability)**
+
+Use `children` for composition instead of `renderX` props. Children are more
+
+readable, compose naturally, and don't require understanding callback
+
+signatures.
+
+**Incorrect: render props**
+
+```tsx
+function Composer({
+  renderHeader,
+  renderFooter,
+  renderActions,
+}: {
+  renderHeader?: () => React.ReactNode
+  renderFooter?: () => React.ReactNode
+  renderActions?: () => React.ReactNode
+}) {
+  return (
+    <form>
+      {renderHeader?.()}
+      <Input />
+      {renderFooter ? renderFooter() : <DefaultFooter />}
+      {renderActions?.()}
+    </form>
+  )
+}
+
+// Usage is awkward and inflexible
+return (
+  <Composer
+    renderHeader={() => <CustomHeader />}
+    renderFooter={() => (
+      <>
+        <Formatting />
+        <Emojis />
+      </>
+    )}
+    renderActions={() => <SubmitButton />}
+  />
+)
+```
+
+**Correct: compound components with children**
+
+```tsx
+function ComposerFrame({ children }: { children: React.ReactNode }) {
+  return <form>{children}</form>
+}
+
+function ComposerFooter({ children }: { children: React.ReactNode }) {
+  return <footer className='flex'>{children}</footer>
+}
+
+// Usage is flexible
+return (
+  <Composer.Frame>
+    <CustomHeader />
+    <Composer.Input />
+    <Composer.Footer>
+      <Composer.Formatting />
+      <Composer.Emojis />
+      <SubmitButton />
+    </Composer.Footer>
+  </Composer.Frame>
+)
+```
+
+**When render props are appropriate:**
+
+```tsx
+// Render props work well when you need to pass data back
+<List
+  data={items}
+  renderItem={({ item, index }) => <Item item={item} index={index} />}
+/>
+```
+
+Use render props when the parent needs to provide data or state to the child.
+
+Use children when composing static structure.
+
+---
+
+## 4. React 19 APIs
+
+**Impact: MEDIUM**
+
+React 19+ only. Don't use `forwardRef`; use `use()` instead of `useContext()`.
+
+### 4.1 React 19 API Changes
+
+**Impact: MEDIUM (cleaner component definitions and context usage)**
+
+> **⚠️ React 19+ only.** Skip this if you're on React 18 or earlier.
+
+In React 19, `ref` is now a regular prop (no `forwardRef` wrapper needed), and `use()` replaces `useContext()`.
+
+**Incorrect: forwardRef in React 19**
+
+```tsx
+const ComposerInput = forwardRef<TextInput, Props>((props, ref) => {
+  return <TextInput ref={ref} {...props} />
+})
+```
+
+**Correct: ref as a regular prop**
+
+```tsx
+function ComposerInput({ ref, ...props }: Props & { ref?: React.Ref<TextInput> }) {
+  return <TextInput ref={ref} {...props} />
+}
+```
+
+**Incorrect: useContext in React 19**
+
+```tsx
+const value = useContext(MyContext)
+```
+
+**Correct: use instead of useContext**
+
+```tsx
+const value = use(MyContext)
+```
+
+`use()` can also be called conditionally, unlike `useContext()`.
+
+---
+
+## References
+
+1. [https://react.dev](https://react.dev)
+2. [https://react.dev/learn/passing-data-deeply-with-context](https://react.dev/learn/passing-data-deeply-with-context)
+3. [https://react.dev/reference/react/use](https://react.dev/reference/react/use)

--- a/catalog/skills/items/composition-patterns/README.md
+++ b/catalog/skills/items/composition-patterns/README.md
@@ -1,0 +1,60 @@
+# React Composition Patterns
+
+A structured repository for React composition patterns that scale. These
+patterns help avoid boolean prop proliferation by using compound components,
+lifting state, and composing internals.
+
+## Structure
+
+- `rules/` - Individual rule files (one per rule)
+  - `_sections.md` - Section metadata (titles, impacts, descriptions)
+  - `_template.md` - Template for creating new rules
+  - `area-description.md` - Individual rule files
+- `metadata.json` - Document metadata (version, organization, abstract)
+- **`AGENTS.md`** - Compiled output (generated)
+
+## Rules
+
+### Component Architecture (CRITICAL)
+
+- `architecture-avoid-boolean-props.md` - Don't add boolean props to customize
+  behavior
+- `architecture-compound-components.md` - Structure as compound components with
+  shared context
+
+### State Management (HIGH)
+
+- `state-lift-state.md` - Lift state into provider components
+- `state-context-interface.md` - Define clear context interfaces
+  (state/actions/meta)
+- `state-decouple-implementation.md` - Decouple state management from UI
+
+### Implementation Patterns (MEDIUM)
+
+- `patterns-children-over-render-props.md` - Prefer children over renderX props
+- `patterns-explicit-variants.md` - Create explicit component variants
+
+## Core Principles
+
+1. **Composition over configuration** — Instead of adding props, let consumers
+   compose
+2. **Lift your state** — State in providers, not trapped in components
+3. **Compose your internals** — Subcomponents access context, not props
+4. **Explicit variants** — Create ThreadComposer, EditComposer, not Composer
+   with isThread
+
+## Creating a New Rule
+
+1. Copy `rules/_template.md` to `rules/area-description.md`
+2. Choose the appropriate area prefix:
+   - `architecture-` for Component Architecture
+   - `state-` for State Management
+   - `patterns-` for Implementation Patterns
+3. Fill in the frontmatter and content
+4. Ensure you have clear examples with explanations
+
+## Impact Levels
+
+- `CRITICAL` - Foundational patterns, prevents unmaintainable code
+- `HIGH` - Significant maintainability improvements
+- `MEDIUM` - Good practices for cleaner code

--- a/catalog/skills/items/composition-patterns/SKILL.md
+++ b/catalog/skills/items/composition-patterns/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: vercel-composition-patterns
+description:
+  React composition patterns that scale. Use when refactoring components with
+  boolean prop proliferation, building flexible component libraries, or
+  designing reusable APIs. Triggers on tasks involving compound components,
+  render props, context providers, or component architecture. Includes React 19
+  API changes.
+license: MIT
+metadata:
+  author: vercel
+  version: '1.0.0'
+---
+
+# React Composition Patterns
+
+Composition patterns for building flexible, maintainable React components. Avoid
+boolean prop proliferation by using compound components, lifting state, and
+composing internals. These patterns make codebases easier for both humans and AI
+agents to work with as they scale.
+
+## When to Apply
+
+Reference these guidelines when:
+
+- Refactoring components with many boolean props
+- Building reusable component libraries
+- Designing flexible component APIs
+- Reviewing component architecture
+- Working with compound components or context providers
+
+## Rule Categories by Priority
+
+| Priority | Category                | Impact | Prefix          |
+| -------- | ----------------------- | ------ | --------------- |
+| 1        | Component Architecture  | HIGH   | `architecture-` |
+| 2        | State Management        | MEDIUM | `state-`        |
+| 3        | Implementation Patterns | MEDIUM | `patterns-`     |
+| 4        | React 19 APIs           | MEDIUM | `react19-`      |
+
+## Quick Reference
+
+### 1. Component Architecture (HIGH)
+
+- `architecture-avoid-boolean-props` - Don't add boolean props to customize
+  behavior; use composition
+- `architecture-compound-components` - Structure complex components with shared
+  context
+
+### 2. State Management (MEDIUM)
+
+- `state-decouple-implementation` - Provider is the only place that knows how
+  state is managed
+- `state-context-interface` - Define generic interface with state, actions, meta
+  for dependency injection
+- `state-lift-state` - Move state into provider components for sibling access
+
+### 3. Implementation Patterns (MEDIUM)
+
+- `patterns-explicit-variants` - Create explicit variant components instead of
+  boolean modes
+- `patterns-children-over-render-props` - Use children for composition instead
+  of renderX props
+
+### 4. React 19 APIs (MEDIUM)
+
+> **⚠️ React 19+ only.** Skip this section if using React 18 or earlier.
+
+- `react19-no-forwardref` - Don't use `forwardRef`; use `use()` instead of `useContext()`
+
+## How to Use
+
+Read individual rule files for detailed explanations and code examples:
+
+```
+rules/architecture-avoid-boolean-props.md
+rules/state-context-interface.md
+```
+
+Each rule file contains:
+
+- Brief explanation of why it matters
+- Incorrect code example with explanation
+- Correct code example with explanation
+- Additional context and references
+
+## Full Compiled Document
+
+For the complete guide with all rules expanded: `AGENTS.md`

--- a/catalog/skills/items/composition-patterns/metadata.json
+++ b/catalog/skills/items/composition-patterns/metadata.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.0.0",
+  "organization": "Engineering",
+  "date": "January 2026",
+  "abstract": "Composition patterns for building flexible, maintainable React components. Avoid boolean prop proliferation by using compound components, lifting state, and composing internals. These patterns make codebases easier for both humans and AI agents to work with as they scale.",
+  "references": [
+    "https://react.dev",
+    "https://react.dev/learn/passing-data-deeply-with-context",
+    "https://react.dev/reference/react/use"
+  ]
+}

--- a/catalog/skills/items/composition-patterns/rules/_sections.md
+++ b/catalog/skills/items/composition-patterns/rules/_sections.md
@@ -1,0 +1,29 @@
+# Sections
+
+This file defines all sections, their ordering, impact levels, and descriptions.
+The section ID (in parentheses) is the filename prefix used to group rules.
+
+---
+
+## 1. Component Architecture (architecture)
+
+**Impact:** HIGH
+**Description:** Fundamental patterns for structuring components to avoid prop
+proliferation and enable flexible composition.
+
+## 2. State Management (state)
+
+**Impact:** MEDIUM
+**Description:** Patterns for lifting state and managing shared context across
+composed components.
+
+## 3. Implementation Patterns (patterns)
+
+**Impact:** MEDIUM
+**Description:** Specific techniques for implementing compound components and
+context providers.
+
+## 4. React 19 APIs (react19)
+
+**Impact:** MEDIUM
+**Description:** React 19+ only. Don't use `forwardRef`; use `use()` instead of `useContext()`.

--- a/catalog/skills/items/composition-patterns/rules/_template.md
+++ b/catalog/skills/items/composition-patterns/rules/_template.md
@@ -1,0 +1,24 @@
+---
+title: Rule Title Here
+impact: MEDIUM
+impactDescription: brief description of impact
+tags: composition, components
+---
+
+## Rule Title Here
+
+Brief explanation of the rule and why it matters.
+
+**Incorrect:**
+
+```tsx
+// Bad code example
+```
+
+**Correct:**
+
+```tsx
+// Good code example
+```
+
+Reference: [Link](https://example.com)

--- a/catalog/skills/items/composition-patterns/rules/architecture-avoid-boolean-props.md
+++ b/catalog/skills/items/composition-patterns/rules/architecture-avoid-boolean-props.md
@@ -1,0 +1,100 @@
+---
+title: Avoid Boolean Prop Proliferation
+impact: CRITICAL
+impactDescription: prevents unmaintainable component variants
+tags: composition, props, architecture
+---
+
+## Avoid Boolean Prop Proliferation
+
+Don't add boolean props like `isThread`, `isEditing`, `isDMThread` to customize
+component behavior. Each boolean doubles possible states and creates
+unmaintainable conditional logic. Use composition instead.
+
+**Incorrect (boolean props create exponential complexity):**
+
+```tsx
+function Composer({
+  onSubmit,
+  isThread,
+  channelId,
+  isDMThread,
+  dmId,
+  isEditing,
+  isForwarding,
+}: Props) {
+  return (
+    <form>
+      <Header />
+      <Input />
+      {isDMThread ? (
+        <AlsoSendToDMField id={dmId} />
+      ) : isThread ? (
+        <AlsoSendToChannelField id={channelId} />
+      ) : null}
+      {isEditing ? (
+        <EditActions />
+      ) : isForwarding ? (
+        <ForwardActions />
+      ) : (
+        <DefaultActions />
+      )}
+      <Footer onSubmit={onSubmit} />
+    </form>
+  )
+}
+```
+
+**Correct (composition eliminates conditionals):**
+
+```tsx
+// Channel composer
+function ChannelComposer() {
+  return (
+    <Composer.Frame>
+      <Composer.Header />
+      <Composer.Input />
+      <Composer.Footer>
+        <Composer.Attachments />
+        <Composer.Formatting />
+        <Composer.Emojis />
+        <Composer.Submit />
+      </Composer.Footer>
+    </Composer.Frame>
+  )
+}
+
+// Thread composer - adds "also send to channel" field
+function ThreadComposer({ channelId }: { channelId: string }) {
+  return (
+    <Composer.Frame>
+      <Composer.Header />
+      <Composer.Input />
+      <AlsoSendToChannelField id={channelId} />
+      <Composer.Footer>
+        <Composer.Formatting />
+        <Composer.Emojis />
+        <Composer.Submit />
+      </Composer.Footer>
+    </Composer.Frame>
+  )
+}
+
+// Edit composer - different footer actions
+function EditComposer() {
+  return (
+    <Composer.Frame>
+      <Composer.Input />
+      <Composer.Footer>
+        <Composer.Formatting />
+        <Composer.Emojis />
+        <Composer.CancelEdit />
+        <Composer.SaveEdit />
+      </Composer.Footer>
+    </Composer.Frame>
+  )
+}
+```
+
+Each variant is explicit about what it renders. We can share internals without
+sharing a single monolithic parent.

--- a/catalog/skills/items/composition-patterns/rules/architecture-compound-components.md
+++ b/catalog/skills/items/composition-patterns/rules/architecture-compound-components.md
@@ -1,0 +1,112 @@
+---
+title: Use Compound Components
+impact: HIGH
+impactDescription: enables flexible composition without prop drilling
+tags: composition, compound-components, architecture
+---
+
+## Use Compound Components
+
+Structure complex components as compound components with a shared context. Each
+subcomponent accesses shared state via context, not props. Consumers compose the
+pieces they need.
+
+**Incorrect (monolithic component with render props):**
+
+```tsx
+function Composer({
+  renderHeader,
+  renderFooter,
+  renderActions,
+  showAttachments,
+  showFormatting,
+  showEmojis,
+}: Props) {
+  return (
+    <form>
+      {renderHeader?.()}
+      <Input />
+      {showAttachments && <Attachments />}
+      {renderFooter ? (
+        renderFooter()
+      ) : (
+        <Footer>
+          {showFormatting && <Formatting />}
+          {showEmojis && <Emojis />}
+          {renderActions?.()}
+        </Footer>
+      )}
+    </form>
+  )
+}
+```
+
+**Correct (compound components with shared context):**
+
+```tsx
+const ComposerContext = createContext<ComposerContextValue | null>(null)
+
+function ComposerProvider({ children, state, actions, meta }: ProviderProps) {
+  return (
+    <ComposerContext value={{ state, actions, meta }}>
+      {children}
+    </ComposerContext>
+  )
+}
+
+function ComposerFrame({ children }: { children: React.ReactNode }) {
+  return <form>{children}</form>
+}
+
+function ComposerInput() {
+  const {
+    state,
+    actions: { update },
+    meta: { inputRef },
+  } = use(ComposerContext)
+  return (
+    <TextInput
+      ref={inputRef}
+      value={state.input}
+      onChangeText={(text) => update((s) => ({ ...s, input: text }))}
+    />
+  )
+}
+
+function ComposerSubmit() {
+  const {
+    actions: { submit },
+  } = use(ComposerContext)
+  return <Button onPress={submit}>Send</Button>
+}
+
+// Export as compound component
+const Composer = {
+  Provider: ComposerProvider,
+  Frame: ComposerFrame,
+  Input: ComposerInput,
+  Submit: ComposerSubmit,
+  Header: ComposerHeader,
+  Footer: ComposerFooter,
+  Attachments: ComposerAttachments,
+  Formatting: ComposerFormatting,
+  Emojis: ComposerEmojis,
+}
+```
+
+**Usage:**
+
+```tsx
+<Composer.Provider state={state} actions={actions} meta={meta}>
+  <Composer.Frame>
+    <Composer.Header />
+    <Composer.Input />
+    <Composer.Footer>
+      <Composer.Formatting />
+      <Composer.Submit />
+    </Composer.Footer>
+  </Composer.Frame>
+</Composer.Provider>
+```
+
+Consumers explicitly compose exactly what they need. No hidden conditionals. And the state, actions and meta are dependency-injected by a parent provider, allowing multiple usages of the same component structure.

--- a/catalog/skills/items/composition-patterns/rules/patterns-children-over-render-props.md
+++ b/catalog/skills/items/composition-patterns/rules/patterns-children-over-render-props.md
@@ -1,0 +1,87 @@
+---
+title: Prefer Composing Children Over Render Props
+impact: MEDIUM
+impactDescription: cleaner composition, better readability
+tags: composition, children, render-props
+---
+
+## Prefer Children Over Render Props
+
+Use `children` for composition instead of `renderX` props. Children are more
+readable, compose naturally, and don't require understanding callback
+signatures.
+
+**Incorrect (render props):**
+
+```tsx
+function Composer({
+  renderHeader,
+  renderFooter,
+  renderActions,
+}: {
+  renderHeader?: () => React.ReactNode
+  renderFooter?: () => React.ReactNode
+  renderActions?: () => React.ReactNode
+}) {
+  return (
+    <form>
+      {renderHeader?.()}
+      <Input />
+      {renderFooter ? renderFooter() : <DefaultFooter />}
+      {renderActions?.()}
+    </form>
+  )
+}
+
+// Usage is awkward and inflexible
+return (
+  <Composer
+    renderHeader={() => <CustomHeader />}
+    renderFooter={() => (
+      <>
+        <Formatting />
+        <Emojis />
+      </>
+    )}
+    renderActions={() => <SubmitButton />}
+  />
+)
+```
+
+**Correct (compound components with children):**
+
+```tsx
+function ComposerFrame({ children }: { children: React.ReactNode }) {
+  return <form>{children}</form>
+}
+
+function ComposerFooter({ children }: { children: React.ReactNode }) {
+  return <footer className='flex'>{children}</footer>
+}
+
+// Usage is flexible
+return (
+  <Composer.Frame>
+    <CustomHeader />
+    <Composer.Input />
+    <Composer.Footer>
+      <Composer.Formatting />
+      <Composer.Emojis />
+      <SubmitButton />
+    </Composer.Footer>
+  </Composer.Frame>
+)
+```
+
+**When render props are appropriate:**
+
+```tsx
+// Render props work well when you need to pass data back
+<List
+  data={items}
+  renderItem={({ item, index }) => <Item item={item} index={index} />}
+/>
+```
+
+Use render props when the parent needs to provide data or state to the child.
+Use children when composing static structure.

--- a/catalog/skills/items/composition-patterns/rules/patterns-explicit-variants.md
+++ b/catalog/skills/items/composition-patterns/rules/patterns-explicit-variants.md
@@ -1,0 +1,100 @@
+---
+title: Create Explicit Component Variants
+impact: MEDIUM
+impactDescription: self-documenting code, no hidden conditionals
+tags: composition, variants, architecture
+---
+
+## Create Explicit Component Variants
+
+Instead of one component with many boolean props, create explicit variant
+components. Each variant composes the pieces it needs. The code documents
+itself.
+
+**Incorrect (one component, many modes):**
+
+```tsx
+// What does this component actually render?
+<Composer
+  isThread
+  isEditing={false}
+  channelId='abc'
+  showAttachments
+  showFormatting={false}
+/>
+```
+
+**Correct (explicit variants):**
+
+```tsx
+// Immediately clear what this renders
+<ThreadComposer channelId="abc" />
+
+// Or
+<EditMessageComposer messageId="xyz" />
+
+// Or
+<ForwardMessageComposer messageId="123" />
+```
+
+Each implementation is unique, explicit and self-contained. Yet they can each
+use shared parts.
+
+**Implementation:**
+
+```tsx
+function ThreadComposer({ channelId }: { channelId: string }) {
+  return (
+    <ThreadProvider channelId={channelId}>
+      <Composer.Frame>
+        <Composer.Input />
+        <AlsoSendToChannelField channelId={channelId} />
+        <Composer.Footer>
+          <Composer.Formatting />
+          <Composer.Emojis />
+          <Composer.Submit />
+        </Composer.Footer>
+      </Composer.Frame>
+    </ThreadProvider>
+  )
+}
+
+function EditMessageComposer({ messageId }: { messageId: string }) {
+  return (
+    <EditMessageProvider messageId={messageId}>
+      <Composer.Frame>
+        <Composer.Input />
+        <Composer.Footer>
+          <Composer.Formatting />
+          <Composer.Emojis />
+          <Composer.CancelEdit />
+          <Composer.SaveEdit />
+        </Composer.Footer>
+      </Composer.Frame>
+    </EditMessageProvider>
+  )
+}
+
+function ForwardMessageComposer({ messageId }: { messageId: string }) {
+  return (
+    <ForwardMessageProvider messageId={messageId}>
+      <Composer.Frame>
+        <Composer.Input placeholder="Add a message, if you'd like." />
+        <Composer.Footer>
+          <Composer.Formatting />
+          <Composer.Emojis />
+          <Composer.Mentions />
+        </Composer.Footer>
+      </Composer.Frame>
+    </ForwardMessageProvider>
+  )
+}
+```
+
+Each variant is explicit about:
+
+- What provider/state it uses
+- What UI elements it includes
+- What actions are available
+
+No boolean prop combinations to reason about. No impossible states.

--- a/catalog/skills/items/composition-patterns/rules/react19-no-forwardref.md
+++ b/catalog/skills/items/composition-patterns/rules/react19-no-forwardref.md
@@ -1,0 +1,42 @@
+---
+title: React 19 API Changes
+impact: MEDIUM
+impactDescription: cleaner component definitions and context usage
+tags: react19, refs, context, hooks
+---
+
+## React 19 API Changes
+
+> **⚠️ React 19+ only.** Skip this if you're on React 18 or earlier.
+
+In React 19, `ref` is now a regular prop (no `forwardRef` wrapper needed), and `use()` replaces `useContext()`.
+
+**Incorrect (forwardRef in React 19):**
+
+```tsx
+const ComposerInput = forwardRef<TextInput, Props>((props, ref) => {
+  return <TextInput ref={ref} {...props} />
+})
+```
+
+**Correct (ref as a regular prop):**
+
+```tsx
+function ComposerInput({ ref, ...props }: Props & { ref?: React.Ref<TextInput> }) {
+  return <TextInput ref={ref} {...props} />
+}
+```
+
+**Incorrect (useContext in React 19):**
+
+```tsx
+const value = useContext(MyContext)
+```
+
+**Correct (use instead of useContext):**
+
+```tsx
+const value = use(MyContext)
+```
+
+`use()` can also be called conditionally, unlike `useContext()`.

--- a/catalog/skills/items/composition-patterns/rules/state-context-interface.md
+++ b/catalog/skills/items/composition-patterns/rules/state-context-interface.md
@@ -1,0 +1,191 @@
+---
+title: Define Generic Context Interfaces for Dependency Injection
+impact: HIGH
+impactDescription: enables dependency-injectable state across use-cases
+tags: composition, context, state, typescript, dependency-injection
+---
+
+## Define Generic Context Interfaces for Dependency Injection
+
+Define a **generic interface** for your component context with three parts:
+`state`, `actions`, and `meta`. This interface is a contract that any provider
+can implement—enabling the same UI components to work with completely different
+state implementations.
+
+**Core principle:** Lift state, compose internals, make state
+dependency-injectable.
+
+**Incorrect (UI coupled to specific state implementation):**
+
+```tsx
+function ComposerInput() {
+  // Tightly coupled to a specific hook
+  const { input, setInput } = useChannelComposerState()
+  return <TextInput value={input} onChangeText={setInput} />
+}
+```
+
+**Correct (generic interface enables dependency injection):**
+
+```tsx
+// Define a GENERIC interface that any provider can implement
+interface ComposerState {
+  input: string
+  attachments: Attachment[]
+  isSubmitting: boolean
+}
+
+interface ComposerActions {
+  update: (updater: (state: ComposerState) => ComposerState) => void
+  submit: () => void
+}
+
+interface ComposerMeta {
+  inputRef: React.RefObject<TextInput>
+}
+
+interface ComposerContextValue {
+  state: ComposerState
+  actions: ComposerActions
+  meta: ComposerMeta
+}
+
+const ComposerContext = createContext<ComposerContextValue | null>(null)
+```
+
+**UI components consume the interface, not the implementation:**
+
+```tsx
+function ComposerInput() {
+  const {
+    state,
+    actions: { update },
+    meta,
+  } = use(ComposerContext)
+
+  // This component works with ANY provider that implements the interface
+  return (
+    <TextInput
+      ref={meta.inputRef}
+      value={state.input}
+      onChangeText={(text) => update((s) => ({ ...s, input: text }))}
+    />
+  )
+}
+```
+
+**Different providers implement the same interface:**
+
+```tsx
+// Provider A: Local state for ephemeral forms
+function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState(initialState)
+  const inputRef = useRef(null)
+  const submit = useForwardMessage()
+
+  return (
+    <ComposerContext
+      value={{
+        state,
+        actions: { update: setState, submit },
+        meta: { inputRef },
+      }}
+    >
+      {children}
+    </ComposerContext>
+  )
+}
+
+// Provider B: Global synced state for channels
+function ChannelProvider({ channelId, children }: Props) {
+  const { state, update, submit } = useGlobalChannel(channelId)
+  const inputRef = useRef(null)
+
+  return (
+    <ComposerContext
+      value={{
+        state,
+        actions: { update, submit },
+        meta: { inputRef },
+      }}
+    >
+      {children}
+    </ComposerContext>
+  )
+}
+```
+
+**The same composed UI works with both:**
+
+```tsx
+// Works with ForwardMessageProvider (local state)
+<ForwardMessageProvider>
+  <Composer.Frame>
+    <Composer.Input />
+    <Composer.Submit />
+  </Composer.Frame>
+</ForwardMessageProvider>
+
+// Works with ChannelProvider (global synced state)
+<ChannelProvider channelId="abc">
+  <Composer.Frame>
+    <Composer.Input />
+    <Composer.Submit />
+  </Composer.Frame>
+</ChannelProvider>
+```
+
+**Custom UI outside the component can access state and actions:**
+
+The provider boundary is what matters—not the visual nesting. Components that
+need shared state don't have to be inside the `Composer.Frame`. They just need
+to be within the provider.
+
+```tsx
+function ForwardMessageDialog() {
+  return (
+    <ForwardMessageProvider>
+      <Dialog>
+        {/* The composer UI */}
+        <Composer.Frame>
+          <Composer.Input placeholder="Add a message, if you'd like." />
+          <Composer.Footer>
+            <Composer.Formatting />
+            <Composer.Emojis />
+          </Composer.Footer>
+        </Composer.Frame>
+
+        {/* Custom UI OUTSIDE the composer, but INSIDE the provider */}
+        <MessagePreview />
+
+        {/* Actions at the bottom of the dialog */}
+        <DialogActions>
+          <CancelButton />
+          <ForwardButton />
+        </DialogActions>
+      </Dialog>
+    </ForwardMessageProvider>
+  )
+}
+
+// This button lives OUTSIDE Composer.Frame but can still submit based on its context!
+function ForwardButton() {
+  const {
+    actions: { submit },
+  } = use(ComposerContext)
+  return <Button onPress={submit}>Forward</Button>
+}
+
+// This preview lives OUTSIDE Composer.Frame but can read composer's state!
+function MessagePreview() {
+  const { state } = use(ComposerContext)
+  return <Preview message={state.input} attachments={state.attachments} />
+}
+```
+
+The `ForwardButton` and `MessagePreview` are not visually inside the composer
+box, but they can still access its state and actions. This is the power of
+lifting state into providers.
+
+The UI is reusable bits you compose together. The state is dependency-injected
+by the provider. Swap the provider, keep the UI.

--- a/catalog/skills/items/composition-patterns/rules/state-decouple-implementation.md
+++ b/catalog/skills/items/composition-patterns/rules/state-decouple-implementation.md
@@ -1,0 +1,113 @@
+---
+title: Decouple State Management from UI
+impact: MEDIUM
+impactDescription: enables swapping state implementations without changing UI
+tags: composition, state, architecture
+---
+
+## Decouple State Management from UI
+
+The provider component should be the only place that knows how state is managed.
+UI components consume the context interface—they don't know if state comes from
+useState, Zustand, or a server sync.
+
+**Incorrect (UI coupled to state implementation):**
+
+```tsx
+function ChannelComposer({ channelId }: { channelId: string }) {
+  // UI component knows about global state implementation
+  const state = useGlobalChannelState(channelId)
+  const { submit, updateInput } = useChannelSync(channelId)
+
+  return (
+    <Composer.Frame>
+      <Composer.Input
+        value={state.input}
+        onChange={(text) => sync.updateInput(text)}
+      />
+      <Composer.Submit onPress={() => sync.submit()} />
+    </Composer.Frame>
+  )
+}
+```
+
+**Correct (state management isolated in provider):**
+
+```tsx
+// Provider handles all state management details
+function ChannelProvider({
+  channelId,
+  children,
+}: {
+  channelId: string
+  children: React.ReactNode
+}) {
+  const { state, update, submit } = useGlobalChannel(channelId)
+  const inputRef = useRef(null)
+
+  return (
+    <Composer.Provider
+      state={state}
+      actions={{ update, submit }}
+      meta={{ inputRef }}
+    >
+      {children}
+    </Composer.Provider>
+  )
+}
+
+// UI component only knows about the context interface
+function ChannelComposer() {
+  return (
+    <Composer.Frame>
+      <Composer.Header />
+      <Composer.Input />
+      <Composer.Footer>
+        <Composer.Submit />
+      </Composer.Footer>
+    </Composer.Frame>
+  )
+}
+
+// Usage
+function Channel({ channelId }: { channelId: string }) {
+  return (
+    <ChannelProvider channelId={channelId}>
+      <ChannelComposer />
+    </ChannelProvider>
+  )
+}
+```
+
+**Different providers, same UI:**
+
+```tsx
+// Local state for ephemeral forms
+function ForwardMessageProvider({ children }) {
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
+
+  return (
+    <Composer.Provider
+      state={state}
+      actions={{ update: setState, submit: forwardMessage }}
+    >
+      {children}
+    </Composer.Provider>
+  )
+}
+
+// Global synced state for channels
+function ChannelProvider({ channelId, children }) {
+  const { state, update, submit } = useGlobalChannel(channelId)
+
+  return (
+    <Composer.Provider state={state} actions={{ update, submit }}>
+      {children}
+    </Composer.Provider>
+  )
+}
+```
+
+The same `Composer.Input` component works with both providers because it only
+depends on the context interface, not the implementation.

--- a/catalog/skills/items/composition-patterns/rules/state-lift-state.md
+++ b/catalog/skills/items/composition-patterns/rules/state-lift-state.md
@@ -1,0 +1,125 @@
+---
+title: Lift State into Provider Components
+impact: HIGH
+impactDescription: enables state sharing outside component boundaries
+tags: composition, state, context, providers
+---
+
+## Lift State into Provider Components
+
+Move state management into dedicated provider components. This allows sibling
+components outside the main UI to access and modify state without prop drilling
+or awkward refs.
+
+**Incorrect (state trapped inside component):**
+
+```tsx
+function ForwardMessageComposer() {
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
+
+  return (
+    <Composer.Frame>
+      <Composer.Input />
+      <Composer.Footer />
+    </Composer.Frame>
+  )
+}
+
+// Problem: How does this button access composer state?
+function ForwardMessageDialog() {
+  return (
+    <Dialog>
+      <ForwardMessageComposer />
+      <MessagePreview /> {/* Needs composer state */}
+      <DialogActions>
+        <CancelButton />
+        <ForwardButton /> {/* Needs to call submit */}
+      </DialogActions>
+    </Dialog>
+  )
+}
+```
+
+**Incorrect (useEffect to sync state up):**
+
+```tsx
+function ForwardMessageDialog() {
+  const [input, setInput] = useState('')
+  return (
+    <Dialog>
+      <ForwardMessageComposer onInputChange={setInput} />
+      <MessagePreview input={input} />
+    </Dialog>
+  )
+}
+
+function ForwardMessageComposer({ onInputChange }) {
+  const [state, setState] = useState(initialState)
+  useEffect(() => {
+    onInputChange(state.input) // Sync on every change 😬
+  }, [state.input])
+}
+```
+
+**Incorrect (reading state from ref on submit):**
+
+```tsx
+function ForwardMessageDialog() {
+  const stateRef = useRef(null)
+  return (
+    <Dialog>
+      <ForwardMessageComposer stateRef={stateRef} />
+      <ForwardButton onPress={() => submit(stateRef.current)} />
+    </Dialog>
+  )
+}
+```
+
+**Correct (state lifted to provider):**
+
+```tsx
+function ForwardMessageProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = useState(initialState)
+  const forwardMessage = useForwardMessage()
+  const inputRef = useRef(null)
+
+  return (
+    <Composer.Provider
+      state={state}
+      actions={{ update: setState, submit: forwardMessage }}
+      meta={{ inputRef }}
+    >
+      {children}
+    </Composer.Provider>
+  )
+}
+
+function ForwardMessageDialog() {
+  return (
+    <ForwardMessageProvider>
+      <Dialog>
+        <ForwardMessageComposer />
+        <MessagePreview /> {/* Custom components can access state and actions */}
+        <DialogActions>
+          <CancelButton />
+          <ForwardButton /> {/* Custom components can access state and actions */}
+        </DialogActions>
+      </Dialog>
+    </ForwardMessageProvider>
+  )
+}
+
+function ForwardButton() {
+  const { actions } = use(Composer.Context)
+  return <Button onPress={actions.submit}>Forward</Button>
+}
+```
+
+The ForwardButton lives outside the Composer.Frame but still has access to the
+submit action because it's within the provider. Even though it's a one-off
+component, it can still access the composer's state and actions from outside the
+UI itself.
+
+**Key insight:** Components that need shared state don't have to be visually
+nested inside each other—they just need to be within the same provider.

--- a/catalog/skills/items/frontend-design/LICENSE.txt
+++ b/catalog/skills/items/frontend-design/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/catalog/skills/items/frontend-design/SKILL.md
+++ b/catalog/skills/items/frontend-design/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: frontend-design
+description: Guidance for distinctive, intentional visual design when building new UI or reshaping an existing one. Helps with aesthetic direction, typography, and making choices that don't read as templated defaults.
+license: Complete terms in LICENSE.txt
+---
+
+# Frontend Design
+
+Approach this as the design lead at a small studio known for giving every client a visual identity that could not be mistaken for anyone else's. This client has already rejected proposals that felt templated, and is paying for a distinctive point of view: make deliberate, opinionated choices about palette, typography, and layout that are specific to this brief, and take one real aesthetic risk you can justify.
+
+## Ground it in the subject
+
+If the brief does not pin down what the product or subject is, pin it yourself before designing: name one concrete subject, its audience, and the page's single job, and state your choice. If there's any information in your memory about the human's preferences, context about what they're building, or designs you've made before – use that as a hint. The subject's own world, its materials, instruments, artifacts, and vernacular, is where distinctive choices come from. Build with the brief's real content and subject matter throughout.
+
+## Design principles
+
+For web designs, the hero is a thesis. Open with the most characteristic thing in the subject's world, in whatever form makes sense for it: a headline, an image, an animation, a live demo, an interactive moment. Be deliberate with your choice: a big number with a small label, supporting stats, and a gradient accent is the template answer, only use if that's truly the best option.
+
+Typography carries the personality of the page. Pair the display and body faces deliberately, not the same families you would reach for on any other project, and set a clear type scale with intentional weights, widths, and spacing. Make the type treatment itself a memorable part of the design, not a neutral delivery vehicle for the content.
+
+Structure is information. Structural devices, numbering, eyebrows, dividers, labels, should encode something true about the content, not decorate it. Many generic designs use numbered markers (01 / 02 / 03), but that's only appropriate if the content actually is a sequence - like a real process or a typed timeline where order carries information the reader needs. Question if choices like numbered markers actually make sense before incorporating them.
+
+Leverage motion deliberately. Think about where and if animation can serve the subject: a page-load sequence, a scroll-triggered reveal, hover micro-interactions, ambient atmosphere. An orchestrated moment usually lands harder than scattered effects; choose what the direction calls for. However, sometimes less is more, and extra animation contributes to the feeling that the design is AI-generated.
+
+Match complexity to the vision. Maximalist directions need elaborate execution; minimal directions need precision in spacing, type, and detail. Elegance is executing the chosen vision well.
+
+Consider written content carefully. Often a design brief may not contain real content, and it's up to you to come up with copy. Copy can make a design feel as templated as the design itself. See the below section on writing for more guidance.
+
+## Process: brainstorm, explore, plan, critique, build, critique again
+
+For calibration: AI-generated design right now clusters around three looks: (1) a warm cream background (near #F4F1EA) with a high-contrast serif display and a terracotta accent; (2) a near-black background with a single bright acid-green or vermilion accent; (3) a broadsheet-style layout with hairline rules, zero border-radius, and dense newspaper-like columns. All three are legitimate for some briefs, but they are defaults rather than choices, and they appear regardless of subject. Where the brief pins down a visual direction, follow it exactly — the brief's own words always win, including when it asks for one of these looks. Where it leaves an axis free, don't spend that freedom on one of these defaults. Just like a human designer who's hired, there's often a careful balance between doing what you're good at and taking each project as a chance to experiment and learn.
+
+Work in two passes. First, brainstorm a short design plan based on the human's design brief: create a compact token system with color, type, layout, and signature. Color: describe the palette as 4–6 named hex values. Type: the typefaces for 2+ roles (a characterful display face that's used with restraint, a complementary body face, and a utility face for captions or data if needed). Layout: a layout concept, using one-sentence prose descriptions and ASCII wireframes to ideate and compare. Signature: the single unique element this page will be remembered by that embodies the brief in an appropriate way.
+
+Then review that plan against the brief before building: if any part of it reads like the generic default you would produce for any similar page (work through a similar prompt to see if you arrive somewhere similar) rather than a choice made for this specific brief — revise that part, say what you changed and why. Only after you've confirmed the relative uniqueness of your design plan should you start to write the code, following the revised plan exactly and deriving every color and type decision from it.
+
+When writing the code, be careful of structuring your CSS selector specificities. It's easy to generate CSS classes that cancel each other out (especially with a type-based selector like .section and a element-based selector like .cta). This can happen often with paddings/margins between sections.
+
+Try to do a lot of this planning and iteration in your thinking, and only show ideas to the user when you have higher confidence it'll delight them.
+
+## Restraint and self-critique
+
+Spend your boldness in one place. Let the signature element be the one memorable thing, keep everything around it quiet and disciplined, and cut any decoration that does not serve the brief. Not taking a risk can be a risk itself! Build to a quality floor without announcing it: responsive down to mobile, visible keyboard focus, reduced motion respected. Critique your own work as you build, taking screenshots if your environment supports it – a picture is worth 1000 tokens. Consider Chanel's advice: before leaving the house, take a look in the mirror and remove one accessory. Human creators have memory and always try to do something new, so if you have a space to quickly jot down notes about what you've tried, it can help you in future passes.
+
+## More on writing in design
+
+Words appear in a design for one reason: to make it easier to understand, and therefore easier to use. They are design material, not decoration. Bring the same intentionality to copy that you would bring to spacing and color. Before writing anything, ask what the design needs to say, and how it can best be said to help the person navigate the experience.
+
+Write from the end user's side of the screen. Name things by what people control and recognize, never by how the system is built. A person manages notifications, not webhook config. Describe what something does in plain terms rather than selling it. Being specific is always better than being clever.
+
+Use active voice as default. A control should say exactly what happens when it's used: "Save changes," not "Submit." An action keeps the same name through the whole flow, so the button that says "Publish" produces a toast that says "Published." The vocabulary of an interface is the signposting for someone navigating the product. Cohesion and consistency are how people learn their way around.
+
+Treat failure and emptiness as moments for direction, not mood. Explain what went wrong and how to fix it, in the interface's voice rather than a person's. Errors don't apologize, and they are never vague about what happened. An empty screen is an invitation to act.
+
+Keep the register conversational and tuned: plain verbs, sentence case, no filler, with tone matched to the brand and the audience. Let each element do exactly one job. A label labels, an example demonstrates, and nothing quietly does double duty.

--- a/catalog/skills/items/webapp-testing/LICENSE.txt
+++ b/catalog/skills/items/webapp-testing/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Anthropic, PBC.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/catalog/skills/items/webapp-testing/SKILL.md
+++ b/catalog/skills/items/webapp-testing/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: webapp-testing
+description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
+license: Complete terms in LICENSE.txt
+---
+
+# Web Application Testing
+
+To test local web applications, write native Python Playwright scripts.
+
+**Helper Scripts Available**:
+- `scripts/with_server.py` - Manages server lifecycle (supports multiple servers)
+
+**Always run scripts with `--help` first** to see usage. DO NOT read the source until you try running the script first and find that a customized solution is abslutely necessary. These scripts can be very large and thus pollute your context window. They exist to be called directly as black-box scripts rather than ingested into your context window.
+
+## Decision Tree: Choosing Your Approach
+
+```
+User task → Is it static HTML?
+    ├─ Yes → Read HTML file directly to identify selectors
+    │         ├─ Success → Write Playwright script using selectors
+    │         └─ Fails/Incomplete → Treat as dynamic (below)
+    │
+    └─ No (dynamic webapp) → Is the server already running?
+        ├─ No → Run: python scripts/with_server.py --help
+        │        Then use the helper + write simplified Playwright script
+        │
+        └─ Yes → Reconnaissance-then-action:
+            1. Navigate and wait for networkidle
+            2. Take screenshot or inspect DOM
+            3. Identify selectors from rendered state
+            4. Execute actions with discovered selectors
+```
+
+## Example: Using with_server.py
+
+To start a server, run `--help` first, then use the helper:
+
+**Single server:**
+```bash
+python scripts/with_server.py --server "npm run dev" --port 5173 -- python your_automation.py
+```
+
+**Multiple servers (e.g., backend + frontend):**
+```bash
+python scripts/with_server.py \
+  --server "cd backend && python server.py" --port 3000 \
+  --server "cd frontend && npm run dev" --port 5173 \
+  -- python your_automation.py
+```
+
+To create an automation script, include only Playwright logic (servers are managed automatically):
+```python
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True) # Always launch chromium in headless mode
+    page = browser.new_page()
+    page.goto('http://localhost:5173') # Server already running and ready
+    page.wait_for_load_state('networkidle') # CRITICAL: Wait for JS to execute
+    # ... your automation logic
+    browser.close()
+```
+
+## Reconnaissance-Then-Action Pattern
+
+1. **Inspect rendered DOM**:
+   ```python
+   page.screenshot(path='/tmp/inspect.png', full_page=True)
+   content = page.content()
+   page.locator('button').all()
+   ```
+
+2. **Identify selectors** from inspection results
+
+3. **Execute actions** using discovered selectors
+
+## Common Pitfall
+
+❌ **Don't** inspect the DOM before waiting for `networkidle` on dynamic apps
+✅ **Do** wait for `page.wait_for_load_state('networkidle')` before inspection
+
+## Best Practices
+
+- **Use bundled scripts as black boxes** - To accomplish a task, consider whether one of the scripts available in `scripts/` can help. These scripts handle common, complex workflows reliably without cluttering the context window. Use `--help` to see usage, then invoke directly.
+- Use `sync_playwright()` for synchronous scripts
+- Always close the browser when done
+- Use descriptive selectors: `text=`, `role=`, CSS selectors, or IDs
+- Add appropriate waits: `page.wait_for_selector()` or `page.wait_for_timeout()`
+
+## Reference Files
+
+- **examples/** - Examples showing common patterns:
+  - `element_discovery.py` - Discovering buttons, links, and inputs on a page
+  - `static_html_automation.py` - Using file:// URLs for local HTML
+  - `console_logging.py` - Capturing console logs during automation

--- a/catalog/skills/items/webapp-testing/examples/console_logging.py
+++ b/catalog/skills/items/webapp-testing/examples/console_logging.py
@@ -1,0 +1,35 @@
+from playwright.sync_api import sync_playwright
+
+# Example: Capturing console logs during browser automation
+
+url = 'http://localhost:5173'  # Replace with your URL
+
+console_logs = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page(viewport={'width': 1920, 'height': 1080})
+
+    # Set up console log capture
+    def handle_console_message(msg):
+        console_logs.append(f"[{msg.type}] {msg.text}")
+        print(f"Console: [{msg.type}] {msg.text}")
+
+    page.on("console", handle_console_message)
+
+    # Navigate to page
+    page.goto(url)
+    page.wait_for_load_state('networkidle')
+
+    # Interact with the page (triggers console logs)
+    page.click('text=Dashboard')
+    page.wait_for_timeout(1000)
+
+    browser.close()
+
+# Save console logs to file
+with open('/mnt/user-data/outputs/console.log', 'w') as f:
+    f.write('\n'.join(console_logs))
+
+print(f"\nCaptured {len(console_logs)} console messages")
+print(f"Logs saved to: /mnt/user-data/outputs/console.log")

--- a/catalog/skills/items/webapp-testing/examples/element_discovery.py
+++ b/catalog/skills/items/webapp-testing/examples/element_discovery.py
@@ -1,0 +1,40 @@
+from playwright.sync_api import sync_playwright
+
+# Example: Discovering buttons and other elements on a page
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page()
+
+    # Navigate to page and wait for it to fully load
+    page.goto('http://localhost:5173')
+    page.wait_for_load_state('networkidle')
+
+    # Discover all buttons on the page
+    buttons = page.locator('button').all()
+    print(f"Found {len(buttons)} buttons:")
+    for i, button in enumerate(buttons):
+        text = button.inner_text() if button.is_visible() else "[hidden]"
+        print(f"  [{i}] {text}")
+
+    # Discover links
+    links = page.locator('a[href]').all()
+    print(f"\nFound {len(links)} links:")
+    for link in links[:5]:  # Show first 5
+        text = link.inner_text().strip()
+        href = link.get_attribute('href')
+        print(f"  - {text} -> {href}")
+
+    # Discover input fields
+    inputs = page.locator('input, textarea, select').all()
+    print(f"\nFound {len(inputs)} input fields:")
+    for input_elem in inputs:
+        name = input_elem.get_attribute('name') or input_elem.get_attribute('id') or "[unnamed]"
+        input_type = input_elem.get_attribute('type') or 'text'
+        print(f"  - {name} ({input_type})")
+
+    # Take screenshot for visual reference
+    page.screenshot(path='/tmp/page_discovery.png', full_page=True)
+    print("\nScreenshot saved to /tmp/page_discovery.png")
+
+    browser.close()

--- a/catalog/skills/items/webapp-testing/examples/static_html_automation.py
+++ b/catalog/skills/items/webapp-testing/examples/static_html_automation.py
@@ -1,0 +1,33 @@
+from playwright.sync_api import sync_playwright
+import os
+
+# Example: Automating interaction with static HTML files using file:// URLs
+
+html_file_path = os.path.abspath('path/to/your/file.html')
+file_url = f'file://{html_file_path}'
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page(viewport={'width': 1920, 'height': 1080})
+
+    # Navigate to local HTML file
+    page.goto(file_url)
+
+    # Take screenshot
+    page.screenshot(path='/mnt/user-data/outputs/static_page.png', full_page=True)
+
+    # Interact with elements
+    page.click('text=Click Me')
+    page.fill('#name', 'John Doe')
+    page.fill('#email', 'john@example.com')
+
+    # Submit form
+    page.click('button[type="submit"]')
+    page.wait_for_timeout(500)
+
+    # Take final screenshot
+    page.screenshot(path='/mnt/user-data/outputs/after_submit.png', full_page=True)
+
+    browser.close()
+
+print("Static HTML automation completed!")

--- a/catalog/skills/items/webapp-testing/scripts/with_server.py
+++ b/catalog/skills/items/webapp-testing/scripts/with_server.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Start one or more servers, wait for them to be ready, run a command, then clean up.
+
+Usage:
+    # Single server
+    python scripts/with_server.py --server "npm run dev" --port 5173 -- python automation.py
+    python scripts/with_server.py --server "npm start" --port 3000 -- python test.py
+
+    # Multiple servers
+    python scripts/with_server.py \
+      --server "cd backend && python server.py" --port 3000 \
+      --server "cd frontend && npm run dev" --port 5173 \
+      -- python test.py
+"""
+
+import subprocess
+import socket
+import time
+import sys
+import argparse
+
+def is_server_ready(port, timeout=30):
+    """Wait for server to be ready by polling the port."""
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            with socket.create_connection(('localhost', port), timeout=1):
+                return True
+        except (socket.error, ConnectionRefusedError):
+            time.sleep(0.5)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run command with one or more servers')
+    parser.add_argument('--server', action='append', dest='servers', required=True, help='Server command (can be repeated)')
+    parser.add_argument('--port', action='append', dest='ports', type=int, required=True, help='Port for each server (must match --server count)')
+    parser.add_argument('--timeout', type=int, default=30, help='Timeout in seconds per server (default: 30)')
+    parser.add_argument('command', nargs=argparse.REMAINDER, help='Command to run after server(s) ready')
+
+    args = parser.parse_args()
+
+    # Remove the '--' separator if present
+    if args.command and args.command[0] == '--':
+        args.command = args.command[1:]
+
+    if not args.command:
+        print("Error: No command specified to run")
+        sys.exit(1)
+
+    # Parse server configurations
+    if len(args.servers) != len(args.ports):
+        print("Error: Number of --server and --port arguments must match")
+        sys.exit(1)
+
+    servers = []
+    for cmd, port in zip(args.servers, args.ports):
+        servers.append({'cmd': cmd, 'port': port})
+
+    server_processes = []
+
+    try:
+        # Start all servers
+        for i, server in enumerate(servers):
+            print(f"Starting server {i+1}/{len(servers)}: {server['cmd']}")
+
+            # Use shell=True to support commands with cd and &&
+            process = subprocess.Popen(
+                server['cmd'],
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+            server_processes.append(process)
+
+            # Wait for this server to be ready
+            print(f"Waiting for server on port {server['port']}...")
+            if not is_server_ready(server['port'], timeout=args.timeout):
+                raise RuntimeError(f"Server failed to start on port {server['port']} within {args.timeout}s")
+
+            print(f"Server ready on port {server['port']}")
+
+        print(f"\nAll {len(servers)} server(s) ready")
+
+        # Run the command
+        print(f"Running: {' '.join(args.command)}\n")
+        result = subprocess.run(args.command)
+        sys.exit(result.returncode)
+
+    finally:
+        # Clean up all servers
+        print(f"\nStopping {len(server_processes)} server(s)...")
+        for i, process in enumerate(server_processes):
+            try:
+                process.terminate()
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+            print(f"Server {i+1} stopped")
+        print("All servers stopped")
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -106,6 +106,31 @@ definitions:
       public_url:
         type: string
     type: object
+  canonical.SkillFile:
+    properties:
+      content:
+        description: Content is the file body as UTF-8 text. Binary blobs are still
+          stored as text.
+        type: string
+      kind:
+        allOf:
+        - $ref: '#/definitions/canonical.SkillFileKind'
+        description: Kind is informational; not load-bearing for validation.
+      path:
+        description: Path is relative to the skill root, forward slashes, never absolute
+          or containing "..".
+        type: string
+    type: object
+  canonical.SkillFileKind:
+    enum:
+    - markdown
+    - script
+    - asset
+    type: string
+    x-enum-varnames:
+    - SkillFileKindMarkdown
+    - SkillFileKindScript
+    - SkillFileKindAsset
   connector.PermissionDecision:
     properties:
       approved:
@@ -1297,6 +1322,81 @@ definitions:
         type: string
       workspace_id:
         type: string
+    type: object
+  skillcatalog.Publisher:
+    properties:
+      name:
+        type: string
+      url:
+        type: string
+    type: object
+  skilldirectory.errorResponse:
+    properties:
+      error:
+        type: string
+    type: object
+  skilldirectory.importResponse:
+    properties:
+      capability_id:
+        type: string
+      installed:
+        type: boolean
+    type: object
+  skilldirectory.itemResponse:
+    properties:
+      categories:
+        items:
+          type: string
+        type: array
+      description:
+        type: string
+      featured_rank:
+        type: integer
+      files:
+        items:
+          $ref: '#/definitions/canonical.SkillFile'
+        type: array
+      homepage_url:
+        type: string
+      icon_url:
+        type: string
+      id:
+        type: string
+      installed:
+        type: boolean
+      installed_capability_id:
+        type: string
+      instruction:
+        type: string
+      license:
+        type: string
+      name:
+        type: string
+      publisher:
+        $ref: '#/definitions/skillcatalog.Publisher'
+      repository_url:
+        type: string
+      slug:
+        type: string
+      source_path:
+        type: string
+      source_ref:
+        type: string
+      title:
+        type: string
+      trigger:
+        type: string
+      verified:
+        type: boolean
+      version:
+        type: string
+    type: object
+  skilldirectory.listResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/skilldirectory.itemResponse'
+        type: array
     type: object
   specmem.createFragmentRequest:
     properties:
@@ -8399,6 +8499,128 @@ paths:
       summary: Update workspace settings
       tags:
       - workspaces
+  /api/v1/workspaces/{workspaceID}/skill-directory:
+    get:
+      parameters:
+      - description: workspace id
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/skilldirectory.listResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+      summary: List Skill Directory items
+      tags:
+      - skill-directory
+  /api/v1/workspaces/{workspaceID}/skill-directory/{catalogID}:
+    get:
+      parameters:
+      - description: workspace id
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: skill catalog item id
+        in: path
+        name: catalogID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/skilldirectory.itemResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+      summary: Get a Skill Directory item
+      tags:
+      - skill-directory
+  /api/v1/workspaces/{workspaceID}/skill-directory/{catalogID}/import:
+    post:
+      description: Stores the reviewed Skill package as a private workspace Skill
+        capability. The package is not executed or bound to an Agent.
+      parameters:
+      - description: workspace id
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: skill catalog item id
+        in: path
+        name: catalogID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: already installed
+          schema:
+            $ref: '#/definitions/skilldirectory.importResponse'
+        "201":
+          description: imported
+          schema:
+            $ref: '#/definitions/skilldirectory.importResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/skilldirectory.errorResponse'
+      summary: Import a Skill Directory item
+      tags:
+      - skill-directory
   /api/v1/workspaces/{workspaceID}/spec/fragments:
     get:
       description: Returns spec fragments visible to the workspace. Optional source/tag

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -42,6 +42,7 @@ import (
 	imhistoryapi "github.com/MiniMax-AI-Dev/parsar/server/internal/api/imhistoryapi"
 	mcpdirectoryapi "github.com/MiniMax-AI-Dev/parsar/server/internal/api/mcpdirectory"
 	runtimeapi "github.com/MiniMax-AI-Dev/parsar/server/internal/api/runtime"
+	skilldirectoryapi "github.com/MiniMax-AI-Dev/parsar/server/internal/api/skilldirectory"
 	specmemapi "github.com/MiniMax-AI-Dev/parsar/server/internal/api/specmem"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/audit"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
@@ -75,6 +76,7 @@ import (
 	runtimesweeper "github.com/MiniMax-AI-Dev/parsar/server/internal/runtime/sweeper"
 	e2bsandbox "github.com/MiniMax-AI-Dev/parsar/server/internal/sandbox/e2b"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/skillcatalog"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/specmemory"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/storage/blob"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/storage/oss"
@@ -708,6 +710,7 @@ func main() {
 			SharedRuntimeToken: strings.TrimSpace(envLookup("PARSAR_SHARED_RUNTIME_TOKEN")),
 		}
 		mcpCatalog := mcpcatalog.New(mcpcatalog.Options{})
+		skillCatalog := skillcatalog.New(skillcatalog.Options{})
 		mcpOAuthSecrets, mcpOAuthSecretsErr := secrets.New(cfg.Secret.MasterKey)
 		if mcpOAuthSecretsErr != nil {
 			log.Bg().Warn("MCP connector OAuth disabled", "error", mcpOAuthSecretsErr)
@@ -728,6 +731,11 @@ func main() {
 				Secrets:              mcpOAuthSecrets,
 				PublicURL:            publicURL,
 				CookieSecure:         cfg.Auth.Cookie.Secure,
+			})
+			skilldirectoryapi.RegisterRoutes(r, skilldirectoryapi.Deps{
+				Catalog: skillCatalog,
+				Store:   dbStore,
+				Blobs:   blobStore,
 			})
 			runtimeapi.RegisterAdminRoutes(r, runtimeDeps)
 		})

--- a/server/internal/api/mcpdirectory/handler.go
+++ b/server/internal/api/mcpdirectory/handler.go
@@ -27,7 +27,7 @@ type catalogLoader interface {
 
 type directoryStore interface {
 	auth.RoleStore
-	ListMCPDirectoryInstalls(ctx context.Context, workspaceID string) ([]store.MCPDirectoryInstall, error)
+	ListCapabilityDirectoryInstalls(ctx context.Context, workspaceID, capabilityType, sourceFormat string) ([]store.CapabilityDirectoryInstall, error)
 	ImportCapability(ctx context.Context, input store.ImportCapabilityInput) (store.ImportCapabilityResult, error)
 }
 
@@ -89,6 +89,11 @@ type sourcePayload struct {
 	CatalogID      string `json:"catalog_id"`
 	CatalogVersion string `json:"catalog_version"`
 }
+
+const (
+	directoryCapabilityType = "mcp"
+	directorySourceFormat   = "mcp_catalog"
+)
 
 func RegisterRoutes(r chi.Router, deps Deps) {
 	h := &handler{deps: deps}
@@ -234,7 +239,7 @@ func (h *handler) importItem(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, store.ErrCapabilityNameTaken) {
 			// A concurrent identical import can lose the capability name race.
 			// Re-read provenance before reporting a real name conflict.
-			if current, listErr := h.deps.Store.ListMCPDirectoryInstalls(r.Context(), workspaceID); listErr == nil {
+			if current, listErr := h.deps.Store.ListCapabilityDirectoryInstalls(r.Context(), workspaceID, directoryCapabilityType, directorySourceFormat); listErr == nil {
 				if existing, installed := installMap(current)[item.ID]; installed {
 					writeJSON(w, http.StatusOK, importResponse{Installed: true, CapabilityID: existing.CapabilityID})
 					return
@@ -280,13 +285,13 @@ func (h *handler) authorizeRoles(w http.ResponseWriter, r *http.Request, allowed
 	return workspaceID, true
 }
 
-func (h *handler) load(w http.ResponseWriter, r *http.Request, workspaceID string) (mcpcatalog.Catalog, []store.MCPDirectoryInstall, bool) {
+func (h *handler) load(w http.ResponseWriter, r *http.Request, workspaceID string) (mcpcatalog.Catalog, []store.CapabilityDirectoryInstall, bool) {
 	catalog, err := h.deps.Catalog.Load()
 	if err != nil {
 		writeError(w, http.StatusServiceUnavailable, "mcp_catalog_unavailable")
 		return mcpcatalog.Catalog{}, nil, false
 	}
-	installs, err := h.deps.Store.ListMCPDirectoryInstalls(r.Context(), workspaceID)
+	installs, err := h.deps.Store.ListCapabilityDirectoryInstalls(r.Context(), workspaceID, directoryCapabilityType, directorySourceFormat)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "directory_install_state_failed")
 		return mcpcatalog.Catalog{}, nil, false
@@ -294,15 +299,15 @@ func (h *handler) load(w http.ResponseWriter, r *http.Request, workspaceID strin
 	return catalog, installs, true
 }
 
-func installMap(installs []store.MCPDirectoryInstall) map[string]store.MCPDirectoryInstall {
-	result := make(map[string]store.MCPDirectoryInstall, len(installs))
+func installMap(installs []store.CapabilityDirectoryInstall) map[string]store.CapabilityDirectoryInstall {
+	result := make(map[string]store.CapabilityDirectoryInstall, len(installs))
 	for _, install := range installs {
 		result[install.CatalogID] = install
 	}
 	return result
 }
 
-func summarizeItem(item mcpcatalog.Item, install store.MCPDirectoryInstall, connected bool) itemResponse {
+func summarizeItem(item mcpcatalog.Item, install store.CapabilityDirectoryInstall, connected bool) itemResponse {
 	var installedCapabilityID *string
 	if install.CapabilityID != "" {
 		id := install.CapabilityID

--- a/server/internal/api/mcpdirectory/handler_test.go
+++ b/server/internal/api/mcpdirectory/handler_test.go
@@ -31,7 +31,7 @@ func (f fakeCatalog) Load() (mcpcatalog.Catalog, error) { return f.catalog, f.er
 type fakeDirectoryStore struct {
 	role              string
 	roleErr           error
-	installs          []store.MCPDirectoryInstall
+	installs          []store.CapabilityDirectoryInstall
 	listErr           error
 	importErr         error
 	concurrentInstall bool
@@ -61,19 +61,19 @@ func (f *fakeDirectoryStore) GetWorkspaceMemberRole(context.Context, string, str
 	return f.role, nil
 }
 
-func (f *fakeDirectoryStore) ListMCPDirectoryInstalls(context.Context, string) ([]store.MCPDirectoryInstall, error) {
-	return append([]store.MCPDirectoryInstall(nil), f.installs...), f.listErr
+func (f *fakeDirectoryStore) ListCapabilityDirectoryInstalls(context.Context, string, string, string) ([]store.CapabilityDirectoryInstall, error) {
+	return append([]store.CapabilityDirectoryInstall(nil), f.installs...), f.listErr
 }
 
 func (f *fakeDirectoryStore) ImportCapability(_ context.Context, input store.ImportCapabilityInput) (store.ImportCapabilityResult, error) {
 	f.imported = &input
 	if f.importErr != nil {
 		if f.concurrentInstall {
-			f.installs = append(f.installs, store.MCPDirectoryInstall{CatalogID: "context7", CapabilityID: testCapabilityID})
+			f.installs = append(f.installs, store.CapabilityDirectoryInstall{CatalogID: "context7", CapabilityID: testCapabilityID})
 		}
 		return store.ImportCapabilityResult{}, f.importErr
 	}
-	f.installs = append(f.installs, store.MCPDirectoryInstall{CatalogID: "context7", CapabilityID: testCapabilityID})
+	f.installs = append(f.installs, store.CapabilityDirectoryInstall{CatalogID: "context7", CapabilityID: testCapabilityID})
 	return store.ImportCapabilityResult{Capability: store.CapabilityRead{ID: testCapabilityID, Name: input.Name, Type: input.Type}}, nil
 }
 
@@ -128,7 +128,7 @@ func TestDirectoryImportUsesServerCatalogAndCreatesNoSecretsOrBindings(t *testin
 }
 
 func TestDirectoryImportIsIdempotent(t *testing.T) {
-	fs := &fakeDirectoryStore{role: "admin", installs: []store.MCPDirectoryInstall{{CatalogID: "context7", CapabilityID: testCapabilityID}}}
+	fs := &fakeDirectoryStore{role: "admin", installs: []store.CapabilityDirectoryInstall{{CatalogID: "context7", CapabilityID: testCapabilityID}}}
 	rec := request(t, fs, http.MethodPost, "/api/v1/workspaces/"+testWorkspaceID+"/mcp-directory/context7/import")
 	if rec.Code != http.StatusOK || fs.imported != nil {
 		t.Fatalf("status=%d imported=%v body=%s", rec.Code, fs.imported != nil, rec.Body.String())

--- a/server/internal/api/skilldirectory/handler.go
+++ b/server/internal/api/skilldirectory/handler.go
@@ -1,0 +1,353 @@
+// Package skilldirectory exposes the reviewed, repository-backed Skill
+// Directory. Directory entries are imported as ordinary workspace Skill
+// capabilities; this package does not create a second capability model.
+package skilldirectory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/skillcatalog"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/storage/blob"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+type catalogLoader interface {
+	Load() (skillcatalog.Catalog, error)
+	LoadItem(id string) (skillcatalog.Item, skillcatalog.Package, error)
+}
+
+type directoryStore interface {
+	auth.RoleStore
+	ListCapabilityDirectoryInstalls(ctx context.Context, workspaceID, capabilityType, sourceFormat string) ([]store.CapabilityDirectoryInstall, error)
+	ImportCapability(ctx context.Context, input store.ImportCapabilityInput) (store.ImportCapabilityResult, error)
+}
+
+type itemResponse struct {
+	ID                    string                 `json:"id"`
+	Name                  string                 `json:"name"`
+	Description           string                 `json:"description"`
+	Publisher             skillcatalog.Publisher `json:"publisher"`
+	IconURL               string                 `json:"icon_url,omitempty"`
+	HomepageURL           string                 `json:"homepage_url,omitempty"`
+	RepositoryURL         string                 `json:"repository_url,omitempty"`
+	Verified              bool                   `json:"verified"`
+	Categories            []string               `json:"categories"`
+	FeaturedRank          int                    `json:"featured_rank"`
+	Version               string                 `json:"version"`
+	License               string                 `json:"license"`
+	SourceRef             string                 `json:"source_ref,omitempty"`
+	SourcePath            string                 `json:"source_path,omitempty"`
+	Slug                  string                 `json:"slug,omitempty"`
+	Title                 string                 `json:"title,omitempty"`
+	Instruction           string                 `json:"instruction,omitempty"`
+	Trigger               string                 `json:"trigger,omitempty"`
+	Files                 []canonical.SkillFile  `json:"files,omitempty"`
+	Installed             bool                   `json:"installed"`
+	InstalledCapabilityID *string                `json:"installed_capability_id"`
+}
+
+type listResponse struct {
+	Items []itemResponse `json:"items"`
+}
+
+type importResponse struct {
+	Installed    bool   `json:"installed"`
+	CapabilityID string `json:"capability_id"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+type sourcePayload struct {
+	SourceFormat   string `json:"source_format"`
+	CatalogID      string `json:"catalog_id"`
+	CatalogVersion string `json:"catalog_version"`
+}
+
+const (
+	sourceFormat   = "skill_catalog"
+	capabilityType = "skill"
+)
+
+type Deps struct {
+	Catalog catalogLoader
+	Store   directoryStore
+	Blobs   blob.Store
+}
+
+type handler struct {
+	deps Deps
+}
+
+func RegisterRoutes(r chi.Router, deps Deps) {
+	h := &handler{deps: deps}
+	r.Get("/api/v1/workspaces/{workspaceID}/skill-directory", h.list)
+	r.Get("/api/v1/workspaces/{workspaceID}/skill-directory/{catalogID}", h.get)
+	r.Post("/api/v1/workspaces/{workspaceID}/skill-directory/{catalogID}/import", h.importItem)
+}
+
+// list godoc
+//
+//	@Summary	List Skill Directory items
+//	@Tags		skill-directory
+//	@Produce	json
+//	@Param		workspaceID path string true "workspace id"
+//	@Success	200 {object} listResponse
+//	@Failure	400 {object} errorResponse
+//	@Failure	401 {object} errorResponse
+//	@Failure	403 {object} errorResponse
+//	@Failure	503 {object} errorResponse
+//	@Router		/api/v1/workspaces/{workspaceID}/skill-directory [get]
+func (h *handler) list(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := h.authorize(w, r, "owner", "admin", "member", "viewer")
+	if !ok {
+		return
+	}
+	catalog, installs, ok := h.load(w, r, workspaceID)
+	if !ok {
+		return
+	}
+	byCatalog := installMap(installs)
+	items := make([]itemResponse, 0, len(catalog.Items))
+	for _, item := range catalog.Items {
+		items = append(items, summarizeItem(item, byCatalog[item.ID]))
+	}
+	writeJSON(w, http.StatusOK, listResponse{Items: items})
+}
+
+// get godoc
+//
+//	@Summary	Get a Skill Directory item
+//	@Tags		skill-directory
+//	@Produce	json
+//	@Param		workspaceID path string true "workspace id"
+//	@Param		catalogID path string true "skill catalog item id"
+//	@Success	200 {object} itemResponse
+//	@Failure	400 {object} errorResponse
+//	@Failure	403 {object} errorResponse
+//	@Failure	404 {object} errorResponse
+//	@Failure	503 {object} errorResponse
+//	@Router		/api/v1/workspaces/{workspaceID}/skill-directory/{catalogID} [get]
+func (h *handler) get(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := h.authorize(w, r, "owner", "admin", "member", "viewer")
+	if !ok {
+		return
+	}
+	installs, ok := h.loadInstalls(w, r, workspaceID)
+	if !ok {
+		return
+	}
+	item, pkg, err := h.loadItem(chi.URLParam(r, "catalogID"))
+	if err != nil {
+		h.writeCatalogError(w, err)
+		return
+	}
+	response := summarizeItem(item, installMap(installs)[item.ID])
+	if pkg.Spec.Skill != nil {
+		response.Slug = pkg.Spec.Skill.Slug
+		response.Title = pkg.Spec.Skill.Title
+		response.Instruction = pkg.Spec.Skill.Instruction
+		response.Trigger = pkg.Spec.Skill.Trigger
+		response.Files = append([]canonical.SkillFile(nil), pkg.Spec.Skill.Files...)
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// importItem godoc
+//
+//	@Summary	Import a Skill Directory item
+//	@Description	Stores the reviewed Skill package as a private workspace Skill capability. The package is not executed or bound to an Agent.
+//	@Tags		skill-directory
+//	@Produce	json
+//	@Param		workspaceID path string true "workspace id"
+//	@Param		catalogID path string true "skill catalog item id"
+//	@Success	200 {object} importResponse "already installed"
+//	@Success	201 {object} importResponse "imported"
+//	@Failure	400 {object} errorResponse
+//	@Failure	403 {object} errorResponse
+//	@Failure	404 {object} errorResponse
+//	@Failure	409 {object} errorResponse
+//	@Failure	503 {object} errorResponse
+//	@Router		/api/v1/workspaces/{workspaceID}/skill-directory/{catalogID}/import [post]
+func (h *handler) importItem(w http.ResponseWriter, r *http.Request) {
+	workspaceID, ok := h.authorize(w, r, "owner", "admin", "member")
+	if !ok {
+		return
+	}
+	installs, ok := h.loadInstalls(w, r, workspaceID)
+	if !ok {
+		return
+	}
+	catalogID := chi.URLParam(r, "catalogID")
+	item, pkg, err := h.loadItem(catalogID)
+	if err != nil {
+		h.writeCatalogError(w, err)
+		return
+	}
+	if existing, installed := installMap(installs)[catalogID]; installed {
+		writeJSON(w, http.StatusOK, importResponse{Installed: true, CapabilityID: existing.CapabilityID})
+		return
+	}
+	if h.deps.Blobs == nil {
+		writeError(w, http.StatusServiceUnavailable, "skill_directory_storage_unavailable")
+		return
+	}
+	ref, err := h.deps.Blobs.NewRef("skill", workspaceID, item.ID+".zip")
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "skill_package_reference_failed")
+		return
+	}
+	if err := h.deps.Blobs.PutBytes(r.Context(), ref, workspaceID, pkg.Zip); err != nil {
+		writeError(w, http.StatusInternalServerError, "skill_package_storage_failed")
+		return
+	}
+	payload, err := json.Marshal(sourcePayload{
+		SourceFormat:   sourceFormat,
+		CatalogID:      item.ID,
+		CatalogVersion: item.Version,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "skill_catalog_provenance_failed")
+		return
+	}
+	result, err := h.deps.Store.ImportCapability(r.Context(), store.ImportCapabilityInput{
+		WorkspaceID:   workspaceID,
+		Name:          item.Name,
+		Description:   item.Description,
+		Visibility:    "workspace",
+		Type:          capabilityType,
+		CreatorID:     auth.UserIDFromContext(r.Context()),
+		Version:       item.Version,
+		SourcePayload: payload,
+		Spec:          pkg.Spec,
+		OssKey:        ref,
+		SHA256:        pkg.SHA256,
+	})
+	if err != nil {
+		if errors.Is(err, store.ErrCapabilityNameTaken) {
+			if current, listErr := h.deps.Store.ListCapabilityDirectoryInstalls(r.Context(), workspaceID, capabilityType, sourceFormat); listErr == nil {
+				if existing, installed := installMap(current)[item.ID]; installed {
+					writeJSON(w, http.StatusOK, importResponse{Installed: true, CapabilityID: existing.CapabilityID})
+					return
+				}
+			}
+			writeError(w, http.StatusConflict, "capability_name_conflict")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "skill_import_failed")
+		return
+	}
+	writeJSON(w, http.StatusCreated, importResponse{Installed: true, CapabilityID: result.Capability.ID})
+}
+
+func (h *handler) authorize(w http.ResponseWriter, r *http.Request, allowed ...string) (string, bool) {
+	if h.deps.Catalog == nil || h.deps.Store == nil {
+		writeError(w, http.StatusServiceUnavailable, "skill_directory_unavailable")
+		return "", false
+	}
+	workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
+	if _, err := uuid.Parse(workspaceID); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_workspace_id")
+		return "", false
+	}
+	if err := auth.RequireWorkspaceRole(r.Context(), h.deps.Store, workspaceID, allowed...); err != nil {
+		switch {
+		case errors.Is(err, auth.ErrUnauthenticated):
+			writeError(w, http.StatusUnauthorized, "unauthenticated")
+		case errors.Is(err, auth.ErrForbidden), errors.Is(err, auth.ErrNotMember):
+			writeError(w, http.StatusForbidden, "forbidden")
+		default:
+			writeError(w, http.StatusInternalServerError, "workspace_authorization_failed")
+		}
+		return "", false
+	}
+	return workspaceID, true
+}
+
+func (h *handler) load(w http.ResponseWriter, r *http.Request, workspaceID string) (skillcatalog.Catalog, []store.CapabilityDirectoryInstall, bool) {
+	catalog, err := h.deps.Catalog.Load()
+	if err != nil {
+		writeError(w, http.StatusServiceUnavailable, "skill_catalog_unavailable")
+		return skillcatalog.Catalog{}, nil, false
+	}
+	installs, ok := h.loadInstalls(w, r, workspaceID)
+	if !ok {
+		return skillcatalog.Catalog{}, nil, false
+	}
+	return catalog, installs, true
+}
+
+func (h *handler) loadInstalls(w http.ResponseWriter, r *http.Request, workspaceID string) ([]store.CapabilityDirectoryInstall, bool) {
+	installs, err := h.deps.Store.ListCapabilityDirectoryInstalls(r.Context(), workspaceID, capabilityType, sourceFormat)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "skill_directory_install_state_failed")
+		return nil, false
+	}
+	return installs, true
+}
+
+func (h *handler) loadItem(id string) (skillcatalog.Item, skillcatalog.Package, error) {
+	return h.deps.Catalog.LoadItem(strings.TrimSpace(id))
+}
+
+func (h *handler) writeCatalogError(w http.ResponseWriter, err error) {
+	if errors.Is(err, skillcatalog.ErrItemNotFound) {
+		writeError(w, http.StatusNotFound, "skill_not_found")
+		return
+	}
+	writeError(w, http.StatusServiceUnavailable, "skill_catalog_item_unavailable")
+}
+
+func installMap(installs []store.CapabilityDirectoryInstall) map[string]store.CapabilityDirectoryInstall {
+	result := make(map[string]store.CapabilityDirectoryInstall, len(installs))
+	for _, install := range installs {
+		result[install.CatalogID] = install
+	}
+	return result
+}
+
+func summarizeItem(item skillcatalog.Item, install store.CapabilityDirectoryInstall) itemResponse {
+	var installedCapabilityID *string
+	if install.CapabilityID != "" {
+		id := install.CapabilityID
+		installedCapabilityID = &id
+	}
+	return itemResponse{
+		ID:                    item.ID,
+		Name:                  item.Name,
+		Description:           item.Description,
+		Publisher:             item.Publisher,
+		IconURL:               item.IconURL,
+		HomepageURL:           item.HomepageURL,
+		RepositoryURL:         item.RepositoryURL,
+		Verified:              item.Verified,
+		Categories:            append([]string(nil), item.Categories...),
+		FeaturedRank:          item.FeaturedRank,
+		Version:               item.Version,
+		License:               item.License,
+		SourceRef:             item.SourceRef,
+		SourcePath:            item.SourcePath,
+		Installed:             install.CapabilityID != "",
+		InstalledCapabilityID: installedCapabilityID,
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, code string) {
+	writeJSON(w, status, errorResponse{Error: code})
+}

--- a/server/internal/api/skilldirectory/handler_test.go
+++ b/server/internal/api/skilldirectory/handler_test.go
@@ -1,0 +1,210 @@
+package skilldirectory
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/skillcatalog"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/storage/blob"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+const (
+	testWorkspaceID  = "00000000-0000-0000-0000-000000000011"
+	testUserID       = "00000000-0000-0000-0000-000000000022"
+	testCapabilityID = "00000000-0000-0000-0000-000000000033"
+)
+
+type fakeCatalog struct {
+	catalog skillcatalog.Catalog
+	pkg     skillcatalog.Package
+	err     error
+}
+
+func (f fakeCatalog) Load() (skillcatalog.Catalog, error) { return f.catalog, f.err }
+
+func (f fakeCatalog) LoadItem(id string) (skillcatalog.Item, skillcatalog.Package, error) {
+	item, found := f.catalog.Find(id)
+	if !found {
+		return skillcatalog.Item{}, skillcatalog.Package{}, skillcatalog.ErrItemNotFound
+	}
+	return item, f.pkg, nil
+}
+
+type fakeDirectoryStore struct {
+	role      string
+	roleErr   error
+	installs  []store.CapabilityDirectoryInstall
+	listErr   error
+	importErr error
+	imported  *store.ImportCapabilityInput
+}
+
+func (f *fakeDirectoryStore) GetWorkspaceMemberRole(context.Context, string, string) (string, error) {
+	if f.roleErr != nil {
+		return "", f.roleErr
+	}
+	return f.role, nil
+}
+
+func (f *fakeDirectoryStore) ListCapabilityDirectoryInstalls(context.Context, string, string, string) ([]store.CapabilityDirectoryInstall, error) {
+	return append([]store.CapabilityDirectoryInstall(nil), f.installs...), f.listErr
+}
+
+func (f *fakeDirectoryStore) ImportCapability(_ context.Context, input store.ImportCapabilityInput) (store.ImportCapabilityResult, error) {
+	f.imported = &input
+	if f.importErr != nil {
+		return store.ImportCapabilityResult{}, f.importErr
+	}
+	f.installs = append(f.installs, store.CapabilityDirectoryInstall{CatalogID: "frontend-design", CapabilityID: testCapabilityID})
+	return store.ImportCapabilityResult{Capability: store.CapabilityRead{ID: testCapabilityID, Name: input.Name, Type: input.Type}}, nil
+}
+
+func TestDirectoryListAllowsMembersAndReportsInstallation(t *testing.T) {
+	fs := &fakeDirectoryStore{
+		role:     "member",
+		installs: []store.CapabilityDirectoryInstall{{CatalogID: "frontend-design", CapabilityID: testCapabilityID}},
+	}
+	rec := request(t, fs, http.MethodGet, "/api/v1/workspaces/"+testWorkspaceID+"/skill-directory")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var response listResponse
+	decodeResponse(t, rec, &response)
+	if len(response.Items) != 1 || !response.Items[0].Installed || response.Items[0].InstalledCapabilityID == nil || *response.Items[0].InstalledCapabilityID != testCapabilityID {
+		t.Fatalf("response=%+v", response)
+	}
+}
+
+func TestDirectoryImportRejectsViewer(t *testing.T) {
+	fs := &fakeDirectoryStore{role: "viewer"}
+	bs := blob.NewMemoryStore("http://test")
+	rec := requestWithDeps(t, fs, bs, http.MethodPost, "/api/v1/workspaces/"+testWorkspaceID+"/skill-directory/frontend-design/import")
+	if rec.Code != http.StatusForbidden || fs.imported != nil {
+		t.Fatalf("status=%d imported=%v body=%s", rec.Code, fs.imported != nil, rec.Body.String())
+	}
+}
+
+func TestDirectoryDetailReturnsCompleteSkillContent(t *testing.T) {
+	fs := &fakeDirectoryStore{role: "member"}
+	bs := blob.NewMemoryStore("http://test")
+	rec := requestWithDeps(t, fs, bs, http.MethodGet, "/api/v1/workspaces/"+testWorkspaceID+"/skill-directory/frontend-design")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var response itemResponse
+	decodeResponse(t, rec, &response)
+	if response.Slug != "frontend-design" || response.Instruction != "Use deliberate visual direction." || len(response.Files) != 1 || response.Files[0].Path != "references/patterns.md" {
+		t.Fatalf("response=%+v", response)
+	}
+}
+
+func TestDirectoryImportStoresZipAndReusesCapabilityImport(t *testing.T) {
+	fs := &fakeDirectoryStore{role: "member"}
+	bs := blob.NewMemoryStore("http://test")
+	rec := requestWithDeps(t, fs, bs, http.MethodPost, "/api/v1/workspaces/"+testWorkspaceID+"/skill-directory/frontend-design/import")
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if fs.imported == nil || fs.imported.Type != "skill" || fs.imported.Visibility != "workspace" || fs.imported.CreatorID != testUserID || len(fs.imported.InlineSecrets) != 0 {
+		t.Fatalf("import input=%+v", fs.imported)
+	}
+	if fs.imported.OssKey == "" || fs.imported.SHA256 == "" {
+		t.Fatalf("storage fields missing: %+v", fs.imported)
+	}
+	stored, err := bs.Download(context.Background(), fs.imported.OssKey)
+	if err != nil {
+		t.Fatalf("download stored package: %v", err)
+	}
+	if string(stored) != "skill-zip" {
+		t.Fatalf("stored zip=%q", stored)
+	}
+	var source sourcePayload
+	if err := json.Unmarshal(fs.imported.SourcePayload, &source); err != nil {
+		t.Fatal(err)
+	}
+	if source.SourceFormat != sourceFormat || source.CatalogID != "frontend-design" || source.CatalogVersion != "1.0.0" {
+		t.Fatalf("source=%+v", source)
+	}
+
+	rec = requestWithDeps(t, fs, bs, http.MethodPost, "/api/v1/workspaces/"+testWorkspaceID+"/skill-directory/frontend-design/import")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("repeat status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDirectoryUnknownItemReturnsNotFound(t *testing.T) {
+	fs := &fakeDirectoryStore{role: "member"}
+	bs := blob.NewMemoryStore("http://test")
+	rec := requestWithDeps(t, fs, bs, http.MethodGet, "/api/v1/workspaces/"+testWorkspaceID+"/skill-directory/missing")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDirectoryImportUnknownItemReturnsNotFound(t *testing.T) {
+	fs := &fakeDirectoryStore{role: "member"}
+	bs := blob.NewMemoryStore("http://test")
+	rec := requestWithDeps(t, fs, bs, http.MethodPost, "/api/v1/workspaces/"+testWorkspaceID+"/skill-directory/missing/import")
+	if rec.Code != http.StatusNotFound || fs.imported != nil {
+		t.Fatalf("status=%d imported=%v body=%s", rec.Code, fs.imported != nil, rec.Body.String())
+	}
+}
+
+func request(t *testing.T, fs *fakeDirectoryStore, method, path string) *httptest.ResponseRecorder {
+	return requestWithDeps(t, fs, blob.NewMemoryStore("http://test"), method, path)
+}
+
+func requestWithDeps(t *testing.T, fs *fakeDirectoryStore, bs blob.Store, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	router := chi.NewRouter()
+	router.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r.WithContext(auth.WithUserID(r.Context(), testUserID)))
+		})
+	})
+	RegisterRoutes(router, Deps{Catalog: testCatalogLoader(), Store: fs, Blobs: bs})
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, httptest.NewRequest(method, path, nil))
+	return rec
+}
+
+func testCatalogLoader() fakeCatalog {
+	zipBytes := []byte("skill-zip")
+	sum := sha256.Sum256(zipBytes)
+	return fakeCatalog{
+		catalog: skillcatalog.Catalog{
+			SchemaVersion: 1,
+			UpdatedAt:     "2026-08-03T00:00:00Z",
+			Items: []skillcatalog.Item{{
+				ID: "frontend-design", Name: "Frontend Design", Description: "Design interfaces.",
+				Publisher: skillcatalog.Publisher{Name: "Anthropic", URL: "https://github.com/anthropics/skills"},
+				Verified:  true, Categories: []string{"Design"}, FeaturedRank: 1, Version: "1.0.0", License: "Apache-2.0",
+				SourceRef: "b29e7cf65e5cb78a5ac33d582270551bc74a14eb", SourcePath: "skills/frontend-design", ContentPath: "items/frontend-design",
+			}},
+		},
+		pkg: skillcatalog.Package{
+			Spec: canonical.Spec{SchemaVersion: canonical.SchemaVersionCurrent, Kind: canonical.KindSkill, Skill: &canonical.SkillSpec{
+				Slug: "frontend-design", Title: "Frontend Design", Instruction: "Use deliberate visual direction.",
+				Files: []canonical.SkillFile{{Path: "references/patterns.md", Content: "patterns", Kind: canonical.SkillFileKindMarkdown}},
+			}},
+			Zip: zipBytes, SHA256: hex.EncodeToString(sum[:]),
+		},
+	}
+}
+
+func decodeResponse(t *testing.T, rec *httptest.ResponseRecorder, target any) {
+	t.Helper()
+	if err := json.Unmarshal(rec.Body.Bytes(), target); err != nil {
+		t.Fatalf("decode response: %v; body=%s", err, rec.Body.String())
+	}
+}

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -3590,18 +3590,17 @@ where c.workspace_id = @workspace_id::uuid
   and c.deleted_at is null
 order by c.name asc, c.created_at desc;
 
--- name: ListMCPDirectoryInstalls :many
--- Catalog provenance lives on capability versions rather than the capability
--- row. Keep the newest matching provenance per catalog id.
+-- name: ListCapabilityDirectoryInstalls :many
+-- Shared provenance lookup for built-in MCP and Skill directories.
 select distinct on (cv.source_payload->>'catalog_id')
   coalesce(cv.source_payload->>'catalog_id', '')::text as catalog_id,
   c.id::text as capability_id
 from capability c
 join capability_version cv on cv.capability_id = c.id
 where c.workspace_id = @workspace_id::uuid
-  and c.type = 'mcp'
+  and c.type = @capability_type
   and c.deleted_at is null
-  and cv.source_payload->>'source_format' = 'mcp_catalog'
+  and cv.source_payload->>'source_format' = @source_format::text
   and coalesce(cv.source_payload->>'catalog_id', '') <> ''
 order by cv.source_payload->>'catalog_id', cv.created_at desc, cv.id desc;
 

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -7737,6 +7737,52 @@ func (q *Queries) ListCapabilityCredentialMissingForRun(ctx context.Context, arg
 	return items, nil
 }
 
+const listCapabilityDirectoryInstalls = `-- name: ListCapabilityDirectoryInstalls :many
+select distinct on (cv.source_payload->>'catalog_id')
+  coalesce(cv.source_payload->>'catalog_id', '')::text as catalog_id,
+  c.id::text as capability_id
+from capability c
+join capability_version cv on cv.capability_id = c.id
+where c.workspace_id = $1::uuid
+  and c.type = $2
+  and c.deleted_at is null
+  and cv.source_payload->>'source_format' = $3::text
+  and coalesce(cv.source_payload->>'catalog_id', '') <> ''
+order by cv.source_payload->>'catalog_id', cv.created_at desc, cv.id desc
+`
+
+type ListCapabilityDirectoryInstallsParams struct {
+	WorkspaceID    pgtype.UUID `json:"workspace_id"`
+	CapabilityType string      `json:"capability_type"`
+	SourceFormat   string      `json:"source_format"`
+}
+
+type ListCapabilityDirectoryInstallsRow struct {
+	CatalogID    string `json:"catalog_id"`
+	CapabilityID string `json:"capability_id"`
+}
+
+// Shared provenance lookup for built-in MCP and Skill directories.
+func (q *Queries) ListCapabilityDirectoryInstalls(ctx context.Context, arg ListCapabilityDirectoryInstallsParams) ([]ListCapabilityDirectoryInstallsRow, error) {
+	rows, err := q.db.Query(ctx, listCapabilityDirectoryInstalls, arg.WorkspaceID, arg.CapabilityType, arg.SourceFormat)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListCapabilityDirectoryInstallsRow{}
+	for rows.Next() {
+		var i ListCapabilityDirectoryInstallsRow
+		if err := rows.Scan(&i.CatalogID, &i.CapabilityID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listCapabilityVersionsByCapability = `-- name: ListCapabilityVersionsByCapability :many
 select id::text as id, capability_id::text as capability_id, version,
   git_repo_url, git_ref, path, content,
@@ -8270,47 +8316,6 @@ func (q *Queries) ListIdleSandboxBindings(ctx context.Context, arg ListIdleSandb
 			&i.KilledAt,
 			&i.Metadata,
 		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listMCPDirectoryInstalls = `-- name: ListMCPDirectoryInstalls :many
-select distinct on (cv.source_payload->>'catalog_id')
-  coalesce(cv.source_payload->>'catalog_id', '')::text as catalog_id,
-  c.id::text as capability_id
-from capability c
-join capability_version cv on cv.capability_id = c.id
-where c.workspace_id = $1::uuid
-  and c.type = 'mcp'
-  and c.deleted_at is null
-  and cv.source_payload->>'source_format' = 'mcp_catalog'
-  and coalesce(cv.source_payload->>'catalog_id', '') <> ''
-order by cv.source_payload->>'catalog_id', cv.created_at desc, cv.id desc
-`
-
-type ListMCPDirectoryInstallsRow struct {
-	CatalogID    string `json:"catalog_id"`
-	CapabilityID string `json:"capability_id"`
-}
-
-// Catalog provenance lives on capability versions rather than the capability
-// row. Keep the newest matching provenance per catalog id.
-func (q *Queries) ListMCPDirectoryInstalls(ctx context.Context, workspaceID pgtype.UUID) ([]ListMCPDirectoryInstallsRow, error) {
-	rows, err := q.db.Query(ctx, listMCPDirectoryInstalls, workspaceID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []ListMCPDirectoryInstallsRow{}
-	for rows.Next() {
-		var i ListMCPDirectoryInstallsRow
-		if err := rows.Scan(&i.CatalogID, &i.CapabilityID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/server/internal/dev/uploads_routes_test.go
+++ b/server/internal/dev/uploads_routes_test.go
@@ -48,6 +48,9 @@ type fakeOSSClient struct {
 	// tests don't accidentally start receiving bytes they didn't ask
 	// for. Used by the skill / plugin zip import integration tests.
 	download func(key string) ([]byte, error)
+	// putBytesFn lets tests observe or fail server-side object writes without
+	// changing the behavior of the presigned upload tests.
+	putBytesFn func(key string, data []byte) error
 }
 
 func (f *fakeOSSClient) PresignPut(_ context.Context, key string, ttl time.Duration) (string, time.Time, error) {
@@ -69,6 +72,13 @@ func (f *fakeOSSClient) PresignGet(_ context.Context, key string, ttl time.Durat
 		return "", time.Time{}, f.returnErr
 	}
 	return f.urlFromKey(key) + "?get=1", f.expiresAt, nil
+}
+
+func (f *fakeOSSClient) PutBytes(_ context.Context, key string, data []byte) error {
+	if f.putBytesFn != nil {
+		return f.putBytesFn(key, data)
+	}
+	return nil
 }
 
 func (f *fakeOSSClient) Download(_ context.Context, key string) ([]byte, error) {

--- a/server/internal/skillcatalog/loader.go
+++ b/server/internal/skillcatalog/loader.go
@@ -1,0 +1,208 @@
+package skillcatalog
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	skillcatalogdata "github.com/MiniMax-AI-Dev/parsar/catalog/skills"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/parser"
+)
+
+var ErrItemNotFound = errors.New("skill catalog item not found")
+
+type Options struct {
+	BuiltinJSON []byte
+	Files       fs.FS
+}
+
+type Loader struct {
+	builtin    Catalog
+	files      fs.FS
+	builtinErr error
+}
+
+func New(options Options) *Loader {
+	builtinJSON := options.BuiltinJSON
+	if len(builtinJSON) == 0 {
+		builtinJSON = skillcatalogdata.CatalogJSON
+	}
+	files := options.Files
+	if files == nil {
+		files = skillcatalogdata.FS
+	}
+	builtin, builtinErr := Decode(builtinJSON)
+	return &Loader{builtin: builtin, files: files, builtinErr: builtinErr}
+}
+
+func (l *Loader) Load() (Catalog, error) {
+	if l == nil {
+		return Catalog{}, errors.New("skill catalog loader is nil")
+	}
+	if l.builtinErr != nil {
+		return Catalog{}, fmt.Errorf("load builtin skill catalog: %w", l.builtinErr)
+	}
+	return l.builtin, nil
+}
+
+func (l *Loader) LoadItem(id string) (Item, Package, error) {
+	catalog, err := l.Load()
+	if err != nil {
+		return Item{}, Package{}, err
+	}
+	item, found := catalog.Find(id)
+	if !found {
+		return Item{}, Package{}, fmt.Errorf("%w: %s", ErrItemNotFound, strings.TrimSpace(id))
+	}
+	if l.files == nil {
+		return Item{}, Package{}, errors.New("skill catalog files are unavailable")
+	}
+	pkg, err := l.loadPackage(item)
+	return item, pkg, err
+}
+
+func (c Catalog) Find(id string) (Item, bool) {
+	id = strings.TrimSpace(id)
+	for _, item := range c.Items {
+		if item.ID == id {
+			return item, true
+		}
+	}
+	return Item{}, false
+}
+
+func (l *Loader) loadPackage(item Item) (Package, error) {
+	entries, err := readEntries(l.files, item.ContentPath)
+	if err != nil {
+		return Package{}, fmt.Errorf("read skill %q package: %w", item.ID, err)
+	}
+	skillMD, ok := entries["SKILL.md"]
+	if !ok {
+		return Package{}, fmt.Errorf("skill %q package is missing SKILL.md", item.ID)
+	}
+	parsed, err := parser.ParseSkill(string(skillMD), parser.SourceFormatMarkdown)
+	if err != nil {
+		return Package{}, fmt.Errorf("parse skill %q SKILL.md: %w", item.ID, err)
+	}
+	if parsed.Spec.Skill == nil {
+		return Package{}, fmt.Errorf("skill %q parser returned a nil skill spec", item.ID)
+	}
+
+	files := make([]canonical.SkillFile, 0, len(entries)-1)
+	paths := make([]string, 0, len(entries))
+	for rel := range entries {
+		paths = append(paths, rel)
+	}
+	sort.Strings(paths)
+	for _, rel := range paths {
+		if rel == "SKILL.md" {
+			continue
+		}
+		files = append(files, canonical.SkillFile{
+			Path:    rel,
+			Content: string(entries[rel]),
+			Kind:    skillFileKind(rel),
+		})
+	}
+	parsed.Spec.Skill.Files = files
+
+	zipBytes, err := buildZip(entries, paths)
+	if err != nil {
+		return Package{}, fmt.Errorf("package skill %q: %w", item.ID, err)
+	}
+	if _, err := parser.ParseSkillZip(zipBytes); err != nil {
+		return Package{}, fmt.Errorf("validate packaged skill %q: %w", item.ID, err)
+	}
+	sum := sha256.Sum256(zipBytes)
+	return Package{
+		Spec:   parsed.Spec,
+		Files:  files,
+		Zip:    zipBytes,
+		SHA256: hex.EncodeToString(sum[:]),
+	}, nil
+}
+
+func readEntries(files fs.FS, root string) (map[string][]byte, error) {
+	entries := make(map[string][]byte)
+	err := fs.WalkDir(files, root, func(filePath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel := strings.TrimPrefix(filePath, strings.TrimSuffix(root, "/")+"/")
+		if rel == filePath || rel == "" || path.IsAbs(rel) || strings.HasPrefix(rel, "../") || rel == ".." {
+			return fmt.Errorf("invalid embedded path %q", filePath)
+		}
+		content, err := fs.ReadFile(files, filePath)
+		if err != nil {
+			return err
+		}
+		entries[rel] = content
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func buildZip(entries map[string][]byte, paths []string) ([]byte, error) {
+	var buf bytes.Buffer
+	writer := zip.NewWriter(&buf)
+	for _, rel := range paths {
+		header := &zip.FileHeader{Name: rel, Method: zip.Deflate}
+		header.SetModTime(time.Unix(0, 0).UTC())
+		header.SetMode(0o644)
+		part, err := writer.CreateHeader(header)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := io.Copy(part, bytes.NewReader(entries[rel])); err != nil {
+			return nil, err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func skillFileKind(rel string) canonical.SkillFileKind {
+	switch strings.ToLower(path.Ext(rel)) {
+	case ".md", ".markdown":
+		return canonical.SkillFileKindMarkdown
+	case ".py", ".sh", ".bash", ".js", ".ts", ".mjs", ".cjs":
+		return canonical.SkillFileKindScript
+	default:
+		return canonical.SkillFileKindAsset
+	}
+}
+
+func Decode(data []byte) (Catalog, error) {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	var catalog Catalog
+	if err := decoder.Decode(&catalog); err != nil {
+		return Catalog{}, fmt.Errorf("decode skill catalog: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return Catalog{}, fmt.Errorf("decode skill catalog: trailing JSON data")
+	}
+	if err := catalog.Validate(); err != nil {
+		return Catalog{}, err
+	}
+	return catalog, nil
+}

--- a/server/internal/skillcatalog/loader_test.go
+++ b/server/internal/skillcatalog/loader_test.go
@@ -1,0 +1,57 @@
+package skillcatalog
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+)
+
+func TestBuiltinCatalogLoadsPackages(t *testing.T) {
+	loader := New(Options{})
+	catalog, err := loader.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(catalog.Items) != 3 {
+		t.Fatalf("items = %d, want 3", len(catalog.Items))
+	}
+	for _, item := range catalog.Items {
+		_, pkg, err := loader.LoadItem(item.ID)
+		if err != nil {
+			t.Fatalf("LoadItem(%q): %v", item.ID, err)
+		}
+		if pkg.Spec.Kind != canonical.KindSkill || pkg.Spec.Skill == nil {
+			t.Fatalf("LoadItem(%q) returned %#v", item.ID, pkg.Spec)
+		}
+		if len(pkg.Zip) == 0 || len(pkg.SHA256) != 64 {
+			t.Fatalf("LoadItem(%q) returned invalid package metadata", item.ID)
+		}
+		if !bytes.Contains(pkg.Zip, []byte("SKILL.md")) {
+			t.Fatalf("LoadItem(%q) zip does not contain SKILL.md", item.ID)
+		}
+	}
+}
+
+func TestCatalogRejectsUnsafeContentPath(t *testing.T) {
+	catalog := Catalog{
+		SchemaVersion: SchemaVersion,
+		UpdatedAt:     "2026-08-03T00:00:00Z",
+		Items: []Item{{
+			ID:           "demo",
+			Name:         "Demo",
+			Description:  "Demo skill",
+			Publisher:    Publisher{Name: "Publisher", URL: "https://example.com"},
+			Categories:   []string{"Testing"},
+			FeaturedRank: 1,
+			Version:      "1.0.0",
+			License:      "MIT",
+			SourceRef:    "0000000000000000000000000000000000000000",
+			SourcePath:   "skills/demo",
+			ContentPath:  "items/other",
+		}},
+	}
+	if err := catalog.Validate(); err == nil {
+		t.Fatal("Validate succeeded for mismatched content path")
+	}
+}

--- a/server/internal/skillcatalog/types.go
+++ b/server/internal/skillcatalog/types.go
@@ -1,0 +1,45 @@
+package skillcatalog
+
+import (
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+)
+
+const SchemaVersion = 1
+
+type Catalog struct {
+	SchemaVersion int    `json:"schema_version"`
+	UpdatedAt     string `json:"updated_at"`
+	Items         []Item `json:"items"`
+}
+
+type Item struct {
+	ID            string    `json:"id"`
+	Name          string    `json:"name"`
+	Description   string    `json:"description"`
+	Publisher     Publisher `json:"publisher"`
+	IconURL       string    `json:"icon_url,omitempty"`
+	HomepageURL   string    `json:"homepage_url,omitempty"`
+	RepositoryURL string    `json:"repository_url,omitempty"`
+	Verified      bool      `json:"verified"`
+	Categories    []string  `json:"categories"`
+	FeaturedRank  int       `json:"featured_rank"`
+	Version       string    `json:"version"`
+	License       string    `json:"license"`
+	SourceRef     string    `json:"source_ref"`
+	SourcePath    string    `json:"source_path"`
+	ContentPath   string    `json:"content_path"`
+}
+
+type Publisher struct {
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// Package is the server-authoritative representation used by both the detail
+// endpoint and the existing capability import pipeline.
+type Package struct {
+	Spec   canonical.Spec
+	Files  []canonical.SkillFile
+	Zip    []byte
+	SHA256 string
+}

--- a/server/internal/skillcatalog/validate.go
+++ b/server/internal/skillcatalog/validate.go
@@ -1,0 +1,98 @@
+package skillcatalog
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var (
+	idPattern  = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+	shaPattern = regexp.MustCompile(`^[0-9a-f]{40}$`)
+)
+
+func (c Catalog) Validate() error {
+	if c.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("skill catalog schema_version %d is unsupported", c.SchemaVersion)
+	}
+	if _, err := time.Parse(time.RFC3339, strings.TrimSpace(c.UpdatedAt)); err != nil {
+		return fmt.Errorf("skill catalog updated_at must be RFC3339: %w", err)
+	}
+	seen := make(map[string]struct{}, len(c.Items))
+	for index, item := range c.Items {
+		if err := item.Validate(); err != nil {
+			return fmt.Errorf("skill catalog item[%d]: %w", index, err)
+		}
+		if _, duplicate := seen[item.ID]; duplicate {
+			return fmt.Errorf("skill catalog item id %q is duplicated", item.ID)
+		}
+		seen[item.ID] = struct{}{}
+	}
+	return nil
+}
+
+func (i Item) Validate() error {
+	if !idPattern.MatchString(i.ID) {
+		return fmt.Errorf("id %q is invalid", i.ID)
+	}
+	if strings.TrimSpace(i.Name) == "" || strings.TrimSpace(i.Description) == "" {
+		return fmt.Errorf("item %q name and description are required", i.ID)
+	}
+	if strings.TrimSpace(i.Publisher.Name) == "" {
+		return fmt.Errorf("item %q publisher name is required", i.ID)
+	}
+	for label, value := range map[string]string{
+		"publisher.url":  i.Publisher.URL,
+		"icon_url":       i.IconURL,
+		"homepage_url":   i.HomepageURL,
+		"repository_url": i.RepositoryURL,
+	} {
+		if err := validateHTTPSURL(label, value, label == "publisher.url"); err != nil {
+			return fmt.Errorf("item %q: %w", i.ID, err)
+		}
+	}
+	if i.FeaturedRank < 1 {
+		return fmt.Errorf("item %q featured_rank must be positive", i.ID)
+	}
+	if strings.TrimSpace(i.Version) == "" || strings.TrimSpace(i.License) == "" {
+		return fmt.Errorf("item %q version and license are required", i.ID)
+	}
+	if !shaPattern.MatchString(i.SourceRef) {
+		return fmt.Errorf("item %q source_ref must be a full lowercase commit SHA", i.ID)
+	}
+	if strings.TrimSpace(i.SourcePath) == "" || strings.HasPrefix(i.SourcePath, "/") || strings.Contains(i.SourcePath, "..") {
+		return fmt.Errorf("item %q source_path is invalid", i.ID)
+	}
+	if i.ContentPath != "items/"+i.ID {
+		return fmt.Errorf("item %q content_path must be items/%s", i.ID, i.ID)
+	}
+	seenCategories := make(map[string]struct{}, len(i.Categories))
+	for _, category := range i.Categories {
+		category = strings.TrimSpace(category)
+		if category == "" {
+			return fmt.Errorf("item %q has an empty category", i.ID)
+		}
+		if _, duplicate := seenCategories[category]; duplicate {
+			return fmt.Errorf("item %q category %q is duplicated", i.ID, category)
+		}
+		seenCategories[category] = struct{}{}
+	}
+	return nil
+}
+
+func validateHTTPSURL(label, value string, required bool) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		if required {
+			return fmt.Errorf("%s is required", label)
+		}
+		return nil
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil {
+		return fmt.Errorf("%s must be an https URL without embedded credentials", label)
+	}
+	return nil
+}

--- a/server/internal/skillcatalog/validate_test.go
+++ b/server/internal/skillcatalog/validate_test.go
@@ -1,0 +1,57 @@
+package skillcatalog
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func validCatalogItem(id string) Item {
+	return Item{
+		ID:           id,
+		Name:         "Example Skill",
+		Description:  "A reviewed example skill.",
+		Publisher:    Publisher{Name: "Example", URL: "https://example.com"},
+		Categories:   []string{"Testing"},
+		FeaturedRank: 1,
+		Version:      "1.0.0",
+		License:      "MIT",
+		SourceRef:    strings.Repeat("a", 40),
+		SourcePath:   "skills/example",
+		ContentPath:  "items/" + id,
+	}
+}
+
+func TestCatalogRejectsDuplicateIDs(t *testing.T) {
+	first := validCatalogItem("example")
+	second := validCatalogItem("example")
+	if err := (Catalog{SchemaVersion: SchemaVersion, UpdatedAt: "2026-08-03T00:00:00Z", Items: []Item{first, second}}).Validate(); err == nil {
+		t.Fatal("Validate accepted duplicate catalog IDs")
+	}
+}
+
+func TestCatalogRejectsInvalidURL(t *testing.T) {
+	item := validCatalogItem("example")
+	item.RepositoryURL = "http://example.com/repository"
+	if err := item.Validate(); err == nil {
+		t.Fatal("Validate accepted a non-HTTPS repository URL")
+	}
+}
+
+func TestCatalogRejectsUnsupportedSchemaVersion(t *testing.T) {
+	data, err := json.Marshal(Catalog{SchemaVersion: SchemaVersion + 1, UpdatedAt: "2026-08-03T00:00:00Z"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Decode(data); err == nil {
+		t.Fatal("Decode accepted an unsupported schema version")
+	}
+}
+
+func TestCatalogRejectsSourcePathTraversal(t *testing.T) {
+	item := validCatalogItem("example")
+	item.SourcePath = "skills/../example"
+	if err := item.Validate(); err == nil {
+		t.Fatal("Validate accepted a source path containing ..")
+	}
+}

--- a/server/internal/storage/blob/blob.go
+++ b/server/internal/storage/blob/blob.go
@@ -45,6 +45,10 @@ type Store interface {
 	// OSS keys (PG ignores them and returns "pg:<uuid>").
 	NewRef(kind, workspaceID, filename string) (string, error)
 
+	// PutBytes stores a server-owned object without requiring a browser
+	// presign round trip. The reference must belong to workspaceID.
+	PutBytes(ctx context.Context, ref, workspaceID string, data []byte) error
+
 	// UploadURL returns where/how the browser PUTs the zip bytes for ref.
 	// workspaceID is bound into the PG proxy token so the eventual write
 	// persists ownership; OSS ignores it (the key already encodes it).

--- a/server/internal/storage/blob/oss_store.go
+++ b/server/internal/storage/blob/oss_store.go
@@ -2,6 +2,7 @@ package blob
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/storage/oss"
@@ -12,6 +13,7 @@ import (
 type ossBackend interface {
 	PresignPut(ctx context.Context, key string, ttl time.Duration) (string, time.Time, error)
 	PresignGet(ctx context.Context, key string, ttl time.Duration) (string, time.Time, error)
+	PutBytes(ctx context.Context, key string, data []byte) error
 	Download(ctx context.Context, key string) ([]byte, error)
 }
 
@@ -33,6 +35,16 @@ func (s *OSSStore) NewRef(kind, workspaceID, filename string) (string, error) {
 	default:
 		return "", ErrInvalidRef
 	}
+}
+
+func (s *OSSStore) PutBytes(ctx context.Context, ref, workspaceID string, data []byte) error {
+	if strings.TrimSpace(ref) == "" || !oss.KeyBelongsToWorkspace(ref, workspaceID) {
+		return ErrInvalidRef
+	}
+	if int64(len(data)) > MaxBlobBytes {
+		return ErrTooLarge
+	}
+	return s.oss.PutBytes(ctx, ref, data)
 }
 
 func (s *OSSStore) UploadURL(ctx context.Context, ref, workspaceID string, ttl time.Duration) (URLSpec, error) {

--- a/server/internal/storage/blob/oss_store_test.go
+++ b/server/internal/storage/blob/oss_store_test.go
@@ -11,6 +11,7 @@ import (
 type fakeOSS struct {
 	putURL, getURL string
 	downloaded     []byte
+	putBytes       []byte
 	lastKey        string
 }
 
@@ -21,6 +22,11 @@ func (f *fakeOSS) PresignPut(ctx context.Context, key string, ttl time.Duration)
 func (f *fakeOSS) PresignGet(ctx context.Context, key string, ttl time.Duration) (string, time.Time, error) {
 	f.lastKey = key
 	return f.getURL, time.Now().Add(ttl), nil
+}
+func (f *fakeOSS) PutBytes(_ context.Context, key string, data []byte) error {
+	f.lastKey = key
+	f.putBytes = append([]byte(nil), data...)
+	return nil
 }
 func (f *fakeOSS) Download(ctx context.Context, key string) ([]byte, error) {
 	f.lastKey = key
@@ -74,5 +80,16 @@ func TestOSSStoreBelongsToWorkspaceUsesKeyShape(t *testing.T) {
 	ok, _ = s.BelongsToWorkspace(context.Background(), "capabilities/plugins/ws-1/x/p.zip", "ws-2")
 	if ok {
 		t.Fatal("key under ws-1 must not belong to ws-2")
+	}
+}
+
+func TestOSSStorePutBytes(t *testing.T) {
+	f := &fakeOSS{}
+	s := NewOSSStore(f)
+	if err := s.PutBytes(context.Background(), "capabilities/skills/ws-1/x.zip", "ws-1", []byte("zip")); err != nil {
+		t.Fatalf("PutBytes: %v", err)
+	}
+	if string(f.putBytes) != "zip" {
+		t.Fatalf("stored bytes = %q, want zip", f.putBytes)
 	}
 }

--- a/server/internal/storage/oss/client.go
+++ b/server/internal/storage/oss/client.go
@@ -1,6 +1,7 @@
 package oss
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -129,6 +130,27 @@ func (c *Client) PresignPut(ctx context.Context, key string, ttl time.Duration) 
 		return "", time.Time{}, fmt.Errorf("oss: presign put %q: %w", key, err)
 	}
 	return res.URL, res.Expiration, nil
+}
+
+// PutBytes stores a server-generated capability package directly. User
+// uploads continue to use presigned URLs.
+func (c *Client) PutBytes(ctx context.Context, key string, data []byte) error {
+	if c == nil {
+		return ErrNotConfigured
+	}
+	if strings.TrimSpace(key) == "" {
+		return ErrInvalidKey
+	}
+	_, err := c.sdk.PutObject(ctx, &aliyun.PutObjectRequest{
+		Bucket:      aliyun.Ptr(c.bucket),
+		Key:         aliyun.Ptr(key),
+		Body:        bytes.NewReader(data),
+		ContentType: aliyun.Ptr(PresignPutContentType),
+	})
+	if err != nil {
+		return fmt.Errorf("oss: put object %q: %w", key, err)
+	}
+	return nil
 }
 
 // PresignGet returns a presigned URL for HTTP GET. Same TTL

--- a/server/internal/store/capability_directory.go
+++ b/server/internal/store/capability_directory.go
@@ -14,10 +14,6 @@ type CapabilityDirectoryInstall struct {
 	CapabilityID string
 }
 
-// MCPDirectoryInstall is retained as a source-compatible name for the MCP
-// Directory handler and its existing callers.
-type MCPDirectoryInstall = CapabilityDirectoryInstall
-
 func (s *Store) ListCapabilityDirectoryInstalls(ctx context.Context, workspaceID, capabilityType, sourceFormat string) ([]CapabilityDirectoryInstall, error) {
 	wid, err := uuid(workspaceID)
 	if err != nil {
@@ -36,8 +32,4 @@ func (s *Store) ListCapabilityDirectoryInstalls(ctx context.Context, workspaceID
 		installs = append(installs, CapabilityDirectoryInstall{CatalogID: row.CatalogID, CapabilityID: row.CapabilityID})
 	}
 	return installs, nil
-}
-
-func (s *Store) ListMCPDirectoryInstalls(ctx context.Context, workspaceID string) ([]MCPDirectoryInstall, error) {
-	return s.ListCapabilityDirectoryInstalls(ctx, workspaceID, "mcp", "mcp_catalog")
 }

--- a/server/internal/store/capability_directory_test.go
+++ b/server/internal/store/capability_directory_test.go
@@ -50,9 +50,9 @@ func TestMCPDirectoryImportPersistsProvenanceWithoutSecretsOrBindings(t *testing
 		t.Fatalf("created secrets=%v", result.CreatedSecretIDs)
 	}
 
-	installs, err := st.ListMCPDirectoryInstalls(ctx, ids.WorkspaceID)
+	installs, err := st.ListCapabilityDirectoryInstalls(ctx, ids.WorkspaceID, "mcp", "mcp_catalog")
 	if err != nil {
-		t.Fatalf("ListMCPDirectoryInstalls: %v", err)
+		t.Fatalf("ListCapabilityDirectoryInstalls: %v", err)
 	}
 	if len(installs) != 1 || installs[0].CatalogID != "filesystem" || installs[0].CapabilityID != result.Capability.ID {
 		t.Fatalf("installs=%+v", installs)

--- a/server/internal/store/mcp_directory.go
+++ b/server/internal/store/mcp_directory.go
@@ -7,28 +7,37 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
 )
 
-// MCPDirectoryInstall identifies the workspace capability created from one
-// MCP Directory catalog item.
-type MCPDirectoryInstall struct {
+// CapabilityDirectoryInstall identifies the workspace capability created from
+// one built-in MCP or Skill Directory catalog item.
+type CapabilityDirectoryInstall struct {
 	CatalogID    string
 	CapabilityID string
 }
 
-func (s *Store) ListMCPDirectoryInstalls(ctx context.Context, workspaceID string) ([]MCPDirectoryInstall, error) {
+// MCPDirectoryInstall is retained as a source-compatible name for the MCP
+// Directory handler and its existing callers.
+type MCPDirectoryInstall = CapabilityDirectoryInstall
+
+func (s *Store) ListCapabilityDirectoryInstalls(ctx context.Context, workspaceID, capabilityType, sourceFormat string) ([]CapabilityDirectoryInstall, error) {
 	wid, err := uuid(workspaceID)
 	if err != nil {
-		return nil, fmt.Errorf("list mcp directory installs: workspace_id: %w", err)
+		return nil, fmt.Errorf("list capability directory installs: workspace_id: %w", err)
 	}
-	rows, err := sqlc.New(s.db).ListMCPDirectoryInstalls(ctx, wid)
+	rows, err := sqlc.New(s.db).ListCapabilityDirectoryInstalls(ctx, sqlc.ListCapabilityDirectoryInstallsParams{
+		WorkspaceID:    wid,
+		CapabilityType: capabilityType,
+		SourceFormat:   sourceFormat,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("list mcp directory installs: %w", err)
+		return nil, fmt.Errorf("list capability directory installs: %w", err)
 	}
-	installs := make([]MCPDirectoryInstall, 0, len(rows))
+	installs := make([]CapabilityDirectoryInstall, 0, len(rows))
 	for _, row := range rows {
-		installs = append(installs, MCPDirectoryInstall{
-			CatalogID:    row.CatalogID,
-			CapabilityID: row.CapabilityID,
-		})
+		installs = append(installs, CapabilityDirectoryInstall{CatalogID: row.CatalogID, CapabilityID: row.CapabilityID})
 	}
 	return installs, nil
+}
+
+func (s *Store) ListMCPDirectoryInstalls(ctx context.Context, workspaceID string) ([]MCPDirectoryInstall, error) {
+	return s.ListCapabilityDirectoryInstalls(ctx, workspaceID, "mcp", "mcp_catalog")
 }


### PR DESCRIPTION
## Summary

- Add a reviewed, embedded Skill Directory under Capabilities -> Marketplace.
- Add the Directory list, detail, and import flow while reusing the existing Capability, Capability Version, Blob Store, workspace binding, and runtime paths.
- Ship the initial curated catalog entries:
  - Anthropic Frontend Design
  - Anthropic Webapp Testing
  - Vercel React Composition Patterns
- Keep the catalog server-authoritative and pin each item to an upstream commit.

## Scope

This PR contains the Skill Directory core only:

- Catalog schema, validation, embedded package loading, and source metadata.
- Workspace Skill Directory list/detail/import APIs.
- OpenAPI definitions and generated Store/blob support required by Skill import.
- Capabilities -> Marketplace Skill Directory UI.
- Import of complete Skill packages, including supporting files and upstream licenses.

The following are intentionally excluded and will be delivered separately:

- Additional curated Skill packages.
- MCP Directory changes.
- OAuth and credential binding changes.
- Member Agent Capability permission changes.

## Behavior

- Import accepts only a catalog ID; the server supplies the package contents.
- Imported Skills become private workspace Capabilities.
- Import does not bind an Agent, execute scripts, or run third-party content.
- Duplicate imports are idempotent.
- Details expose the complete package contents, not only the top-level `SKILL.md`.
- Workspace members can import reviewed Skills; viewers can browse only.
- Vendored packages retain their upstream license files.

## Verification

- `make check` passed.
- `pnpm --filter @parsar/web build` passed.
- Targeted Skill Directory, Skill Catalog, Blob Store, and Store tests passed.
- `git diff --check` passed.
- Local API returned the three initial catalog items and loaded their package details successfully.

No model or Agent runtime behavior is changed by the Directory core.
