### PR TITLE
fix(web): remove disabled scheduled delivery option

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -3201,8 +3201,6 @@
       "cronLabel": "cron expression",
       "cronPlaceholder": "0 9 * * *",
       "preview": "Schedule preview",
-      "feishu": "Push to Feishu group",
-      "feishuDisabledHint": "Coming in a later release; Web-only for now.",
       "save": "Save",
       "saving": "Saving…",
       "cancel": "Cancel",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -3201,8 +3201,6 @@
       "cronLabel": "cron 表达式",
       "cronPlaceholder": "0 9 * * *",
       "preview": "频率预览",
-      "feishu": "推送到飞书群",
-      "feishuDisabledHint": "后续版本开放，当前仅 Web 查看。",
       "save": "保存",
       "saving": "保存中…",
       "cancel": "取消",

--- a/apps/web/src/pages/admin/ScheduledTasksPage.tsx
+++ b/apps/web/src/pages/admin/ScheduledTasksPage.tsx
@@ -585,14 +585,6 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
             {t("scheduledTasks.dialog.preview")}: {preview}
           </p>
 
-          <div className="grid min-w-0 gap-0.5 opacity-60">
-            <label className="flex items-center gap-2 text-xs text-fg-subtle">
-              <input type="checkbox" disabled className="h-3.5 w-3.5" />
-              {t("scheduledTasks.dialog.feishu")}
-            </label>
-            <span className="pl-5 text-xs text-fg-faint">{t("scheduledTasks.dialog.feishuDisabledHint")}</span>
-          </div>
-
           {errMsg && (
             <p className="rounded-md bg-danger-subtle px-3 py-2 text-xs text-danger break-all">{errMsg}</p>
           )}


### PR DESCRIPTION
## What & why

The scheduled-task dialog showed a disabled future Feishu delivery option that could not affect the saved task. Remove the misleading control and its copy.

## How

Delete the inert UI block and its dedicated locale keys. Scheduled-task requests, APIs, schemas, and delivery behavior are unchanged.

## Verification

- [x] `make check`
- [x] Locale JSON validation
- [x] Two independent blind reviews
- [ ] Manual E2E (requires a running development stack)

Targeted ESLint reports only the existing `react-hooks/set-state-in-effect` finding at unchanged line 180. With that rule disabled, the file passes. `make check` passed; its Postgres migration smoke test was skipped because Docker was unavailable.