### PR TITLE
fix(web): respect conversation write permissions

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -361,6 +361,7 @@
       "generic": "A runtime capability failed to start. Please retry later or contact an administrator."
     },
     "composer": {
+      "readOnly": "Read-only access. You cannot send messages.",
       "label": "Send message",
       "placeholder": "Chat with {{agent}}…",
       "addContext": "Add attachment / context",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -361,6 +361,7 @@
       "generic": "运行期能力启动失败，请稍后重试或联系管理员。"
     },
     "composer": {
+      "readOnly": "当前为只读权限，无法发送消息。",
       "label": "发送消息",
       "placeholder": "和 {{agent}} 聊聊…",
       "addContext": "添加附件 / 上下文",

--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -52,6 +52,7 @@ import {
   useUpdateConversationTitle,
 } from "../../lib/api-conversations"
 import { useSandboxBinding, type SandboxBinding } from "../../lib/api-sandbox"
+import { useMyWorkspaces } from "../../lib/api-workspaces"
 import type {
   ConversationListItem,
   ConversationTimelineRun,
@@ -87,6 +88,15 @@ export function ConversationsPage() {
   const wsId = useWorkspaceId()
   const restoreViewState = !entityId && focusTarget !== "compose"
   const savedViewState = useMemo(() => readConversationViewState(wsId), [wsId])
+  const workspacesQ = useMyWorkspaces()
+  const workspaces = workspacesQ.data?.workspaces ?? []
+  const writableWorkspaceIds = new Set(
+    workspaces
+      .filter((w) => w.role === "owner" || w.role === "admin" || w.role === "member")
+      .map((w) => w.id),
+  )
+  const workspaceRole = workspaces.find((w) => w.id === wsId)?.role
+  const canWrite = writableWorkspaceIds.has(wsId ?? "")
 
   const agentsQ = useAgents(wsId)
   const allAgents: Agent[] = useMemo(
@@ -263,6 +273,8 @@ export function ConversationsPage() {
         {!folded && (
           <ConversationSidebar
             agents={allAgents}
+            canWrite={canWrite}
+            canDelete={workspaceRole === "owner" || workspaceRole === "admin"}
             selectedAgentId={selectedAgentId}
             onPickAgent={(id) => {
               firstSend.current = null
@@ -290,6 +302,7 @@ export function ConversationsPage() {
         )}
         <ConversationMain
           conv={currentConv}
+          canWrite={entityId ? writableWorkspaceIds.has(currentConv?.workspace_id ?? "") : canWrite}
           convLoading={currentConvQ.isLoading}
           convError={currentConvQ.error}
           agent={selectedAgent}
@@ -342,6 +355,8 @@ function sandboxSendGuard(
 
 interface SidebarProps {
   agents: Agent[]
+  canWrite: boolean
+  canDelete: boolean
   selectedAgentId: string
   onPickAgent: (id: string) => void
   agentsLoading: boolean
@@ -369,6 +384,10 @@ function ConversationSidebar(p: SidebarProps) {
   const [deleteError, setDeleteError] = useState<string>("")
   const renameInputRef = useRef<HTMLInputElement>(null)
   useEffect(() => {
+    if (!p.canWrite) setRenamingConvId(null)
+    if (!p.canDelete) setDeleteConvId(null)
+  }, [p.canWrite, p.canDelete])
+  useEffect(() => {
     if (renamingConvId && renameInputRef.current) {
       renameInputRef.current.focus()
       renameInputRef.current.select()
@@ -386,7 +405,7 @@ function ConversationSidebar(p: SidebarProps) {
     setRenameError("")
   }
   const commitRename = async () => {
-    if (!renamingConvId) return
+    if (!p.canWrite || !renamingConvId) return
     const trimmed = renameDraft.trim()
     if (trimmed === "") {
       setRenameError(t("conversations.sidebar.renameEmpty"))
@@ -409,7 +428,7 @@ function ConversationSidebar(p: SidebarProps) {
 
   const deleteConv = p.conversations.find((c) => c.id === deleteConvId)
   const confirmDelete = async () => {
-    if (!deleteConvId) return
+    if (!p.canDelete || !deleteConvId) return
     setDeleteBusy(true)
     setDeleteError("")
     try {
@@ -489,7 +508,7 @@ function ConversationSidebar(p: SidebarProps) {
       <button
         type="button"
         onClick={p.onNewConversation}
-        disabled={!p.selectedAgentId}
+        disabled={!p.canWrite || !p.selectedAgentId}
         className={cn(
           "mt-3 flex h-9 w-full cursor-pointer items-center justify-center gap-2 rounded-lg border border-line bg-surface px-2.5 text-sm font-medium text-fg shadow-sm transition-[color,background-color,border-color,box-shadow]",
           "hover:border-line-strong hover:bg-surface-muted",
@@ -523,7 +542,7 @@ function ConversationSidebar(p: SidebarProps) {
         ) : (
           p.conversations.map((c) => {
             const isActive = c.id === p.selectedConversationId
-            const isRenaming = renamingConvId === c.id
+            const isRenaming = p.canWrite && renamingConvId === c.id
             // div+role="button" not <button>, so rename/delete can nest.
             return (
               <div
@@ -620,29 +639,33 @@ function ConversationSidebar(p: SidebarProps) {
                     {/* Hover-only action cluster. opacity-0 → */}
                     {/* group-hover:opacity-100 keeps the resting state clean. */}
                     <div className="absolute right-1.5 top-2 flex items-center gap-0.5 opacity-0 transition-opacity group-hover/row:opacity-100">
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          startRename(c)
-                        }}
-                        aria-label={t("conversations.sidebar.renameAria")}
-                        className="flex h-6 w-6 items-center justify-center rounded-md text-fg-faint transition-colors hover:bg-surface-muted hover:text-fg-muted"
-                      >
-                        <Pencil className="h-3 w-3" strokeWidth={2} />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setDeleteError("")
-                          setDeleteConvId(c.id)
-                        }}
-                        aria-label={t("conversations.sidebar.deleteAria")}
-                        className="flex h-6 w-6 items-center justify-center rounded-md text-fg-faint transition-colors hover:bg-danger-subtle hover:text-danger"
-                      >
-                        <Trash2 className="h-3 w-3" strokeWidth={2} />
-                      </button>
+                      {p.canWrite && (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            startRename(c)
+                          }}
+                          aria-label={t("conversations.sidebar.renameAria")}
+                          className="flex h-6 w-6 items-center justify-center rounded-md text-fg-faint transition-colors hover:bg-surface-muted hover:text-fg-muted"
+                        >
+                          <Pencil className="h-3 w-3" strokeWidth={2} />
+                        </button>
+                      )}
+                      {p.canDelete && (
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setDeleteError("")
+                            setDeleteConvId(c.id)
+                          }}
+                          aria-label={t("conversations.sidebar.deleteAria")}
+                          className="flex h-6 w-6 items-center justify-center rounded-md text-fg-faint transition-colors hover:bg-danger-subtle hover:text-danger"
+                        >
+                          <Trash2 className="h-3 w-3" strokeWidth={2} />
+                        </button>
+                      )}
                     </div>
                   </>
                 )}
@@ -653,7 +676,7 @@ function ConversationSidebar(p: SidebarProps) {
       </div>
 
       <Dialog
-        open={deleteConvId !== null}
+        open={p.canDelete && deleteConvId !== null}
         onOpenChange={(next) => {
           if (!next && !deleteBusy) setDeleteConvId(null)
         }}
@@ -716,6 +739,7 @@ function ConversationSidebar(p: SidebarProps) {
 
 interface MainProps {
   conv: import("../../lib/api-types").Conversation | undefined
+  canWrite: boolean
   convLoading: boolean
   convError: unknown
   agent: Agent | undefined
@@ -800,6 +824,7 @@ function ConversationMainInner(p: MainProps & { err: unknown; isUnreachable: boo
         ) : !p.conversationId || !p.conv ? (
           <EmptyChat
             agent={p.agent}
+            canWrite={p.canWrite}
             pageDescription={p.onPageDescription}
             onSendFromEmpty={p.onSendFromEmpty}
             focusComposer={p.focusComposer}
@@ -810,6 +835,7 @@ function ConversationMainInner(p: MainProps & { err: unknown; isUnreachable: boo
           // like the initial no-conversation state until the first send.
           <EmptyChat
             agent={p.agent}
+            canWrite={p.canWrite}
             pageDescription={p.onPageDescription}
             conversationId={p.conversationId}
             workspaceID={p.conv.workspace_id}
@@ -820,6 +846,7 @@ function ConversationMainInner(p: MainProps & { err: unknown; isUnreachable: boo
         ) : (
           <ChatStream
             conversationId={p.conversationId}
+            canWrite={p.canWrite}
             agent={p.agent}
             sidebarFolded={p.folded}
             sandboxGuard={p.sandboxGuard}
@@ -836,6 +863,7 @@ function ConversationMainInner(p: MainProps & { err: unknown; isUnreachable: boo
 
 function EmptyChat({
   agent,
+  canWrite,
   pageDescription,
   conversationId,
   workspaceID,
@@ -845,6 +873,7 @@ function EmptyChat({
   sandboxGuard,
 }: {
   agent: Agent | undefined
+  canWrite: boolean
   pageDescription: string
   /** When set, composer sends into this conv (in-chat flow). */
   conversationId?: string
@@ -894,7 +923,7 @@ function EmptyChat({
             <ComposerForm
               conversationId={conversationId ?? ""}
               agentId={agent?.id}
-              disabled={!agent || sandboxGuard?.blocked}
+              disabled={!canWrite || !agent || sandboxGuard?.blocked}
               autoFocus={focusComposer}
               placeholder={
                 agent
@@ -907,7 +936,7 @@ function EmptyChat({
                   ? (title) => onRenameAfterFirstMessage(conversationId, title)
                   : undefined
               }
-              blockReason={sandboxGuard?.blocked ? sandboxGuard.message : undefined}
+              blockReason={!canWrite ? t("conversations.composer.readOnly") : sandboxGuard?.blocked ? sandboxGuard.message : undefined}
             />
           </div>
         </div>
@@ -922,11 +951,13 @@ function EmptyChat({
 
 function ChatStream({
   conversationId,
+  canWrite,
   agent,
   sidebarFolded,
   sandboxGuard,
 }: {
   conversationId: string
+  canWrite: boolean
   agent: Agent | undefined
   sidebarFolded?: boolean
   sandboxGuard?: SandboxSendGuard
@@ -1051,7 +1082,7 @@ function ChatStream({
             >
               {someRunActive ? t("conversations.stream.thinking") : t("conversations.stream.ready")}
             </span>
-            {someRunActive && (
+            {canWrite && someRunActive && (
               <Button
                 variant="outline"
                 size="sm"
@@ -1156,7 +1187,7 @@ function ChatStream({
               active={someRunActive}
               cancelling={cancelRunMut.isPending}
               onCancel={
-                activeRunId
+                canWrite && activeRunId
                   ? () => {
                       cancelRunMut.mutate({ runID: activeRunId, reason: "user_clicked_cancel" })
                     }
@@ -1195,7 +1226,7 @@ function ChatStream({
           <ComposerForm
             conversationId={conversationId}
             placeholder={t("conversations.composer.placeholder", { agent: agent?.name ?? "" })}
-            disabled={!agent || sandboxGuard?.blocked}
+            disabled={!canWrite || !agent || sandboxGuard?.blocked}
             onRunStarted={setActiveRunId}
             onStartError={setChatToast}
             activeRunId={activeRunId}
@@ -1206,7 +1237,7 @@ function ChatStream({
             // abort. Server-side useCancelRun handles the actual run
             // cancellation + connector.Abort.
             onCancelActiveRun={
-              activeRunId
+              canWrite && activeRunId
                 ? () => {
                     const runID = activeRunId
                     setActiveRunId(null)
@@ -1215,7 +1246,7 @@ function ChatStream({
                 : undefined
             }
             cancelling={cancelRunMut.isPending}
-            blockReason={sandboxGuard?.blocked ? sandboxGuard.message : undefined}
+            blockReason={!canWrite ? t("conversations.composer.readOnly") : sandboxGuard?.blocked ? sandboxGuard.message : undefined}
           />
         </div>
       </div>

--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -272,6 +272,7 @@ export function ConversationsPage() {
       <div className="flex h-[calc(100vh-65px)] min-h-0">
         {!folded && (
           <ConversationSidebar
+            key={wsId}
             agents={allAgents}
             canWrite={canWrite}
             canDelete={workspaceRole === "owner" || workspaceRole === "admin"}

--- a/tests/e2e/conversation-composer.spec.ts
+++ b/tests/e2e/conversation-composer.spec.ts
@@ -1,14 +1,9 @@
-import { expect, test, type Page, type Route } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+import {
+  mockApp, json, WORKSPACE_ID, CONVERSATION_ID, OTHER_CONVERSATION_ID, type Surface, type Failure,
+} from "./helpers/conversation-app";
 
-const WORKSPACE_ID = "00000000-0000-0000-0000-000000000011";
-const CONVERSATION_ID = "00000000-0000-0000-0000-000000000012";
-const AGENT_ID = "00000000-0000-0000-0000-000000000013";
-const OTHER_CONVERSATION_ID = "00000000-0000-0000-0000-000000000014";
-const OTHER_AGENT_ID = "00000000-0000-0000-0000-000000000015";
-const OTHER_WORKSPACE_ID = "00000000-0000-0000-0000-000000000016";
 const DRAFT = "Keep this draft\n    with indentation\nand line breaks";
-type Surface = "existing" | "empty" | "new";
-type Failure = "create" | "message" | "network";
 
 for (const surface of ["existing", "empty", "new"] as const) {
   test(`${surface} composer preserves multiline input and sends with Enter`, async ({ page }) => {
@@ -304,72 +299,4 @@ for (const response of [{ agent_run_id: "run-1" }, { run_ids: ["run-1"] }]) {
     await expect(page.getByText(DRAFT, { exact: true })).toBeVisible();
     expect(state.sent).toEqual([DRAFT]);
   });
-}
-
-async function mockApp(page: Page, surface: Surface, failure: Failure | null) {
-  const state = {
-    failure: failure as Failure | null, sent: [] as string[], messageRequests: 0,
-    createRequests: 0, messageTargets: [] as string[],
-    waitForSend: Promise.resolve(), waitForCreate: Promise.resolve(),
-  };
-  const createdAt = new Date().toISOString();
-  let creates = 0;
-  let conversation = {
-    id: CONVERSATION_ID, workspace_id: WORKSPACE_ID, title: "Test Conversation", surface: "web",
-    form: "thread", status: "active", metadata: {}, primary_agent_id: AGENT_ID,
-    created_at: createdAt, updated_at: createdAt, message_count: surface === "existing" ? 1 : 0,
-  };
-  await page.addInitScript(() => localStorage.setItem("i18nextLng", "en-US"));
-  await page.route("**/api/v1/**", async (route) => {
-    const path = new URL(route.request().url()).pathname;
-    const method = route.request().method();
-    if (path === "/api/v1/me") return json(route, { user_id: "user-1", email: "user@example.com", name: "User" });
-    if (path === "/api/v1/me/workspaces") return json(route, { user_id: "user-1", workspaces: [
-      { id: WORKSPACE_ID, name: "Send Test", slug: "send-test", role: "owner" },
-      { id: OTHER_WORKSPACE_ID, name: "Other Workspace", slug: "other-workspace", role: "owner" },
-    ] });
-    if (path === "/api/v1/me/discoverable-workspaces") return json(route, { workspaces: [], total: 0 });
-    if (path === `/api/v1/workspaces/${WORKSPACE_ID}/agents`) return json(route, { agents: [
-      { id: AGENT_ID, workspace_id: WORKSPACE_ID, name: "Test Agent", status: "active", connector_type: "http_agent", config: {} },
-      { id: OTHER_AGENT_ID, workspace_id: WORKSPACE_ID, name: "Other Agent", status: "active", connector_type: "http_agent", config: {} },
-    ] });
-    const otherConversation = { ...conversation, id: OTHER_CONVERSATION_ID, title: "Other Conversation", message_count: 1 };
-    if (path === `/api/v1/workspaces/${WORKSPACE_ID}/conversations`) {
-      if (method !== "POST") return json(route, { conversations: surface === "new" && !creates ? [] : [conversation, otherConversation] });
-      state.createRequests++;
-      await state.waitForCreate;
-      if (state.failure === "create") return json(route, { error: "server_unreachable", message: "create rejected" }, 503);
-      creates++;
-      conversation = { ...conversation, id: `00000000-0000-0000-0000-${String(100 + creates).padStart(12, "0")}` };
-      return json(route, conversation, 201);
-    }
-    if (path === `/api/v1/conversations/${OTHER_CONVERSATION_ID}`) return json(route, otherConversation);
-    if (path === `/api/v1/conversations/${OTHER_CONVERSATION_ID}/timeline`) return json(route, {
-      conversation_id: OTHER_CONVERSATION_ID, messages: [], agent_runs: [],
-    });
-    if (path === `/api/v1/conversations/${conversation.id}`) return json(route, conversation);
-    if (path === `/api/v1/conversations/${conversation.id}/messages`) {
-      state.messageRequests++;
-      state.messageTargets.push(conversation.id);
-      expect(method).toBe("POST");
-      if (state.failure === "network") return route.abort("failed");
-      if (state.failure === "message") return json(route, { error: "invalid_content", message: "message rejected" }, 422);
-      await state.waitForSend;
-      state.sent.push(route.request().postDataJSON().content);
-      conversation.message_count++;
-      return json(route, { message_id: "message-new" }, 201);
-    }
-    if (path === `/api/v1/conversations/${conversation.id}/timeline`) return json(route, {
-      conversation_id: conversation.id, agent_runs: [], messages: [
-        ...(surface === "existing" ? ["Earlier message"] : []), ...state.sent,
-      ].map((content, index) => ({ id: `message-${index}`, conversation_id: conversation.id, sender_type: "user", content, created_at: createdAt })),
-    });
-    if (path === `/api/v1/workspaces/${WORKSPACE_ID}/interactions`) return json(route, { interactions: [] });
-    return json(route, {});
-  });
-  return state;
-}
-
-async function json(route: Route, body: unknown, status = 200) {
-  await route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
 }

--- a/tests/e2e/conversation-permissions.spec.ts
+++ b/tests/e2e/conversation-permissions.spec.ts
@@ -1,0 +1,172 @@
+import { expect, test, type Page } from "@playwright/test";
+import {
+  mockApp, json, WORKSPACE_ID, OTHER_WORKSPACE_ID, CONVERSATION_ID, OTHER_CONVERSATION_ID,
+} from "./helpers/conversation-app";
+
+const READ_ONLY = "Read-only access. You cannot send messages.";
+const RUN_ID = "00000000-0000-0000-0000-000000000021";
+const cancelActions = ["Cancel all", "Cancel current task", "Stop generating"];
+
+for (const role of ["owner", "admin", "member", "viewer", undefined]) {
+  for (const surface of ["existing", "empty", "new"] as const) {
+    test(`${surface} conversation permissions for ${role ?? "unknown role"}`, async ({ page }) => {
+      const state = await mockApp(page, surface, null);
+      state.role = role;
+      if (surface === "existing") await mockActiveRun(page);
+      await page.goto(`/?admin=conversations&ws=${WORKSPACE_ID}&${surface === "new" ? "focus=compose" : `id=${CONVERSATION_ID}`}`);
+      await expect(page.getByRole("button", { name: "Switch workspace", exact: true })).toHaveText("Send Test");
+      const input = page.locator("form").getByRole("textbox");
+      const create = page.getByRole("button", { name: "New conversation", exact: true });
+      const writable = role === "owner" || role === "admin" || role === "member";
+      const deletable = role === "owner" || role === "admin";
+
+      if (surface === "existing") {
+        await expect(page.getByText("Earlier message", { exact: true })).toBeVisible();
+        await expect(page.getByRole("button", { name: "Expand execution trace", exact: true })).toBeEnabled();
+        for (const name of cancelActions) {
+          const cancel = page.getByRole("button", { name, exact: true });
+          if (writable) await expect(cancel).toBeEnabled();
+          else await expect(cancel).toHaveCount(0);
+        }
+      }
+      if (!writable) {
+        await expect(input).toBeDisabled();
+        await expect(create).toBeDisabled();
+        await expect(page.locator("form")).toContainText(READ_ONLY);
+        await expect(page.getByRole("button", { name: /^(Rename|Delete) conversation$/ })).toHaveCount(0);
+        await page.locator("form").dispatchEvent("submit");
+        if (surface !== "new") {
+          await page.getByText("Other Conversation", { exact: true }).click();
+          await expect(page).toHaveURL(new RegExp(`id=${OTHER_CONVERSATION_ID}`));
+        }
+        expect(state.writes).toEqual([]);
+        return;
+      }
+
+      await expect(input).toBeEnabled();
+      await expect(create).toBeEnabled();
+      await input.fill("Allowed message");
+      await page.getByRole("button", { name: "send", exact: true }).click();
+      await expect.poll(() => state.sent).toEqual(["Allowed message"]);
+      await expect(input).toHaveValue("");
+      await page.getByRole("button", { name: "Rename conversation", exact: true }).first().click();
+      const rename = page.getByRole("textbox", { name: "Rename conversation", exact: true });
+      await rename.fill("Renamed conversation");
+      await rename.press("Enter");
+      await expect(page.getByText("Renamed conversation", { exact: true })).toBeVisible();
+      const remove = page.getByRole("button", { name: "Delete conversation", exact: true });
+      if (deletable) {
+        await remove.first().click();
+        await page.getByRole("dialog").getByRole("button", { name: "Delete", exact: true }).click();
+        await expect(page.getByText("Renamed conversation", { exact: true })).toHaveCount(0);
+        expect(state.writes.some((request) => request.startsWith("DELETE "))).toBe(true);
+      } else {
+        await expect(remove).toHaveCount(0);
+        expect(state.writes.some((request) => request.startsWith("DELETE "))).toBe(false);
+      }
+    });
+  }
+}
+
+for (const name of cancelActions) {
+  test(`members can use ${name}`, async ({ page }) => {
+    const state = await mockApp(page, "existing", null);
+    state.role = "member";
+    await mockActiveRun(page);
+    await page.goto(`/?admin=conversations&ws=${WORKSPACE_ID}&id=${CONVERSATION_ID}`);
+    await page.getByRole("button", { name, exact: true }).click();
+    await expect.poll(() => state.writes).toEqual([name === "Cancel all"
+      ? `POST /api/v1/conversations/${CONVERSATION_ID}/cancel-all`
+      : `POST /api/v1/agent-runs/${RUN_ID}/cancel`]);
+  });
+}
+
+test("conversation writes are unavailable while workspace roles load", async ({ page }) => {
+  const state = await mockApp(page, "new", null);
+  let releaseRole!: () => void;
+  state.waitForRole = new Promise<void>((resolve) => { releaseRole = resolve; });
+  const roles = page.waitForRequest("**/api/v1/me/workspaces");
+  await page.goto(`/?admin=conversations&ws=${WORKSPACE_ID}&focus=compose`);
+  await roles;
+  await expect(page.getByRole("main")).toBeVisible();
+  const input = page.locator("form").getByRole("textbox");
+  await expect(input).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "New conversation", exact: true })).toHaveCount(0);
+  expect(state.writes).toEqual([]);
+  releaseRole();
+  await expect(input).toBeEnabled();
+});
+
+test("conversation writes stay disabled when workspace roles cannot be fetched", async ({ page }) => {
+  const state = await mockApp(page, "new", null);
+  await page.route("**/api/v1/me/workspaces", (route) => json(route, { error: "unavailable" }, 503));
+  await page.goto(`/?admin=conversations&ws=${WORKSPACE_ID}&focus=compose`);
+  await expect(page.locator("form")).toContainText(READ_ONLY);
+  await expect(page.locator("form").getByRole("textbox")).toBeDisabled();
+  await expect(page.getByRole("button", { name: "New conversation", exact: true })).toBeDisabled();
+  expect(state.writes).toEqual([]);
+});
+
+for (const action of ["Rename", "Delete"]) {
+  test(`losing permission closes the pending ${action.toLowerCase()}`, async ({ page }) => {
+    const state = await mockApp(page, "existing", null);
+    await page.goto(`/?admin=conversations&ws=${WORKSPACE_ID}&id=${CONVERSATION_ID}`);
+    await page.getByRole("button", { name: `${action} conversation`, exact: true }).first().click();
+    const pending = action === "Delete" ? page.getByRole("dialog") : page.getByRole("textbox", { name: "Rename conversation" });
+    await expect(pending).toBeVisible();
+    state.role = "viewer";
+    const roles = page.waitForResponse("**/api/v1/me/workspaces");
+    await page.evaluate(() => window.dispatchEvent(new Event("visibilitychange")));
+    await roles;
+    await expect(pending).toHaveCount(0);
+    await expect(page.locator("form").getByRole("textbox")).toBeDisabled();
+    expect(state.writes).toEqual([]);
+  });
+}
+
+for (const [role, conversationRole] of [["owner", "viewer"], ["viewer", "owner"], ["owner", undefined]]) {
+  test(`conversation actions use its own workspace role ${conversationRole ?? "unknown"}, not URL role ${role}`, async ({ page }) => {
+    const state = await mockApp(page, "existing", null);
+    state.role = role;
+    state.otherRole = conversationRole;
+    state.conversationWorkspaceId = OTHER_WORKSPACE_ID;
+    await mockActiveRun(page);
+    await page.goto(`/?admin=conversations&ws=${WORKSPACE_ID}&id=${CONVERSATION_ID}`);
+    const input = page.locator("form").getByRole("textbox");
+    if (conversationRole === "owner") {
+      await expect(input).toBeEnabled();
+      await input.fill("Allowed in this conversation");
+      await page.getByRole("button", { name: "send", exact: true }).click();
+      await expect.poll(() => state.sent).toEqual(["Allowed in this conversation"]);
+    } else {
+      await expect(page.getByRole("button", { name: "Expand execution trace", exact: true })).toBeEnabled();
+      await expect(input).toBeDisabled();
+      for (const name of cancelActions) await expect(page.getByRole("button", { name, exact: true })).toHaveCount(0);
+      expect(state.writes).toEqual([]);
+    }
+  });
+}
+
+async function mockActiveRun(page: Page) {
+  await page.route(`**/api/v1/conversations/${CONVERSATION_ID}/timeline?*`, (route) => json(route, {
+    conversation_id: CONVERSATION_ID,
+    messages: [{ id: "message-1", conversation_id: CONVERSATION_ID, sender_type: "user", content: "Earlier message", created_at: new Date().toISOString() }],
+    agent_runs: [{ id: RUN_ID, status: "running", created_at: new Date().toISOString(), steps: [] }],
+  }));
+  await page.addInitScript(() => {
+    class MockEventSource extends EventTarget {
+      private timer: ReturnType<typeof setTimeout>;
+      constructor() {
+        super();
+        this.timer = setTimeout(() => {
+          this.dispatchEvent(new Event("open"));
+          this.dispatchEvent(new MessageEvent("tool", { data: JSON.stringify({
+            tool: { id: "tool-1", name: "read", stage: "before", args: { path: "README.md" } },
+          }) }));
+        }, 0);
+      }
+      close() { clearTimeout(this.timer); }
+    }
+    window.EventSource = MockEventSource as unknown as typeof EventSource;
+  });
+}

--- a/tests/e2e/conversation-permissions.spec.ts
+++ b/tests/e2e/conversation-permissions.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 import {
-  mockApp, json, WORKSPACE_ID, OTHER_WORKSPACE_ID, CONVERSATION_ID, OTHER_CONVERSATION_ID,
+  mockApp, json, WORKSPACE_ID, OTHER_WORKSPACE_ID, CONVERSATION_ID, OTHER_CONVERSATION_ID, OTHER_AGENT_ID,
 } from "./helpers/conversation-app";
 
 const READ_ONLY = "Read-only access. You cannot send messages.";
@@ -123,6 +123,44 @@ for (const action of ["Rename", "Delete"]) {
     expect(state.writes).toEqual([]);
   });
 }
+
+test("workspace navigation discards a pending delete target", async ({ page }) => {
+  const state = await mockApp(page, "new", null);
+  const conversation = {
+    id: OTHER_CONVERSATION_ID, workspace_id: OTHER_WORKSPACE_ID, title: "Other Conversation",
+    primary_agent_id: OTHER_AGENT_ID, surface: "web", form: "thread", status: "active",
+    metadata: {}, message_count: 1, created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+  };
+  await page.route((url) => url.pathname.startsWith(`/api/v1/workspaces/${OTHER_WORKSPACE_ID}/`), (route) => {
+    const path = new URL(route.request().url()).pathname;
+    if (path.endsWith("/conversations")) return json(route, { conversations: [conversation] });
+    if (path.endsWith("/agents")) return json(route, { agents: [{
+      id: OTHER_AGENT_ID, workspace_id: OTHER_WORKSPACE_ID, name: "Other Agent", status: "active", connector_type: "http_agent", config: {},
+    }] });
+    return route.fallback();
+  });
+  await page.route(`**/api/v1/conversations/${OTHER_CONVERSATION_ID}`, (route) => {
+    if (route.request().method() === "DELETE") state.writes.push(`DELETE /api/v1/conversations/${OTHER_CONVERSATION_ID}`);
+    return json(route, conversation);
+  });
+  await page.goto(`/?admin=conversations&ws=${WORKSPACE_ID}&focus=compose`);
+  await expect(page.locator("form").getByRole("textbox")).toBeEnabled();
+  await page.evaluate((url) => {
+    window.history.pushState({}, "", url);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, `/?admin=conversations&ws=${OTHER_WORKSPACE_ID}&id=${OTHER_CONVERSATION_ID}`);
+  await page.getByRole("button", { name: "Delete conversation", exact: true }).click();
+  await expect(page.getByRole("dialog")).toBeVisible();
+  await page.goBack();
+  await expect(page).toHaveURL(new RegExp(`ws=${WORKSPACE_ID}`));
+  state.otherRole = "viewer";
+  const roles = page.waitForResponse("**/api/v1/me/workspaces");
+  await page.evaluate(() => window.dispatchEvent(new Event("visibilitychange")));
+  await roles;
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.locator("form").getByRole("textbox")).toBeEnabled();
+  expect(state.writes).toEqual([]);
+});
 
 for (const [role, conversationRole] of [["owner", "viewer"], ["viewer", "owner"], ["owner", undefined]]) {
   test(`conversation actions use its own workspace role ${conversationRole ?? "unknown"}, not URL role ${role}`, async ({ page }) => {

--- a/tests/e2e/helpers/conversation-app.ts
+++ b/tests/e2e/helpers/conversation-app.ts
@@ -1,0 +1,93 @@
+import { expect, type Page, type Route } from "@playwright/test";
+
+export const WORKSPACE_ID = "00000000-0000-0000-0000-000000000011";
+export const CONVERSATION_ID = "00000000-0000-0000-0000-000000000012";
+export const AGENT_ID = "00000000-0000-0000-0000-000000000013";
+export const OTHER_CONVERSATION_ID = "00000000-0000-0000-0000-000000000014";
+export const OTHER_AGENT_ID = "00000000-0000-0000-0000-000000000015";
+export const OTHER_WORKSPACE_ID = "00000000-0000-0000-0000-000000000016";
+export type Surface = "existing" | "empty" | "new";
+export type Failure = "create" | "message" | "network";
+export async function mockApp(page: Page, surface: Surface, failure: Failure | null) {
+  const state = {
+    failure: failure as Failure | null, sent: [] as string[], messageRequests: 0,
+    createRequests: 0, messageTargets: [] as string[],
+    waitForSend: Promise.resolve(), waitForCreate: Promise.resolve(),
+    role: "owner" as string | undefined, otherRole: "owner" as string | undefined,
+    conversationWorkspaceId: WORKSPACE_ID, waitForRole: Promise.resolve(), writes: [] as string[],
+  };
+  const createdAt = new Date().toISOString();
+  let creates = 0;
+  let deleted = false;
+  let conversation = {
+    id: CONVERSATION_ID, workspace_id: WORKSPACE_ID, title: "Test Conversation", surface: "web",
+    form: "thread", status: "active", metadata: {}, primary_agent_id: AGENT_ID,
+    created_at: createdAt, updated_at: createdAt, message_count: surface === "existing" ? 1 : 0,
+  };
+  await page.addInitScript(() => localStorage.setItem("i18nextLng", "en-US"));
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const method = route.request().method();
+    if (method !== "GET") state.writes.push(`${method} ${path}`);
+    if (path === "/api/v1/me") return json(route, { user_id: "user-1", email: "user@example.com", name: "User" });
+    if (path === "/api/v1/me/workspaces") {
+      await state.waitForRole;
+      return json(route, { user_id: "user-1", workspaces: [
+        { id: WORKSPACE_ID, name: "Send Test", slug: "send-test", role: state.role },
+        { id: OTHER_WORKSPACE_ID, name: "Other Workspace", slug: "other-workspace", role: state.otherRole },
+      ] });
+    }
+    if (path === "/api/v1/me/discoverable-workspaces") return json(route, { workspaces: [], total: 0 });
+    if (path === `/api/v1/workspaces/${WORKSPACE_ID}/agents`) return json(route, { agents: [
+      { id: AGENT_ID, workspace_id: WORKSPACE_ID, name: "Test Agent", status: "active", connector_type: "http_agent", config: {} },
+      { id: OTHER_AGENT_ID, workspace_id: WORKSPACE_ID, name: "Other Agent", status: "active", connector_type: "http_agent", config: {} },
+    ] });
+    const otherConversation = { ...conversation, id: OTHER_CONVERSATION_ID, title: "Other Conversation", message_count: 1 };
+    if (path === `/api/v1/workspaces/${WORKSPACE_ID}/conversations`) {
+      if (method !== "POST") return json(route, { conversations: surface === "new" && !creates ? [] : [...(deleted ? [] : [conversation]), otherConversation] });
+      state.createRequests++;
+      await state.waitForCreate;
+      if (state.failure === "create") return json(route, { error: "server_unreachable", message: "create rejected" }, 503);
+      creates++;
+      deleted = false;
+      conversation = { ...conversation, id: `00000000-0000-0000-0000-${String(100 + creates).padStart(12, "0")}` };
+      return json(route, conversation, 201);
+    }
+    if (path === `/api/v1/conversations/${OTHER_CONVERSATION_ID}`) return json(route, otherConversation);
+    if (path === `/api/v1/conversations/${OTHER_CONVERSATION_ID}/timeline`) return json(route, {
+      conversation_id: OTHER_CONVERSATION_ID, messages: [], agent_runs: [],
+    });
+    if (path === `/api/v1/conversations/${conversation.id}`) {
+      if (method === "DELETE") {
+        deleted = true;
+        return route.fulfill({ status: 204 });
+      }
+      if (deleted) return json(route, { error: "not_found" }, 404);
+      if (method === "PATCH") conversation.title = route.request().postDataJSON().title;
+      return json(route, { ...conversation, workspace_id: state.conversationWorkspaceId });
+    }
+    if (path === `/api/v1/conversations/${conversation.id}/messages`) {
+      state.messageRequests++;
+      state.messageTargets.push(conversation.id);
+      expect(method).toBe("POST");
+      if (state.failure === "network") return route.abort("failed");
+      if (state.failure === "message") return json(route, { error: "invalid_content", message: "message rejected" }, 422);
+      await state.waitForSend;
+      state.sent.push(route.request().postDataJSON().content);
+      conversation.message_count++;
+      return json(route, { message_id: "message-new" }, 201);
+    }
+    if (path === `/api/v1/conversations/${conversation.id}/timeline`) return json(route, {
+      conversation_id: conversation.id, agent_runs: [], messages: [
+        ...(surface === "existing" ? ["Earlier message"] : []), ...state.sent,
+      ].map((content, index) => ({ id: `message-${index}`, conversation_id: conversation.id, sender_type: "user", content, created_at: createdAt })),
+    });
+    if (path === `/api/v1/workspaces/${WORKSPACE_ID}/interactions`) return json(route, { interactions: [] });
+    return json(route, {});
+  });
+  return state;
+}
+
+export async function json(route: Route, body: unknown, status = 200) {
+  await route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+}


### PR DESCRIPTION
## Summary

- Match conversation write controls to the user's workspace role.
- Allow only workspace owners and admins to delete conversations.
- Keep read-only conversation views and hide unauthorized actions.
- Close pending rename and delete controls when access or workspace changes.

## Scope

Only the conversation UI, bilingual read-only copy, and tests. No backend, authorization policy, other pages, or visual redesign changes.

## Validation

- 26 conversation permission, 29 composer, and 14 interaction permission E2E tests passed.
- `make check` and `make test-web` passed. The Postgres migration smoke test was skipped because Docker is unavailable locally.
