### PR TITLE
fix: use bearer auth for MiniMax in Claude Code

### DIFF
--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -306,6 +306,13 @@ func injectClaudeManagedModel(opts map[string]any, modelID string, mr store.Mode
 	// (ANTHROPIC_AUTH_TOKEN). When both vars are set Claude Code prefers
 	// AUTH_TOKEN, so set only the one matching the scheme.
 	authScheme := stringFromMap(mr.ProviderConfig, "auth_scheme")
+	if authScheme == "" {
+		switch strings.ToLower(strings.TrimSpace(mr.ProviderType)) {
+		case "minimax-cn", "minimax-en":
+			// MiniMax's Claude Code setup uses Authorization: Bearer.
+			authScheme = "bearer"
+		}
+	}
 	if authScheme == "bearer" {
 		delete(env, "ANTHROPIC_API_KEY")
 		env["ANTHROPIC_AUTH_TOKEN"] = apiKey

--- a/server/internal/connector/agentdaemon/model_injection_test.go
+++ b/server/internal/connector/agentdaemon/model_injection_test.go
@@ -506,6 +506,31 @@ func TestInjectManagedModel_BearerAuthScheme_InjectsAuthToken(t *testing.T) {
 	}
 }
 
+func TestInjectManagedModel_MiniMaxDefaultsToAuthToken(t *testing.T) {
+	for _, providerType := range []string{"minimax-cn", "minimax-en"} {
+		t.Run(providerType, func(t *testing.T) {
+			opts := map[string]any{}
+			mr := store.ModelRuntime{
+				ModelID:      "model-minimax",
+				ModelKey:     "MiniMax-M3",
+				ProviderType: providerType,
+				Adapter:      "@ai-sdk/anthropic",
+				BaseURL:      "https://api.minimax.io/anthropic",
+			}
+			if err := injectClaudeManagedModel(opts, mr.ModelID, mr, "sk-minimax"); err != nil {
+				t.Fatalf("injectClaudeManagedModel: %v", err)
+			}
+			env := opts["env"].(map[string]any)
+			if got := env["ANTHROPIC_AUTH_TOKEN"]; got != "sk-minimax" {
+				t.Fatalf("ANTHROPIC_AUTH_TOKEN=%v, want sk-minimax", got)
+			}
+			if _, exists := env["ANTHROPIC_API_KEY"]; exists {
+				t.Fatal("ANTHROPIC_API_KEY should not be set for MiniMax Claude Code")
+			}
+		})
+	}
+}
+
 // ----------------------------------------------------------------------
 // applySpecMemoryInjection
 // ----------------------------------------------------------------------


### PR DESCRIPTION
## What & why

MiniMax preset models do not set `auth_scheme`, so Claude Code received the credential through `ANTHROPIC_API_KEY` and MiniMax rejected the request with HTTP 401. MiniMax's [Claude Code setup](https://platform.minimax.io/docs/token-plan/claude-code) uses `ANTHROPIC_AUTH_TOKEN` and Bearer authentication.

## How

When `auth_scheme` is unset, default the `minimax-cn` and `minimax-en` providers to Bearer authentication in the Claude Code model injector. Explicit auth-scheme values and all other providers keep their existing behavior. Regression coverage exercises both MiniMax regions.

## Verification

- [x] `make check`
- [ ] Relevant E2E target (if any): no dedicated MiniMax E2E target exists
- [x] Manual smoke: local Parsar dispatched Claude Code to a paired development machine and no longer received the authentication 401; the upstream service subsequently returned a transient 503

## Notes for reviewers

The change is limited to the Claude Code runtime injector; direct Anthropic-compatible API health checks keep their existing authentication behavior.