### PR TITLE
fix: prepare writable server data during installation

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -48,3 +48,6 @@ jobs:
         with:
           scandir: ./scripts
           severity: error
+
+      - name: Check installer lifecycle without Docker
+        run: bash scripts/check-installer.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,9 @@ description and keep ownership on the side listed here.
 - The one-command installer is both install and upgrade path. Default GHCR
   images must be pulled before `docker compose up` so `:latest` does not
   silently reuse a stale local image after `main` changes.
+- After pulling, the installer prepares its server data mount for the image's
+  actual UID/GID and verifies writability before starting services. Only the
+  preparation container runs as root; the server retains its configured user.
 - `install.sh` may still write stable random overrides such as
   `PARSAR_MASTER_KEY` and `PARSAR_SHARED_RUNTIME_TOKEN` for safer local
   installs, but raw Compose/Dokploy deployments must not depend on those
@@ -589,7 +592,8 @@ make check
 CI may run independently based on the changed paths: `make check-go` for sqlc
 drift plus non-store Go tests, `make check-store` for migration/store
 integration tests, `make check-web` for web typecheck plus design lint, and
-`make check-cli` for CLI/plugin typechecks. Keep the subtargets aligned with
+`make check-cli` for CLI/plugin typechecks, and `make check-installer` for
+Docker-free installer lifecycle checks. Keep the subtargets aligned with
 the full gate whenever the required checks change.
 
 - Any DB change must ship with a migration. Migrations are immutable

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ dev-db:
 # Backward-compatible alias. Prefer `make dev-db` for the DB-only dev stack.
 dev: dev-db
 
-check: check-go check-store check-web check-cli check-hygiene
+check: check-go check-store check-web check-cli check-hygiene check-installer
 	@printf 'Parsar harness checks passed.\n'
 
 check-setup:
@@ -113,6 +113,10 @@ check-web: check-setup typecheck-web lint-web-design
 check-cli: check-setup node-deps
 	pnpm --filter @parsar/cli typecheck
 	pnpm --filter @parsar/opencode-plugin typecheck
+
+.PHONY: check-installer
+check-installer:
+	bash scripts/check-installer.sh
 
 check-hygiene: check-setup
 	@for polluted in .parsar logs state cache config; do \

--- a/install.sh
+++ b/install.sh
@@ -104,6 +104,22 @@ wait_for_health() {
   return 1
 }
 
+prepare_data_directory() {
+  local data_owner
+  local PARSAR_IMAGE_PULL_POLICY=never
+  export PARSAR_IMAGE_PULL_POLICY
+  data_owner="$(compose run -T --rm --no-deps --workdir / --entrypoint /bin/sh parsar-server \
+    -c 'printf "%s:%s" "$(id -u)" "$(id -g)"')"
+  [[ "$data_owner" =~ ^[0-9]+:[0-9]+$ ]] || die "could not determine the server image user"
+
+  # Only the one-off preparation runs as root; the server keeps its image user.
+  compose run -T --rm --no-deps --user 0:0 --workdir / --entrypoint /bin/sh parsar-server \
+    -c 'chown -Rh "$1" /var/lib/parsar' sh "$data_owner"
+  compose run -T --rm --no-deps --workdir / --entrypoint /bin/sh parsar-server \
+    -c 'test -w /var/lib/parsar && mkdir -p /var/lib/parsar/.parsar && test -w /var/lib/parsar/.parsar' \
+    || die "server data directory is not writable by its configured user"
+}
+
 home="${PARSAR_HOME:-$HOME/.parsar}"
 port="${PARSAR_LOCAL_PORT:-18080}"
 bind="${PARSAR_BIND_ADDR:-127.0.0.1}"
@@ -166,6 +182,8 @@ fi
 
 log "Pulling images"
 compose pull parsar-server parsar-runtime
+log "Preparing server data directory"
+prepare_data_directory
 log "Starting Parsar"
 compose up -d --remove-orphans
 

