### PR TITLE
fix: load managed skills in Codex and OpenCode

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,20 @@ git worktree add .worktrees/feature-name -b feature/name origin/main
 
 Direct development on `main` is not allowed. Every session honours this rule.
 
+## Independent blind review
+
+Substantial changes require two independent reviews after implementation and
+verification. Give each reviewer the requirements, acceptance criteria,
+project rules, and scope boundaries, but no implementation summary, suspected
+defects, or findings from the other reviewer. Each reviewer inspects the full
+diff.
+
+After material fixes, repeat the two independent reviews. Once only small
+convergence fixes remain, one independent reviewer is enough. If the same
+review-and-fix cycle keeps repeating, stop patching and reassess the design. If
+the design still does not converge, report the problem instead of expanding
+the change.
+
 ## Architecture baseline
 
 - **Server**: Go + Chi.
@@ -164,6 +178,9 @@ description and keep ownership on the side listed here.
 - Adapter-specific state directories must be derived from `AgentStateKey`
   under `~/.parsar/`; never use the repo checkout, container image working
   directory, or the process CWD as hidden state.
+- Keep uploaded Skill archives engine-neutral. Materialize adapter-managed
+  copies below the `AgentStateKey` runtime directory, then register that root
+  through the engine's native CLI, config, or RPC surface.
 
 ### Plugin Bundle (KindBundle) architecture
 

--- a/apps/parsar-daemon/internal/agent/claudecode/skills.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/skills.go
@@ -23,11 +23,11 @@ type skillDescriptor struct {
 	SHA256      string
 }
 
-// SkillInstallResult carries warnings the session should surface. Unlike
-// PluginInstallResult there is no Dirs list — skill targets are auto-
-// scanned by Claude Code from <workDir>/.claude/skills/, no CLI flag.
+// SkillInstallResult carries installed directories and warnings. Claude Code
+// auto-scans its project root; other adapters register the returned root.
 type SkillInstallResult struct {
-	Warnings []string
+	SkillDirs []string
+	Warnings  []string
 }
 
 // installSkills materialises every skill under
@@ -40,26 +40,55 @@ func installSkills(
 	workDir string,
 	skills []skillDescriptor,
 ) (SkillInstallResult, error) {
-	if logger == nil {
-		logger = obslog.Bg()
-	}
 	if len(skills) == 0 {
 		return SkillInstallResult{}, nil
 	}
 	if strings.TrimSpace(workDir) == "" {
 		return SkillInstallResult{}, errors.New("claudecode skills: workDir is required")
 	}
+	return installSkillsAtRoot(ctx, logger, filepath.Join(workDir, ".claude", "skills"), skills, "claudecode skills")
+}
 
