### PR TITLE
fix(web): simplify connection save actions

### DIFF
--- a/apps/web/src/components/admin/channel-connectors/discordFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/discordFields.tsx
@@ -113,7 +113,6 @@ function DiscordConnectorFieldsInner({
   const saving = mut.isPending || createSecretMut.isPending
 
   const missingRequired = missingRequiredFor(draft, secretInputs)
-  const missingRequiredToEnable = missingRequiredFor({ ...draft, enabled: true }, secretInputs)
   const missingDraftIdentity = !draft.app_id.trim()
 
   const selectedIntents = parseIntents(draft.intents)
@@ -130,8 +129,8 @@ function DiscordConnectorFieldsInner({
     })
   }
 
-  const onSave = async (nextEnabled = draft.enabled) => {
-    const nextDraft = { ...draft, enabled: nextEnabled }
+  const onSave = async () => {
+    const nextDraft = draft
     if (missingRequiredFor(nextDraft, secretInputs)) {
       setErrorMsg(t("connections.connector.discord.errors.incomplete"))
       return
@@ -306,18 +305,6 @@ function DiscordConnectorFieldsInner({
             ? t("connections.connector.actions.save")
             : t("connections.connector.actions.saveDraft")}
         </button>
-        {!draft.enabled && (
-          <button
-            type="button"
-            onClick={() => void onSave(true)}
-            disabled={!canEdit || saving || Boolean(missingRequiredToEnable)}
-            className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
-            data-testid="discord-save-enable-button"
-          >
-            {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            {t("connections.connector.actions.saveAndEnable")}
-          </button>
-        )}
       </div>
     </Card>
   )

--- a/apps/web/src/components/admin/channel-connectors/slackFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/slackFields.tsx
@@ -115,11 +115,10 @@ function SlackConnectorFieldsInner({
   const saving = mut.isPending || createSecretMut.isPending
 
   const missingRequired = missingRequiredFor(draft, secretInputs)
-  const missingRequiredToEnable = missingRequiredFor({ ...draft, enabled: true }, secretInputs)
   const missingDraftIdentity = !draft.app_id.trim()
 
-  const onSave = async (nextEnabled = draft.enabled) => {
-    const nextDraft = { ...draft, enabled: nextEnabled }
+  const onSave = async () => {
+    const nextDraft = draft
     if (missingRequiredFor(nextDraft, secretInputs)) {
       setErrorMsg(t("connections.connector.slack.errors.incomplete"))
       return
@@ -309,18 +308,6 @@ function SlackConnectorFieldsInner({
             ? t("connections.connector.actions.save")
             : t("connections.connector.actions.saveDraft")}
         </button>
-        {!draft.enabled && (
-          <button
-            type="button"
-            onClick={() => void onSave(true)}
-            disabled={!canEdit || saving || Boolean(missingRequiredToEnable)}
-            className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
-            data-testid="slack-save-enable-button"
-          >
-            {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            {t("connections.connector.actions.saveAndEnable")}
-          </button>
-        )}
       </div>
     </Card>
   )

--- a/apps/web/src/components/admin/channel-connectors/teamsFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/teamsFields.tsx
@@ -95,11 +95,10 @@ function TeamsConnectorFieldsInner({
   const saving = mut.isPending || createSecretMut.isPending
 
   const missingRequired = missingRequiredFor(draft, secretInputs)
-  const missingRequiredToEnable = missingRequiredFor({ ...draft, enabled: true }, secretInputs)
   const missingDraftIdentity = !draft.app_id.trim()
 
-  const onSave = async (nextEnabled = draft.enabled) => {
-    const nextDraft = { ...draft, enabled: nextEnabled }
+  const onSave = async () => {
+    const nextDraft = draft
     if (missingRequiredFor(nextDraft, secretInputs)) {
       setErrorMsg(t("connections.connector.teams.errors.incomplete"))
       return
@@ -249,18 +248,6 @@ function TeamsConnectorFieldsInner({
             ? t("connections.connector.actions.save")
             : t("connections.connector.actions.saveDraft")}
         </button>
-        {!draft.enabled && (
-          <button
-            type="button"
-            onClick={() => void onSave(true)}
-            disabled={!canEdit || saving || Boolean(missingRequiredToEnable)}
-            className="inline-flex items-center gap-2 rounded-md bg-surface-emphasis px-3 py-1.5 text-sm font-medium text-white hover:bg-surface-emphasis disabled:opacity-60"
-            data-testid="teams-save-enable-button"
-          >
-            {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
-            {t("connections.connector.actions.saveAndEnable")}
-          </button>
-        )}
       </div>
     </Card>
   )

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -2954,7 +2954,6 @@
       "actions": {
         "save": "Save",
         "saveDraft": "Save draft",
-        "saveAndEnable": "Save and enable",
         "reset": "Reset"
       },
       "status": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -2954,7 +2954,6 @@
       "actions": {
         "save": "保存",
         "saveDraft": "保存草稿",
-        "saveAndEnable": "保存并启用",
         "reset": "重置"
       },
       "status": {


### PR DESCRIPTION
## What & why

Slack, Discord, and Teams connection forms exposed both an enabled-state control and a second activation action. Keep one state control and one persistence action so the flow has a single path.

## How

The existing enabled checkbox remains the source of the desired state. The existing save action persists disabled drafts, enabled configurations, and disabling changes. Feishu provisioning, validation, secret handling, APIs, and backend behavior are unchanged.

## Verification

- [x] make check
- [x] ESLint on the three changed React components
- [x] Two independent blind reviews found no actionable issues
- [ ] Relevant E2E target: none for this interaction-only change
- [ ] Manual smoke: not run

## Notes for reviewers

The scope intentionally excludes shared-component refactors, other Connections cleanup, Settings navigation, and backend changes.