### PR TITLE
fix(web): hide unauthorized workspace actions

### DIFF
--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -148,6 +148,7 @@ export function WorkspaceSwitcher() {
 
             {workspaces.map((ws) => {
               const isActive = ws.id === wsId
+              const canManage = ws.role === "owner" || ws.role === "admin"
               return (
                 <div
                   key={ws.id}
@@ -176,17 +177,21 @@ export function WorkspaceSwitcher() {
                       <Check className="h-3.5 w-3.5 text-fg-muted" strokeWidth={2} />
                     )}
                   </DropdownMenu.Item>
-                  <RowAction
-                    title={t("workspaceCrud.workspace.renameTitle")}
-                    onSelect={() => setRenameWs(ws)}
-                    icon={<Pencil className="h-3.5 w-3.5" strokeWidth={1.75} />}
-                  />
-                  <RowAction
-                    title={t("workspaceCrud.workspace.archiveTitle")}
-                    onSelect={() => setArchiveWs(ws)}
-                    icon={<Archive className="h-3.5 w-3.5" strokeWidth={1.75} />}
-                    danger
-                  />
+                  {canManage && (
+                    <>
+                      <RowAction
+                        title={t("workspaceCrud.workspace.renameTitle")}
+                        onSelect={() => setRenameWs(ws)}
+                        icon={<Pencil className="h-3.5 w-3.5" strokeWidth={1.75} />}
+                      />
+                      <RowAction
+                        title={t("workspaceCrud.workspace.archiveTitle")}
+                        onSelect={() => setArchiveWs(ws)}
+                        icon={<Archive className="h-3.5 w-3.5" strokeWidth={1.75} />}
+                        danger
+                      />
+                    </>
+                  )}
                 </div>
               )
             })}


### PR DESCRIPTION
## What & why

The workspace switcher showed rename and archive actions to members and viewers, although those roles cannot use them. Hide those actions while keeping workspace switching unchanged.

## How

Render the existing actions only for owner and admin roles. No API, permission, dialog, or other workspace flow changes.

## Verification

- [x] `make check`
- [x] Targeted ESLint for `WorkspaceSwitcher.tsx`
- [x] Two independent blind reviews
- [ ] Manual smoke (not run)

`make check` passed. Its Postgres migration smoke test was skipped because Docker was unavailable.