### PR TITLE
fix(claudecode): support home-relative work directories

### DIFF
--- a/apps/parsar-daemon/internal/agent/claudecode/plugins_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/plugins_test.go
@@ -581,6 +581,27 @@ func TestResolveSessionWorkDir_RespectsExplicitDir(t *testing.T) {
 	}
 }
 
+func TestResolveSessionWorkDir_ExpandsHomeRelativeDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := resolveSessionWorkDir("~/projects/demo", "conv-ignored")
+	if err != nil {
+		t.Fatalf("resolveSessionWorkDir: %v", err)
+	}
+	want := filepath.Join(home, "projects", "demo")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	info, err := os.Stat(got)
+	if err != nil {
+		t.Fatalf("stat home-relative dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("home-relative dir %q is not a directory", got)
+	}
+}
+
 // TestResolveSessionWorkDir_RejectsRelativeDir: relative paths are
 // ambiguous (resolved against daemon cwd, which is not a stable anchor
 // for user-facing config). The user gets a clear error instead of a

--- a/apps/parsar-daemon/internal/agent/claudecode/session.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/session.go
@@ -668,8 +668,8 @@ func (s *Session) closeOut() {
 // Resolution order:
 //
 //  1. req.WorkDir wins. Local mode where the operator pinned a project
-//     root. Must be absolute (we reject relative paths instead of
-//     resolving them against daemon cwd, since the daemon's cwd is
+//     root. Must be absolute or start with ~/ (we reject relative paths
+//     instead of resolving them against daemon cwd, since the daemon's cwd is
 //     not a meaningful anchor for user-facing config) and we mkdir -p
 //     so the user can name a path that doesn't exist yet.
 //  2. conversationID present → per-conversation scratch dir under
@@ -683,7 +683,13 @@ func (s *Session) closeOut() {
 // clearer message.
 func resolveSessionWorkDir(workDir, conversationID string) (string, error) {
 	if trimmed := strings.TrimSpace(workDir); trimmed != "" {
-		if !filepath.IsAbs(trimmed) {
+		if strings.HasPrefix(trimmed, "~/") {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return "", fmt.Errorf("resolve home dir: %w", err)
+			}
+			trimmed = filepath.Join(home, strings.TrimPrefix(trimmed, "~/"))
+		} else if !filepath.IsAbs(trimmed) {
 			return "", fmt.Errorf("work_dir must be an absolute path, got %q", trimmed)
 		}
 		if err := os.MkdirAll(trimmed, 0o755); err != nil {


### PR DESCRIPTION
## Summary
- expand `~/...` work directories before Claude Code creates or uses the directory
- add a regression test for home-relative workspace paths

## Boundary
This change is confined to the Claude Code daemon adapter's working-directory resolution. It aligns that adapter with the repository-wide contract that user-supplied working directories may be absolute or home-relative; it does not change server-side routing or persisted state.

## Testing
- Not run locally: this machine does not have the Go toolchain installed, so `make check` and the targeted Go test could not be executed.
- `git diff --check` passed.