### PR TITLE
Add capability file editing

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "@vitejs/plugin-react": "^6.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fflate": "^0.8.3",
     "i18next": "^26.3.4",
     "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^1.22.0",

--- a/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
@@ -8,13 +8,13 @@
  *   - When the previous version was imported, prefill rawText + format so the
  *     user can tweak. inline_secret plaintexts CANNOT carry forward (server
  *     only stores ciphertext).
- *   - Plugin / skill-zip kinds: if the user doesn't upload a new zip, the
- *     server reuses the previous version's OSS bytes (commit handler treats
- *     missing oss_key as "reuse latest"). UI shows the existing filename.
+ *   - Plugin kinds can reuse the previous OSS bytes. Stored Skill zips are
+ *     downloaded into the browser editor and uploaded again on save.
  *   - Commits to .../capabilities/{id}/versions/import/commit (after an
  *     optional PATCH for name/description).
  */
 import { useEffect, useMemo, useState } from "react"
+import { strFromU8, strToU8, unzipSync, zipSync } from "fflate"
 import { Loader2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
@@ -32,10 +32,16 @@ import { ApiError } from "../../../lib/api-client"
 import { useUpdateCapability } from "../../../lib/api-capabilities"
 import type { Capability, CapabilityVersion } from "../../../lib/api-types"
 
-import { useImportCapabilityVersionMutation } from "./api"
+import {
+  downloadStoredZip,
+  putToPresignedURL,
+  useImportCapabilityVersionMutation,
+  usePresignUploadMutation,
+} from "./api"
 import { ImportMCPForm } from "./ImportMCPForm"
 import { ImportSkillForm } from "./ImportSkillForm"
 import { ImportPluginForm, type PluginUploadState } from "./ImportPluginForm"
+import { SkillFileTree, type SkillFileTreeEntry } from "./SkillFileTree"
 import { isImportSpecReady } from "./importValidation"
 import type {
   CanonicalKind,
@@ -56,6 +62,19 @@ interface Props {
   onCommitted: () => void
 }
 
+const SKILL_ZIP_MAX_BYTES = 8 * 1024 * 1024
+
+interface SkillArchiveEntry {
+  archivePath: string
+  path: string
+  bytes: Uint8Array
+  text: string | null
+  dirty: boolean
+  directory: boolean
+  hidden: boolean
+  kind: SkillFileTreeEntry["kind"]
+}
+
 export function AddCapabilityVersionDialog({
   workspaceID,
   capability,
@@ -67,6 +86,7 @@ export function AddCapabilityVersionDialog({
   const { t } = useTranslation("admin")
   const commitMut = useImportCapabilityVersionMutation(workspaceID, capability.id)
   const updateMut = useUpdateCapability(workspaceID)
+  const presignMut = usePresignUploadMutation(workspaceID)
 
   const kind = capability.type as CanonicalKind
 
@@ -87,8 +107,30 @@ export function AddCapabilityVersionDialog({
   })
   /** Skill zip ossKey from ImportSkillForm; null in paste mode. */
   const [skillOssKey, setSkillOssKey] = useState<string | null>(null)
+  const [skillArchive, setSkillArchive] = useState<SkillArchiveEntry[] | null>(null)
+  const [skillArchiveStatus, setSkillArchiveStatus] = useState<
+    "idle" | "loading" | "ready" | "error"
+  >("idle")
+  const [skillArchiveError, setSkillArchiveError] = useState<string | null>(null)
+  const [skillLoadAttempt, setSkillLoadAttempt] = useState(0)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
 
   const prefill = usePrefillFromLatest(latestVersion)
+  const latestSpec = latestVersion?.canonical_spec as CanonicalSpec | undefined
+  const editsStoredSkillZip = kind === "skill" && !!latestVersion?.oss_key?.trim()
+  const skillTreeFiles = useMemo<SkillFileTreeEntry[]>(
+    () =>
+      (skillArchive ?? [])
+        .filter((file) => !file.directory && !file.hidden)
+        .map((file) => ({
+          path: file.path,
+          content: file.text,
+          kind: file.kind,
+          size: file.bytes.byteLength,
+        })),
+    [skillArchive],
+  )
   // For plugin / skill-zip rounds where the user keeps the previous OSS blob,
   // we display the existing filename (derived from the latest version's oss_key)
   // so the form feels like "edit", not "blank slate".
@@ -111,29 +153,57 @@ export function AddCapabilityVersionDialog({
     setSourceFormat(prefill.format)
     setPluginUpload({ ossKey: null, uploadSource: null, validation: null })
     setSkillOssKey(null)
+    setSkillArchive(null)
+    setSkillArchiveStatus(editsStoredSkillZip ? "loading" : "idle")
+    setSkillArchiveError(null)
+    setSubmitError(null)
+    setIsSaving(false)
     commitMut.reset()
     updateMut.reset()
+    presignMut.reset()
     // intentionally only on the open transition
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
-  const errMsg = commitMut.error instanceof ApiError
-    ? commitMut.error.envelope.message
-    : commitMut.error instanceof Error
-      ? commitMut.error.message
-      : updateMut.error instanceof ApiError
-        ? updateMut.error.envelope.message
-        : updateMut.error instanceof Error
-          ? updateMut.error.message
-          : null
+  useEffect(() => {
+    if (!open || !editsStoredSkillZip || !workspaceID || !latestVersion?.oss_key) return
+    let cancelled = false
+    void downloadStoredZip(workspaceID, latestVersion.oss_key)
+      .then((bytes) => unpackSkillArchive(bytes))
+      .then((archive) => {
+        if (cancelled) return
+        setSkillArchive(archive)
+        setSkillArchiveStatus("ready")
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return
+        setSkillArchive(null)
+        setSkillArchiveStatus("error")
+        setSkillArchiveError(formatError(error))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [editsStoredSkillZip, latestVersion?.oss_key, open, skillLoadAttempt, workspaceID])
+
+  const errMsg =
+    submitError ??
+    (commitMut.error instanceof ApiError
+      ? commitMut.error.envelope.message
+      : commitMut.error instanceof Error
+        ? commitMut.error.message
+        : updateMut.error instanceof ApiError
+          ? updateMut.error.envelope.message
+          : updateMut.error instanceof Error
+            ? updateMut.error.message
+            : null)
 
   const trimmedName = name.trim()
-  const nameError =
-    !trimmedName
-      ? t("capabilities.errors.nameRequired")
-      : trimmedName.length > 50
-        ? t("capabilities.errors.nameTooLong")
-        : null
+  const nameError = !trimmedName
+    ? t("capabilities.errors.nameRequired")
+    : trimmedName.length > 50
+      ? t("capabilities.errors.nameTooLong")
+      : null
   // For plugin / skill-zip kinds we accept "no new upload" and let the server
   // reuse the previous OSS blob. So the canSubmit guard relaxes when an
   // inherited blob exists.
@@ -141,19 +211,27 @@ export function AddCapabilityVersionDialog({
     kind !== "plugin"
       ? true
       : pluginUpload.ossKey
-        ? pluginUpload.validation?.valid ?? false
+        ? (pluginUpload.validation?.valid ?? false)
         : !!inheritedOssLabel
 
   const skillSpecReady =
     kind !== "skill"
       ? true
-      : !!skillOssKey || !!inheritedOssLabel || (!!spec && isImportSpecReady(kind, spec, inlineSecrets))
+      : editsStoredSkillZip
+        ? skillArchiveStatus === "ready" &&
+          skillTreeFiles.some((file) => file.path.toLowerCase() === "skill.md")
+        : !!skillOssKey ||
+          !!inheritedOssLabel ||
+          (!!spec && isImportSpecReady(kind, spec, inlineSecrets))
 
-  const mcpSpecReady = kind !== "mcp" ? true : !!spec && isImportSpecReady(kind, spec, inlineSecrets)
+  const mcpSpecReady =
+    kind !== "mcp" ? true : !!spec && isImportSpecReady(kind, spec, inlineSecrets)
 
   const canSubmit =
     !commitMut.isPending &&
     !updateMut.isPending &&
+    !presignMut.isPending &&
+    !isSaving &&
     !!workspaceID &&
     !nameError &&
     pluginHasUsableArtifact &&
@@ -162,11 +240,30 @@ export function AddCapabilityVersionDialog({
 
   const submit = async () => {
     if (!canSubmit) return
-    // PATCH name/description only when they actually changed.
-    const nextDesc = description.trim()
-    const nameChanged = trimmedName !== capability.name
-    const descChanged = nextDesc !== (capability.description ?? "").trim()
+    setSubmitError(null)
+    setIsSaving(true)
     try {
+      let editedSkillOssKey: string | undefined
+      if (editsStoredSkillZip) {
+        if (!workspaceID || !skillArchive) throw new Error("Skill archive is not ready")
+        const zipFile = buildSkillZipFile(
+          skillArchive,
+          `${safeZipBase(latestSpec?.skill?.slug ?? capability.name)}.zip`,
+        )
+        if (zipFile.size > SKILL_ZIP_MAX_BYTES) {
+          throw new Error("Edited Skill zip exceeds the 8 MiB upload limit")
+        }
+        const presign = await presignMut.mutateAsync({
+          filename: zipFile.name,
+          prefix: "skill",
+        })
+        await putToPresignedURL(presign, zipFile)
+        editedSkillOssKey = presign.ossKey
+      }
+
+      const nextDesc = description.trim()
+      const nameChanged = trimmedName !== capability.name
+      const descChanged = nextDesc !== (capability.description ?? "").trim()
       if (nameChanged || descChanged) {
         await updateMut.mutateAsync({
           capabilityID: capability.id,
@@ -176,52 +273,53 @@ export function AddCapabilityVersionDialog({
           },
         })
       }
-    } catch {
-      // updateMut.error surfaces via errMsg; abort the version commit.
-      return
-    }
-    // For plugin / skill-zip without a new upload, the server falls back to
-    // the previous version's oss_key. We still need a canonical_spec on the
-    // wire (kind at minimum) so the backend's spec.Kind check passes.
-    const fallbackSpec: CanonicalSpec | null = spec
-      ? spec
-      : kind === "plugin"
-        ? ({ kind: "plugin" } as unknown as CanonicalSpec)
-        : kind === "skill"
-          ? ({ kind: "skill" } as unknown as CanonicalSpec)
-          : null
-    if (!fallbackSpec) return
 
-    const ossKeyToSend =
-      kind === "plugin"
-        ? pluginUpload.ossKey ?? undefined
-        : kind === "skill"
-          ? skillOssKey ?? undefined
-          : undefined
-    const uploadSourceToSend =
-      kind === "plugin"
-        ? pluginUpload.uploadSource ?? undefined
-        : kind === "skill" && skillOssKey
-          ? "zip"
-          : undefined
+      // The backend reparses Skill ZIP bytes and remains the canonical source.
+      const fallbackSpec: CanonicalSpec | null =
+        spec ??
+        (editsStoredSkillZip ? (latestSpec ?? null) : null) ??
+        (kind === "plugin"
+          ? ({ kind: "plugin" } as unknown as CanonicalSpec)
+          : kind === "skill"
+            ? ({ kind: "skill" } as unknown as CanonicalSpec)
+            : null)
+      if (!fallbackSpec) throw new Error("Capability content is not ready")
 
-    const payload: ImportCapabilityVersionCommitRequest = {
-      canonical_spec: fallbackSpec,
-      inline_secrets: kind === "plugin" || inlineSecrets.length === 0 ? undefined : inlineSecrets,
-      source_payload: rawText
-        ? { raw_text: rawText, source_format: sourceFormat }
-        : undefined,
-      // omit oss_key on plugin/skill-zip reuse — backend treats missing key
-      // as "carry forward the previous version's blob".
-      oss_key: ossKeyToSend,
-      upload_source: uploadSourceToSend,
+      const ossKeyToSend =
+        editedSkillOssKey ??
+        (kind === "plugin"
+          ? (pluginUpload.ossKey ?? undefined)
+          : kind === "skill"
+            ? (skillOssKey ?? undefined)
+            : undefined)
+      const uploadSourceToSend = editsStoredSkillZip
+        ? "zip"
+        : kind === "plugin"
+          ? (pluginUpload.uploadSource ?? undefined)
+          : kind === "skill" && skillOssKey
+            ? "zip"
+            : undefined
+
+      const payload: ImportCapabilityVersionCommitRequest = {
+        canonical_spec: fallbackSpec,
+        inline_secrets: kind === "plugin" || inlineSecrets.length === 0 ? undefined : inlineSecrets,
+        source_payload:
+          editsStoredSkillZip && latestVersion
+            ? editedSourcePayload(latestVersion)
+            : rawText
+              ? { raw_text: rawText, source_format: sourceFormat }
+              : undefined,
+        oss_key: ossKeyToSend,
+        upload_source: uploadSourceToSend,
+      }
+      await commitMut.mutateAsync(payload)
+      onOpenChange(false)
+      onCommitted()
+    } catch (error) {
+      setSubmitError(formatError(error))
+    } finally {
+      setIsSaving(false)
     }
-    commitMut.mutate(payload, {
-      onSuccess: () => {
-        onOpenChange(false)
-        onCommitted()
-      },
-    })
   }
 
   // Inherited inline_secret env entries (server-allocated secret_id from
@@ -236,41 +334,49 @@ export function AddCapabilityVersionDialog({
       <DialogContent
         className="max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-6xl overflow-x-hidden overflow-y-auto"
         onInteractOutside={(e) => {
-          if (commitMut.isPending || updateMut.isPending) e.preventDefault()
+          if (isSaving || commitMut.isPending || updateMut.isPending) e.preventDefault()
         }}
       >
         <DialogHeader>
           <DialogTitle>
             {t("capabilities.versions.add.title", { name: capability.name })}
           </DialogTitle>
-          <DialogDescription>
-            {t("capabilities.versions.add.description")}
-          </DialogDescription>
+          <DialogDescription>{t("capabilities.versions.add.description")}</DialogDescription>
         </DialogHeader>
 
         {prefill.didPrefill && (
           <InfoBanner>
             {t("capabilities.versions.add.prefillFromLatest", {
               version: latestVersion?.version ?? "",
-              defaultValue: "Pre-filled with the previous version ({{version}}). Edits will be submitted as a new version.",
+              defaultValue:
+                "Pre-filled with the previous version ({{version}}). Edits will be submitted as a new version.",
             })}
           </InfoBanner>
         )}
-        {inheritedOssLabel && (kind === "plugin" || kind === "skill") && (
+        {editsStoredSkillZip && inheritedOssLabel && (
+          <InfoBanner>
+            {t("capabilities.versions.add.editStoredZip", {
+              filename: inheritedOssLabel,
+              defaultValue:
+                "Editing {{filename}}. Saving uploads the complete folder as a new version.",
+            })}
+          </InfoBanner>
+        )}
+        {!editsStoredSkillZip && inheritedOssLabel && (kind === "plugin" || kind === "skill") && (
           <InfoBanner>
             {t("capabilities.versions.add.reuseExistingZip", {
               filename: inheritedOssLabel,
-              defaultValue: "Current version package: {{filename}}. If you do not re-upload, the new version will reuse this package.",
+              defaultValue:
+                "Current version package: {{filename}}. If you do not re-upload, the new version will reuse this package.",
             })}
           </InfoBanner>
         )}
         {inheritedInlineSecrets.length > 0 && (
           <WarningBanner>
             {t("capabilities.versions.add.inlineSecretLostWarning", {
-              keys: inheritedInlineSecrets
-                .map((e) => `${e.server}.${e.envKey}`)
-                .join(", "),
-              defaultValue: "Previous-version inline secrets ({{keys}}) are hidden. Re-enter them in plaintext to keep, or switch to managed credentials.",
+              keys: inheritedInlineSecrets.map((e) => `${e.server}.${e.envKey}`).join(", "),
+              defaultValue:
+                "Previous-version inline secrets ({{keys}}) are hidden. Re-enter them in plaintext to keep, or switch to managed credentials.",
             })}
           </WarningBanner>
         )}
@@ -319,6 +425,46 @@ export function AddCapabilityVersionDialog({
               initialRawText={prefill.rawText}
               initialFormat={prefill.format}
             />
+          ) : kind === "skill" && editsStoredSkillZip ? (
+            <div className="grid gap-3">
+              {skillArchiveStatus === "loading" && (
+                <div className="flex min-h-40 items-center justify-center gap-2 rounded-lg border border-line bg-surface-subtle text-sm text-fg-muted">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  {t("capabilities.versions.add.loadingZip", "Loading the current Skill package…")}
+                </div>
+              )}
+              {skillArchiveStatus === "error" && (
+                <div className="rounded-lg border border-danger-border bg-danger-subtle p-4 text-sm text-danger-emphasis">
+                  <p className="break-all">{skillArchiveError}</p>
+                  <Button
+                    className="mt-3"
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setSkillArchiveStatus("loading")
+                      setSkillArchiveError(null)
+                      setSkillLoadAttempt((attempt) => attempt + 1)
+                    }}
+                  >
+                    {t("capabilities.actions.retry", "Retry")}
+                  </Button>
+                </div>
+              )}
+              {skillArchiveStatus === "ready" && (
+                <SkillFileTree
+                  files={skillTreeFiles}
+                  editable
+                  onFileChange={(path, content) => {
+                    setSkillArchive(
+                      (current) =>
+                        current?.map((file) =>
+                          file.path === path ? { ...file, text: content, dirty: true } : file,
+                        ) ?? null,
+                    )
+                  }}
+                />
+              )}
+            </div>
           ) : kind === "skill" ? (
             <ImportSkillForm
               workspaceID={workspaceID}
@@ -358,13 +504,13 @@ export function AddCapabilityVersionDialog({
           <Button
             variant="outline"
             size="sm"
-            disabled={commitMut.isPending || updateMut.isPending}
+            disabled={isSaving || commitMut.isPending || updateMut.isPending}
             onClick={() => onOpenChange(false)}
           >
             {t("capabilities.actions.cancel")}
           </Button>
           <Button size="sm" disabled={!canSubmit} onClick={submit}>
-            {(commitMut.isPending || updateMut.isPending) && (
+            {(isSaving || commitMut.isPending || updateMut.isPending) && (
               <Loader2 className="h-3.5 w-3.5 animate-spin" />
             )}
             {t("capabilities.actions.addVersion")}
@@ -388,19 +534,186 @@ function usePrefillFromLatest(latestVersion: CapabilityVersion | undefined): {
 } {
   return useMemo(() => {
     const sp = latestVersion?.source_payload as
-      | { raw_text?: string; source_format?: string; format?: string; body?: string }
-      | undefined
+      { raw_text?: string; source_format?: string; format?: string; body?: string } | undefined
     // Accepts two source_payload shapes for forward-compat:
     //   { raw_text, source_format } — new dialog
     //   { format, body }            — early server code
     const rawText = sp?.raw_text ?? sp?.body ?? ""
     const fmtRaw = (sp?.source_format ?? sp?.format ?? "").toLowerCase()
     const valid: SourceFormat[] = ["json", "toml", "markdown"]
-    const format = (valid as string[]).includes(fmtRaw)
-      ? (fmtRaw as SourceFormat)
-      : "json"
+    const format = (valid as string[]).includes(fmtRaw) ? (fmtRaw as SourceFormat) : "json"
     return { rawText, format, didPrefill: rawText.length > 0 }
   }, [latestVersion])
+}
+
+function unpackSkillArchive(bytes: Uint8Array): SkillArchiveEntry[] {
+  const unpacked = unzipSync(bytes)
+  const archivePaths = Object.keys(unpacked)
+  const normalizedPaths = archivePaths.map(normalizeZipPath)
+  const root = detectSingleRoot(normalizedPaths)
+  const entries = archivePaths.map((archivePath): SkillArchiveEntry => {
+    const normalized = normalizeZipPath(archivePath)
+    const path = root && normalized.startsWith(root) ? normalized.slice(root.length) : normalized
+    const directory = /[\\/]$/.test(archivePath) || path === ""
+    const hidden = directory || isMacOSMetadata(path)
+    const fileBytes = unpacked[archivePath]
+    return {
+      archivePath,
+      path,
+      bytes: fileBytes,
+      text: directory ? null : decodeEditableText(path, fileBytes),
+      dirty: false,
+      directory,
+      hidden,
+      kind: inferSkillFileKind(path),
+    }
+  })
+  if (!entries.some((entry) => !entry.directory && entry.path.toLowerCase() === "skill.md")) {
+    throw new Error("The stored package does not contain a root SKILL.md")
+  }
+  return entries.sort((a, b) => {
+    if (a.path.toLowerCase() === "skill.md") return -1
+    if (b.path.toLowerCase() === "skill.md") return 1
+    return a.path.localeCompare(b.path)
+  })
+}
+
+function buildSkillZipFile(entries: SkillArchiveEntry[], filename: string): File {
+  const files: Record<string, Uint8Array> = {}
+  for (const entry of entries) {
+    if (entry.directory) continue
+    files[entry.archivePath] =
+      entry.dirty && entry.text !== null ? strToU8(entry.text) : entry.bytes
+  }
+  const zipped = zipSync(files, { level: 6 })
+  return new File([zipped], filename, { type: "application/zip" })
+}
+
+function decodeEditableText(path: string, bytes: Uint8Array): string | null {
+  if (path.toLowerCase() === "skill.md") return strFromU8(bytes)
+  if (!isTextPath(path)) return null
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+  } catch {
+    return null
+  }
+}
+
+function isTextPath(path: string): boolean {
+  const lower = path.toLowerCase()
+  const basename = lower.split("/").pop() ?? lower
+  if (["dockerfile", "makefile", "license", ".gitignore", ".env"].includes(basename)) {
+    return true
+  }
+  return [
+    ".md",
+    ".markdown",
+    ".txt",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".py",
+    ".sh",
+    ".bash",
+    ".js",
+    ".jsx",
+    ".mjs",
+    ".cjs",
+    ".ts",
+    ".tsx",
+    ".css",
+    ".html",
+    ".htm",
+    ".xml",
+    ".svg",
+    ".csv",
+    ".ini",
+    ".cfg",
+    ".conf",
+    ".sql",
+    ".graphql",
+    ".gql",
+    ".go",
+    ".rs",
+    ".java",
+    ".rb",
+    ".php",
+    ".pl",
+    ".ps1",
+    ".bat",
+    ".cmd",
+  ].some((extension) => lower.endsWith(extension))
+}
+
+function inferSkillFileKind(path: string): SkillFileTreeEntry["kind"] {
+  const lower = path.toLowerCase()
+  if (lower.endsWith(".md") || lower.endsWith(".markdown")) return "markdown"
+  if (
+    [".py", ".sh", ".bash", ".js", ".ts", ".mjs", ".cjs"].some((extension) =>
+      lower.endsWith(extension),
+    )
+  ) {
+    return "script"
+  }
+  return "asset"
+}
+
+function normalizeZipPath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/$/, "")
+}
+
+function detectSingleRoot(paths: string[]): string {
+  const first = paths.find(
+    (path) =>
+      path !== "" && path !== "__MACOSX" && !path.startsWith("__MACOSX/") && path.includes("/"),
+  )
+  if (!first) return ""
+  const slash = first.indexOf("/")
+  if (slash <= 0) return ""
+  const root = first.slice(0, slash + 1)
+  if (root.startsWith(".")) return ""
+  for (const path of paths) {
+    if (path === "" || path === "__MACOSX" || path.startsWith("__MACOSX/")) continue
+    if (`${path}/` === root) continue
+    if (!path.startsWith(root)) return ""
+  }
+  return root
+}
+
+function isMacOSMetadata(path: string): boolean {
+  return (
+    path === "__MACOSX" ||
+    path.startsWith("__MACOSX/") ||
+    path.endsWith("/.DS_Store") ||
+    path === ".DS_Store"
+  )
+}
+
+function editedSourcePayload(version: CapabilityVersion): Record<string, unknown> {
+  const existing = version.source_payload
+  const source =
+    existing && typeof existing === "object" && !Array.isArray(existing)
+      ? (existing as Record<string, unknown>)
+      : {}
+  return {
+    ...source,
+    edited_from_version_id: version.id,
+    edited_via: "web_file_editor",
+  }
+}
+
+function safeZipBase(value: string): string {
+  const safe = value
+    .trim()
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return safe || "skill"
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof ApiError) return error.envelope.message
+  return error instanceof Error ? error.message : String(error)
 }
 
 /**

--- a/apps/web/src/pages/admin/capabilities/SkillFileTree.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillFileTree.tsx
@@ -1,17 +1,8 @@
-/**
- * Preview panel for a multi-file Skill zip. SKILL.md expanded; others
- * collapsed by default. Renders as syntax-highlighted source (not
- * rendered markdown) so packaging mistakes — broken frontmatter,
- * indentation — stay visible. shiki is loaded lazily; the highlighter
- * is created on first expand and reused.
- */
+/** Multi-file Skill viewer with an optional plain-text edit mode. */
 import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ChevronRight, FileText, FolderOpen } from "lucide-react"
-import {
-  createHighlighterCore,
-  type HighlighterCore,
-} from "shiki/core"
+import { createHighlighterCore, type HighlighterCore } from "shiki/core"
 import { createOnigurumaEngine } from "shiki/engine/oniguruma"
 
 import {
@@ -21,25 +12,40 @@ import {
 } from "../../../components/ui/collapsible"
 import type { CanonicalSkillSpec, SkillFile } from "./types"
 
-interface Props {
-  skill: CanonicalSkillSpec
+export interface SkillFileTreeEntry {
+  path: string
+  content: string | null
+  kind: SkillFile["kind"]
+  size?: number
 }
 
-export function SkillFileTree({ skill }: Props) {
-  const { t } = useTranslation("admin")
-  const files = useMemo(() => skill.files ?? [], [skill.files])
+interface Props {
+  skill?: CanonicalSkillSpec
+  files?: SkillFileTreeEntry[]
+  editable?: boolean
+  onFileChange?: (path: string, content: string) => void
+}
 
-  const grouped = useMemo(() => groupFiles(files), [files])
+export function SkillFileTree({ skill, files, editable = false, onFileChange }: Props) {
+  const { t } = useTranslation("admin")
+  const entries = useMemo(() => files ?? (skill ? buildTreeEntries(skill) : []), [files, skill])
+  const skillMd = entries.find((file) => file.path.toLowerCase() === "skill.md")
+  const grouped = useMemo(
+    () => groupFiles(entries.filter((file) => file !== skillMd)),
+    [entries, skillMd],
+  )
 
   return (
     <section className="grid gap-3">
-      <SkillMdCard skill={skill} />
+      {skillMd && <SkillMdCard file={skillMd} editable={editable} onFileChange={onFileChange} />}
 
       {grouped.references.length > 0 && (
         <GroupCard
           icon={<FolderOpen className="h-4 w-4 text-fg-subtle" />}
           title={t("capabilities.import.skill.fileTree.references", "references/")}
           files={grouped.references}
+          editable={editable}
+          onFileChange={onFileChange}
         />
       )}
       {grouped.scripts.length > 0 && (
@@ -47,6 +53,8 @@ export function SkillFileTree({ skill }: Props) {
           icon={<FolderOpen className="h-4 w-4 text-fg-subtle" />}
           title={t("capabilities.import.skill.fileTree.scripts", "scripts/")}
           files={grouped.scripts}
+          editable={editable}
+          onFileChange={onFileChange}
         />
       )}
       {grouped.other.length > 0 && (
@@ -54,19 +62,25 @@ export function SkillFileTree({ skill }: Props) {
           icon={<FolderOpen className="h-4 w-4 text-fg-subtle" />}
           title={t("capabilities.import.skill.fileTree.other", "Other files")}
           files={grouped.other}
+          editable={editable}
+          onFileChange={onFileChange}
         />
       )}
     </section>
   )
 }
 
-function SkillMdCard({ skill }: { skill: CanonicalSkillSpec }) {
+function SkillMdCard({
+  file,
+  editable,
+  onFileChange,
+}: {
+  file: SkillFileTreeEntry
+  editable: boolean
+  onFileChange?: (path: string, content: string) => void
+}) {
   const { t } = useTranslation("admin")
   const [open, setOpen] = useState(true)
-
-  // Parser drops the raw bytes; rebuild from canonical fields so what
-  // the user sees matches what's been imported.
-  const source = useMemo(() => buildSkillMdSource(skill), [skill])
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
@@ -82,7 +96,7 @@ function SkillMdCard({ skill }: { skill: CanonicalSkillSpec }) {
           </span>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <ShikiCode content={source} lang="markdown" />
+          <FileBody file={file} editable={editable} onFileChange={onFileChange} />
         </CollapsibleContent>
       </div>
     </Collapsible>
@@ -119,10 +133,14 @@ function GroupCard({
   icon,
   title,
   files,
+  editable,
+  onFileChange,
 }: {
   icon: React.ReactNode
   title: string
-  files: SkillFile[]
+  files: SkillFileTreeEntry[]
+  editable: boolean
+  onFileChange?: (path: string, content: string) => void
 }) {
   const [open, setOpen] = useState(false)
   return (
@@ -134,14 +152,12 @@ function GroupCard({
           />
           {icon}
           <span className="font-mono text-sm text-fg-muted">{title}</span>
-          <span className="ml-auto text-xs text-fg-subtle">
-            {files.length}
-          </span>
+          <span className="ml-auto text-xs text-fg-subtle">{files.length}</span>
         </CollapsibleTrigger>
         <CollapsibleContent>
           <ul className="grid gap-2 p-3">
             {files.map((f) => (
-              <FileRow key={f.path} file={f} />
+              <FileRow key={f.path} file={f} editable={editable} onFileChange={onFileChange} />
             ))}
           </ul>
         </CollapsibleContent>
@@ -150,7 +166,15 @@ function GroupCard({
   )
 }
 
-function FileRow({ file }: { file: SkillFile }) {
+function FileRow({
+  file,
+  editable,
+  onFileChange,
+}: {
+  file: SkillFileTreeEntry
+  editable: boolean
+  onFileChange?: (path: string, content: string) => void
+}) {
   const [open, setOpen] = useState(false)
   return (
     <li>
@@ -161,19 +185,49 @@ function FileRow({ file }: { file: SkillFile }) {
           />
           <FileText className="h-3.5 w-3.5 shrink-0 text-fg-subtle" />
           <code className="truncate font-mono text-xs text-fg-emphasis">{file.path}</code>
-          <span className="ml-auto text-xs uppercase tracking-wide text-fg-faint">
-            {file.kind}
-          </span>
+          <span className="ml-auto text-xs uppercase tracking-wide text-fg-faint">{file.kind}</span>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <FileBody file={file} />
+          <FileBody file={file} editable={editable} onFileChange={onFileChange} />
         </CollapsibleContent>
       </Collapsible>
     </li>
   )
 }
 
-function FileBody({ file }: { file: SkillFile }) {
+function FileBody({
+  file,
+  editable,
+  onFileChange,
+}: {
+  file: SkillFileTreeEntry
+  editable: boolean
+  onFileChange?: (path: string, content: string) => void
+}) {
+  const { t } = useTranslation("admin")
+  if (file.content === null) {
+    return (
+      <div className="bg-surface-subtle px-3 py-4 text-xs text-fg-subtle">
+        {t("capabilities.versions.add.binaryPreserved", {
+          size: file.size ?? 0,
+          defaultValue: "Binary file ({{size}} bytes). It will be preserved unchanged.",
+        })}
+      </div>
+    )
+  }
+  if (editable) {
+    return (
+      <textarea
+        value={file.content}
+        onChange={(event) => onFileChange?.(file.path, event.target.value)}
+        rows={16}
+        spellCheck={false}
+        autoCorrect="off"
+        autoCapitalize="off"
+        className="block min-h-64 w-full resize-y border-0 bg-surface-subtle px-3 py-2 font-mono text-xs leading-relaxed text-fg focus:outline-none focus:ring-2 focus:ring-inset focus:ring-line-strong"
+      />
+    )
+  }
   const lang = inferLang(file.path)
   return <ShikiCode content={file.content} lang={lang} />
 }
@@ -223,15 +277,15 @@ function ShikiCode({ content, lang }: { content: string; lang: string }) {
 /* ---------- helpers ---------------------------------------------------- */
 
 interface Grouped {
-  references: SkillFile[]
-  scripts: SkillFile[]
-  other: SkillFile[]
+  references: SkillFileTreeEntry[]
+  scripts: SkillFileTreeEntry[]
+  other: SkillFileTreeEntry[]
 }
 
-function groupFiles(files: SkillFile[]): Grouped {
-  const references: SkillFile[] = []
-  const scripts: SkillFile[] = []
-  const other: SkillFile[] = []
+function groupFiles(files: SkillFileTreeEntry[]): Grouped {
+  const references: SkillFileTreeEntry[] = []
+  const scripts: SkillFileTreeEntry[] = []
+  const other: SkillFileTreeEntry[] = []
   // Stable sort makes the list reproducible across re-uploads.
   const sorted = [...files].sort((a, b) => a.path.localeCompare(b.path))
   for (const f of sorted) {
@@ -242,13 +296,23 @@ function groupFiles(files: SkillFile[]): Grouped {
   return { references, scripts, other }
 }
 
+function buildTreeEntries(skill: CanonicalSkillSpec): SkillFileTreeEntry[] {
+  return [
+    {
+      path: "SKILL.md",
+      content: buildSkillMdSource(skill),
+      kind: "markdown",
+    },
+    ...(skill.files ?? []).map((file) => ({ ...file })),
+  ]
+}
+
 function inferLang(path: string): string {
   const lower = path.toLowerCase()
   if (lower.endsWith(".py")) return "python"
   if (lower.endsWith(".sh") || lower.endsWith(".bash")) return "bash"
   if (lower.endsWith(".ts") || lower.endsWith(".tsx")) return "typescript"
-  if (lower.endsWith(".js") || lower.endsWith(".jsx") || lower.endsWith(".mjs"))
-    return "javascript"
+  if (lower.endsWith(".js") || lower.endsWith(".jsx") || lower.endsWith(".mjs")) return "javascript"
   if (lower.endsWith(".json")) return "json"
   if (lower.endsWith(".yaml") || lower.endsWith(".yml")) return "yaml"
   if (lower.endsWith(".toml")) return "toml"

--- a/apps/web/src/pages/admin/capabilities/api.ts
+++ b/apps/web/src/pages/admin/capabilities/api.ts
@@ -42,7 +42,18 @@ export interface PresignUploadResponse {
   expiresAt: string
 }
 
-async function postPresignUpload(workspaceID: string, filename: string, prefix: string): Promise<PresignUploadResponse> {
+export interface PresignDownloadResponse {
+  downloadUrl: string
+  method?: string
+  headers?: Record<string, string>
+  expiresAt: string
+}
+
+async function postPresignUpload(
+  workspaceID: string,
+  filename: string,
+  prefix: string,
+): Promise<PresignUploadResponse> {
   return apiRequest<PresignUploadResponse>(
     `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/uploads/presign-upload`,
     {
@@ -76,7 +87,7 @@ export function usePresignUploadMutation(workspaceID: string | null) {
  * older servers that don't send method/headers.
  */
 export async function putToPresignedURL(presign: PresignUploadResponse, file: File): Promise<void> {
-  const resp = await fetch(presign.uploadUrl, {
+  const resp = await fetch(resolvePresignedBlobURL(presign.uploadUrl), {
     method: presign.method ?? "PUT",
     body: file,
     headers: presign.headers ?? { "Content-Type": "application/octet-stream" },
@@ -89,6 +100,39 @@ export async function putToPresignedURL(presign: PresignUploadResponse, file: Fi
       message: `Upload failed: ${resp.status} ${resp.statusText}${detail ? ` — ${detail.slice(0, 200)}` : ""}`,
     })
   }
+}
+
+/** Download a workspace-owned blob through the existing presign route. */
+export async function downloadStoredZip(workspaceID: string, ossKey: string): Promise<Uint8Array> {
+  const presign = await apiRequest<PresignDownloadResponse>(
+    `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/uploads/presign-download`,
+    {
+      method: "POST",
+      body: { ossKey },
+    },
+  )
+  const resp = await fetch(resolvePresignedBlobURL(presign.downloadUrl), {
+    method: presign.method ?? "GET",
+    headers: presign.headers,
+  })
+  if (!resp.ok) {
+    const detail = await resp.text().catch(() => "")
+    throw new ApiError({
+      status: resp.status,
+      code: "blob_download_failed",
+      message: `Download failed: ${resp.status} ${resp.statusText}${detail ? ` — ${detail.slice(0, 200)}` : ""}`,
+    })
+  }
+  return new Uint8Array(await resp.arrayBuffer())
+}
+
+function resolvePresignedBlobURL(blobURL: string): string {
+  if (!import.meta.env.DEV || typeof window === "undefined") return blobURL
+  const parsed = new URL(blobURL, window.location.href)
+  if (parsed.origin === window.location.origin || !parsed.pathname.startsWith("/internal/blobs/")) {
+    return blobURL
+  }
+  return `${parsed.pathname}${parsed.search}`
 }
 
 /**
@@ -147,7 +191,9 @@ export function useImportCommitMutation(workspaceID: string | null) {
       void qc.invalidateQueries({ queryKey: KEY_CAPABILITIES_WORKSPACE(workspaceID ?? "_none") })
       void qc.invalidateQueries({ queryKey: ["admin", "capability"] })
       if (workspaceID) {
-        void qc.invalidateQueries({ queryKey: KEY_CAPABILITY_VERSIONS(workspaceID, res.capability.id) })
+        void qc.invalidateQueries({
+          queryKey: KEY_CAPABILITY_VERSIONS(workspaceID, res.capability.id),
+        })
       }
     },
   })
@@ -189,7 +235,9 @@ export function useImportCapabilityVersionMutation(
       void qc.invalidateQueries({ queryKey: KEY_CAPABILITIES_WORKSPACE(workspaceID ?? "_none") })
       void qc.invalidateQueries({ queryKey: ["admin", "capability"] })
       if (workspaceID) {
-        void qc.invalidateQueries({ queryKey: KEY_CAPABILITY_VERSIONS(workspaceID, res.capability.id) })
+        void qc.invalidateQueries({
+          queryKey: KEY_CAPABILITY_VERSIONS(workspaceID, res.capability.id),
+        })
       }
     },
   })

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -45,7 +45,6 @@ import {
   useCapabilitiesQuery,
   useCapabilityQuery,
   useCapabilityVersionsQuery,
-  useUpdateCapability,
 } from "../../../lib/api-capabilities"
 import {
   useDelete,
@@ -66,7 +65,9 @@ import { MarketplaceTab } from "./MarketplaceTab"
 import { DeleteCapabilityDialog } from "./DeleteCapabilityDialog"
 import { ImportCapabilityDialog } from "./ImportCapabilityDialog"
 import { AddCapabilityVersionDialog } from "./AddCapabilityVersionDialog"
+import { SkillFileTree } from "./SkillFileTree"
 import { UninstallMarketplaceDialog } from "./UninstallMarketplaceDialog"
+import type { CanonicalSkillSpec } from "./types"
 
 interface AgentInstallation {
   agentID: string
@@ -715,8 +716,6 @@ export function CapabilityDetailPage({ id }: { id: string }) {
   const versionsQ = useCapabilityVersionsQuery(wid, id)
   const agentsQ = useAgents(wid)
   const workspacesQ = useMyWorkspaces()
-  const updateMut = useUpdateCapability(wid)
-  const [editOpen, setEditOpen] = useState(false)
   const [addVersionOpen, setAddVersionOpen] = useState(false)
   const [viewVersion, setViewVersion] = useState<CapabilityVersion | null>(null)
   const [toast, setToast] = useState<string | null>(null)
@@ -759,7 +758,7 @@ export function CapabilityDetailPage({ id }: { id: string }) {
         action={
           <>
             <Badge variant={capability.deprecated_at ? "neutral" : "success"} dot>{t(capability.deprecated_at ? "capabilities.status.deprecated" : "capabilities.status.active")}</Badge>
-            {isAdmin && <Button size="sm" variant="outline" onClick={() => setEditOpen(true)}>{t("capabilities.actions.edit")}</Button>}
+            {isAdmin && <Button size="sm" variant="outline" onClick={() => setAddVersionOpen(true)}>{t("capabilities.actions.edit")}</Button>}
             {isAdmin && <Button size="sm" onClick={() => setAddVersionOpen(true)}><Plus className="h-3.5 w-3.5" />{t("capabilities.actions.addVersion")}</Button>}
           </>
         }
@@ -839,24 +838,6 @@ export function CapabilityDetailPage({ id }: { id: string }) {
         </Card>
       </div>
 
-      <EditCapabilityDialog
-        open={editOpen}
-        capability={capability}
-        pending={updateMut.isPending}
-        error={updateMut.error}
-        onOpenChange={(open) => {
-          setEditOpen(open)
-          if (!open) updateMut.reset()
-        }}
-        onSubmit={(body) => {
-          updateMut.mutate({ capabilityID: capability.id, body }, {
-            onSuccess: () => {
-              setEditOpen(false)
-              setToast(t("capabilities.toast.updated", { name: body.name ?? capability.name }))
-            },
-          })
-        }}
-      />
       <AddCapabilityVersionDialog
         workspaceID={wid}
         capability={capability}
@@ -882,73 +863,12 @@ export function CapabilityTypeBadge({ type }: { type: Capability["type"] }) {
   return <Badge variant="neutral">MCP</Badge>
 }
 
-/**
- * EditCapabilityDialog — minimal name + description editor.
- *
- * The pre-M4 page used CreateCapabilityDialog in mode="edit" for this, which
- * dragged in the full create form just to disable most of it. Now that the
- * create path goes through the import flow, this dialog is small enough to
- * inline.
- */
-function EditCapabilityDialog({ open, capability, pending, error, onOpenChange, onSubmit }: {
-  open: boolean
-  capability: Capability
-  pending: boolean
-  error: unknown
-  onOpenChange: (open: boolean) => void
-  onSubmit: (body: { name?: string; description?: string }) => void
-}) {
-  const { t } = useTranslation("admin")
-  const [name, setName] = useState(capability.name)
-  const [description, setDescription] = useState(capability.description ?? "")
-
-  useEffect(() => {
-    if (!open) return
-    setName(capability.name)
-    setDescription(capability.description ?? "")
-  }, [open, capability])
-
-  const errMsg = error instanceof ApiError ? error.envelope.message : error instanceof Error ? error.message : null
-  const trimmedName = name.trim()
-  const validationError = !trimmedName
-    ? t("capabilities.errors.nameRequired")
-    : trimmedName.length > 50
-      ? t("capabilities.errors.nameTooLong")
-      : null
-
-  return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>{t("capabilities.edit.title")}</DialogTitle>
-          <DialogDescription>{t("capabilities.edit.description")}</DialogDescription>
-        </DialogHeader>
-        <div className="space-y-3">
-          <FormField label={t("capabilities.fields.name.label")} help={t("capabilities.fields.name.help")} required>
-            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder={t("capabilities.fields.name.placeholder")} />
-          </FormField>
-          <FormField label={t("capabilities.fields.description.label")}>
-            <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t("capabilities.fields.description.placeholder")} />
-          </FormField>
-          {(validationError || errMsg) && <ErrorBanner message={validationError ?? errMsg ?? ""} />}
-        </div>
-        <DialogFooter>
-          <Button variant="outline" size="sm" onClick={() => onOpenChange(false)} disabled={pending}>{t("capabilities.actions.cancel")}</Button>
-          <Button size="sm" disabled={pending || !!validationError} onClick={() => onSubmit({ name: trimmedName, description: description.trim() })}>
-            {pending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}{t("capabilities.actions.save")}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  )
-}
-
 function ViewVersionContentDialog({ version, capability, onOpenChange }: { version: CapabilityVersion | null; capability: Capability; onOpenChange: (open: boolean) => void }) {
   const { t } = useTranslation("admin")
   const body = version ? renderViewVersionBody(version, capability, t) : null
   return (
     <Dialog open={!!version} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-6xl overflow-y-auto">
         <DialogHeader>
           <DialogTitle>{t("capabilities.versions.viewContent.title", { version: version?.version })}</DialogTitle>
           <DialogDescription>{t("capabilities.versions.viewContent.description")}</DialogDescription>
@@ -981,7 +901,7 @@ function renderViewVersionBody(version: CapabilityVersion, capability: Capabilit
   const canonicalSpec = version.canonical_spec as
     | {
         mcp?: Record<string, unknown>
-        skill?: CanonicalSkillSpecView
+        skill?: CanonicalSkillSpec
         plugin?: CanonicalPluginSpecView
         system_prompt?: { prompt?: string; mode?: string }
       }
@@ -1040,21 +960,7 @@ function renderViewVersionBody(version: CapabilityVersion, capability: Capabilit
 
   // skill
   if (canonicalSpec?.skill) {
-    const skill = canonicalSpec.skill
-    return (
-      <div className="space-y-2 rounded-md border border-line bg-surface-subtle p-3">
-        {skill.slug && <DetailField label="slug" value={skill.slug} mono />}
-        {skill.title && <DetailField label="title" value={skill.title} />}
-        {skill.description && <DetailField label="description" value={skill.description} />}
-        {skill.trigger && <DetailField label="trigger" value={skill.trigger} />}
-        {skill.instruction && (
-          <DetailField
-            label="instruction"
-            value={<pre className="whitespace-pre-wrap font-mono text-sm leading-relaxed text-fg-muted">{skill.instruction}</pre>}
-          />
-        )}
-      </div>
-    )
+    return <SkillFileTree skill={canonicalSpec.skill} />
   }
   return (
     <div className="space-y-2 rounded-md border border-line bg-surface-subtle p-3">
@@ -1076,14 +982,6 @@ interface CanonicalPluginSpecView {
   github_repo?: string
   github_ref?: string
   github_path?: string
-}
-
-interface CanonicalSkillSpecView {
-  slug?: string
-  title?: string
-  description?: string
-  instruction?: string
-  trigger?: string
 }
 
 function useCapabilityVersionSummary(workspaceID: string | null, capabilities: Capability[]) {
@@ -1149,20 +1047,12 @@ function countCapabilityInstalls(groups: AgentCapability[][]) {
   return counts
 }
 
-function FormField({ label, help, required, children }: { label: string; help?: string; required?: boolean; children: React.ReactNode }) {
-  return <label className="grid gap-1.5"><span className="text-sm font-medium text-fg-muted">{label}{required && <span className="text-danger"> *</span>}</span>{children}{help && <span className="text-xs leading-relaxed text-fg-subtle">{help}</span>}</label>
-}
-
 function DetailField({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
   return <div className="rounded-md border border-line bg-surface p-3"><p className="text-xs text-fg-subtle">{label}</p><div className={`mt-1 text-sm text-fg ${mono ? "font-mono" : ""}`}>{value}</div></div>
 }
 
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
   return <section className="rounded-lg border border-line bg-surface p-4"><h3 className="mb-3 text-base font-semibold text-fg">{title}</h3>{children}</section>
-}
-
-function ErrorBanner({ message }: { message: string }) {
-  return <div className="rounded-md border border-danger-border bg-danger-subtle px-3 py-2 text-sm text-danger-emphasis" role="alert">{message}</div>
 }
 
 function ToastBanner({ message }: { message: string }) {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
       '/dev': devProxy,
       '/api': devProxy,
       '/agent-daemon': devProxy,
+      '/internal/blobs': devProxy,
     },
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       i18next:
         specifier: ^26.3.4
         version: 26.3.4(typescript@5.9.3)
@@ -1482,6 +1485,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -3619,6 +3625,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
+
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- add a browser-side editor for Skill ZIP capabilities
- preserve binary files and unchanged file bytes when repacking the ZIP
- reuse the existing blob upload and capability version import/commit flow
- show the complete Skill file tree in the version viewer
- keep the implementation frontend-only, without changing parsers, database schema, import logic, bindings, or runtime

## Context

This is a stacked PR based on #243 (`codex/remove-capability-publish-workflow`).

MCP capabilities continue to use the existing JSON/TOML editing flow. Skill capabilities download the existing ZIP, edit text files in the browser, repack the complete folder, upload it through the existing presign flow, and create a new version through the existing import commit endpoint. Skills.sh source metadata is preserved.

## Validation

- `pnpm --filter @parsar/web typecheck`
- `pnpm --filter @parsar/web build`
- local end-to-end test on `grill-me`, creating version `1.0.1`
- verified a new `oss_key` and SHA-256 were generated
- verified Skills.sh metadata was preserved
- verified `agents/openai.yaml` remained byte-identical after repacking

Targeted ESLint still reports only pre-existing findings; this change adds no new lint findings.
