### PR TITLE
fix: bind secret disabling to its management workspace

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -384,6 +384,8 @@ description and keep ownership on the side listed here.
   rows without it remain usable but cannot be disabled through the API until
   an operator assigns a verified management workspace in the database.
   Never infer ownership from the workspace supplied in a disable request.
+  The database smoke gate also runs the cross-workspace secret-disable HTTP
+  regression so it cannot silently skip in CI without a test database.
 - Accepting an invitation may set a password only for a newly created user.
   Existing users must authenticate as the invited account; acceptance must
   preserve their identities and passwords, and rejected attempts must leave

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,8 +380,8 @@ description and keep ownership on the side listed here.
 
 - Secret disabling is authorized by `secrets.management_workspace_id`, set
   from the creation workspace. This ownership must not restrict shared reads
-  or runtime use. Legacy rows inherit only an explicit workspace provenance;
-  rows without it remain usable but cannot be disabled through the API until
+  or runtime use. Legacy rows inherit unambiguous creation metadata or runtime
+  registration ownership. Rows without it remain usable but cannot be disabled until
   an operator assigns a verified management workspace in the database.
   Never infer ownership from the workspace supplied in a disable request.
   The database smoke gate also runs the cross-workspace secret-disable HTTP

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -378,6 +378,12 @@ description and keep ownership on the side listed here.
 
 ### API, DB, and generated surfaces
 