--- a/scripts/check-installer.sh
+++ b/scripts/check-installer.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mkdir -p "$HOME/.parsar/installer-tests"
+test_root="$(mktemp -d "$HOME/.parsar/installer-tests/check.XXXXXX")"
+trap 'rm -rf "$test_root"' EXIT
+mkdir -p "$test_root/bin"
+
+# No Docker daemon is used. Record the lifecycle and simulate image identity
+# and preparation failures; actual filesystem ownership is checked in Docker.
+cat > "$test_root/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$PARSAR_INSTALL_TEST_LOG"
+if [[ "$*" == *' run '* ]]; then
+  # Compose v2.15 accepts pull_policy in YAML but has no run --pull option.
+  [[ "$*" != *'--pull '* && "${PARSAR_IMAGE_PULL_POLICY:-}" == never ]]
+  # The installer closes stdin, so Compose must not request an interactive TTY.
+  [[ "$*" == *' -T '* ]]
+fi
+if [[ "$*" == *'id -u'* ]]; then
+  printf '12001:14001'
+elif [[ "$*" == *'chown -Rh'* && "${PARSAR_INSTALL_TEST_FAIL:-}" == ownership ]]; then
+  exit 1
+elif [[ "$*" == *'test -w'* && "${PARSAR_INSTALL_TEST_FAIL:-}" == writable ]]; then
+  exit 1
+fi
+MOCK
+chmod +x "$test_root/bin/docker"
+
+run_case() {
+  local case_name="$1" failure="$2"
+  shift 2
+  mkdir -p "$test_root/$case_name"
+  PATH="$test_root/bin:$PATH" \
+    PARSAR_INSTALL_TEST_LOG="$test_root/$case_name/docker.log" \
+    PARSAR_INSTALL_TEST_FAIL="$failure" \
+    bash "$repo_root/install.sh" --home "$test_root/$case_name/home" \
+      --compose-file "$repo_root/docker-compose.yml" "$@" > "$test_root/$case_name/output.log" 2>&1
+}
+
+run_case normal ""
+normal_log="$test_root/normal/docker.log"
+grep -q 'chown -Rh.*12001:14001' "$normal_log"
+grep 'chown -Rh' "$normal_log" | grep -q -- '--user 0:0'
+grep 'test -w' "$normal_log" | grep -vq -- '--user'
+pull_line="$(grep -n ' pull ' "$normal_log" | head -1 | cut -d: -f1)"
+owner_line="$(grep -n 'chown -Rh' "$normal_log" | cut -d: -f1)"
+write_line="$(grep -n 'test -w' "$normal_log" | cut -d: -f1)"
+up_line="$(grep -n ' up ' "$normal_log" | cut -d: -f1)"
+[[ "$pull_line" -lt "$owner_line" && "$owner_line" -lt "$write_line" && "$write_line" -lt "$up_line" ]]
+
+for failure in ownership writable; do
+  if run_case "$failure" "$failure"; then
+    echo "Installer ignored $failure failure" >&2
+    exit 1
+  fi
+  if grep -q ' up ' "$test_root/$failure/docker.log"; then
+    echo "Installer started services after $failure failure" >&2
+    exit 1
+  fi
+done
+
+run_case dry "" --dry-run
+if grep -Eq ' (run|pull|up) ' "$test_root/dry/docker.log"; then
+  echo 'Dry run started a container or pulled an image' >&2
+  exit 1
+fi
+echo 'Installer data preparation checks passed.'


### PR DESCRIPTION
The installer created a host-owned server data directory that the image’s ordinary user could not write. Skill marketplace installation consequently failed while creating its npm cache. Installation and upgrade now prepare the dedicated server data mount using the image’s actual UID/GID and verify writability before starting services.

Scope is installer data preparation and its lifecycle checks. Existing contents, server user, service configuration, Skill installation logic and other services’ volumes stay unchanged. Dry-run remains free of container starts and image pulls.

Validation: `make check` and Docker-free lifecycle regressions pass. An isolated Compose check on zju_a100_2 reproduced the unwritable host-owned directory, ran the actual preparation, verified npm cache writes as UID/GID 10001:10001, and confirmed existing file contents were unchanged. Local Docker remained stopped. Independent blind review completed without blocking findings. Preparation also passed a real remote terminal invocation; commands retain Compose v2.15 compatibility.
