### PR TITLE
fix(web): limit agent wizard capabilities to MCP and Skill

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1673,9 +1673,7 @@
       "capabilityTypeTabs": {
         "all": "All",
         "mcp": "MCP",
-        "skill": "Skill",
-        "plugin": "Plugin",
-        "systemPrompt": "System Prompt"
+        "skill": "Skill"
       },
       "capabilitySections": {
         "workspace": "This Workspace",
@@ -1707,7 +1705,7 @@
           },
           "capabilities": {
             "title": "Capabilities",
-            "summary": "Skills, MCPs and plugins enabled by default"
+            "summary": "Skills and MCPs enabled by default"
           }
         },
         "actions": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1673,9 +1673,7 @@
       "capabilityTypeTabs": {
         "all": "全部",
         "mcp": "MCP",
-        "skill": "Skill",
-        "plugin": "插件",
-        "systemPrompt": "系统提示词"
+        "skill": "Skill"
       },
       "capabilitySections": {
         "workspace": "本 Workspace",
@@ -1707,7 +1705,7 @@
           },
           "capabilities": {
             "title": "能力",
-            "summary": "为这个 Agent 启用 Skill / MCP / 插件"
+            "summary": "为这个 Agent 启用 Skill / MCP"
           }
         },
         "actions": {

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -269,7 +269,7 @@ export function CreateAgentDialog({
   const [capabilityVersionChoices, setCapabilityVersionChoices] = useState<Record<string, { pinningMode: "latest" | "pinned"; versionID: string; pinnedVersion?: string }>>({})
   const [visibility, setVisibility] = useState<"workspace" | "tenant" | "public">("public")
   const [capabilitySearch, setCapabilitySearch] = useState("")
-  const [capabilityTypeFilter, setCapabilityTypeFilter] = useState<"all" | "mcp" | "skill" | "plugin" | "system_prompt">("all")
+  const [capabilityTypeFilter, setCapabilityTypeFilter] = useState<"all" | "mcp" | "skill">("all")
   const [deviceID, setDeviceID] = useState("")
   const [workDir, setWorkDir] = useState("")
   const [pairDialogOpen, setPairDialogOpen] = useState(false)
@@ -390,13 +390,11 @@ export function CreateAgentDialog({
   const capabilityTypeCounts = useMemo(() => {
     // Ghost rows have unknown type, so they're excluded from per-type tallies
     // (still count toward "all").
-    const counts = { all: capabilityOptions.length, mcp: 0, skill: 0, plugin: 0, system_prompt: 0 }
+    const counts = { all: capabilityOptions.length, mcp: 0, skill: 0 }
     for (const cap of capabilityOptions) {
       if (cap.deprecated) continue
       if (cap.type === "mcp") counts.mcp++
       else if (cap.type === "skill") counts.skill++
-      else if (cap.type === "plugin") counts.plugin++
-      else if (cap.type === "system_prompt") counts.system_prompt++
     }
     return counts
   }, [capabilityOptions])
@@ -1487,8 +1485,6 @@ export function CreateAgentDialog({
                         <TabsTrigger value="all">{t("agents.form.capabilityTypeTabs.all")} ({capabilityTypeCounts.all})</TabsTrigger>
                         <TabsTrigger value="mcp">{t("agents.form.capabilityTypeTabs.mcp")} ({capabilityTypeCounts.mcp})</TabsTrigger>
                         <TabsTrigger value="skill">{t("agents.form.capabilityTypeTabs.skill")} ({capabilityTypeCounts.skill})</TabsTrigger>
-                        <TabsTrigger value="plugin">{t("agents.form.capabilityTypeTabs.plugin")} ({capabilityTypeCounts.plugin})</TabsTrigger>
-                        <TabsTrigger value="system_prompt">{t("agents.form.capabilityTypeTabs.systemPrompt")} ({capabilityTypeCounts.system_prompt})</TabsTrigger>
                       </TabsList>
                     </Tabs>
                     <div className="max-h-56 overflow-y-auto rounded-md border border-line bg-surface">


### PR DESCRIPTION
## What & why

Capability management now supports MCP and Skill only, but the Agent wizard still showed empty Plugin and System Prompt filters and described plugins as selectable defaults. This made Step 2 disagree with the supported capability surface.

## How

- narrow the Agent wizard filter state and counts to All, MCP, and Skill
- remove the Plugin and System Prompt tabs
- update the English and Chinese capability summaries

## Verification

- [x] `make check`
- [x] `pnpm --filter @parsar/web build`
- [x] Relevant E2E target: not applicable; this only removes unsupported filter tabs

## Notes for reviewers

Frontend-only follow-up to #210. No API, database, or migration changes.