### PR TITLE
fix(web): remove Connectors from Settings tabs

### DIFF
--- a/apps/web/src/components/layout/SettingsTabs.tsx
+++ b/apps/web/src/components/layout/SettingsTabs.tsx
@@ -24,7 +24,6 @@ const TABS: SettingsTab[] = [
   "general",
   "credentials",
   "runtime",
-  "connectors",
   "usage",
   "audit",
 ]


### PR DESCRIPTION
## What & why

Remove the visible Connectors entry from the Settings tab strip so connectors have no duplicate Settings navigation entry.

## How

Remove only the Connectors item from the rendered Settings tabs. Keep the Connections sidebar entry, connector page, direct routes, APIs, and backend behavior unchanged.

## Verification

- [x] make check
- [x] Two independent blind reviews found no actionable issues
- [ ] Relevant E2E target: not applicable for this one-line navigation change
- [ ] Manual smoke: not run

## Notes for reviewers

The scope intentionally excludes route removal, backend changes, renaming, and unrelated navigation cleanup.