### PR TITLE
fix: resolve local capability downloads through the paired server

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,9 @@ description and keep ownership on the side listed here.
 
 ### Runtime and execution concepts
 
+- The daemon resolves loopback Postgres capability-download URLs through its
+  paired server address before calling an adapter. Preserve the signed query
+  and resource path; external storage URLs and browser upload URLs are unchanged.
 - `connector_type` chooses the protocol Parsar uses to run an agent
   (`agent_daemon`, `http_agent`, ...). It does not say where the process
   runs.

--- a/apps/parsar-daemon/internal/cli/capability_downloads.go
+++ b/apps/parsar-daemon/internal/cli/capability_downloads.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"context"
+	"maps"
+	"net"
+	"net/url"
+	"slices"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+// Use the paired server address for loopback PG downloads: inside Compose,
+// the public loopback address points to the runtime container itself.
+func withCapabilityDownloads(factory agent.Factory, serverURL string) agent.Factory {
+	base, err := url.Parse(serverURL)
+	if err != nil || base.Host == "" || (base.Scheme != "http" && base.Scheme != "https") {
+		return factory
+	}
+	return func(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+		opts := maps.Clone(req.AgentOptions)
+		for _, key := range []string{"skills", "plugins"} {
+			items, ok := opts[key].([]any)
+			if !ok {
+				continue
+			}
+			items = slices.Clone(items)
+			for i, item := range items {
+				descriptor, ok := item.(map[string]any)
+				if !ok {
+					continue
+				}
+				raw, _ := descriptor["download_url"].(string)
+				if resolved := capabilityDownloadURL(raw, base); resolved != raw {
+					updated := maps.Clone(descriptor)
+					updated["download_url"] = resolved
+					items[i] = updated
+				}
+			}
+			opts[key] = items
+		}
+		req.AgentOptions = opts
+		return factory(ctx, req, out)
+	}
+}
+
+func capabilityDownloadURL(raw string, base *url.URL) string {
+	u, err := url.Parse(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+		return raw
+	}
+	host := u.Hostname()
+	if !strings.EqualFold(host, "localhost") && !net.ParseIP(host).IsLoopback() {
+		return raw
+	}
+	const blobPath = "/internal/blobs/pg:"
+	start := strings.Index(u.Path, blobPath)
+	if start < 0 {
+		return raw
+	}
+	u.Scheme, u.Host, u.User = base.Scheme, base.Host, nil
+	u.Path = strings.TrimRight(base.Path, "/") + u.Path[start:]
+	u.RawPath = ""
+	return u.String()
+}

--- a/apps/parsar-daemon/internal/cli/capability_downloads_test.go
+++ b/apps/parsar-daemon/internal/cli/capability_downloads_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/claudecode"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestCapabilityDownloadUsesPairedServerOnlyForLoopbackPG(t *testing.T) {
+	base, _ := url.Parse("https://parsar.example.test/team")
+	for _, tc := range []struct{ raw, want string }{
+		{"http://127.0.0.1:28080/internal/blobs/pg:id?token=a%2Bb", "https://parsar.example.test/team/internal/blobs/pg:id?token=a%2Bb"},
+		{"http://localhost:28080/old/internal/blobs/pg:id?token=a", "https://parsar.example.test/team/internal/blobs/pg:id?token=a"},
+		{"http://[::1]:28080/internal/blobs/pg:id?token=a", "https://parsar.example.test/team/internal/blobs/pg:id?token=a"},
+		{"https://bucket.example.test/skill.zip?Signature=a", "https://bucket.example.test/skill.zip?Signature=a"},
+		{"http://localhost:28080/other.zip", "http://localhost:28080/other.zip"},
+		{"https://public.example.test/internal/blobs/pg:id?token=a", "https://public.example.test/internal/blobs/pg:id?token=a"},
+		{"file:///internal/blobs/pg:id", "file:///internal/blobs/pg:id"},
+	} {
+		if got := capabilityDownloadURL(tc.raw, base); got != tc.want {
+			t.Errorf("%s: got %s, want %s", tc.raw, got, tc.want)
+		}
+	}
+}
+
+func TestCapabilityDownloadsInstallZIPThroughPairedServer(t *testing.T) {
+	var archive bytes.Buffer
+	w := zip.NewWriter(&archive)
+	for name, content := range map[string]string{
+		"SKILL.md":             "---\nname: qa-download\ndescription: Test downloaded context\n---\nRead references/policy.md.\n",
+		"references/policy.md": "Collect the laptop on the third working day.\n",
+	} {
+		file, err := w.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := file.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/team/internal/blobs/pg:test" || r.URL.RawQuery != "token=synthetic%2Bsignature" {
+			t.Errorf("download request changed signed resource: %s", r.URL)
+			http.Error(w, "unexpected request", http.StatusForbidden)
+			return
+		}
+		_, _ = w.Write(archive.Bytes())
+	}))
+	defer server.Close()
+	root := t.TempDir()
+	rawURL := "http://127.0.0.1:1/internal/blobs/pg:test?token=synthetic%2Bsignature"
+	descriptor := map[string]any{"name": "qa-download", "version": "1.0.0", "download_url": rawURL, "sha256": fmt.Sprintf("%x", sha256.Sum256(archive.Bytes()))}
+	opts := map[string]any{"skills": []any{descriptor}, "plugins": []any{descriptor}, "model": "preserved"}
+	factory := withCapabilityDownloads(func(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+		if req.RunID != "run-test" || req.AgentOptions["model"] != "preserved" {
+			t.Fatal("unrelated request fields changed")
+		}
+		plugin := req.AgentOptions["plugins"].([]any)[0].(map[string]any)
+		skill := req.AgentOptions["skills"].([]any)[0].(map[string]any)
+		if plugin["download_url"] != skill["download_url"] {
+			t.Fatal("plugin and skill routing differs")
+		}
+		result, err := claudecode.InstallManagedSkills(ctx, nil, root, req.AgentOptions["skills"])
+		if err == nil && len(result.Warnings) > 0 {
+			err = fmt.Errorf("installation warnings: %v", result.Warnings)
+		}
+		return nil, err
+	}, server.URL+"/team")
+	if _, err := factory(context.Background(), proto.PromptRequestPayload{RunID: "run-test", AgentOptions: opts}, nil); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(filepath.Join(root, "qa-download", "references", "policy.md"))
+	if err != nil || string(content) != "Collect the laptop on the third working day.\n" {
+		t.Fatalf("installed reference: %q, %v", content, err)
+	}
+	if descriptor["download_url"] != rawURL {
+		t.Fatal("rewrote the original request options")
+	}
+}

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -334,11 +334,11 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 	return out, nil
 }
 
