### PR TITLE
fix(web): group streamed run message deltas

### DIFF
--- a/apps/web/src/lib/agent-run-event-format.ts
+++ b/apps/web/src/lib/agent-run-event-format.ts
@@ -1,0 +1,34 @@
+import type { AgentRunEvent } from "./api-types"
+
+export interface RawRunEventBlock {
+  key: string
+  text: string
+}
+
+function formatEvent(event: AgentRunEvent): string {
+  return `#${event.sequence} ${event.event_kind}\n${JSON.stringify(event.payload ?? {}, null, 2)}`
+}
+
+export function formatRawRunEvents(events: AgentRunEvent[]): RawRunEventBlock[] {
+  if (events.length > 0 && events.every((event) => event.event_kind === "message.delta")) {
+    const first = events[0]
+    const last = events[events.length - 1]
+    const sequence =
+      first.sequence === last.sequence
+        ? `#${first.sequence}`
+        : `#${first.sequence}-${last.sequence}`
+    const payload = {
+      ...last.payload,
+      delta: events.map((event) => String(event.payload?.delta ?? "")).join(""),
+    }
+
+    return [
+      {
+        key: first.id,
+        text: `${sequence} message.delta\n${JSON.stringify(payload, null, 2)}`,
+      },
+    ]
+  }
+
+  return events.map((event) => ({ key: event.id, text: formatEvent(event) }))
+}

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -61,6 +61,7 @@ import {
   useAgentRunEvents,
   useAgentRuns,
 } from "../../lib/api-agents"
+import { formatRawRunEvents } from "../../lib/agent-run-event-format"
 import type { AgentRunDetail, AgentRunEvent, AgentRunStatus, AgentRunSummary } from "../../lib/api-types"
 import { useWorkspaceId } from "../../lib/workspace"
 import { useRelativeTime } from "../../lib/relative-time"
@@ -1016,9 +1017,12 @@ function RunSteps({ events, loading }: { events: AgentRunEvent[]; loading: boole
                 </div>
                 {open && step.rawEvents.length > 0 && (
                   <div className="mt-2 space-y-2">
-                    {step.rawEvents.map((ev) => (
-                      <pre key={ev.id} className="whitespace-pre-wrap break-all rounded-md bg-surface-inverse p-3 text-xs leading-relaxed text-fg-on-emphasis">
-                        {`#${ev.sequence} ${ev.event_kind}\n${JSON.stringify(ev.payload ?? {}, null, 2)}`}
+                    {formatRawRunEvents(step.rawEvents).map((block) => (
+                      <pre
+                        key={block.key}
+                        className="whitespace-pre-wrap break-all rounded-md bg-surface-inverse p-3 text-xs leading-relaxed text-fg-on-emphasis"
+                      >
+                        {block.text}
                       </pre>
                     ))}
                   </div>


### PR DESCRIPTION
## Summary

- Group `message.delta` events into one raw event block per run step.
- Concatenate streamed text in event order while retaining the latest payload metadata.
- Keep non-delta raw event blocks, styling, and interactions unchanged across harnesses.
- Keep the formatter outside the oversized `RunsPage.tsx`.

## Scope

In scope: admin run raw-event formatting and rendering only.

Out of scope: backend or API changes, state management, harness-specific branches, and UI restyling.

## Testing

- Targeted formatter assertions for grouped deltas and unchanged non-delta events
- `pnpm --filter @parsar/web typecheck`
- `pnpm --filter @parsar/web build`
- `pnpm --filter @parsar/web exec eslint src/lib/agent-run-event-format.ts src/pages/admin/RunsPage.tsx --rule 'react-hooks/set-state-in-effect: off'`
- `make check` (passed; Docker was unavailable, so the repository script skipped its Postgres migration smoke test)

## Review

Two independent blind reviews of the complete diff found no issues.