-	root := filepath.Join(workDir, ".claude", "skills")
+// InstallManagedSkills decodes the portable agent_options["skills"] payload,
+// materializes it below root, and removes entries that are no longer active.
+func InstallManagedSkills(ctx context.Context, logger *slog.Logger, root string, raw any) (SkillInstallResult, error) {
+	if strings.TrimSpace(root) == "" {
+		return SkillInstallResult{}, errors.New("managed skills: root is required")
+	}
+	skills, decodeWarnings := decodeSkillDescriptors(raw)
+	result, err := installSkillsAtRoot(ctx, logger, root, skills, "managed skills")
+	result.Warnings = append(decodeWarnings, result.Warnings...)
+	if err != nil {
+		return result, err
+	}
+	if err := pruneManagedSkills(root, result.SkillDirs); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func installSkillsAtRoot(
+	ctx context.Context,
+	logger *slog.Logger,
+	root string,
+	skills []skillDescriptor,
+	logLabel string,
+) (SkillInstallResult, error) {
+	if logger == nil {
+		logger = obslog.Bg()
+	}
+	if len(skills) == 0 {
+		return SkillInstallResult{}, nil
+	}
 	if err := os.MkdirAll(root, 0o755); err != nil {
-		return SkillInstallResult{}, fmt.Errorf("claudecode skills: mkdir %s: %w", root, err)
+		return SkillInstallResult{}, fmt.Errorf("%s: mkdir %s: %w", logLabel, root, err)
 	}
 
 	result := SkillInstallResult{}
 	for _, s := range skills {
 		if err := s.validate(); err != nil {
 			result.Warnings = append(result.Warnings, fmt.Sprintf("skip skill (invalid descriptor): %v", err))
-			logger.Warn("claudecode skills: invalid descriptor", "err", err.Error())
+			logger.Warn(logLabel+": invalid descriptor", "err", err.Error())
 			continue
 		}
 
@@ -68,26 +97,55 @@ func installSkills(
 		expectedKey := s.cacheKey()
 
 		if existing, err := os.ReadFile(cacheKey); err == nil && string(existing) == expectedKey {
-			logger.Info("claudecode skills: cache hit",
+			logger.Info(logLabel+": cache hit",
 				"name", s.Name, "version", s.Version, "dir", dir)
+			result.SkillDirs = append(result.SkillDirs, dir)
 			continue
 		}
 
 		// Same timeout / cap as plugins — they share the install pipeline.
 		perCtx, cancel := context.WithTimeout(ctx, pluginInstallTimeout)
-		err := installOneSkill(perCtx, logger, root, dir, cacheKey, expectedKey, s)
+		err := installOneSkill(perCtx, logger, root, dir, cacheKey, expectedKey, s, logLabel)
 		cancel()
 		if err != nil {
 			result.Warnings = append(result.Warnings,
 				fmt.Sprintf("skill %s@%s: %v", s.Name, s.Version, err))
-			logger.Warn("claudecode skills: install failed",
+			logger.Warn(logLabel+": install failed",
 				"name", s.Name, "version", s.Version, "err", err.Error())
 			continue
 		}
-		logger.Info("claudecode skills: installed",
+		result.SkillDirs = append(result.SkillDirs, dir)
+		logger.Info(logLabel+": installed",
 			"name", s.Name, "version", s.Version, "dir", dir)
 	}
 	return result, nil
+}
+
+func pruneManagedSkills(root string, activeDirs []string) error {
+	entries, err := os.ReadDir(root)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("managed skills: read root %s: %w", root, err)
+	}
+	active := make(map[string]struct{}, len(activeDirs))
+	for _, dir := range activeDirs {
+		active[filepath.Base(dir)] = struct{}{}
+	}
+	for _, entry := range entries {
+		if entry.Name() == ".tmp" {
+			continue
+		}
+		if _, ok := active[entry.Name()]; ok {
+			continue
+		}
+		path := filepath.Join(root, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("managed skills: remove stale entry %s: %w", path, err)
+		}
+	}
+	return nil
 }
 
 // installOneSkill: same shape as installOnePlugin, only target dir differs.
@@ -99,6 +157,7 @@ func installOneSkill(
 	logger *slog.Logger,
 	root, dir, cacheKey, expectedKey string,
 	s skillDescriptor,
+	logLabel string,
 ) error {
 	tmpDir := filepath.Join(root, ".tmp")
 	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
@@ -139,7 +198,7 @@ func installOneSkill(
 	}
 
 	if err := os.WriteFile(cacheKey, []byte(expectedKey), 0o644); err != nil {
-		logger.Warn("claudecode skills: write cache key failed",
+		logger.Warn(logLabel+": write cache key failed",
 			"path", cacheKey, "err", err.Error())
 	}
 	return nil

--- a/apps/parsar-daemon/internal/agent/claudecode/skills_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/skills_test.go
@@ -31,6 +31,9 @@ func TestInstallSkills_HappyPath_ExtractsAndStampsCacheKey(t *testing.T) {
 	}
 
 	dir := filepath.Join(workDir, ".claude", "skills", "code-review")
+	if len(res.SkillDirs) != 1 || res.SkillDirs[0] != dir {
+		t.Fatalf("skill dirs = %v, want [%s]", res.SkillDirs, dir)
+	}
 	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err != nil {
 		t.Fatalf("SKILL.md missing: %v", err)
 	}
@@ -60,11 +63,47 @@ func TestInstallSkills_CacheHitSkipsDownload(t *testing.T) {
 	if hitsAfterFirst != 1 {
 		t.Fatalf("first install hits = %d, want 1", hitsAfterFirst)
 	}
-	if _, err := installSkills(context.Background(), discardLogger(), workDir, desc); err != nil {
+	second, err := installSkills(context.Background(), discardLogger(), workDir, desc)
+	if err != nil {
 		t.Fatalf("second install: %v", err)
+	}
+	if len(second.SkillDirs) != 1 {
+		t.Fatalf("cache hit skill dirs = %v", second.SkillDirs)
 	}
 	if got := srv.Hits(); got != hitsAfterFirst {
 		t.Fatalf("cache should prevent second download; got %d extra hits", got-hitsAfterFirst)
+	}
+}
+
+func TestInstallManagedSkillsPrunesInactiveEntries(t *testing.T) {
+	body := validSkillZipBytes(t)
+	srv := startPluginServer(t, body)
+	root := t.TempDir()
+	stale := filepath.Join(root, "old-skill")
+	if err := os.MkdirAll(stale, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stale, "SKILL.md"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := InstallManagedSkills(context.Background(), discardLogger(), root, []any{
+		map[string]any{
+			"name": "code-review", "version": "1.0.0",
+			"download_url": srv.URL, "sha256": sha256Hex(body),
+		},
+	})
+	if err != nil {
+		t.Fatalf("InstallManagedSkills: %v", err)
+	}
+	if len(res.SkillDirs) != 1 || res.SkillDirs[0] != filepath.Join(root, "code-review") {
+		t.Fatalf("skill dirs = %v", res.SkillDirs)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale skill still exists: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "code-review", "SKILL.md")); err != nil {
+		t.Fatalf("active skill missing: %v", err)
 	}
 }
 

--- a/apps/parsar-daemon/internal/agent/codex/protocol.go
+++ b/apps/parsar-daemon/internal/agent/codex/protocol.go
@@ -83,6 +83,10 @@ type InitializeResult struct {
 	PlatformOs     string `json:"platformOs,omitempty"`
 }
 
+type SkillsExtraRootsSetParams struct {
+	ExtraRoots []string `json:"extraRoots"`
+}
+
 // ---------------------------------------------------------------------------
 // Approval / sandbox policies
 // ---------------------------------------------------------------------------

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -105,10 +105,17 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 	if cfg.killTimeout <= 0 {
 		cfg.killTimeout = rpcKillTimeout
 	}
+	req.AgentStateKey = effectiveAgentStateKey(req)
 
 	plan, err := BuildSessionPlan(req.RunID, req.AgentStateKey, req.WorkDir, req.AgentOptions)
 	if err != nil {
 		return nil, fmt.Errorf("codex: build session plan: %w", err)
+	}
+
+	skillRoot, err := prepareManagedSkills(parent, cfg.logger, req)
+	if err != nil {
+		plan.Cleanup()
+		return nil, err
 	}
 
 	cancelCtx, cancelFn := context.WithCancel(parent)
@@ -151,6 +158,14 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		cancelFn()
 		plan.Cleanup()
 		return nil, fmt.Errorf("codex: rpc start: %w", err)
+	}
+	if skillRoot != "" {
+		if err := setSkillExtraRoots(cancelCtx, rpc, []string{skillRoot}); err != nil {
+			cancelFn()
+			_ = rpc.Close()
+			plan.Cleanup()
+			return nil, fmt.Errorf("codex: register skill root: %w", err)
+		}
 	}
 
 	// thread/start (or resume) + turn/start happen in the run goroutine

--- a/apps/parsar-daemon/internal/agent/codex/skills.go
+++ b/apps/parsar-daemon/internal/agent/codex/skills.go
@@ -1,0 +1,52 @@
+package codex
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/claudecode"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func effectiveAgentStateKey(req proto.PromptRequestPayload) string {
+	if strings.TrimSpace(req.AgentStateKey) != "" {
+		return req.AgentStateKey
+	}
+	if id := strings.TrimSpace(req.ConversationID); id != "" {
+		return "_legacy_conversation/" + id + "/codex"
+	}
+	if id := strings.TrimSpace(req.RunID); id != "" {
+		return "_legacy_run/" + id + "/codex"
+	}
+	return ""
+}
+
+func prepareManagedSkills(ctx context.Context, logger *slog.Logger, req proto.PromptRequestPayload) (string, error) {
+	rawSkills := req.AgentOptions["skills"]
+	root, err := agent.ManagedSkillsRoot("codex", req.AgentStateKey, req.ConversationID, req.RunID)
+	if err != nil {
+		return "", fmt.Errorf("codex: resolve managed skills root: %w", err)
+	}
+	result, err := claudecode.InstallManagedSkills(ctx, logger, root, rawSkills)
+	if err != nil {
+		return "", fmt.Errorf("codex: install skills: %w", err)
+	}
+	for _, warning := range result.Warnings {
+		logger.Warn("codex: skill install warning", "run_id", req.RunID, "msg", warning)
+	}
+	if len(result.SkillDirs) == 0 {
+		return "", nil
+	}
+	return root, nil
+}
+
+func setSkillExtraRoots(ctx context.Context, rpc *JSONRPCClient, roots []string) error {
+	if len(roots) == 0 {
+		return nil
+	}
+	_, err := rpc.Request(ctx, "skills/extraRoots/set", SkillsExtraRootsSetParams{ExtraRoots: roots})
+	return err
+}

--- a/apps/parsar-daemon/internal/agent/codex/skills_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/skills_test.go
@@ -1,0 +1,76 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestSetSkillExtraRootsUsesCodexRPC(t *testing.T) {
+	client, server, cleanup := NewTestClient()
+	defer cleanup()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- setSkillExtraRoots(context.Background(), client.JSONRPCClient, []string{"/managed/skills"})
+	}()
+
+	decoder := json.NewDecoder(server.FromClient)
+	var request struct {
+		ID     string                    `json:"id"`
+		Method string                    `json:"method"`
+		Params SkillsExtraRootsSetParams `json:"params"`
+	}
+	if err := decoder.Decode(&request); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+	if request.Method != "skills/extraRoots/set" {
+		t.Fatalf("method = %q", request.Method)
+	}
+	if len(request.Params.ExtraRoots) != 1 || request.Params.ExtraRoots[0] != "/managed/skills" {
+		t.Fatalf("params = %+v", request.Params)
+	}
+	response, _ := json.Marshal(map[string]any{"jsonrpc": "2.0", "id": request.ID, "result": map[string]any{}})
+	if _, err := server.ToClient.Write(append(response, '\n')); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+	if err := <-result; err != nil {
+		t.Fatalf("setSkillExtraRoots: %v", err)
+	}
+}
+
+func TestPrepareManagedSkillsPrunesWhenPayloadOmitsSkills(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PARSAR_HOME", home)
+	stale := filepath.Join(home, "runtime", "codex", "state", "conv-1", "agent-1", "codex", "skills", "stale")
+	if err := os.MkdirAll(stale, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := prepareManagedSkills(context.Background(), nil, proto.PromptRequestPayload{
+		AgentStateKey: "conv-1/agent-1/codex",
+	})
+	if err != nil {
+		t.Fatalf("prepareManagedSkills: %v", err)
+	}
+	if root != "" {
+		t.Fatalf("root = %q, want empty", root)
+	}
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Fatalf("stale skill still exists: %v", err)
+	}
+}
+
+func TestEffectiveAgentStateKeyFallsBackToConversation(t *testing.T) {
+	got := effectiveAgentStateKey(proto.PromptRequestPayload{
+		ConversationID: "conv-legacy",
+		RunID:          "run-ignored",
+	})
+	if got != "_legacy_conversation/conv-legacy/codex" {
+		t.Fatalf("state key = %q", got)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/opencode/session.go
+++ b/apps/parsar-daemon/internal/agent/opencode/session.go
@@ -73,7 +73,12 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		cfg.killTimeout = 3 * time.Second
 	}
 
-	buildRes, err := BuildArgs(req.RunID, req.Prompt, req.WorkDir, req.AgentOptions)
+	opts, err := prepareManagedSkills(parent, cfg.logger, req)
+	if err != nil {
+		return nil, err
+	}
+
+	buildRes, err := BuildArgs(req.RunID, req.Prompt, req.WorkDir, opts)
 	if err != nil {
 		return nil, fmt.Errorf("opencode: build args: %w", err)
 	}

--- a/apps/parsar-daemon/internal/agent/opencode/session_test.go
+++ b/apps/parsar-daemon/internal/agent/opencode/session_test.go
@@ -1,10 +1,17 @@
 package opencode_test
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -29,6 +36,20 @@ func TestMain(m *testing.M) {
 }
 
 func runFakeOpenCode(role string) {
+	if dumpPath := os.Getenv("OPENCODE_TESTHELPER_CONFIG_DUMP"); dumpPath != "" {
+		body, err := json.Marshal(map[string]string{
+			"config_dir":      os.Getenv("OPENCODE_CONFIG_DIR"),
+			"xdg_config_home": os.Getenv("XDG_CONFIG_HOME"),
+		})
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "encode managed config env: %v\n", err)
+			os.Exit(65)
+		}
+		if err := os.WriteFile(dumpPath, body, 0o600); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "dump managed config: %v\n", err)
+			os.Exit(65)
+		}
+	}
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetEscapeHTML(false)
 
@@ -165,6 +186,91 @@ func TestSessionJSONSuccessEmitsDeltaUsageAndDone(t *testing.T) {
 	if done.Usage.Provider != "opencode" || done.Usage.InputTokens != 4 || done.Usage.OutputTokens != 2 {
 		t.Fatalf("done usage = %#v", done.Usage)
 	}
+}
+
+func TestSessionInstallsAndRegistersManagedSkills(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PARSAR_HOME", home)
+	t.Setenv("OPENCODE_CONFIG_DIR", "")
+	userConfigHome := filepath.Join(t.TempDir(), "user-config")
+	t.Setenv("XDG_CONFIG_HOME", userConfigHome)
+	body := openCodeSkillZip(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	dumpPath := filepath.Join(t.TempDir(), "opencode.json")
+	out := make(chan proto.Envelope, 32)
+	req := opencodeHelperReq("run_skills", "hello", "json-success")
+	req.ConversationID = "conv-skills"
+	req.AgentStateKey = "conv-skills/agent-1/opencode"
+	req.AgentOptions["skills"] = []any{map[string]any{
+		"name": "find-skills", "version": "1.0.0", "download_url": srv.URL,
+		"sha256": fmt.Sprintf("%x", sha256.Sum256(body)),
+	}}
+	req.AgentOptions["env"].(map[string]any)["OPENCODE_TESTHELPER_CONFIG_DUMP"] = dumpPath
+
+	sess, err := opencode.NewSessionForTest(context.Background(), req, out, opencodeHelperConfig())
+	if err != nil {
+		t.Fatalf("NewSessionForTest: %v", err)
+	}
+	defer sess.Cancel(context.Background())
+	if _, closed := drainOpenCode(t, out, 5*time.Second); !closed {
+		t.Fatal("out did not close")
+	}
+
+	skillRoot := filepath.Join(home, "runtime", "opencode", "state", "conv-skills", "agent-1", "opencode", "skills")
+	if _, err := os.Stat(filepath.Join(skillRoot, "find-skills", "SKILL.md")); err != nil {
+		t.Fatalf("managed skill missing: %v", err)
+	}
+	dumped, err := os.ReadFile(dumpPath)
+	if err != nil {
+		t.Fatalf("read dumped config: %v", err)
+	}
+	var configEnv map[string]string
+	if err := json.Unmarshal(dumped, &configEnv); err != nil {
+		t.Fatalf("decode dumped config env: %v", err)
+	}
+	if got, want := configEnv["config_dir"], filepath.Dir(skillRoot); got != want {
+		t.Fatalf("OPENCODE_CONFIG_DIR = %q, want %q", got, want)
+	}
+	if got := configEnv["xdg_config_home"]; got != userConfigHome {
+		t.Fatalf("XDG_CONFIG_HOME = %q, want inherited %q", got, userConfigHome)
+	}
+
+	cleanupReq := opencodeHelperReq("run_skills_cleanup", "hello", "json-success")
+	cleanupReq.ConversationID = req.ConversationID
+	cleanupReq.AgentStateKey = req.AgentStateKey
+	cleanupOut := make(chan proto.Envelope, 32)
+	cleanupSession, err := opencode.NewSessionForTest(context.Background(), cleanupReq, cleanupOut, opencodeHelperConfig())
+	if err != nil {
+		t.Fatalf("cleanup session: %v", err)
+	}
+	defer cleanupSession.Cancel(context.Background())
+	if _, closed := drainOpenCode(t, cleanupOut, 5*time.Second); !closed {
+		t.Fatal("cleanup out did not close")
+	}
+	if _, err := os.Stat(filepath.Join(skillRoot, "find-skills")); !os.IsNotExist(err) {
+		t.Fatalf("unbound skill still exists: %v", err)
+	}
+}
+
+func openCodeSkillZip(t *testing.T) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := zip.NewWriter(&buffer)
+	entry, err := writer.Create("SKILL.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Write([]byte("---\nname: find-skills\ndescription: Find skills\n---\nUse the catalog.")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
 }
 
 func TestSessionPlainStdoutFallsBackToDeltaAndDone(t *testing.T) {

--- a/apps/parsar-daemon/internal/agent/opencode/skills.go
+++ b/apps/parsar-daemon/internal/agent/opencode/skills.go
@@ -1,0 +1,134 @@
+package opencode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/claudecode"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+const (
+	openCodeConfigDirEnv     = "OPENCODE_CONFIG_DIR"
+	openCodeConfigContentEnv = "OPENCODE_CONFIG_CONTENT"
+)
+
+func prepareManagedSkills(ctx context.Context, logger *slog.Logger, req proto.PromptRequestPayload) (map[string]any, error) {
+	rawSkills, hasSkills := req.AgentOptions["skills"]
+	if !hasSkills && strings.TrimSpace(req.AgentStateKey) == "" && strings.TrimSpace(req.ConversationID) == "" && strings.TrimSpace(req.RunID) == "" {
+		return req.AgentOptions, nil
+	}
+	root, err := agent.ManagedSkillsRoot("opencode", req.AgentStateKey, req.ConversationID, req.RunID)
+	if err != nil {
+		return nil, fmt.Errorf("opencode: resolve managed skills root: %w", err)
+	}
+	result, err := claudecode.InstallManagedSkills(ctx, logger, root, rawSkills)
+	if err != nil {
+		return nil, fmt.Errorf("opencode: install skills: %w", err)
+	}
+	for _, warning := range result.Warnings {
+		logger.Warn("opencode: skill install warning", "run_id", req.RunID, "msg", warning)
+	}
+	if len(result.SkillDirs) == 0 {
+		return req.AgentOptions, nil
+	}
+	return withOpenCodeSkillRoot(req.AgentOptions, root)
+}
+
+func withOpenCodeSkillRoot(opts map[string]any, root string) (map[string]any, error) {
+	out := make(map[string]any, len(opts)+1)
+	for key, value := range opts {
+		out[key] = value
+	}
+	env := map[string]any{}
+	if raw := opts["env"]; raw != nil {
+		existing, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("opencode.BuildArgs: env must be object, got %T", raw)
+		}
+		for key, value := range existing {
+			env[key] = value
+		}
+	}
+	configDir, err := openCodeEnvValue(env, openCodeConfigDirEnv)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(configDir) == "" {
+		env[openCodeConfigDirEnv] = filepath.Dir(root)
+	} else {
+		inline, err := openCodeEnvValue(env, openCodeConfigContentEnv)
+		if err != nil {
+			return nil, err
+		}
+		inline, err = addOpenCodeSkillPath(inline, root)
+		if err != nil {
+			return nil, err
+		}
+		env[openCodeConfigContentEnv] = inline
+	}
+	out["env"] = env
+	return out, nil
+}
+
+func openCodeEnvValue(env map[string]any, key string) (string, error) {
+	if raw, ok := env[key]; ok {
+		value, ok := raw.(string)
+		if !ok {
+			return "", fmt.Errorf("opencode.BuildArgs: env[%q] must be string, got %T", key, raw)
+		}
+		return value, nil
+	}
+	return os.Getenv(key), nil
+}
+
+func addOpenCodeSkillPath(rawConfig, root string) (string, error) {
+	config := map[string]any{}
+	if strings.TrimSpace(rawConfig) != "" {
+		if err := json.Unmarshal([]byte(rawConfig), &config); err != nil {
+			return "", fmt.Errorf("opencode: %s must be valid JSON: %w", openCodeConfigContentEnv, err)
+		}
+		if config == nil {
+			config = map[string]any{}
+		}
+	}
+	skills, ok := config["skills"].(map[string]any)
+	if !ok && config["skills"] != nil {
+		return "", fmt.Errorf("opencode: %s skills must be object, got %T", openCodeConfigContentEnv, config["skills"])
+	}
+	if skills == nil {
+		skills = map[string]any{}
+	}
+	paths := []any{}
+	if rawPaths := skills["paths"]; rawPaths != nil {
+		var ok bool
+		paths, ok = rawPaths.([]any)
+		if !ok {
+			return "", fmt.Errorf("opencode: %s skills.paths must be array, got %T", openCodeConfigContentEnv, rawPaths)
+		}
+	}
+	found := false
+	for _, path := range paths {
+		value, ok := path.(string)
+		if !ok {
+			return "", fmt.Errorf("opencode: %s skills.paths entries must be strings", openCodeConfigContentEnv)
+		}
+		found = found || value == root
+	}
+	if found {
+		return rawConfig, nil
+	}
+	skills["paths"] = append(paths, root)
+	config["skills"] = skills
+	body, err := json.Marshal(config)
+	if err != nil {
+		return "", fmt.Errorf("opencode: marshal %s: %w", openCodeConfigContentEnv, err)
+	}
+	return string(body), nil
+}

--- a/apps/parsar-daemon/internal/agent/opencode/skills_test.go
+++ b/apps/parsar-daemon/internal/agent/opencode/skills_test.go
@@ -1,0 +1,38 @@
+package opencode
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestWithOpenCodeSkillRootPreservesExistingConfigDir(t *testing.T) {
+	t.Setenv(openCodeConfigDirEnv, "/user/opencode")
+	t.Setenv(openCodeConfigContentEnv, `{"agent":{"review":{}},"skills":{"paths":["/user/skills"],"urls":["https://example.com/skills"]}}`)
+
+	opts, err := withOpenCodeSkillRoot(map[string]any{
+		"env": map[string]any{"KEEP": "value"},
+	}, "/managed/skills")
+	if err != nil {
+		t.Fatalf("withOpenCodeSkillRoot: %v", err)
+	}
+	env := opts["env"].(map[string]any)
+	if _, overridden := env[openCodeConfigDirEnv]; overridden {
+		t.Fatalf("%s must remain inherited", openCodeConfigDirEnv)
+	}
+	if env["KEEP"] != "value" {
+		t.Fatalf("existing env was not preserved: %v", env)
+	}
+	var config struct {
+		Agent  map[string]any `json:"agent"`
+		Skills struct {
+			Paths []string `json:"paths"`
+			URLs  []string `json:"urls"`
+		} `json:"skills"`
+	}
+	if err := json.Unmarshal([]byte(env[openCodeConfigContentEnv].(string)), &config); err != nil {
+		t.Fatal(err)
+	}
+	if len(config.Agent) != 1 || len(config.Skills.Paths) != 2 || config.Skills.Paths[1] != "/managed/skills" || len(config.Skills.URLs) != 1 {
+		t.Fatalf("merged config = %+v", config)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/runtime_paths.go
+++ b/apps/parsar-daemon/internal/agent/runtime_paths.go
@@ -1,0 +1,64 @@
+package agent
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/paths"
+)
+
+// ManagedSkillsRoot returns an adapter-owned skill directory scoped to one
+// agent state. It never derives runtime state from the subprocess cwd.
+func ManagedSkillsRoot(agentKind, agentStateKey, conversationID, runID string) (string, error) {
+	root, err := paths.Root()
+	if err != nil {
+		return "", fmt.Errorf("agent: resolve managed skills root: %w", err)
+	}
+	kind := safeRuntimePathPart(agentKind)
+	if kind == "" {
+		return "", fmt.Errorf("agent: invalid agent kind %q", agentKind)
+	}
+	base := filepath.Join(root, "runtime", kind)
+	if key := strings.TrimSpace(agentStateKey); key != "" {
+		parts := safeRuntimePathParts(key)
+		if len(parts) == 0 {
+			return "", fmt.Errorf("agent: invalid agent state key %q", agentStateKey)
+		}
+		return filepath.Join(append([]string{base, "state"}, append(parts, "skills")...)...), nil
+	}
+	if id := safeRuntimePathPart(conversationID); id != "" {
+		return filepath.Join(base, "conv-"+id, "skills"), nil
+	}
+	if id := safeRuntimePathPart(runID); id != "" {
+		return filepath.Join(base, "run-"+id, "skills"), nil
+	}
+	return "", fmt.Errorf("agent: agent state key, conversation id, or run id is required")
+}
+
+func safeRuntimePathParts(value string) []string {
+	raw := strings.Split(value, "/")
+	parts := make([]string, 0, len(raw))
+	for _, part := range raw {
+		if safe := safeRuntimePathPart(part); safe != "" {
+			parts = append(parts, safe)
+		}
+	}
+	return parts
+}
+
+func safeRuntimePathPart(value string) string {
+	var b strings.Builder
+	for _, r := range strings.TrimSpace(value) {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.' {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	value = b.String()
+	if value == "." || value == ".." {
+		return ""
+	}
+	return value
+}

--- a/apps/parsar-daemon/internal/agent/runtime_paths_test.go
+++ b/apps/parsar-daemon/internal/agent/runtime_paths_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestManagedSkillsRootUsesStableAgentState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PARSAR_HOME", home)
+	got, err := ManagedSkillsRoot("codex", "conv-1/agent-1/codex", "ignored", "ignored")
+	if err != nil {
+		t.Fatalf("ManagedSkillsRoot: %v", err)
+	}
+	want := filepath.Join(home, "runtime", "codex", "state", "conv-1", "agent-1", "codex", "skills")
+	if got != want {
+		t.Fatalf("root = %q, want %q", got, want)
+	}
+}
+
+func TestManagedSkillsRootSanitizesFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PARSAR_HOME", home)
+	got, err := ManagedSkillsRoot("opencode", "", "../conv name", "ignored")
+	if err != nil {
+		t.Fatalf("ManagedSkillsRoot: %v", err)
+	}
+	want := filepath.Join(home, "runtime", "opencode", "conv-.._conv_name", "skills")
+	if got != want {
+		t.Fatalf("root = %q, want %q", got, want)
+	}
+}

--- a/server/internal/capability/render/codex.go
+++ b/server/internal/capability/render/codex.go
@@ -9,11 +9,8 @@ import (
 )
 
 // codexRenderer serializes capability specs for the Codex agent runtime
-// (`codex app-server --stdio`). Today only KindMCP is supported; Codex
-// has its own Agent Skills convention that is not interchangeable with
-// Claude Code's, and Codex has no plugin concept at all — both return
-// ErrUnsupported, which the agentdaemon connector treats as a soft
-// degrade (skip + surface a disabled-capability notice).
+// (`codex app-server --stdio`). The daemon materializes portable Skill
+// archives in managed state and registers that root with the app server.
 //
 // The KindMCP wire shape is intentionally identical to
 // claudeCodeRenderer's (`{"mcpServers": {"<name>": {"command","args","env"}}}`)
@@ -45,7 +42,7 @@ type codexMCPServer struct {
 }
 
 func (codexRenderer) Supports(kind canonical.Kind) bool {
-	return kind == canonical.KindMCP || kind == canonical.KindSystemPrompt || kind == canonical.KindBundle
+	return kind == canonical.KindMCP || kind == canonical.KindSkill || kind == canonical.KindSystemPrompt || kind == canonical.KindBundle
 }
 
 func (codexRenderer) Render(_ context.Context, spec canonical.Spec) (Output, error) {
@@ -56,10 +53,7 @@ func (codexRenderer) Render(_ context.Context, spec canonical.Spec) (Output, err
 	case canonical.KindMCP:
 		return renderCodexMCP(spec.MCP)
 	case canonical.KindSkill:
-		// Codex Agent Skills live under .agents/skills/SKILL.md, parsed
-		// by the runtime. Materialising a Claude-Code skill zip into
-		// that layout would mis-render — bail.
-		return Output{}, ErrUnsupported
+		return renderClaudeCodeSkill(spec.Skill)
 	case canonical.KindPlugin:
 		// No plugin concept in Codex.
 		return Output{}, ErrUnsupported

--- a/server/internal/capability/render/opencode.go
+++ b/server/internal/capability/render/opencode.go
@@ -35,7 +35,7 @@ type openCodeMCPServer struct {
 }
 
 func (openCodeRenderer) Supports(kind canonical.Kind) bool {
-	return kind == canonical.KindMCP || kind == canonical.KindSystemPrompt || kind == canonical.KindBundle
+	return kind == canonical.KindMCP || kind == canonical.KindSkill || kind == canonical.KindSystemPrompt || kind == canonical.KindBundle
 }
 
 func (openCodeRenderer) Render(_ context.Context, spec canonical.Spec) (Output, error) {
@@ -46,9 +46,7 @@ func (openCodeRenderer) Render(_ context.Context, spec canonical.Spec) (Output, 
 	case canonical.KindMCP:
 		return renderOpenCodeMCP(spec.MCP)
 	case canonical.KindSkill:
-		// OpenCode materializes skills via git clone at session-spawn time
-		// (see capability_runtime.go buildSkillCloneCommand).
-		return Output{}, ErrUnsupported
+		return renderClaudeCodeSkill(spec.Skill)
 	case canonical.KindPlugin:
 		// Plugins are Claude Code only; OpenCode has no plugin concept.
 		return Output{}, ErrUnsupported

--- a/server/internal/capability/render/pi.go
+++ b/server/internal/capability/render/pi.go
@@ -14,9 +14,7 @@ import (
 // claudecode skills with one claudeCodeSkillDocument unmarshal. Managed
 // MCP and plugin delivery are out of scope for pi, so both return
 // ErrUnsupported, which the agentdaemon connector treats as a soft
-// degrade (skip + disabled-capability notice). This makes pi the mirror
-// of codex: codex renders MCP and rejects Skill; pi renders Skill and
-// rejects MCP.
+// degrade (skip + disabled-capability notice).
 type piRenderer struct{}
 
 func (piRenderer) Target() Target { return TargetPi }

--- a/server/internal/capability/render/renderer.go
+++ b/server/internal/capability/render/renderer.go
@@ -41,8 +41,8 @@ type Output struct {
 }
 
 // ErrUnsupported indicates the renderer cannot serialize this Spec for its
-// Target (e.g. OpenCode/Codex can't render Skill or Plugin). Callers should
-// treat it as "skip this capability for this target".
+// Target (for example, Codex and OpenCode cannot render Plugin). Callers
+// should treat it as "skip this capability for this target".
 var ErrUnsupported = errors.New("render: spec kind unsupported for target")
 
 // Renderer implementations must be pure and side-effect free.

--- a/server/internal/capability/render/renderer_test.go
+++ b/server/internal/capability/render/renderer_test.go
@@ -85,9 +85,9 @@ func TestSupports(t *testing.T) {
 		{TargetClaudeCode, canonical.KindMCP, true},
 		{TargetClaudeCode, canonical.KindSkill, true},
 		{TargetCodex, canonical.KindMCP, true},
-		{TargetCodex, canonical.KindSkill, false},
+		{TargetCodex, canonical.KindSkill, true},
 		{TargetOpenCode, canonical.KindMCP, true},
-		{TargetOpenCode, canonical.KindSkill, false},
+		{TargetOpenCode, canonical.KindSkill, true},
 		{TargetPi, canonical.KindMCP, false},
 		{TargetPi, canonical.KindSkill, true},
 	}
@@ -135,13 +135,6 @@ func TestOpenCodeRenderer_MCPGolden(t *testing.T) {
 	}
 	if got, want := srv.Env["GITHUB_HOST"], "https://api.github.com"; got != want {
 		t.Fatalf("literal value: want %q got %q", want, got)
-	}
-}
-
-func TestOpenCodeRenderer_SkillUnsupported(t *testing.T) {
-	_, err := openCodeRenderer{}.Render(context.Background(), skillFixture())
-	if !errors.Is(err, ErrUnsupported) {
-		t.Fatalf("expected ErrUnsupported, got %v", err)
 	}
 }
 
@@ -293,34 +286,42 @@ func TestOpenCodeRenderer_StreamableHTTP(t *testing.T) {
 	}
 }
 
-// TestCodexRenderer_SkillAndPluginUnsupported pins the soft-degrade
-// contract — codex must return ErrUnsupported for Skill and Plugin so
-// the agentdaemon connector skips them with a Disabled notice instead
-// of hard-failing the prompt. Don't bundle MCP here: that case is
-// covered by TestCodexRenderer_MCPGolden and would re-regress this
-// test back into the old "always unsupported" shape if accidentally
-// edited.
-func TestCodexRenderer_SkillAndPluginUnsupported(t *testing.T) {
-	cases := []canonical.Spec{
-		skillFixture(),
-		{
-			SchemaVersion: canonical.SchemaVersionCurrent,
-			Kind:          canonical.KindPlugin,
-			Plugin: &canonical.PluginSpec{
-				Name:         "my-plugin",
-				Version:      "1.0.0",
-				Description:  "x",
-				OssKey:       "capabilities/plugins/u1/my-plugin.zip",
-				SHA256:       "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
-				UploadSource: canonical.UploadSourceZip,
-			},
+func TestCodexRenderer_PluginUnsupported(t *testing.T) {
+	spec := canonical.Spec{
+		SchemaVersion: canonical.SchemaVersionCurrent,
+		Kind:          canonical.KindPlugin,
+		Plugin: &canonical.PluginSpec{
+			Name:         "my-plugin",
+			Version:      "1.0.0",
+			Description:  "x",
+			OssKey:       "capabilities/plugins/u1/my-plugin.zip",
+			SHA256:       "ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",
+			UploadSource: canonical.UploadSourceZip,
 		},
 	}
-	for _, spec := range cases {
-		_, err := codexRenderer{}.Render(context.Background(), spec)
-		if !errors.Is(err, ErrUnsupported) {
-			t.Fatalf("expected ErrUnsupported for kind=%s, got %v", spec.Kind, err)
-		}
+	if _, err := (codexRenderer{}).Render(context.Background(), spec); !errors.Is(err, ErrUnsupported) {
+		t.Fatalf("expected ErrUnsupported, got %v", err)
+	}
+}
+
+func TestManagedSkillRenderersMatchClaudeCode(t *testing.T) {
+	want, err := (claudeCodeRenderer{}).Render(context.Background(), skillFixture())
+	if err != nil {
+		t.Fatalf("claudecode render: %v", err)
+	}
+	for name, renderer := range map[string]Renderer{
+		"codex":    codexRenderer{},
+		"opencode": openCodeRenderer{},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := renderer.Render(context.Background(), skillFixture())
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			if string(got.Content) != string(want.Content) {
+				t.Fatalf("skill descriptor differs: got %s want %s", got.Content, want.Content)
+			}
+		})
 	}
 }
 
@@ -410,9 +411,7 @@ func TestPiRenderer_SkillByteEqualsClaudeCode(t *testing.T) {
 // TestPiRenderer_MCPAndPluginUnsupported pins pi's soft-degrade contract:
 // managed MCP and plugin delivery are out of scope, so both return
 // ErrUnsupported and the agentdaemon connector skips them with a Disabled
-// notice instead of hard-failing the prompt. pi is the mirror of codex —
-// it supports Skill (which codex rejects) and rejects MCP (which codex
-// renders) — so keep this distinct from the codex unsupported test.
+// notice instead of hard-failing the prompt.
 func TestPiRenderer_MCPAndPluginUnsupported(t *testing.T) {
 	cases := []canonical.Spec{
 		mcpFixture(),

--- a/server/internal/connector/agentdaemon/capability_runtime.go
+++ b/server/internal/connector/agentdaemon/capability_runtime.go
@@ -60,10 +60,8 @@ type ResolvedPlugin struct {
 
 // ResolvedSkill is the per-skill descriptor the connector embeds in
 // agent_options["skills"]. Daemon-side code reads this list, downloads
-// each Zip from DownloadURL, verifies SHA256, extracts to
-// <workDir>/.claude/skills/<name>/. Claude Code's startup auto-scans
-// that directory and registers each skill via the native Skill tool —
-// no CLI flag is needed.
+// each Zip from DownloadURL, verifies SHA256, and extracts it into the
+// target adapter's skill root.
 //
 // JSON shape is byte-identical to ResolvedPlugin so the daemon's
 // generic zip installer can decode both with the same code.
@@ -181,7 +179,7 @@ var errCapabilityVersionUnavailable = errors.New("agent_daemon: capability versi
 
 // disabledForUnsupportedCapability builds the DisabledCapability surfaced
 // when a renderer returns render.ErrUnsupported — e.g. an opencode/codex
-// agent enabling a skill or plugin capability. MissingCredentials is left
+// agent enabling a plugin capability. MissingCredentials is left
 // empty; emitDisabledCapabilityNotices treats that as a "non-credential"
 // disable and posts a generic notice.
 func disabledForUnsupportedCapability(cap store.EnabledCapabilityRead) DisabledCapability {

--- a/server/internal/connector/agentdaemon/capability_runtime_dispatch_test.go
+++ b/server/internal/connector/agentdaemon/capability_runtime_dispatch_test.go
@@ -38,36 +38,27 @@ func TestTargetForAgentKind(t *testing.T) {
 	}
 }
 
-// TestResolveCapabilityAdditions_CodexSkillSoftDegrades verifies that an
-// agent on the codex engine that lists a skill capability does
-// not hard-fail the prompt. The codex renderer returns render.ErrUnsupported
-// for KindSkill; the connector must skip the row and surface it as a
-// Disabled capability so the channel emits a runtime_error nudge.
-func TestResolveCapabilityAdditions_CodexSkillSoftDegrades(t *testing.T) {
-	presigner := &stubPluginPresigner{}
-	c := &Connector{
-		capabilities: stubCapabilityStore{rows: []store.EnabledCapabilityRead{
-			newSkillRow(t, "skill-a", "Skill A", "do a"),
-		}},
-		oss: presigner,
-		log: discardLogger(),
-	}
-	got, err := c.resolveCapabilityAdditions(context.Background(), defaultPromptInput(), "codex")
-	if err != nil {
-		t.Fatalf("codex skill must soft-degrade, got hard error: %v", err)
-	}
-	if len(got.Skills) != 0 {
-		t.Fatalf("codex must not produce skills, got %+v", got.Skills)
-	}
-	if len(got.Disabled) != 1 {
-		t.Fatalf("expected 1 disabled capability, got %d", len(got.Disabled))
-	}
-	if got.Disabled[0].CapabilityID != "skill-a" {
-		t.Fatalf("disabled.capability_id = %q, want skill-a", got.Disabled[0].CapabilityID)
-	}
-	if len(got.Disabled[0].MissingCredentials) != 0 {
-		t.Fatalf("ErrUnsupported soft-degrade must not synthesise missing credentials, got %+v",
-			got.Disabled[0].MissingCredentials)
+func TestResolveCapabilityAdditions_ManagedSkillsRender(t *testing.T) {
+	for _, agentKind := range []string{"codex", "opencode"} {
+		t.Run(agentKind, func(t *testing.T) {
+			c := &Connector{
+				capabilities: stubCapabilityStore{rows: []store.EnabledCapabilityRead{
+					newSkillRow(t, "skill-a", "Skill A", "do a"),
+				}},
+				oss: &stubPluginPresigner{},
+				log: discardLogger(),
+			}
+			got, err := c.resolveCapabilityAdditions(context.Background(), defaultPromptInput(), agentKind)
+			if err != nil {
+				t.Fatalf("resolve skill: %v", err)
+			}
+			if len(got.Skills) != 1 {
+				t.Fatalf("expected 1 skill, got %+v", got.Skills)
+			}
+			if len(got.Disabled) != 0 {
+				t.Fatalf("supported skill must not be disabled, got %+v", got.Disabled)
+			}
+		})
 	}
 }
 
@@ -125,8 +116,7 @@ func TestResolveCapabilityAdditions_OpenCodeMCPStillRenders(t *testing.T) {
 
 // TestResolveCapabilityAdditions_PiSkillRenders is the positive half of
 // pi's scope: pi delivers managed skills (via --skill), so a skill row on
-// a pi agent must render, not degrade. pi is the inverse of codex here —
-// codex rejects skills, pi accepts them.
+// a pi agent must render, not degrade.
 func TestResolveCapabilityAdditions_PiSkillRenders(t *testing.T) {
 	presigner := &stubPluginPresigner{}
 	c := &Connector{
@@ -201,16 +191,7 @@ func TestResolveCapabilityAdditions_EmptyAgentKindDefaultsClaudeCode(t *testing.
 	}
 }
 
-// TestBuildAgentOptions_CodexSkillSurfacesDisabledNotice walks the
-// production buildAgentOptions entry — not just resolveCapabilityAdditions
-// directly — to confirm that an unsupported-by-agent-kind capability
-// flows all the way through emitDisabledCapabilityNotices and lands in
-// the SystemMessages sink as a CapabilityCredentialMissing notice.
-//
-// This is the contract the channel layer relies on: a codex agent
-// enabling a skill capability must produce a user-visible nudge
-// instead of silently dropping the capability.
-func TestBuildAgentOptions_CodexSkillSurfacesDisabledNotice(t *testing.T) {
+func TestBuildAgentOptions_CodexSkillIsEnabled(t *testing.T) {
 	sm := &fakeSystemMessageStore{}
 	c := &Connector{
 		capabilities: stubCapabilityStore{rows: []store.EnabledCapabilityRead{
@@ -232,23 +213,13 @@ func TestBuildAgentOptions_CodexSkillSurfacesDisabledNotice(t *testing.T) {
 
 	opts, err := c.buildAgentOptions(context.Background(), in)
 	if err != nil {
-		t.Fatalf("buildAgentOptions must soft-degrade unsupported skill, got hard error: %v", err)
+		t.Fatalf("buildAgentOptions: %v", err)
 	}
-	if _, ok := opts["skills"]; ok {
-		t.Fatalf("opts['skills'] must be absent for codex (skill unsupported), got %+v", opts["skills"])
+	if _, ok := opts["skills"]; !ok {
+		t.Fatalf("opts['skills'] missing for codex: %+v", opts)
 	}
-	if len(sm.runtimeErrors) != 1 {
-		t.Fatalf("expected exactly 1 runtime_error notice for the disabled skill, got %d: %+v", len(sm.runtimeErrors), sm.runtimeErrors)
-	}
-	notice := sm.runtimeErrors[0]
-	if notice.SubKind != CapabilityCredentialMissing {
-		t.Errorf("SubKind = %q, want %q", notice.SubKind, CapabilityCredentialMissing)
-	}
-	if notice.CapabilityID != "skill-a" {
-		t.Errorf("CapabilityID = %q, want skill-a", notice.CapabilityID)
-	}
-	if notice.RunID != "run-1" || notice.ConversationID != "conv-1" {
-		t.Errorf("notice missing scope: %+v", notice)
+	if len(sm.runtimeErrors) != 0 {
+		t.Fatalf("supported skill must not emit runtime_error notices: %+v", sm.runtimeErrors)
 	}
 }
 


### PR DESCRIPTION
## What & why
Managed Skill capabilities were soft-degraded for Codex/OpenCode instead of being available in real conversations.

## Scope
- deliver existing portable Skill descriptors to Codex/OpenCode
- verify, cache, and materialize archives under stable AgentStateKey state, and prune unbound entries
- register through Codex `skills/extraRoots/set` and OpenCode native config discovery without replacing existing user config
- document the independent blind-review protocol

## Explicitly out of scope
- frontend/UI changes
- generic capability compatibility/error taxonomy
- non-standard `SKILL.md` import normalization
- API, database, schema, toolchain, or version changes

## Verification
- `make check`
- focused daemon, renderer, and connector Go tests
- OpenCode 1.3 native discovery probe
- two blind-review rounds after material fixes, then one final convergence review with no findings

`make check` passed; its PostgreSQL migration smoke test was skipped automatically because Docker was unavailable.

Supersedes the managed-Skill portion of #251. The other #251 changes are already covered by later merged work or are stale.