+- Secret disabling is authorized by `secrets.management_workspace_id`, set
+  from the creation workspace. This ownership must not restrict shared reads
+  or runtime use. Legacy rows inherit only an explicit workspace provenance;
+  rows without it remain usable but cannot be disabled through the API until
+  an operator assigns a verified management workspace in the database.
+  Never infer ownership from the workspace supplied in a disable request.
 - Accepting an invitation may set a password only for a newly created user.
   Existing users must authenticate as the invited account; acceptance must
   preserve their identities and passwords, and rejected attempts must leave

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1557,6 +1557,7 @@
       "disabled": "Disabled"
     },
     "actions": {
+      "disableUnavailable": "Disable is only available in the recorded management workspace. Contact your administrator if ownership is missing.",
       "disable": "Disable"
     },
     "create": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1557,6 +1557,7 @@
       "disabled": "已禁用"
     },
     "actions": {
+      "disableUnavailable": "只能在凭证所属工作区禁用；若未记录归属，请联系管理员。",
       "disable": "禁用"
     },
     "create": {

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -879,6 +879,7 @@ export type SecretStatus = "active" | "disabled"
  */
 export interface Secret {
   id: string
+  management_workspace_id?: string
   slug: string
   name: string
   kind: string

--- a/apps/web/src/pages/admin/credentials/OrgSecretsTab.tsx
+++ b/apps/web/src/pages/admin/credentials/OrgSecretsTab.tsx
@@ -129,6 +129,7 @@ export function OrgSecretsTab({ workspaceID, query = "", createRequest = 0 }: Or
 
         {/* Model API Keys — read-only. Rotation lives on the Models page. */}
         <SecretGroup
+          workspaceID={workspaceID}
           label={t("secrets.sections.modelKeys")}
           items={modelKeys}
           empty={t("secrets.empty.modelKeys")}
@@ -138,6 +139,7 @@ export function OrgSecretsTab({ workspaceID, query = "", createRequest = 0 }: Or
           onDisable={setConfirmTarget}
         />
         <SecretGroup
+          workspaceID={workspaceID}
           label={t("secrets.sections.runtimeKeys")}
           items={runtimeKeys}
           empty={t("secrets.empty.runtimeKeys")}
@@ -146,6 +148,7 @@ export function OrgSecretsTab({ workspaceID, query = "", createRequest = 0 }: Or
         />
         {otherKeys.length > 0 && (
           <SecretGroup
+            workspaceID={workspaceID}
             label={t("secrets.sections.otherKeys")}
             items={otherKeys}
             fmtAgo={fmtAgo}
@@ -194,6 +197,7 @@ export function OrgSecretsTab({ workspaceID, query = "", createRequest = 0 }: Or
 }
 
 interface GroupProps {
+  workspaceID: string
   label: string
   items: Secret[]
   empty?: string
@@ -205,7 +209,7 @@ interface GroupProps {
   onOpenModels?: () => void
 }
 
-function SecretGroup({ label, items, empty, fmtAgo, onDisable, readOnlyLabel, onOpenModels }: GroupProps) {
+function SecretGroup({ workspaceID, label, items, empty, fmtAgo, onDisable, readOnlyLabel, onOpenModels }: GroupProps) {
   const { t } = useTranslation("admin")
   return (
     <LedgerGroup label={label} count={items.length}>
@@ -214,6 +218,7 @@ function SecretGroup({ label, items, empty, fmtAgo, onDisable, readOnlyLabel, on
       ) : (
         items.map((secret) => {
           const active = secret.status === "active"
+          const canDisable = secret.management_workspace_id === workspaceID
           const statusLabel = active ? t("secrets.status.active") : t("secrets.status.disabled")
           return (
             <LedgerRow key={secret.id} role="listitem" tabIndex={-1}>
@@ -236,7 +241,13 @@ function SecretGroup({ label, items, empty, fmtAgo, onDisable, readOnlyLabel, on
                 {readOnlyLabel && onOpenModels ? (
                   <ActionIconButton icon={ArrowUpRight} label={readOnlyLabel} onClick={onOpenModels} />
                 ) : active ? (
-                  <ActionIconButton icon={Ban} label={t("secrets.actions.disable")} tone="danger" onClick={() => onDisable(secret)} />
+                  <ActionIconButton
+                    icon={Ban}
+                    label={t(canDisable ? "secrets.actions.disable" : "secrets.actions.disableUnavailable")}
+                    tone="danger"
+                    disabled={!canDisable}
+                    onClick={() => onDisable(secret)}
+                  />
                 ) : null}
               </RowActions>
             </LedgerRow>

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1701,6 +1701,36 @@ definitions:
       required:
         type: boolean
     type: object
+  store.SecretRead:
+    properties:
+      auth_type:
+        type: string
+      created_at:
+        type: string
+      id:
+        type: string
+      key_version:
+        type: string
+      kind:
+        type: string
+      management_workspace_id:
+        type: string
+      masked:
+        type: string
+      metadata:
+        additionalProperties: {}
+        type: object
+      name:
+        type: string
+      provider:
+        type: string
+      slug:
+        type: string
+      status:
+        type: string
+      updated_at:
+        type: string
+    type: object
 info:
   contact: {}
   description: |-
@@ -8391,7 +8421,10 @@ paths:
         "200":
           description: Secret list
           schema:
-            additionalProperties: true
+            additionalProperties:
+              items:
+                $ref: '#/definitions/store.SecretRead'
+              type: array
             type: object
         "400":
           description: Invalid UUID
@@ -8431,8 +8464,7 @@ paths:
         "201":
           description: Created secret
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/store.SecretRead'
         "400":
           description: Invalid body or UUID
           schema:
@@ -8450,8 +8482,9 @@ paths:
       - secrets
   /api/v1/workspaces/{workspaceID}/secrets/{secretID}/disable:
     post:
-      description: Marks the secret as disabled so agents can no longer bind to it.
-        Owner/admin only.
+      description: Marks the secret as disabled. Caller must be owner/admin of the
+        secret's recorded management workspace. Shared use does not grant management
+        rights; legacy secrets without recorded ownership cannot be disabled.
       operationId: disableDevSecret
       parameters:
       - description: Workspace UUID
@@ -8470,8 +8503,7 @@ paths:
         "200":
           description: Disabled secret
           schema:
-            additionalProperties: true
-            type: object
+            $ref: '#/definitions/store.SecretRead'
         "400":
           description: Invalid UUID
           schema:
@@ -8485,7 +8517,7 @@ paths:
               type: string
             type: object
         "404":
-          description: Secret not found
+          description: Secret not found in this management workspace
           schema:
             additionalProperties:
               type: string

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -83,5 +83,6 @@ fi
 )
 
 go test ./server/internal/store -count=1
+go test ./server/internal/dev -run '^TestSecretDisableRequiresItsManagementWorkspace$' -count=1
 
 echo "Parsar migration and store integration smoke test passed."

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -1967,17 +1967,17 @@ limit @item_limit;
 -- (via generateAutoSlug("secret")); name is the display name and
 -- may repeat.
 insert into secrets(
-  id, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_by, created_at, updated_at
+  id, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_by, management_workspace_id, created_at, updated_at
 )
 values (
-  @id::uuid, @slug, @name, @kind, @provider, @auth_type, @encrypted_payload::jsonb, @key_version, 'active', @metadata::jsonb, @created_by::uuid, @now, @now
+  @id::uuid, @slug, @name, @kind, @provider, @auth_type, @encrypted_payload::jsonb, @key_version, 'active', @metadata::jsonb, @created_by::uuid, @management_workspace_id::uuid, @now, @now
 )
-returning id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, created_at, updated_at;
+returning id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at;
 
 -- name: ListSecrets :many
 -- Organization-level, no longer filtered by workspace. Optionally
 -- filter by kind (pass empty string to return all kinds).
-select id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, created_at, updated_at
+select id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 from secrets
 where (@kind_filter::text = '' or kind = @kind_filter::text)
   and deleted_at is null
@@ -1985,7 +1985,7 @@ order by created_at desc, id desc
 limit @item_limit;
 
 -- name: ListSecretsForWorkspace :many
-select id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, created_at, updated_at
+select id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 from secrets
 where (coalesce(metadata->>'workspace_id', '') = '' or metadata->>'workspace_id' = @workspace_id::text)
   and deleted_at is null
@@ -1993,7 +1993,7 @@ order by created_at desc, id desc
 limit @item_limit;
 
 -- name: GetSecretPayload :one
-select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_at, updated_at
+select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 from secrets
 where id = @id::uuid
   and deleted_at is null;
@@ -2006,7 +2006,7 @@ set encrypted_payload = @encrypted_payload::jsonb,
     updated_at = @now
 where id = @id::uuid
   and deleted_at is null
-returning id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_at, updated_at;
+returning id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at;
 
 -- name: ResolveSlackBotSecretByTeam :one
 -- Resolve the active Slack bot-token secret for a workspace, keyed by the
@@ -2016,7 +2016,7 @@ returning id::text, slug, name, kind, provider, auth_type, encrypted_payload, ke
 -- Slack channel decrypts encrypted_payload to mint the per-call Web API bearer,
 -- so a re-installed app rotates without a process restart. Newest active row
 -- wins when two installs share a team (re-install supersedes).
-select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_at, updated_at
+select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 from secrets
 where kind = 'slack_bot'
   and status = 'active'
@@ -2033,7 +2033,7 @@ limit 1;
 -- Discord channel decrypts encrypted_payload to mint the per-call API/Gateway
 -- bearer, so a re-installed bot rotates without a process restart. Newest active
 -- row wins when two installs share a guild (re-install supersedes).
-select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_at, updated_at
+select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 from secrets
 where kind = 'discord_bot'
   and status = 'active'
@@ -2046,8 +2046,9 @@ limit 1;
 update secrets
 set status = 'disabled', updated_at = @now
 where id = @id::uuid
+  and management_workspace_id = @workspace_id::uuid
   and deleted_at is null
-returning id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, created_at, updated_at;
+returning id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at;
 
 -- name: ActiveSecretSlugExists :one
 select exists (

--- a/server/internal/db/sqlc/models.go
+++ b/server/internal/db/sqlc/models.go
@@ -693,6 +693,8 @@ type Secret struct {
 	UpdatedAt pgtype.Timestamptz `json:"updated_at"`
 	// Soft-delete marker; non-null means deleted
 	DeletedAt pgtype.Timestamptz `json:"deleted_at"`
+	// Workspace whose owner/admin may disable this secret; does not restrict shared use
+	ManagementWorkspaceID pgtype.UUID `json:"management_workspace_id"`
 }
 
 // Workspace-level spec fragments, each independently injectable and editable

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -2715,40 +2715,42 @@ func (q *Queries) CreateScheduledTask(ctx context.Context, arg CreateScheduledTa
 
 const createSecret = `-- name: CreateSecret :one
 insert into secrets(
-  id, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_by, created_at, updated_at
+  id, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_by, management_workspace_id, created_at, updated_at
 )
 values (
-  $1::uuid, $2, $3, $4, $5, $6, $7::jsonb, $8, 'active', $9::jsonb, $10::uuid, $11, $11
+  $1::uuid, $2, $3, $4, $5, $6, $7::jsonb, $8, 'active', $9::jsonb, $10::uuid, $11::uuid, $12, $12
 )
-returning id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, created_at, updated_at
+returning id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 `
 
 type CreateSecretParams struct {
-	ID               pgtype.UUID        `json:"id"`
-	Slug             string             `json:"slug"`
-	Name             string             `json:"name"`
-	Kind             string             `json:"kind"`
-	Provider         string             `json:"provider"`
-	AuthType         string             `json:"auth_type"`
-	EncryptedPayload []byte             `json:"encrypted_payload"`
-	KeyVersion       string             `json:"key_version"`
-	Metadata         []byte             `json:"metadata"`
-	CreatedBy        pgtype.UUID        `json:"created_by"`
-	Now              pgtype.Timestamptz `json:"now"`
+	ID                    pgtype.UUID        `json:"id"`
+	Slug                  string             `json:"slug"`
+	Name                  string             `json:"name"`
+	Kind                  string             `json:"kind"`
+	Provider              string             `json:"provider"`
+	AuthType              string             `json:"auth_type"`
+	EncryptedPayload      []byte             `json:"encrypted_payload"`
+	KeyVersion            string             `json:"key_version"`
+	Metadata              []byte             `json:"metadata"`
+	CreatedBy             pgtype.UUID        `json:"created_by"`
+	ManagementWorkspaceID pgtype.UUID        `json:"management_workspace_id"`
+	Now                   pgtype.Timestamptz `json:"now"`
 }
 
 type CreateSecretRow struct {
-	ID         string             `json:"id"`
-	Slug       string             `json:"slug"`
-	Name       string             `json:"name"`
-	Kind       string             `json:"kind"`
-	Provider   string             `json:"provider"`
-	AuthType   string             `json:"auth_type"`
-	KeyVersion string             `json:"key_version"`
-	Status     string             `json:"status"`
-	Metadata   []byte             `json:"metadata"`
-	CreatedAt  pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+	ID                    string             `json:"id"`
+	Slug                  string             `json:"slug"`
+	Name                  string             `json:"name"`
+	Kind                  string             `json:"kind"`
+	Provider              string             `json:"provider"`
+	AuthType              string             `json:"auth_type"`
+	KeyVersion            string             `json:"key_version"`
+	Status                string             `json:"status"`
+	Metadata              []byte             `json:"metadata"`
+	ManagementWorkspaceID string             `json:"management_workspace_id"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 }
 
 // Organization-level shared secret. slug is supplied by the caller
@@ -2766,6 +2768,7 @@ func (q *Queries) CreateSecret(ctx context.Context, arg CreateSecretParams) (Cre
 		arg.KeyVersion,
 		arg.Metadata,
 		arg.CreatedBy,
+		arg.ManagementWorkspaceID,
 		arg.Now,
 	)
 	var i CreateSecretRow
@@ -2779,6 +2782,7 @@ func (q *Queries) CreateSecret(ctx context.Context, arg CreateSecretParams) (Cre
 		&i.KeyVersion,
 		&i.Status,
 		&i.Metadata,
+		&i.ManagementWorkspaceID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -3368,31 +3372,34 @@ const disableSecret = `-- name: DisableSecret :one
 update secrets
 set status = 'disabled', updated_at = $1
 where id = $2::uuid
+  and management_workspace_id = $3::uuid
   and deleted_at is null
-returning id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, created_at, updated_at
+returning id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 `
 
 type DisableSecretParams struct {
-	Now pgtype.Timestamptz `json:"now"`
-	ID  pgtype.UUID        `json:"id"`
+	Now         pgtype.Timestamptz `json:"now"`
+	ID          pgtype.UUID        `json:"id"`
+	WorkspaceID pgtype.UUID        `json:"workspace_id"`
 }
 
 type DisableSecretRow struct {
-	ID         string             `json:"id"`
-	Slug       string             `json:"slug"`
-	Name       string             `json:"name"`
-	Kind       string             `json:"kind"`
-	Provider   string             `json:"provider"`
-	AuthType   string             `json:"auth_type"`
-	KeyVersion string             `json:"key_version"`
-	Status     string             `json:"status"`
-	Metadata   []byte             `json:"metadata"`
-	CreatedAt  pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+	ID                    string             `json:"id"`
+	Slug                  string             `json:"slug"`
+	Name                  string             `json:"name"`
+	Kind                  string             `json:"kind"`
+	Provider              string             `json:"provider"`
+	AuthType              string             `json:"auth_type"`
+	KeyVersion            string             `json:"key_version"`
+	Status                string             `json:"status"`
+	Metadata              []byte             `json:"metadata"`
+	ManagementWorkspaceID string             `json:"management_workspace_id"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 }
 
 func (q *Queries) DisableSecret(ctx context.Context, arg DisableSecretParams) (DisableSecretRow, error) {
-	row := q.db.QueryRow(ctx, disableSecret, arg.Now, arg.ID)
+	row := q.db.QueryRow(ctx, disableSecret, arg.Now, arg.ID, arg.WorkspaceID)
 	var i DisableSecretRow
 	err := row.Scan(
 		&i.ID,
@@ -3404,6 +3411,7 @@ func (q *Queries) DisableSecret(ctx context.Context, arg DisableSecretParams) (D
 		&i.KeyVersion,
 		&i.Status,
 		&i.Metadata,
+		&i.ManagementWorkspaceID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -6114,25 +6122,26 @@ func (q *Queries) GetScheduledTaskScope(ctx context.Context, id pgtype.UUID) (Ge
 }
 
 const getSecretPayload = `-- name: GetSecretPayload :one
-select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_at, updated_at
+select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 from secrets
 where id = $1::uuid
   and deleted_at is null
 `
 
 type GetSecretPayloadRow struct {
-	ID               string             `json:"id"`
-	Slug             string             `json:"slug"`
-	Name             string             `json:"name"`
-	Kind             string             `json:"kind"`
-	Provider         string             `json:"provider"`
-	AuthType         string             `json:"auth_type"`
-	EncryptedPayload []byte             `json:"encrypted_payload"`
-	KeyVersion       string             `json:"key_version"`
-	Status           string             `json:"status"`
-	Metadata         []byte             `json:"metadata"`
-	CreatedAt        pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	ID                    string             `json:"id"`
+	Slug                  string             `json:"slug"`
+	Name                  string             `json:"name"`
+	Kind                  string             `json:"kind"`
+	Provider              string             `json:"provider"`
+	AuthType              string             `json:"auth_type"`
+	EncryptedPayload      []byte             `json:"encrypted_payload"`
+	KeyVersion            string             `json:"key_version"`
+	Status                string             `json:"status"`
+	Metadata              []byte             `json:"metadata"`
+	ManagementWorkspaceID string             `json:"management_workspace_id"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 }
 
 func (q *Queries) GetSecretPayload(ctx context.Context, id pgtype.UUID) (GetSecretPayloadRow, error) {
@@ -6149,6 +6158,7 @@ func (q *Queries) GetSecretPayload(ctx context.Context, id pgtype.UUID) (GetSecr
 		&i.KeyVersion,
 		&i.Status,
 		&i.Metadata,
+		&i.ManagementWorkspaceID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -8961,7 +8971,7 @@ func (q *Queries) ListScheduledTasksByWorkspacePage(ctx context.Context, arg Lis
 }
 
 const listSecrets = `-- name: ListSecrets :many
-select id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, created_at, updated_at
+select id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 from secrets
 where ($1::text = '' or kind = $1::text)
   and deleted_at is null
@@ -8975,17 +8985,18 @@ type ListSecretsParams struct {
 }
 
 type ListSecretsRow struct {
-	ID         string             `json:"id"`
-	Slug       string             `json:"slug"`
-	Name       string             `json:"name"`
-	Kind       string             `json:"kind"`
-	Provider   string             `json:"provider"`
-	AuthType   string             `json:"auth_type"`
-	KeyVersion string             `json:"key_version"`
-	Status     string             `json:"status"`
-	Metadata   []byte             `json:"metadata"`
-	CreatedAt  pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+	ID                    string             `json:"id"`
+	Slug                  string             `json:"slug"`
+	Name                  string             `json:"name"`
+	Kind                  string             `json:"kind"`
+	Provider              string             `json:"provider"`
+	AuthType              string             `json:"auth_type"`
+	KeyVersion            string             `json:"key_version"`
+	Status                string             `json:"status"`
+	Metadata              []byte             `json:"metadata"`
+	ManagementWorkspaceID string             `json:"management_workspace_id"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 }
 
 // Organization-level, no longer filtered by workspace. Optionally
@@ -9009,6 +9020,7 @@ func (q *Queries) ListSecrets(ctx context.Context, arg ListSecretsParams) ([]Lis
 			&i.KeyVersion,
 			&i.Status,
 			&i.Metadata,
+			&i.ManagementWorkspaceID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -9023,7 +9035,7 @@ func (q *Queries) ListSecrets(ctx context.Context, arg ListSecretsParams) ([]Lis
 }
 
 const listSecretsForWorkspace = `-- name: ListSecretsForWorkspace :many
-select id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, created_at, updated_at
+select id::text, slug, name, kind, provider, auth_type, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 from secrets
 where (coalesce(metadata->>'workspace_id', '') = '' or metadata->>'workspace_id' = $1::text)
   and deleted_at is null
@@ -9037,17 +9049,18 @@ type ListSecretsForWorkspaceParams struct {
 }
 
 type ListSecretsForWorkspaceRow struct {
-	ID         string             `json:"id"`
-	Slug       string             `json:"slug"`
-	Name       string             `json:"name"`
-	Kind       string             `json:"kind"`
-	Provider   string             `json:"provider"`
-	AuthType   string             `json:"auth_type"`
-	KeyVersion string             `json:"key_version"`
-	Status     string             `json:"status"`
-	Metadata   []byte             `json:"metadata"`
-	CreatedAt  pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt  pgtype.Timestamptz `json:"updated_at"`
+	ID                    string             `json:"id"`
+	Slug                  string             `json:"slug"`
+	Name                  string             `json:"name"`
+	Kind                  string             `json:"kind"`
+	Provider              string             `json:"provider"`
+	AuthType              string             `json:"auth_type"`
+	KeyVersion            string             `json:"key_version"`
+	Status                string             `json:"status"`
+	Metadata              []byte             `json:"metadata"`
+	ManagementWorkspaceID string             `json:"management_workspace_id"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 }
 
 func (q *Queries) ListSecretsForWorkspace(ctx context.Context, arg ListSecretsForWorkspaceParams) ([]ListSecretsForWorkspaceRow, error) {
@@ -9069,6 +9082,7 @@ func (q *Queries) ListSecretsForWorkspace(ctx context.Context, arg ListSecretsFo
 			&i.KeyVersion,
 			&i.Status,
 			&i.Metadata,
+			&i.ManagementWorkspaceID,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 		); err != nil {
@@ -10898,7 +10912,7 @@ func (q *Queries) ResolveAgentNameForConversation(ctx context.Context, conversat
 }
 
 const resolveDiscordBotSecretByGuild = `-- name: ResolveDiscordBotSecretByGuild :one
-select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_at, updated_at
+select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 from secrets
 where kind = 'discord_bot'
   and status = 'active'
@@ -10909,18 +10923,19 @@ limit 1
 `
 
 type ResolveDiscordBotSecretByGuildRow struct {
-	ID               string             `json:"id"`
-	Slug             string             `json:"slug"`
-	Name             string             `json:"name"`
-	Kind             string             `json:"kind"`
-	Provider         string             `json:"provider"`
-	AuthType         string             `json:"auth_type"`
-	EncryptedPayload []byte             `json:"encrypted_payload"`
-	KeyVersion       string             `json:"key_version"`
-	Status           string             `json:"status"`
-	Metadata         []byte             `json:"metadata"`
-	CreatedAt        pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	ID                    string             `json:"id"`
+	Slug                  string             `json:"slug"`
+	Name                  string             `json:"name"`
+	Kind                  string             `json:"kind"`
+	Provider              string             `json:"provider"`
+	AuthType              string             `json:"auth_type"`
+	EncryptedPayload      []byte             `json:"encrypted_payload"`
+	KeyVersion            string             `json:"key_version"`
+	Status                string             `json:"status"`
+	Metadata              []byte             `json:"metadata"`
+	ManagementWorkspaceID string             `json:"management_workspace_id"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 }
 
 // Resolve the active Discord bot-token secret for a guild, keyed by the Discord
@@ -10944,6 +10959,7 @@ func (q *Queries) ResolveDiscordBotSecretByGuild(ctx context.Context, guildID st
 		&i.KeyVersion,
 		&i.Status,
 		&i.Metadata,
+		&i.ManagementWorkspaceID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -11014,7 +11030,7 @@ func (q *Queries) ResolveModelRuntime(ctx context.Context, id pgtype.UUID) (Reso
 }
 
 const resolveSlackBotSecretByTeam = `-- name: ResolveSlackBotSecretByTeam :one
-select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_at, updated_at
+select id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 from secrets
 where kind = 'slack_bot'
   and status = 'active'
@@ -11025,18 +11041,19 @@ limit 1
 `
 
 type ResolveSlackBotSecretByTeamRow struct {
-	ID               string             `json:"id"`
-	Slug             string             `json:"slug"`
-	Name             string             `json:"name"`
-	Kind             string             `json:"kind"`
-	Provider         string             `json:"provider"`
-	AuthType         string             `json:"auth_type"`
-	EncryptedPayload []byte             `json:"encrypted_payload"`
-	KeyVersion       string             `json:"key_version"`
-	Status           string             `json:"status"`
-	Metadata         []byte             `json:"metadata"`
-	CreatedAt        pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	ID                    string             `json:"id"`
+	Slug                  string             `json:"slug"`
+	Name                  string             `json:"name"`
+	Kind                  string             `json:"kind"`
+	Provider              string             `json:"provider"`
+	AuthType              string             `json:"auth_type"`
+	EncryptedPayload      []byte             `json:"encrypted_payload"`
+	KeyVersion            string             `json:"key_version"`
+	Status                string             `json:"status"`
+	Metadata              []byte             `json:"metadata"`
+	ManagementWorkspaceID string             `json:"management_workspace_id"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 }
 
 // Resolve the active Slack bot-token secret for a workspace, keyed by the
@@ -11060,6 +11077,7 @@ func (q *Queries) ResolveSlackBotSecretByTeam(ctx context.Context, teamID string
 		&i.KeyVersion,
 		&i.Status,
 		&i.Metadata,
+		&i.ManagementWorkspaceID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -12485,7 +12503,7 @@ set encrypted_payload = $1::jsonb,
     updated_at = $3
 where id = $4::uuid
   and deleted_at is null
-returning id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_at, updated_at
+returning id::text, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, coalesce(management_workspace_id::text, '')::text as management_workspace_id, created_at, updated_at
 `
 
 type UpdateSecretPayloadParams struct {
@@ -12496,18 +12514,19 @@ type UpdateSecretPayloadParams struct {
 }
 
 type UpdateSecretPayloadRow struct {
-	ID               string             `json:"id"`
-	Slug             string             `json:"slug"`
-	Name             string             `json:"name"`
-	Kind             string             `json:"kind"`
-	Provider         string             `json:"provider"`
-	AuthType         string             `json:"auth_type"`
-	EncryptedPayload []byte             `json:"encrypted_payload"`
-	KeyVersion       string             `json:"key_version"`
-	Status           string             `json:"status"`
-	Metadata         []byte             `json:"metadata"`
-	CreatedAt        pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
+	ID                    string             `json:"id"`
+	Slug                  string             `json:"slug"`
+	Name                  string             `json:"name"`
+	Kind                  string             `json:"kind"`
+	Provider              string             `json:"provider"`
+	AuthType              string             `json:"auth_type"`
+	EncryptedPayload      []byte             `json:"encrypted_payload"`
+	KeyVersion            string             `json:"key_version"`
+	Status                string             `json:"status"`
+	Metadata              []byte             `json:"metadata"`
+	ManagementWorkspaceID string             `json:"management_workspace_id"`
+	CreatedAt             pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt             pgtype.Timestamptz `json:"updated_at"`
 }
 
 func (q *Queries) UpdateSecretPayload(ctx context.Context, arg UpdateSecretPayloadParams) (UpdateSecretPayloadRow, error) {
@@ -12529,6 +12548,7 @@ func (q *Queries) UpdateSecretPayload(ctx context.Context, arg UpdateSecretPaylo
 		&i.KeyVersion,
 		&i.Status,
 		&i.Metadata,
+		&i.ManagementWorkspaceID,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/server/internal/dev/agent_credential_binding.go
+++ b/server/internal/dev/agent_credential_binding.go
@@ -34,6 +34,7 @@ func materialiseInlineSecrets(
 	cfg map[string]any,
 	inputs []createAgentInlineSecretBody,
 	actorID string,
+	workspaceID string,
 ) (map[string]any, bool) {
 	if len(inputs) == 0 {
 		return cfg, true
@@ -66,14 +67,15 @@ func materialiseInlineSecrets(
 			return nil, false
 		}
 		secret, err := rs.CreateSecret(ctx, store.CreateSecretInput{
-			Name:               displayName,
-			Kind:               "capability_inline",
-			Provider:           "inline",
-			AuthType:           "literal",
-			Payload:            payload,
-			Masked:             maskSecretValue(plaintext),
-			CreatedBy:          actorID,
-			CredentialKindCode: kind,
+			ManagementWorkspaceID: workspaceID,
+			Name:                  displayName,
+			Kind:                  "capability_inline",
+			Provider:              "inline",
+			AuthType:              "literal",
+			Payload:               payload,
+			Masked:                maskSecretValue(plaintext),
+			CreatedBy:             actorID,
+			CredentialKindCode:    kind,
 		}, encrypted)
 		if err != nil {
 			return nil, false

--- a/server/internal/dev/routes_agents.go
+++ b/server/internal/dev/routes_agents.go
@@ -326,7 +326,7 @@ func createAgent(runtimeStore RuntimeStore, agentDaemonSandbox AgentDaemonSandbo
 		// fully-resolved binding map. Failure here is fatal — the agent
 		// is not created, the secrets that did succeed are left as
 		// orphans (we explicitly chose not to clean them up).
-		if cfg, ok := materialiseInlineSecrets(r.Context(), runtimeStore, req.Config, req.InlineNewSecrets, actorIDFromRequest(r)); ok {
+		if cfg, ok := materialiseInlineSecrets(r.Context(), runtimeStore, req.Config, req.InlineNewSecrets, actorIDFromRequest(r), workspaceID); ok {
 			req.Config = cfg
 		} else if len(req.InlineNewSecrets) > 0 {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to materialise inline_new_secrets"})
@@ -527,7 +527,7 @@ func updateAgent(runtimeStore RuntimeStore) http.HandlerFunc {
 		// pass could wrap the chain in a tx + rollback.
 		configChanged := fields["config"] || len(req.InlineNewSecrets) > 0
 		if configChanged {
-			if cfg, ok := materialiseInlineSecrets(r.Context(), runtimeStore, req.Config, req.InlineNewSecrets, actorIDFromRequest(r)); ok {
+			if cfg, ok := materialiseInlineSecrets(r.Context(), runtimeStore, req.Config, req.InlineNewSecrets, actorIDFromRequest(r), agent.WorkspaceID); ok {
 				req.Config = cfg
 			} else if len(req.InlineNewSecrets) > 0 {
 				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "failed to materialise inline_new_secrets"})

--- a/server/internal/dev/routes_secret_management_test.go
+++ b/server/internal/dev/routes_secret_management_test.go
@@ -1,0 +1,80 @@
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestSecretDisableRequiresItsManagementWorkspace(t *testing.T) {
+	t.Setenv("PARSAR_MASTER_KEY", "test-secret-management-key")
+	db := openDevRouteTestDB(t)
+	ctx := context.Background()
+	st := store.New(db)
+	ids := store.DefaultDevFixtureIDs()
+	_, err := st.InsertDevFixture(ctx, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	employee, err := st.AddWorkspaceMember(ctx, store.AddWorkspaceMemberInput{
+		WorkspaceID: ids.WorkspaceID, Email: "secret-viewer@example.com", Role: "viewer", Now: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := chi.NewRouter()
+	RegisterRoutesWithStore(r, st)
+	create := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+ids.WorkspaceID+"/secrets",
+		`{"name":"Shared test credential","kind":"runtime","provider":"test","auth_type":"api_key","payload":{"api_key":"synthetic"}}`, ids.UserID)
+	var secret store.SecretRead
+	if err := json.Unmarshal(create.Body.Bytes(), &secret); err != nil || create.Code != http.StatusCreated || secret.ManagementWorkspaceID != ids.WorkspaceID {
+		t.Fatalf("create secret: %d %s", create.Code, create.Body.String())
+	}
+	personal, err := st.CreateWorkspace(ctx, store.CreateWorkspaceInput{Name: "Viewer-owned workspace", CreatedBy: employee.Member.UserID, Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	disable := func(workspace, user string, want int) {
+		t.Helper()
+		res := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+workspace+"/secrets/"+secret.ID+"/disable", "", user)
+		if res.Code != want {
+			t.Fatalf("disable: got %d, want %d: %s", res.Code, want, res.Body.String())
+		}
+	}
+	disable(ids.WorkspaceID, employee.Member.UserID, http.StatusForbidden)
+	disable(personal.Workspace.ID, employee.Member.UserID, http.StatusNotFound)
+	shared, err := st.GetSecretPayload(ctx, personal.Workspace.ID, secret.ID)
+	if err != nil || shared.Status != "active" || shared.ManagementWorkspaceID != ids.WorkspaceID {
+		t.Fatalf("shared credential changed or unavailable: %v", err)
+	}
+	list := serveCapabilityRoute(t, r, http.MethodGet, "/api/v1/workspaces/"+personal.Workspace.ID+"/secrets", "", employee.Member.UserID)
+	var listed struct {
+		Secrets []store.SecretRead `json:"secrets"`
+	}
+	if err := json.Unmarshal(list.Body.Bytes(), &listed); err != nil || list.Code != http.StatusOK {
+		t.Fatalf("list shared secrets: %d", list.Code)
+	}
+	found := false
+	for _, item := range listed.Secrets {
+		if item.ID == secret.ID {
+			found = item.ManagementWorkspaceID == ids.WorkspaceID
+		}
+	}
+	if !found {
+		t.Fatal("shared credential or its management workspace missing from list")
+	}
+	disable(ids.WorkspaceID, ids.UserID, http.StatusOK)
+	if _, err := db.Exec(ctx, `update secrets set status='active', management_workspace_id=null where id=$1`, secret.ID); err != nil {
+		t.Fatal(err)
+	}
+	disable(ids.WorkspaceID, ids.UserID, http.StatusNotFound)
+	legacy, err := st.GetSecretPayload(ctx, ids.WorkspaceID, secret.ID)
+	if err != nil || legacy.Status != "active" {
+		t.Fatalf("legacy credential should remain usable: %v", err)
+	}
+}

--- a/server/internal/dev/routes_secret_management_test.go
+++ b/server/internal/dev/routes_secret_management_test.go
@@ -11,6 +11,27 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+type secretManagementCaptureStore struct {
+	stubRuntimeStore
+	input store.CreateSecretInput
+}
+
+func (s *secretManagementCaptureStore) CreateSecret(_ context.Context, input store.CreateSecretInput, _ []byte) (store.SecretRead, error) {
+	s.input = input
+	return store.SecretRead{ID: "00000000-0000-0000-0000-000000000099"}, nil
+}
+
+func TestAgentInlineSecretRecordsManagementWithoutChangingSharing(t *testing.T) {
+	t.Setenv("PARSAR_MASTER_KEY", "test-secret-management-key")
+	s := &secretManagementCaptureStore{}
+	ids := store.DefaultDevFixtureIDs()
+	_, ok := materialiseInlineSecrets(context.Background(), s, map[string]any{},
+		[]createAgentInlineSecretBody{{Kind: "github_pat", Plaintext: "synthetic"}}, ids.UserID, ids.WorkspaceID)
+	if !ok || s.input.ManagementWorkspaceID != ids.WorkspaceID || s.input.WorkspaceID != "" {
+		t.Fatal("inline credential must retain its sharing scope and record its management workspace")
+	}
+}
+
 func TestSecretDisableRequiresItsManagementWorkspace(t *testing.T) {
 	t.Setenv("PARSAR_MASTER_KEY", "test-secret-management-key")
 	db := openDevRouteTestDB(t)

--- a/server/internal/dev/routes_secrets.go
+++ b/server/internal/dev/routes_secrets.go
@@ -31,7 +31,7 @@ type createSecretBody struct {
 //	@Produce		json
 //	@Param			workspaceID	path	string			true	"Workspace UUID"
 //	@Param			body		body	createSecretBody	true	"Secret create payload"
-//	@Success		201 {object} map[string]interface{} "Created secret"
+//	@Success		201 {object} store.SecretRead "Created secret"
 //	@Failure		400 {object} map[string]string "Invalid body or UUID"
 //	@Failure		403 {object} map[string]string "Caller is not workspace owner/admin"
 //	@Router			/api/v1/workspaces/{workspaceID}/secrets [post]
@@ -94,7 +94,7 @@ func createSecret(runtimeStore RuntimeStore) http.HandlerFunc {
 //	@ID				listDevSecrets
 //	@Produce		json
 //	@Param			workspaceID	path	string	true	"Workspace UUID"
-//	@Success		200 {object} map[string]interface{} "Secret list"
+//	@Success		200 {object} map[string][]store.SecretRead "Secret list"
 //	@Failure		400 {object} map[string]string "Invalid UUID"
 //	@Failure		403 {object} map[string]string "Caller is not workspace owner/admin"
 //	@Router			/api/v1/workspaces/{workspaceID}/secrets [get]
@@ -126,16 +126,16 @@ func listSecrets(runtimeStore RuntimeStore) http.HandlerFunc {
 // disableSecret marks a secret row as disabled.
 //
 //	@Summary		Disable a secret
-//	@Description	Marks the secret as disabled so agents can no longer bind to it. Owner/admin only.
+//	@Description	Marks the secret as disabled. Caller must be owner/admin of the secret's recorded management workspace. Shared use does not grant management rights; legacy secrets without recorded ownership cannot be disabled.
 //	@Tags			secrets
 //	@ID				disableDevSecret
 //	@Produce		json
 //	@Param			workspaceID	path	string	true	"Workspace UUID"
 //	@Param			secretID	path	string	true	"Secret UUID"
-//	@Success		200 {object} map[string]interface{} "Disabled secret"
+//	@Success		200 {object} store.SecretRead "Disabled secret"
 //	@Failure		400 {object} map[string]string "Invalid UUID"
 //	@Failure		403 {object} map[string]string "Caller is not workspace owner/admin"
-//	@Failure		404 {object} map[string]string "Secret not found"
+//	@Failure		404 {object} map[string]string "Secret not found in this management workspace"
 //	@Router			/api/v1/workspaces/{workspaceID}/secrets/{secretID}/disable [post]
 func disableSecret(runtimeStore RuntimeStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/store/capability_import.go
+++ b/server/internal/store/capability_import.go
@@ -472,17 +472,18 @@ func commitCapabilityVersionInTx(ctx context.Context, q *sqlc.Queries, p commitV
 			keyVersion = "v1"
 		}
 		secretRow, err := q.CreateSecret(ctx, sqlc.CreateSecretParams{
-			ID:               mustUUID(newID()),
-			Slug:             generateAutoSlug("secret"),
-			Name:             secretName,
-			Kind:             "capability_inline",
-			Provider:         "inline",
-			AuthType:         "literal",
-			EncryptedPayload: secret.EncryptedPayload,
-			KeyVersion:       keyVersion,
-			Metadata:         metaJSON,
-			CreatedBy:        p.CreatorID,
-			Now:              timestamptz(p.Now),
+			ID:                    mustUUID(newID()),
+			Slug:                  generateAutoSlug("secret"),
+			Name:                  secretName,
+			Kind:                  "capability_inline",
+			Provider:              "inline",
+			AuthType:              "literal",
+			EncryptedPayload:      secret.EncryptedPayload,
+			KeyVersion:            keyVersion,
+			Metadata:              metaJSON,
+			CreatedBy:             p.CreatorID,
+			ManagementWorkspaceID: p.WorkspaceID,
+			Now:                   timestamptz(p.Now),
 		})
 		if err != nil {
 			if isUniqueViolation(err) {

--- a/server/internal/store/secret_management.go
+++ b/server/internal/store/secret_management.go
@@ -1,0 +1,189 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/audit"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+type CreateSecretInput struct {
+	WorkspaceID string
+	Name        string
+	Kind        string
+	Provider    string
+	AuthType    string
+	Payload     map[string]any
+	Masked      string
+	CreatedBy   string
+	// CredentialKindCode is optional metadata that pins a capability_inline
+	// secret to a single credential_kinds.code. Used by the agent-creation
+	// shared-binding picker to filter secrets by the kind they hold.
+	CredentialKindCode string
+}
+
+type SecretRead struct {
+	ManagementWorkspaceID string         `json:"management_workspace_id,omitempty"`
+	ID                    string         `json:"id"`
+	Slug                  string         `json:"slug"`
+	Name                  string         `json:"name"`
+	Kind                  string         `json:"kind"`
+	Provider              string         `json:"provider"`
+	AuthType              string         `json:"auth_type"`
+	KeyVersion            string         `json:"key_version"`
+	Status                string         `json:"status"`
+	Masked                string         `json:"masked"`
+	Metadata              map[string]any `json:"metadata"`
+	CreatedAt             time.Time      `json:"created_at"`
+	UpdatedAt             time.Time      `json:"updated_at"`
+}
+
+type SecretPayload struct {
+	SecretRead
+	EncryptedPayload []byte
+}
+
+func (s *Store) CreateSecret(ctx context.Context, input CreateSecretInput, encryptedPayload []byte) (SecretRead, error) {
+	now := time.Now().UTC()
+	createdBy := nullableUUID(input.CreatedBy)
+	metaPayload := map[string]any{"masked": strings.TrimSpace(input.Masked)}
+	if code := strings.TrimSpace(input.CredentialKindCode); code != "" {
+		metaPayload["credential_kind_code"] = code
+	}
+	if strings.TrimSpace(input.Kind) == "capability_inline" {
+		metaPayload["workspace_id"] = strings.TrimSpace(input.WorkspaceID)
+	}
+	metadata, err := json.Marshal(metaPayload)
+	if err != nil {
+		return SecretRead{}, err
+	}
+	row, err := sqlc.New(s.db).CreateSecret(ctx, sqlc.CreateSecretParams{
+		ID:                    mustUUID(newID()),
+		Slug:                  generateAutoSlug("secret"),
+		Name:                  strings.TrimSpace(input.Name),
+		Kind:                  secretKind(input.Kind),
+		Provider:              strings.TrimSpace(input.Provider),
+		AuthType:              strings.TrimSpace(input.AuthType),
+		EncryptedPayload:      encryptedPayload,
+		KeyVersion:            "v1",
+		Metadata:              metadata,
+		CreatedBy:             createdBy,
+		ManagementWorkspaceID: nullableUUID(input.WorkspaceID),
+		Now:                   timestamptz(now),
+	})
+	if err != nil {
+		return SecretRead{}, err
+	}
+	read := secretReadFromCreateRow(row)
+
+	s.emitAuditEvent(audit.Event{
+		OccurredAt: now,
+		Source:     audit.SourceAdmin,
+		EventType:  auditSecretCreated,
+		ActorType:  audit.ActorTypeSystem,
+		ActorID:    input.CreatedBy,
+		TargetType: "secret",
+		TargetID:   read.ID,
+		Payload: map[string]any{
+			"source":    auditSourceDevSecretWrite,
+			"name":      read.Name,
+			"slug":      read.Slug,
+			"kind":      read.Kind,
+			"provider":  read.Provider,
+			"auth_type": read.AuthType,
+		},
+	})
+
+	return read, nil
+}
+
+func (s *Store) DisableSecret(ctx context.Context, workspaceID string, secretID string) (SecretRead, error) {
+	now := time.Now().UTC()
+	if _, err := s.GetSecretPayload(ctx, workspaceID, secretID); err != nil {
+		return SecretRead{}, err
+	}
+	secretUUID, err := uuid(secretID)
+	if err != nil {
+		return SecretRead{}, err
+	}
+	workspaceUUID, err := uuid(workspaceID)
+	if err != nil {
+		return SecretRead{}, err
+	}
+	row, err := sqlc.New(s.db).DisableSecret(ctx, sqlc.DisableSecretParams{ID: secretUUID, WorkspaceID: workspaceUUID, Now: timestamptz(now)})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return SecretRead{}, fmt.Errorf("%w: %s", ErrUnknownSecret, secretID)
+		}
+		return SecretRead{}, err
+	}
+	read := secretReadFromDisableRow(row)
+
+	s.emitAuditEvent(audit.Event{
+		OccurredAt: now,
+		Source:     audit.SourceAdmin,
+		EventType:  auditSecretDisabled,
+		ActorType:  audit.ActorTypeSystem,
+		TargetType: "secret",
+		TargetID:   read.ID,
+		Payload: map[string]any{
+			"source": auditSourceDevSecretWrite,
+			"name":   read.Name,
+			"slug":   read.Slug,
+			"status": read.Status,
+		},
+	})
+
+	return read, nil
+}
+
+func secretReadFromCreateRow(row sqlc.CreateSecretRow) SecretRead {
+	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.ManagementWorkspaceID, row.CreatedAt, row.UpdatedAt)
+}
+
+func secretReadFromListRow(row sqlc.ListSecretsRow) SecretRead {
+	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.ManagementWorkspaceID, row.CreatedAt, row.UpdatedAt)
+}
+
+func secretReadFromWorkspaceListRow(row sqlc.ListSecretsForWorkspaceRow) SecretRead {
+	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.ManagementWorkspaceID, row.CreatedAt, row.UpdatedAt)
+}
+
+func secretReadFromDisableRow(row sqlc.DisableSecretRow) SecretRead {
+	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.ManagementWorkspaceID, row.CreatedAt, row.UpdatedAt)
+}
+
+func secretReadFromSecretRow(row sqlc.GetSecretPayloadRow) SecretRead {
+	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.ManagementWorkspaceID, row.CreatedAt, row.UpdatedAt)
+}
+
+func secretReadFromUpdatePayloadRow(row sqlc.UpdateSecretPayloadRow) SecretRead {
+	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.ManagementWorkspaceID, row.CreatedAt, row.UpdatedAt)
+}
+
+func secretRead(id, slug, name, kind, provider, authType, keyVersion, status string, metadataJSON []byte, managementWorkspaceID string, createdAt, updatedAt pgtype.Timestamptz) SecretRead {
+	metadata := decodeJSONMap(metadataJSON)
+	masked, _ := metadata["masked"].(string)
+	return SecretRead{
+		ID:                    id,
+		Slug:                  slug,
+		Name:                  name,
+		Kind:                  kind,
+		Provider:              provider,
+		AuthType:              authType,
+		KeyVersion:            keyVersion,
+		Status:                status,
+		Masked:                masked,
+		Metadata:              metadata,
+		ManagementWorkspaceID: managementWorkspaceID,
+		CreatedAt:             pgTime(createdAt),
+		UpdatedAt:             pgTime(updatedAt),
+	}
+}

--- a/server/internal/store/secret_management.go
+++ b/server/internal/store/secret_management.go
@@ -16,13 +16,16 @@ import (
 
 type CreateSecretInput struct {
 	WorkspaceID string
-	Name        string
-	Kind        string
-	Provider    string
-	AuthType    string
-	Payload     map[string]any
-	Masked      string
-	CreatedBy   string
+	// ManagementWorkspaceID preserves global sharing when WorkspaceID is unset.
+	// When omitted, the creation workspace is also the management workspace.
+	ManagementWorkspaceID string
+	Name                  string
+	Kind                  string
+	Provider              string
+	AuthType              string
+	Payload               map[string]any
+	Masked                string
+	CreatedBy             string
 	// CredentialKindCode is optional metadata that pins a capability_inline
 	// secret to a single credential_kinds.code. Used by the agent-creation
 	// shared-binding picker to filter secrets by the kind they hold.
@@ -53,6 +56,10 @@ type SecretPayload struct {
 func (s *Store) CreateSecret(ctx context.Context, input CreateSecretInput, encryptedPayload []byte) (SecretRead, error) {
 	now := time.Now().UTC()
 	createdBy := nullableUUID(input.CreatedBy)
+	managementWorkspaceID := input.ManagementWorkspaceID
+	if managementWorkspaceID == "" {
+		managementWorkspaceID = input.WorkspaceID
+	}
 	metaPayload := map[string]any{"masked": strings.TrimSpace(input.Masked)}
 	if code := strings.TrimSpace(input.CredentialKindCode); code != "" {
 		metaPayload["credential_kind_code"] = code
@@ -75,7 +82,7 @@ func (s *Store) CreateSecret(ctx context.Context, input CreateSecretInput, encry
 		KeyVersion:            "v1",
 		Metadata:              metadata,
 		CreatedBy:             createdBy,
-		ManagementWorkspaceID: nullableUUID(input.WorkspaceID),
+		ManagementWorkspaceID: nullableUUID(managementWorkspaceID),
 		Now:                   timestamptz(now),
 	})
 	if err != nil {

--- a/server/internal/store/secret_management_migration_test.go
+++ b/server/internal/store/secret_management_migration_test.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSecretManagementMigrationPreservesLegacyOwnership(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+	// Recreate the pre-upgrade shape inside a transaction; rollback preserves
+	// the test database schema for the remaining integration tests.
+	if _, err := tx.Exec(ctx, `
+		ALTER TABLE secrets DROP COLUMN management_workspace_id;
+		INSERT INTO workspaces(id, name, slug, config, created_at, updated_at) VALUES
+		('aabbccdd-eeff-4abb-8cdd-aabbccddeeff', 'Metadata owner', 'metadata-owner', '{}', now(), now()),
+		('10000000-0000-4000-8000-000000000001', 'Runtime owner', 'runtime-owner', '{"runtime_credential_secret_id":"20000000-0000-4000-8000-000000000002"}', now(), now()),
+		('10000000-0000-4000-8000-000000000002', 'Conflict A', 'conflict-a', '{"runtime_credential_secret_id":"20000000-0000-4000-8000-000000000003"}', now(), now()),
+		('10000000-0000-4000-8000-000000000003', 'Conflict B', 'conflict-b', '{"runtime_credential_secret_id":"20000000-0000-4000-8000-000000000003"}', now(), now()),
+		('10000000-0000-4000-8000-000000000004', 'Metadata conflict', 'metadata-conflict', '{"runtime_credential_secret_id":"20000000-0000-4000-8000-000000000004"}', now(), now());
+		INSERT INTO secrets(id, slug, name, kind, provider, auth_type, encrypted_payload, key_version, metadata, created_at, updated_at) VALUES
+		('20000000-0000-4000-8000-000000000001', 'metadata-secret', 'Metadata secret', 'model', 'test', 'api_key', '"legacy-payload"', 'v1', '{"workspace_id":"AABBCCDD-EEFF-4ABB-8CDD-AABBCCDDEEFF"}', now(), now()),
+		('20000000-0000-4000-8000-000000000002', 'runtime-secret', 'Runtime secret', 'runtime', 'test', 'api_key', '"legacy-payload"', 'v1', '{"masked":"test-mask"}', now(), now()),
+		('20000000-0000-4000-8000-000000000003', 'ambiguous-secret', 'Ambiguous secret', 'runtime', 'test', 'api_key', '"legacy-payload"', 'v1', '{}', now(), now()),
+		('20000000-0000-4000-8000-000000000004', 'conflicting-secret', 'Conflicting secret', 'runtime', 'test', 'api_key', '"legacy-payload"', 'v1', '{"workspace_id":"aabbccdd-eeff-4abb-8cdd-aabbccddeeff"}', now(), now()),
+		('20000000-0000-4000-8000-000000000005', 'unowned-secret', 'Unowned secret', 'model', 'test', 'api_key', '"legacy-payload"', 'v1', '{}', now(), now());
+	`); err != nil {
+		t.Fatal(err)
+	}
+	dir := os.Getenv("PARSAR_MIGRATIONS_DIR")
+	if dir == "" {
+		dir = "../../migrations"
+	}
+	migration, err := os.ReadFile(filepath.Join(dir, "000014_secret_management_workspace.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	up := strings.SplitN(string(migration), "-- +goose Down", 2)[0]
+	if _, err := tx.Exec(ctx, up); err != nil {
+		t.Fatal(err)
+	}
+	for slug, want := range map[string]string{
+		"metadata-secret":  "aabbccdd-eeff-4abb-8cdd-aabbccddeeff",
+		"runtime-secret":   "10000000-0000-4000-8000-000000000001",
+		"ambiguous-secret": "", "conflicting-secret": "", "unowned-secret": "",
+	} {
+		var owner, status string
+		var payload []byte
+		if err := tx.QueryRow(ctx, `SELECT coalesce(management_workspace_id::text, ''), status, encrypted_payload FROM secrets WHERE slug = $1`, slug).Scan(&owner, &status, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if owner != want || status != "active" || string(payload) != `"legacy-payload"` {
+			t.Fatalf("%s: owner=%q status=%q payload changed=%v", slug, owner, status, string(payload) != `"legacy-payload"`)
+		}
+	}
+}

--- a/server/internal/store/secret_management_test.go
+++ b/server/internal/store/secret_management_test.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+)
+
+func TestSecretCreationPathsRecordManagementWorkspace(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	st := New(db)
+	ids := mustSeedDevFixture(t, ctx, st)
+	other, err := st.CreateWorkspace(ctx, CreateWorkspaceInput{Name: "Other owner", CreatedBy: ids.UserID, Now: time.Now().UTC()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime, err := st.RegisterWorkspaceRuntimeCredential(ctx, RegisterWorkspaceRuntimeCredentialInput{
+		WorkspaceID: ids.WorkspaceID, Name: "Runtime test", Kind: "runtime", Provider: "test", AuthType: "api_key",
+		EncryptedPayload: []byte(`{}`), CreatedBy: ids.UserID, Now: time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	imported, err := st.ImportCapability(ctx, ImportCapabilityInput{
+		WorkspaceID: ids.WorkspaceID, Name: "Inline test", Visibility: "workspace", Type: "mcp", CreatorID: ids.UserID, Version: "1.0.0",
+		SourcePayload: []byte(`{}`),
+		Spec: canonical.Spec{SchemaVersion: canonical.SchemaVersionCurrent, Kind: canonical.KindMCP,
+			MCP: &canonical.MCPSpec{Servers: []canonical.MCPServer{{Name: "test", Command: "test", StartupTimeoutSec: 30,
+				Env: map[string]canonical.EnvValue{"TOKEN": {Mode: canonical.EnvModeInlineSecret}},
+			}}}},
+		InlineSecrets: []ImportInlineSecret{{ServerName: "test", EnvKey: "TOKEN", SecretName: "Imported test", EncryptedPayload: []byte(`{}`)}},
+	})
+	if err != nil || len(imported.CreatedSecretIDs) != 1 {
+		t.Fatalf("import: %v", err)
+	}
+	shared, err := st.CreateSecret(ctx, CreateSecretInput{
+		ManagementWorkspaceID: ids.WorkspaceID, Name: "Shared inline test", Kind: "capability_inline", Provider: "test", AuthType: "literal",
+	}, []byte(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.GetSecretPayload(ctx, other.Workspace.ID, shared.ID); err != nil {
+		t.Fatalf("management ownership must not narrow existing shared reads: %v", err)
+	}
+	for _, id := range []string{runtime.ID, imported.CreatedSecretIDs[0], shared.ID} {
+		secret, err := st.GetSecretPayload(ctx, ids.WorkspaceID, id)
+		if err != nil || secret.ManagementWorkspaceID != ids.WorkspaceID {
+			t.Fatalf("missing management workspace: %v", err)
+		}
+		if _, err := st.DisableSecret(ctx, other.Workspace.ID, id); !errors.Is(err, ErrUnknownSecret) {
+			t.Fatalf("foreign disable: %v", err)
+		}
+		if _, err := st.DisableSecret(ctx, ids.WorkspaceID, id); err != nil {
+			t.Fatalf("owner disable: %v", err)
+		}
+	}
+}

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -1127,17 +1127,18 @@ func (s *Store) RegisterWorkspaceRuntimeCredential(ctx context.Context, in Regis
 
 	// Step 2 — insert the new credential secret.
 	row, err := q.CreateSecret(ctx, sqlc.CreateSecretParams{
-		ID:               mustUUID(newID()),
-		Slug:             generateAutoSlug("secret"),
-		Name:             strings.TrimSpace(in.Name),
-		Kind:             secretKind(in.Kind),
-		Provider:         strings.TrimSpace(in.Provider),
-		AuthType:         strings.TrimSpace(in.AuthType),
-		EncryptedPayload: in.EncryptedPayload,
-		KeyVersion:       "v1",
-		Metadata:         metadataJSON,
-		CreatedBy:        createdBy,
-		Now:              timestamptz(in.Now),
+		ID:                    mustUUID(newID()),
+		Slug:                  generateAutoSlug("secret"),
+		Name:                  strings.TrimSpace(in.Name),
+		Kind:                  secretKind(in.Kind),
+		Provider:              strings.TrimSpace(in.Provider),
+		AuthType:              strings.TrimSpace(in.AuthType),
+		EncryptedPayload:      in.EncryptedPayload,
+		KeyVersion:            "v1",
+		Metadata:              metadataJSON,
+		CreatedBy:             createdBy,
+		ManagementWorkspaceID: wsUUID,
+		Now:                   timestamptz(in.Now),
 	})
 	if err != nil {
 		return SecretRead{}, fmt.Errorf("insert runtime credential secret: %w", err)

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -698,41 +698,6 @@ type UsageLogRead struct {
 	CreatedAt    time.Time      `json:"created_at"`
 }
 
-type CreateSecretInput struct {
-	WorkspaceID string
-	Name        string
-	Kind        string
-	Provider    string
-	AuthType    string
-	Payload     map[string]any
-	Masked      string
-	CreatedBy   string
-	// CredentialKindCode is optional metadata that pins a capability_inline
-	// secret to a single credential_kinds.code. Used by the agent-creation
-	// shared-binding picker to filter secrets by the kind they hold.
-	CredentialKindCode string
-}
-
-type SecretRead struct {
-	ID         string         `json:"id"`
-	Slug       string         `json:"slug"`
-	Name       string         `json:"name"`
-	Kind       string         `json:"kind"`
-	Provider   string         `json:"provider"`
-	AuthType   string         `json:"auth_type"`
-	KeyVersion string         `json:"key_version"`
-	Status     string         `json:"status"`
-	Masked     string         `json:"masked"`
-	Metadata   map[string]any `json:"metadata"`
-	CreatedAt  time.Time      `json:"created_at"`
-	UpdatedAt  time.Time      `json:"updated_at"`
-}
-
-type SecretPayload struct {
-	SecretRead
-	EncryptedPayload []byte
-}
-
 // CreateModelInput carries the fields of a new shared model.
 // Credential mode is one-of inline_secret / credential_ref.
 type CreateModelInput struct {
@@ -5592,59 +5557,6 @@ func (s *Store) ListWorkspaceUsageLogs(ctx context.Context, workspaceID string, 
 	return usage, nil
 }
 
-func (s *Store) CreateSecret(ctx context.Context, input CreateSecretInput, encryptedPayload []byte) (SecretRead, error) {
-	now := time.Now().UTC()
-	createdBy := nullableUUID(input.CreatedBy)
-	metaPayload := map[string]any{"masked": strings.TrimSpace(input.Masked)}
-	if code := strings.TrimSpace(input.CredentialKindCode); code != "" {
-		metaPayload["credential_kind_code"] = code
-	}
-	if strings.TrimSpace(input.Kind) == "capability_inline" {
-		metaPayload["workspace_id"] = strings.TrimSpace(input.WorkspaceID)
-	}
-	metadata, err := json.Marshal(metaPayload)
-	if err != nil {
-		return SecretRead{}, err
-	}
-	row, err := sqlc.New(s.db).CreateSecret(ctx, sqlc.CreateSecretParams{
-		ID:               mustUUID(newID()),
-		Slug:             generateAutoSlug("secret"),
-		Name:             strings.TrimSpace(input.Name),
-		Kind:             secretKind(input.Kind),
-		Provider:         strings.TrimSpace(input.Provider),
-		AuthType:         strings.TrimSpace(input.AuthType),
-		EncryptedPayload: encryptedPayload,
-		KeyVersion:       "v1",
-		Metadata:         metadata,
-		CreatedBy:        createdBy,
-		Now:              timestamptz(now),
-	})
-	if err != nil {
-		return SecretRead{}, err
-	}
-	read := secretReadFromCreateRow(row)
-
-	s.emitAuditEvent(audit.Event{
-		OccurredAt: now,
-		Source:     audit.SourceAdmin,
-		EventType:  auditSecretCreated,
-		ActorType:  audit.ActorTypeSystem,
-		ActorID:    input.CreatedBy,
-		TargetType: "secret",
-		TargetID:   read.ID,
-		Payload: map[string]any{
-			"source":    auditSourceDevSecretWrite,
-			"name":      read.Name,
-			"slug":      read.Slug,
-			"kind":      read.Kind,
-			"provider":  read.Provider,
-			"auth_type": read.AuthType,
-		},
-	})
-
-	return read, nil
-}
-
 func (s *Store) ListSecrets(ctx context.Context, workspaceID string, limit int32) ([]SecretRead, error) {
 	if limit <= 0 {
 		limit = defaultReadLimit
@@ -5676,42 +5588,6 @@ func (s *Store) ListSecretsByKind(ctx context.Context, kindFilter string, limit 
 		secrets = append(secrets, secretReadFromListRow(row))
 	}
 	return secrets, nil
-}
-
-func (s *Store) DisableSecret(ctx context.Context, workspaceID string, secretID string) (SecretRead, error) {
-	now := time.Now().UTC()
-	if _, err := s.GetSecretPayload(ctx, workspaceID, secretID); err != nil {
-		return SecretRead{}, err
-	}
-	secretUUID, err := uuid(secretID)
-	if err != nil {
-		return SecretRead{}, err
-	}
-	row, err := sqlc.New(s.db).DisableSecret(ctx, sqlc.DisableSecretParams{ID: secretUUID, Now: timestamptz(now)})
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return SecretRead{}, fmt.Errorf("%w: %s", ErrUnknownSecret, secretID)
-		}
-		return SecretRead{}, err
-	}
-	read := secretReadFromDisableRow(row)
-
-	s.emitAuditEvent(audit.Event{
-		OccurredAt: now,
-		Source:     audit.SourceAdmin,
-		EventType:  auditSecretDisabled,
-		ActorType:  audit.ActorTypeSystem,
-		TargetType: "secret",
-		TargetID:   read.ID,
-		Payload: map[string]any{
-			"source": auditSourceDevSecretWrite,
-			"name":   read.Name,
-			"slug":   read.Slug,
-			"status": read.Status,
-		},
-	})
-
-	return read, nil
 }
 
 func (s *Store) GetSecretPayload(ctx context.Context, workspaceID string, secretID string) (SecretPayload, error) {
@@ -8221,49 +8097,6 @@ func usageLogFromWorkspaceRunRow(row sqlc.ListWorkspaceUsageLogsByRunRow) UsageL
 
 func usageLogFromRunRow(row sqlc.ListUsageLogsByRunRow) UsageLogRead {
 	return usageLogFromRow(usageLogRow(row))
-}
-
-func secretReadFromCreateRow(row sqlc.CreateSecretRow) SecretRead {
-	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.CreatedAt, row.UpdatedAt)
-}
-
-func secretReadFromListRow(row sqlc.ListSecretsRow) SecretRead {
-	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.CreatedAt, row.UpdatedAt)
-}
-
-func secretReadFromWorkspaceListRow(row sqlc.ListSecretsForWorkspaceRow) SecretRead {
-	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.CreatedAt, row.UpdatedAt)
-}
-
-func secretReadFromDisableRow(row sqlc.DisableSecretRow) SecretRead {
-	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.CreatedAt, row.UpdatedAt)
-}
-
-func secretReadFromSecretRow(row sqlc.GetSecretPayloadRow) SecretRead {
-	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.CreatedAt, row.UpdatedAt)
-}
-
-func secretReadFromUpdatePayloadRow(row sqlc.UpdateSecretPayloadRow) SecretRead {
-	return secretRead(row.ID, row.Slug, row.Name, row.Kind, row.Provider, row.AuthType, row.KeyVersion, row.Status, row.Metadata, row.CreatedAt, row.UpdatedAt)
-}
-
-func secretRead(id, slug, name, kind, provider, authType, keyVersion, status string, metadataJSON []byte, createdAt, updatedAt pgtype.Timestamptz) SecretRead {
-	metadata := decodeJSONMap(metadataJSON)
-	masked, _ := metadata["masked"].(string)
-	return SecretRead{
-		ID:         id,
-		Slug:       slug,
-		Name:       name,
-		Kind:       kind,
-		Provider:   provider,
-		AuthType:   authType,
-		KeyVersion: keyVersion,
-		Status:     status,
-		Masked:     masked,
-		Metadata:   metadata,
-		CreatedAt:  pgTime(createdAt),
-		UpdatedAt:  pgTime(updatedAt),
-	}
 }
 
 func modelReadFromCreateRow(row sqlc.CreateModelRow) ModelRead {

--- a/server/migrations/000014_secret_management_workspace.sql
+++ b/server/migrations/000014_secret_management_workspace.sql
@@ -9,7 +9,7 @@ ALTER TABLE secrets
 UPDATE secrets s
 SET management_workspace_id = w.id
 FROM workspaces w
-WHERE s.metadata->>'workspace_id' = w.id::text;
+WHERE lower(s.metadata->>'workspace_id') = w.id::text;
 
 COMMENT ON COLUMN secrets.management_workspace_id IS
   'Workspace whose owner/admin may disable this secret; does not restrict shared use';

--- a/server/migrations/000014_secret_management_workspace.sql
+++ b/server/migrations/000014_secret_management_workspace.sql
@@ -3,13 +3,24 @@
 ALTER TABLE secrets
   ADD COLUMN management_workspace_id uuid REFERENCES workspaces(id);
 
--- Only existing explicit workspace provenance is safe to carry forward.
--- Shared legacy credentials without provenance remain usable, but cannot
--- be disabled until an operator assigns a verified management workspace.
+-- Creation metadata and the workspace runtime-registration pointer are
+-- existing provenance. Conflicting or missing ownership remains unassigned.
+WITH provenance AS (
+  SELECT s.id AS secret_id, w.id AS workspace_id
+  FROM secrets s JOIN workspaces w ON lower(s.metadata->>'workspace_id') = w.id::text
+  UNION
+  SELECT s.id, w.id
+  FROM secrets s JOIN workspaces w ON lower(w.config->>'runtime_credential_secret_id') = s.id::text
+), owners AS (
+  SELECT secret_id, min(workspace_id::text)::uuid AS workspace_id
+  FROM provenance
+  GROUP BY secret_id
+  HAVING count(*) = 1
+)
 UPDATE secrets s
-SET management_workspace_id = w.id
-FROM workspaces w
-WHERE lower(s.metadata->>'workspace_id') = w.id::text;
+SET management_workspace_id = o.workspace_id
+FROM owners o
+WHERE s.id = o.secret_id;
 
 COMMENT ON COLUMN secrets.management_workspace_id IS
   'Workspace whose owner/admin may disable this secret; does not restrict shared use';

--- a/server/migrations/000014_secret_management_workspace.sql
+++ b/server/migrations/000014_secret_management_workspace.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+
+ALTER TABLE secrets
+  ADD COLUMN management_workspace_id uuid REFERENCES workspaces(id);
+
+-- Only existing explicit workspace provenance is safe to carry forward.
+-- Shared legacy credentials without provenance remain usable, but cannot
+-- be disabled until an operator assigns a verified management workspace.
+UPDATE secrets s
+SET management_workspace_id = w.id
+FROM workspaces w
+WHERE s.metadata->>'workspace_id' = w.id::text;
+
+COMMENT ON COLUMN secrets.management_workspace_id IS
+  'Workspace whose owner/admin may disable this secret; does not restrict shared use';
+
+-- +goose Down
+
+ALTER TABLE secrets DROP COLUMN management_workspace_id;


### PR DESCRIPTION
## Problem and behavior

A Viewer could create another workspace, become its Owner, and disable a shared credential by substituting that workspace ID in the request. Disabling now requires owner/admin access to the credential’s recorded management workspace. Shared listing and runtime use remain unchanged.

The credentials list disables the action outside that workspace and explains why.

## Scope and compatibility

Only secret disable authorization and the necessary schema, API metadata, UI feedback, tests, and contributor rule. No organization-role system, sharing-policy changes, credential rotation redesign, or model/agent behavior changes. The touched secret creation, disabling, and response mapping code is extracted from the oversized store file.

The migration preserves unambiguous workspace provenance from creation metadata and runtime registration records. Legacy shared credentials without reliable provenance remain usable but cannot be disabled until an operator assigns their verified `management_workspace_id`; ownership is never guessed from a request.

## Validation

- `make check` passes; local Docker remains stopped, so the local Docker smoke check is skipped.
- Isolated real PostgreSQL: initial migrations, upgrade to migration 14, and migration 14 down/up pass. Existing payloads and status are unchanged; explicit legacy ownership and existing runtime ownership are preserved; conflicting provenance stays unassigned.
- Real database HTTP regression: original-workspace Viewer gets 403; the same user as Owner of a newly created workspace gets 404; the original manager can disable. Shared reads still work and unowned legacy credentials stay active.
- Existing capability credential scoping/rotation regression passes.
- Live API reproduction passes, including workspace creation. Browser confirms the foreign credential action is disabled while a credential owned by the current workspace can be disabled through confirmation. An independent blind review found no blocking issues. All GitHub checks pass on the reviewed revision.
