### PR TITLE
Fix Skills installs in production image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,10 @@ description and keep ownership on the side listed here.
 - Local development images stay opt-in through installer overrides such as
   `--image parsar:local` / `--sandbox-image parsar-sandbox:local`; do not make
   local tags the default path for end users.
+- The production server image must provide Node.js 22.20 or newer, `npx`, and
+  `git` for server-side Skills.sh installs. Keep the runtime image compatible
+  with the pinned `skills` package in `skills_install_routes.go`; the image
+  build must fail if these executables are missing.
 
 ### Runtime and execution concepts
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@
 ###############################################################################
 ARG NODE_VERSION=22-alpine
 ARG GO_VERSION=1.25-bookworm
-ARG RUNTIME_BASE=debian:bookworm-slim
+ARG RUNTIME_BASE=node:22.22.0-bookworm-slim
 
 FROM --platform=$BUILDPLATFORM node:${NODE_VERSION} AS web-builder
 ENV PNPM_HOME=/pnpm
@@ -118,10 +118,11 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     done
 
 ###############################################################################
-# Stage 3: runtime — debian-slim with a non-root user.
+# Stage 3: runtime — Node.js on debian-slim with a non-root user.
 #
-# debian-slim (not distroless / scratch) on purpose:
+# Node.js on debian-slim (not distroless / scratch) on purpose:
 #   - ca-certificates + tini ship pre-built.
+#   - Server-side Skills.sh installs require npx and git.
 #   - Operators can `docker exec -it ... bash` to debug.
 #   - The opencode local runner may shell out (rg, basic core utils);
 #     keeping a real userland avoids surprises.
@@ -135,12 +136,17 @@ ARG PARSAR_GID=10001
 # Single RUN to limit the resulting layer count. The apt operations
 # touch the package index and would inflate the image if split.
 RUN set -eux; \
+    node --version; \
+    NODE_DISABLE_COMPILE_CACHE=1 npx --version; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
+        git \
         tini \
         wget \
     ; \
+    git --version; \
+    test ! -e /tmp/node-compile-cache; \
     rm -rf /var/lib/apt/lists/*; \
     groupadd --system --gid ${PARSAR_GID} ${PARSAR_USER}; \
     useradd  --system --uid ${PARSAR_UID} --gid ${PARSAR_GID} \

--- a/server/internal/dev/skills_install_routes.go
+++ b/server/internal/dev/skills_install_routes.go
@@ -15,11 +15,13 @@ import (
 	"strings"
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/paths"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/storage/blob"
 )
 
 const (
 	skillsRegistryName    = "skills.sh"
+	skillsCLIPackage      = "skills@1.5.23"
 	skillInstallAgentName = "claude-code"
 	skillInstallTmpPrefix = "teamgent-skill-*"
 )
@@ -40,7 +42,24 @@ type defaultSkillInstallRunner struct{}
 func (defaultSkillInstallRunner) Run(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
+	env, err := skillInstallCommandEnv()
+	if err != nil {
+		return nil, err
+	}
+	cmd.Env = env
 	return cmd.CombinedOutput()
+}
+
+func skillInstallCommandEnv() ([]string, error) {
+	root, err := paths.Root()
+	if err != nil {
+		return nil, fmt.Errorf("resolve Skills install cache directory: %w", err)
+	}
+	return append(os.Environ(),
+		"DISABLE_TELEMETRY=1",
+		"NPM_CONFIG_CACHE="+filepath.Join(root, "cache", "npm"),
+		"NODE_COMPILE_CACHE="+filepath.Join(root, "cache", "node"),
+	), nil
 }
 
 type skillInstallHTTPDoer interface {
@@ -249,7 +268,7 @@ func validSkillRefPart(part string) bool {
 }
 
 func downloadSkillToTemp(ctx context.Context, runner skillInstallCommandRunner, tmpDir, source, slug string) (string, error) {
-	output, err := runner.Run(ctx, tmpDir, "npx", "--yes", "skills", "add", strings.TrimSpace(source), "--skill", strings.TrimSpace(slug), "--agent", skillInstallAgentName, "--copy", "--yes")
+	output, err := runner.Run(ctx, tmpDir, "npx", "--yes", skillsCLIPackage, "add", strings.TrimSpace(source), "--skill", strings.TrimSpace(slug), "--agent", skillInstallAgentName, "--copy", "--yes")
 	if err != nil {
 		return "", fmt.Errorf("skills add failed: %s", compactCommandOutput(output, err))
 	}

--- a/server/internal/dev/skills_install_routes_test.go
+++ b/server/internal/dev/skills_install_routes_test.go
@@ -90,7 +90,7 @@ func TestSkillInstallFromRegistry_HappyPathReusesSkillZipImport(t *testing.T) {
 	if !runner.called {
 		t.Fatal("skills runner was not called")
 	}
-	wantArgs := []string{"--yes", "skills", "add", "googleworkspace/cli", "--skill", "gws-gmail-triage", "--agent", "claude-code", "--copy", "--yes"}
+	wantArgs := []string{"--yes", "skills@1.5.23", "add", "googleworkspace/cli", "--skill", "gws-gmail-triage", "--agent", "claude-code", "--copy", "--yes"}
 	if runner.lastName != "npx" || !reflect.DeepEqual(runner.lastArgs, wantArgs) {
 		t.Fatalf("runner command = %s %v, want npx %v", runner.lastName, runner.lastArgs, wantArgs)
 	}
@@ -156,6 +156,34 @@ func TestSkillInstallFromRegistry_HappyPathReusesSkillZipImport(t *testing.T) {
 	}
 	if _, err := os.Stat(runner.lastDir); !os.IsNotExist(err) {
 		t.Fatalf("temp dir should be removed after install, stat err=%v", err)
+	}
+}
+
+func TestSkillInstallCommandEnv(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	env, err := skillInstallCommandEnv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := make(map[string]string, len(env))
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[key] = value
+		}
+	}
+	if values["DISABLE_TELEMETRY"] != "1" {
+		t.Fatalf("DISABLE_TELEMETRY = %q, want 1", values["DISABLE_TELEMETRY"])
+	}
+	wantCache := filepath.Join(home, ".parsar", "cache", "npm")
+	if values["NPM_CONFIG_CACHE"] != wantCache {
+		t.Fatalf("NPM_CONFIG_CACHE = %q, want %q", values["NPM_CONFIG_CACHE"], wantCache)
+	}
+	wantCompileCache := filepath.Join(home, ".parsar", "cache", "node")
+	if values["NODE_COMPILE_CACHE"] != wantCompileCache {
+		t.Fatalf("NODE_COMPILE_CACHE = %q, want %q", values["NODE_COMPILE_CACHE"], wantCompileCache)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add Node.js and git to the production runtime for Skills.sh installs
- pin the Skills CLI and keep telemetry off and caches under the Parsar home
- document and test the runtime contract

## Scope
- no frontend, API, permission, catalog, or import-flow changes

## Validation
- `make check`
- production image build
- non-root Skills.sh install smoke test
- two independent blind reviews