-func registerAgentKinds(registry *agent.Registry, agentCLIs agentCLIDiscovery) {
-	registry.RegisterKind(agentCLIs.ClaudeCode, claudecode.Factory)
-	registry.RegisterKind(agentCLIs.OpenCode, opencodeagent.Factory)
-	registry.RegisterKind(agentCLIs.Codex, codex.Factory)
-	registry.RegisterKind(agentCLIs.Pi, pi.Factory)
+func registerAgentKinds(registry *agent.Registry, agentCLIs agentCLIDiscovery, serverURL string) {
+	registry.RegisterKind(agentCLIs.ClaudeCode, withCapabilityDownloads(claudecode.Factory, serverURL))
+	registry.RegisterKind(agentCLIs.OpenCode, withCapabilityDownloads(opencodeagent.Factory, serverURL))
+	registry.RegisterKind(agentCLIs.Codex, withCapabilityDownloads(codex.Factory, serverURL))
+	registry.RegisterKind(agentCLIs.Pi, withCapabilityDownloads(pi.Factory, serverURL))
 }
 
 // spawnBackground forks the daemon into the background. Parent
@@ -428,7 +428,7 @@ func mainLoop(rc *runContext, profile string, prof auth.Profile, agentCLIs agent
 	obslog.Bg().Info("bootstrap ok", "device_id", boot.DeviceID, "ws_url", wsURL, "heartbeat_interval", boot.HeartbeatInterval())
 
 	registry := agent.NewRegistry()
-	registerAgentKinds(registry, agentCLIs)
+	registerAgentKinds(registry, agentCLIs, prof.ServerURL)
 
 	dial := func(ctx context.Context) (*transport.Conn, error) {
 		return transport.Dial(ctx, transport.DialOptions{

--- a/apps/parsar-daemon/internal/cli/connect_test.go
+++ b/apps/parsar-daemon/internal/cli/connect_test.go
@@ -228,7 +228,7 @@ func TestRegisterAgentKindsPreservesDescriptors(t *testing.T) {
 				Resume:    true,
 			},
 		},
-	})
+	}, "https://parsar.example.test")
 
 	kinds := reg.SupportedAgentKinds()
 	if len(kinds) != 4 {


### PR DESCRIPTION
With the default Compose deployment, uploaded ZIP capabilities could have download URLs pointing at the browser-facing loopback address. In the runtime container that address refers to the container itself, so installation failed even after enabling the capability.

The daemon now uses its paired server address for loopback Postgres capability downloads before invoking an adapter. The signed query and blob identifier are preserved. This change is limited to Skill/plugin download address selection; public URLs, external storage downloads, browser uploads, session fields and engine descriptors retain their existing behavior.

Validation: `make check` passes with local Docker stopped. Focused tests cover address selection and a real HTTP ZIP download, checksum verification, extraction and reference-file read. The same checks pass inside the existing remote Linux runtime container. Independent blind review found no blocking issues.
