### PR TITLE
fix: restore OpenCode text responses

### DIFF
--- a/apps/parsar-daemon/internal/agent/opencode/parser.go
+++ b/apps/parsar-daemon/internal/agent/opencode/parser.go
@@ -14,10 +14,11 @@ type translator struct {
 	runID string
 	seq   atomic.Uint64
 
-	deltaBuf strings.Builder
-	plainBuf strings.Builder
-	rawLines []string
-	usage    proto.Usage
+	deltaBuf  strings.Builder
+	plainBuf  strings.Builder
+	rawLines  []string
+	usage     proto.Usage
+	stepUsage usageInfo
 }
 
 type translation struct {
@@ -36,6 +37,7 @@ func (t *translator) Translate(line []byte) (translation, error) {
 	var head struct {
 		Type       string          `json:"type"`
 		Properties json.RawMessage `json:"properties"`
+		Part       json.RawMessage `json:"part"`
 	}
 	if err := json.Unmarshal(line, &head); err != nil || head.Type == "" {
 		if t.plainBuf.Len() > 0 {
@@ -48,8 +50,13 @@ func (t *translator) Translate(line []byte) (translation, error) {
 	switch head.Type {
 	case "message.part.delta":
 		return t.translatePartDelta(head.Properties)
+	case "text":
+		return t.translateTextPart(head.Part)
 	case "message.updated", "message.updated.1":
 		t.captureUsage(head.Properties)
+		return translation{}, nil
+	case "step_finish":
+		t.capturePartUsage(head.Part)
 		return translation{}, nil
 	default:
 		t.captureGenericUsage(line)
@@ -76,12 +83,51 @@ func (t *translator) translatePartDelta(raw json.RawMessage) (translation, error
 	return translation{Envelopes: []proto.Envelope{env}}, nil
 }
 
+func (t *translator) translateTextPart(raw json.RawMessage) (translation, error) {
+	var p struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return translation{}, fmt.Errorf("opencode: parse text part: %w", err)
+	}
+	if p.Text == "" || (p.Type != "" && p.Type != "text") {
+		return translation{}, nil
+	}
+	t.deltaBuf.WriteString(p.Text)
+	env, err := proto.NewEnvelope(proto.TypeDelta, t.runID, proto.DeltaPayload{Delta: p.Text, Sequence: t.seq.Add(1)})
+	if err != nil {
+		return translation{}, err
+	}
+	return translation{Envelopes: []proto.Envelope{env}}, nil
+}
+
 func (t *translator) captureUsage(raw json.RawMessage) {
 	var p struct {
 		Info usageInfo `json:"info"`
 	}
 	if err := json.Unmarshal(raw, &p); err == nil {
 		t.mergeUsage(p.Info)
+	}
+}
+
+func (t *translator) capturePartUsage(raw json.RawMessage) {
+	var p usageInfo
+	if err := json.Unmarshal(raw, &p); err == nil {
+		if p.Tokens.CacheRead == 0 {
+			p.Tokens.CacheRead = p.Tokens.Cache.Read
+		}
+		if p.Tokens.CacheWrite == 0 {
+			p.Tokens.CacheWrite = p.Tokens.Cache.Write
+		}
+		t.stepUsage.Tokens.Input += p.Tokens.Input
+		t.stepUsage.Tokens.Output += p.Tokens.Output
+		t.stepUsage.Tokens.Reasoning += p.Tokens.Reasoning
+		t.stepUsage.Tokens.CacheRead += p.Tokens.CacheRead
+		t.stepUsage.Tokens.CacheWrite += p.Tokens.CacheWrite
+		t.stepUsage.Tokens.Total += p.Tokens.Total
+		t.stepUsage.Cost += p.Cost
+		t.mergeUsage(t.stepUsage)
 	}
 }
 
@@ -112,9 +158,19 @@ type usageTokens struct {
 	CacheRead  int32 `json:"cacheRead"`
 	CacheWrite int32 `json:"cacheWrite"`
 	Total      int32 `json:"total"`
+	Cache      struct {
+		Read  int32 `json:"read"`
+		Write int32 `json:"write"`
+	} `json:"cache"`
 }
 
 func (t *translator) mergeUsage(info usageInfo) {
+	if info.Tokens.CacheRead == 0 {
+		info.Tokens.CacheRead = info.Tokens.Cache.Read
+	}
+	if info.Tokens.CacheWrite == 0 {
+		info.Tokens.CacheWrite = info.Tokens.Cache.Write
+	}
 	if info.Tokens.Input != 0 {
 		t.usage.InputTokens = info.Tokens.Input
 	}

--- a/apps/parsar-daemon/internal/agent/opencode/parser_test.go
+++ b/apps/parsar-daemon/internal/agent/opencode/parser_test.go
@@ -33,6 +33,44 @@ func TestTranslatePartDeltaEmitsDeltaAndDone(t *testing.T) {
 	}
 }
 
+func TestTranslateTextEventsEmitDeltasAndDone(t *testing.T) {
+	tr := opencode.NewTranslatorForTest("run-text")
+	tx, err := tr.Translate([]byte(`{"type":"text","timestamp":1785838824775,"sessionID":"ses_1","part":{"id":"prt_1","messageID":"msg_1","sessionID":"ses_1","type":"text","text":"OK"}}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	if len(tx.Envelopes) != 1 || tx.Envelopes[0].Type != proto.TypeDelta {
+		t.Fatalf("delta envelopes = %#v", tx.Envelopes)
+	}
+	delta := decodePayload[proto.DeltaPayload](t, tx.Envelopes[0])
+	if delta.Delta != "OK" || delta.Sequence == 0 {
+		t.Fatalf("delta payload = %#v", delta)
+	}
+	if _, err = tr.Translate([]byte(`{"type":"step_finish","part":{"id":"prt_2","type":"step-finish"}}`)); err != nil {
+		t.Fatalf("Translate step finish: %v", err)
+	}
+	tx, err = tr.Translate([]byte(`{"type":"text","timestamp":1785838824776,"sessionID":"ses_1","part":{"id":"prt_3","messageID":"msg_1","sessionID":"ses_1","type":"text","text":" again"}}`))
+	if err != nil {
+		t.Fatalf("Translate second text: %v", err)
+	}
+	if len(tx.Envelopes) != 1 || tx.Envelopes[0].Type != proto.TypeDelta {
+		t.Fatalf("second delta envelopes = %#v", tx.Envelopes)
+	}
+	second := decodePayload[proto.DeltaPayload](t, tx.Envelopes[0])
+	if second.Delta != " again" || second.Sequence <= delta.Sequence {
+		t.Fatalf("second delta payload = %#v", second)
+	}
+	if _, err = tr.Translate([]byte(`{"type":"step_finish","part":{"id":"prt_4","type":"step-finish"}}`)); err != nil {
+		t.Fatalf("Translate second step finish: %v", err)
+	}
+
+	envs := tr.TerminalEnvelopes(nil, "", false)
+	done := decodePayload[proto.DonePayload](t, envs[len(envs)-1])
+	if done.Content != "OK again" {
+		t.Fatalf("done content = %q", done.Content)
+	}
+}
+
 func TestTranslateCapturesUsage(t *testing.T) {
 	tr := opencode.NewTranslatorForTest("run-u")
 	_, err := tr.Translate([]byte(`{"type":"message.updated","properties":{"info":{"cost":0.25,"tokens":{"input":10,"output":7,"reasoning":3,"cacheRead":2,"cacheWrite":1,"total":23}}}}`))
@@ -54,6 +92,35 @@ func TestTranslateCapturesUsage(t *testing.T) {
 		t.Fatalf("usage = %#v", got)
 	}
 	if got.Raw["total_tokens"] != float64(23) {
+		t.Fatalf("usage raw = %#v", got.Raw)
+	}
+}
+
+func TestTranslateStepFinishCapturesUsage(t *testing.T) {
+	tr := opencode.NewTranslatorForTest("run-step-finish")
+	_, err := tr.Translate([]byte(`{"type":"step_finish","part":{"type":"step-finish","tokens":{"total":12576,"input":11803,"output":645,"reasoning":0,"cache":{"write":4,"read":128}},"cost":0.00432258}}`))
+	if err != nil {
+		t.Fatalf("Translate: %v", err)
+	}
+	_, err = tr.Translate([]byte(`{"type":"step_finish","part":{"type":"step-finish","tokens":{"total":25,"input":20,"output":3,"reasoning":2,"cache":{"write":1,"read":4}},"cost":0.001}}`))
+	if err != nil {
+		t.Fatalf("Translate second step: %v", err)
+	}
+	envs := tr.TerminalEnvelopes(nil, "", false)
+	var got *proto.UsagePayload
+	for _, env := range envs {
+		if env.Type == proto.TypeUsage {
+			payload := decodePayload[proto.UsagePayload](t, env)
+			got = &payload
+		}
+	}
+	if got == nil {
+		t.Fatalf("usage env missing: %#v", envs)
+	}
+	if got.InputTokens != 11823 || got.OutputTokens != 648 || got.CostUSD != 0.00532258 {
+		t.Fatalf("usage = %#v", got)
+	}
+	if got.Raw["total_tokens"] != float64(12601) || got.Raw["reasoning_tokens"] != float64(2) || got.Raw["cache_read_tokens"] != float64(132) || got.Raw["cache_write_tokens"] != float64(5) {
 		t.Fatalf("usage raw = %#v", got.Raw)
 	}
 }


### PR DESCRIPTION
## What changed

OpenCode emits assistant output from `opencode run --format json` as top-level `text` events with content under `part.text`. The daemon previously ignored those events and could persist a completed run with no output.

This PR:
- translates current `text` events into Parsar delta and final output;
- accumulates usage from each `step_finish` payload, including nested cache counters;
- keeps the existing `message.part.delta` text format supported.

## Scope

Included:
- the OpenCode event parser;
- focused parser regression tests.

Excluded:
- other OpenCode event types and pre-existing error presentation;
- Claude Code, Codex, Pi, model, MCP, API, database, storage, and frontend behavior.

## Validation

- `go test ./apps/parsar-daemon/internal/agent/opencode ./server/internal/connector/agentdaemon`
- `go build -o /tmp/parsar-daemon-pr239 ./apps/parsar-daemon/cmd/parsar-daemon`
- `make check` (passed; the repository check skipped its Postgres migration smoke test because Docker is unavailable)
- two independent blind-review rounds plus one final convergence review; final review: no findings
