### PR TITLE
fix: store executable archives for Markdown skills

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,9 @@ description and keep ownership on the side listed here.
 - Keep uploaded Skill archives engine-neutral. Materialize adapter-managed
   copies below the `AgentStateKey` runtime directory, then register that root
   through the engine's native CLI, config, or RPC surface.
+- Markdown Skill imports and new versions must store an engine-neutral ZIP
+  containing `SKILL.md`, with its storage reference and SHA-256 persisted before
+  reporting success. Existing versions without archives require a new import.
 
 ### Plugin Bundle (KindBundle) architecture
 

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -6395,10 +6395,11 @@ paths:
       consumes:
       - application/json
       description: Adds a new version to an existing capability, sharing the parse/rebuild
-        pipeline with capability import commit. When version is omitted, the server
-        advances the latest version automatically. Spec.kind must match capability.type.
-        When oss_key is omitted for plugin or skill-zip kinds, the previous version's
-        bytes are reused. Owner/admin only.
+        pipeline with capability import commit. Skill Markdown is packaged into a
+        stored ZIP. When version is omitted, the server advances the latest version
+        automatically. Spec.kind must match capability.type. When oss_key is omitted
+        for plugin or skill-zip kinds, the previous version's bytes are reused. Owner/admin
+        only.
       operationId: commitDevCapabilityVersionImport
       parameters:
       - description: Workspace UUID
@@ -6444,6 +6445,12 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "422":
+          description: Invalid Skill content or capability kind mismatch
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "500":
           description: Secrets service unavailable
           schema:
@@ -6451,7 +6458,7 @@ paths:
               type: string
             type: object
         "502":
-          description: Failed to fetch uploaded zip from object storage
+          description: Failed to read or store Skill ZIP
           schema:
             additionalProperties:
               type: string
@@ -6470,8 +6477,9 @@ paths:
       consumes:
       - application/json
       description: Encrypts inline_secrets then runs the whole MCP or Skill import
-        (capability + capability_version + secrets) in a single transaction. For Skill
-        zip imports the canonical_spec is rebuilt from OSS bytes. Owner/admin only.
+        (capability + capability_version + secrets) in a single transaction. Skill
+        Markdown is packaged into a stored ZIP before commit; uploaded Skill ZIPs
+        rebuild canonical_spec from stored bytes. Owner/admin only.
       operationId: commitDevCapabilityImport
       parameters:
       - description: Workspace UUID
@@ -6506,6 +6514,12 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "422":
+          description: Invalid Skill content
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "500":
           description: Secrets service unavailable
           schema:
@@ -6513,7 +6527,7 @@ paths:
               type: string
             type: object
         "502":
-          description: Failed to fetch uploaded zip from object storage
+          description: Failed to read or store Skill ZIP
           schema:
             additionalProperties:
               type: string

--- a/server/internal/dev/capability_import_markdown.go
+++ b/server/internal/dev/capability_import_markdown.go
@@ -1,0 +1,79 @@
+package dev
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/parser"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/storage/blob"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+// Reject invalid version destinations before allocating an archive.
+func validateMarkdownSkillVersionDestination(ctx context.Context, runtimeStore RuntimeStore, workspaceID, capabilityID string) error {
+	existing, err := runtimeStore.GetCapability(ctx, capabilityID)
+	if err != nil {
+		return err
+	}
+	if existing.WorkspaceID != workspaceID {
+		return store.ErrUnknownCapability
+	}
+	if existing.Type != string(canonical.KindSkill) {
+		return store.ErrCapabilityKindMismatch
+	}
+	return nil
+}
+
+// Markdown imports use the same stored ZIP contract as uploaded Skills.
+// Existing archives and non-Skill imports pass through unchanged.
+func ensureSkillImportArchive(ctx context.Context, workspaceID string, spec canonical.Spec, ref, digest string, blobs blob.Store) (string, string, *importHTTPError) {
+	if spec.Kind != canonical.KindSkill || ref != "" {
+		return ref, digest, nil
+	}
+	if err := spec.Validate(); err != nil {
+		return "", "", &importHTTPError{status: http.StatusUnprocessableEntity, message: err.Error()}
+	}
+	if len(spec.Skill.Files) != 0 {
+		return "", "", &importHTTPError{status: http.StatusUnprocessableEntity, message: "multi-file Skills must be imported as a ZIP"}
+	}
+	frontmatter, err := yaml.Marshal(struct {
+		Name        string `yaml:"name"`
+		Slug        string `yaml:"slug"`
+		Title       string `yaml:"title,omitempty"`
+		Description string `yaml:"description,omitempty"`
+		Trigger     string `yaml:"trigger,omitempty"`
+	}{spec.Skill.Slug, spec.Skill.Slug, spec.Skill.Title, spec.Skill.Description, spec.Skill.Trigger})
+	if err != nil {
+		return "", "", &importHTTPError{status: http.StatusInternalServerError, message: "could not encode Skill metadata"}
+	}
+	var archive bytes.Buffer
+	w := zip.NewWriter(&archive)
+	entry, err := w.Create("SKILL.md")
+	if err == nil {
+		_, err = io.WriteString(entry, "---\n"+string(frontmatter)+"---\n"+spec.Skill.Instruction+"\n")
+	}
+	if closeErr := w.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return "", "", &importHTTPError{status: http.StatusInternalServerError, message: "could not package Skill Markdown"}
+	}
+	data := archive.Bytes()
+	if _, err := parser.ParseSkillZip(data); err != nil {
+		return "", "", &importHTTPError{status: http.StatusUnprocessableEntity, message: err.Error()}
+	}
+	ref, httpErr := storeSkillZipBytes(ctx, blobs, http.DefaultClient, workspaceID, "skill.zip", data)
+	if httpErr != nil {
+		return "", "", httpErr
+	}
+	sum := sha256.Sum256(data)
+	return ref, hex.EncodeToString(sum[:]), nil
+}

--- a/server/internal/dev/capability_import_markdown_test.go
+++ b/server/internal/dev/capability_import_markdown_test.go
@@ -1,0 +1,112 @@
+package dev
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/parser"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/storage/blob"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func TestMarkdownSkillArchiveRoundTrip(t *testing.T) {
+	spec := canonical.Spec{SchemaVersion: 1, Kind: canonical.KindSkill, Skill: &canonical.SkillSpec{
+		Slug: "onboarding", Title: "Employee onboarding", Description: "Policy: laptop pickup\nFor new employees",
+		Instruction: "Collect the laptop on working day 3.", Trigger: "onboarding questions",
+	}}
+	blobs := blob.NewMemoryStore("https://api.test")
+	ref, digest, httpErr := ensureSkillImportArchive(t.Context(), "workspace", spec, "", "", blobs)
+	if httpErr != nil {
+		t.Fatalf("package failed: %s", httpErr.message)
+	}
+	assertMarkdownArchive(t, blobs, "workspace", ref, digest, spec)
+
+	for _, test := range []struct {
+		name   string
+		spec   canonical.Spec
+		blobs  blob.Store
+		status int
+	}{
+		{"unavailable storage", spec, nil, http.StatusServiceUnavailable},
+		{"missing instruction", canonical.Spec{SchemaVersion: 1, Kind: canonical.KindSkill, Skill: &canonical.SkillSpec{Slug: "empty"}}, blobs, http.StatusUnprocessableEntity},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ref, digest, err := ensureSkillImportArchive(t.Context(), "workspace", test.spec, "", "", test.blobs)
+			if err == nil || err.status != test.status || ref != "" || digest != "" {
+				t.Fatalf("failed import returned archive: ref=%q digest=%q error=%v", ref, digest, err)
+			}
+		})
+	}
+}
+
+func TestCapabilityImportMarkdownStoresEachVersionArchive(t *testing.T) {
+	r, _, blobs := skillsInstallTestRouter(t, &fakeSkillInstallRunner{t: t})
+	ids := store.DefaultDevFixtureIDs()
+	base := "/api/v1/workspaces/" + ids.WorkspaceID + "/capabilities"
+	preview := serveCapabilityRoute(t, r, http.MethodPost, base+"/import/preview", mustJSON(t, map[string]any{
+		"kind": "skill", "source_format": "markdown", "raw_text": goodSkillMd,
+	}), ids.UserID)
+	if preview.Code != http.StatusOK {
+		t.Fatalf("preview: %d %s", preview.Code, preview.Body.String())
+	}
+	var parsed previewCapabilityImportResponse
+	if err := json.Unmarshal(preview.Body.Bytes(), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	endpoint := base + "/import/commit"
+	var firstRef string
+	for _, version := range []string{"1.0.0", "1.0.1"} {
+		parsed.CanonicalSpec.Skill.Instruction = "Read policy version " + version
+		res := serveCapabilityRoute(t, r, http.MethodPost, endpoint, mustJSON(t, map[string]any{
+			"kind": "skill", "name": "Markdown policy", "version": version, "canonical_spec": parsed.CanonicalSpec,
+		}), ids.UserID)
+		if res.Code != http.StatusCreated {
+			t.Fatalf("commit %s: %d %s", version, res.Code, res.Body.String())
+		}
+		var result commitCapabilityImportResponse
+		if err := json.Unmarshal(res.Body.Bytes(), &result); err != nil {
+			t.Fatal(err)
+		}
+		v := result.CapabilityVersion
+		assertMarkdownArchive(t, blobs, ids.WorkspaceID, v.OssKey, v.SHA256, parsed.CanonicalSpec)
+		if v.OssKey == firstRef {
+			t.Fatal("new version reused the old Markdown archive")
+		}
+		firstRef = v.OssKey
+		endpoint = base + "/" + result.Capability.ID + "/versions/import/commit"
+	}
+}
+
+func assertMarkdownArchive(t *testing.T, blobs blob.Store, workspaceID, ref, digest string, want canonical.Spec) {
+	t.Helper()
+	ctx := context.Background()
+	owned, err := blobs.BelongsToWorkspace(ctx, ref, workspaceID)
+	if err != nil || !owned {
+		t.Fatalf("archive ownership: %v %v", owned, err)
+	}
+	data, err := blobs.Download(ctx, ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(data)
+	if digest != hex.EncodeToString(sum[:]) {
+		t.Fatal("archive checksum does not match stored metadata")
+	}
+	parsed, err := parser.ParseSkillZip(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.Spec.Skill.Files) != 0 {
+		t.Fatal("Markdown archive unexpectedly contains additional files")
+	}
+	parsed.Spec.Skill.Files = nil
+	if !reflect.DeepEqual(parsed.Spec.Skill, want.Skill) {
+		t.Fatalf("archive content differs from committed Skill: %#v, %v", parsed.Spec.Skill, err)
+	}
+}

--- a/server/internal/dev/capability_import_routes.go
+++ b/server/internal/dev/capability_import_routes.go
@@ -324,7 +324,7 @@ func previewPluginImport(ctx context.Context, w http.ResponseWriter, workspaceID
 // is rebuilt from OSS bytes (the on-disk zip is authoritative).
 //
 //	@Summary		Commit a capability import
-//	@Description	Encrypts inline_secrets then runs the whole MCP or Skill import (capability + capability_version + secrets) in a single transaction. For Skill zip imports the canonical_spec is rebuilt from OSS bytes. Owner/admin only.
+//	@Description	Encrypts inline_secrets then runs the whole MCP or Skill import (capability + capability_version + secrets) in a single transaction. Skill Markdown is packaged into a stored ZIP before commit; uploaded Skill ZIPs rebuild canonical_spec from stored bytes. Owner/admin only.
 //	@Tags			capabilities
 //	@ID				commitDevCapabilityImport
 //	@Accept			json
@@ -335,7 +335,8 @@ func previewPluginImport(ctx context.Context, w http.ResponseWriter, workspaceID
 //	@Failure		400 {object} map[string]string "Missing name/kind, unknown kind, or spec rebuild failed"
 //	@Failure		403 {object} map[string]string "Caller is not workspace owner/admin, or oss_key not owned by this workspace"
 //	@Failure		500 {object} map[string]string "Secrets service unavailable"
-//	@Failure		502 {object} map[string]string "Failed to fetch uploaded zip from object storage"
+//	@Failure		422 {object} map[string]string "Invalid Skill content"
+//	@Failure		502 {object} map[string]string "Failed to read or store Skill ZIP"
 //	@Failure		503 {object} map[string]string "Object storage or database not configured"
 //	@Router			/api/v1/workspaces/{workspaceID}/capabilities/import/commit [post]
 func commitCapabilityImport(runtimeStore RuntimeStore, blobStore blob.Store) http.HandlerFunc {
@@ -429,6 +430,11 @@ func commitCapabilityImport(runtimeStore RuntimeStore, blobStore blob.Store) htt
 		if skillZipShaped {
 			importInput.OssKey = body.OssKey
 			importInput.SHA256 = skillSHA256
+		}
+		importInput.OssKey, importInput.SHA256, httpErr = ensureSkillImportArchive(r.Context(), workspaceID, spec, importInput.OssKey, importInput.SHA256, blobStore)
+		if httpErr != nil {
+			writeJSON(w, httpErr.status, map[string]string{"error": httpErr.message})
+			return
 		}
 		result, err := runtimeStore.ImportCapability(r.Context(), importInput)
 		if err != nil {
@@ -575,7 +581,7 @@ func rebuildSkillSpecFromOSS(ctx context.Context, workspaceID, ossKey string, bl
 // capability.type or the store returns ErrCapabilityKindMismatch.
 //
 //	@Summary		Commit a new version of an existing capability
-//	@Description	Adds a new version to an existing capability, sharing the parse/rebuild pipeline with capability import commit. When version is omitted, the server advances the latest version automatically. Spec.kind must match capability.type. When oss_key is omitted for plugin or skill-zip kinds, the previous version's bytes are reused. Owner/admin only.
+//	@Description	Adds a new version to an existing capability, sharing the parse/rebuild pipeline with capability import commit. Skill Markdown is packaged into a stored ZIP. When version is omitted, the server advances the latest version automatically. Spec.kind must match capability.type. When oss_key is omitted for plugin or skill-zip kinds, the previous version's bytes are reused. Owner/admin only.
 //	@Tags			capabilities
 //	@ID				commitDevCapabilityVersionImport
 //	@Accept			json
@@ -587,8 +593,9 @@ func rebuildSkillSpecFromOSS(ctx context.Context, workspaceID, ossKey string, bl
 //	@Failure		400 {object} map[string]string "Invalid capability_id, missing kind, or spec rebuild failed"
 //	@Failure		403 {object} map[string]string "Caller is not workspace owner/admin, or oss_key not owned by this workspace"
 //	@Failure		404 {object} map[string]string "Capability not found in this workspace"
+//	@Failure		422 {object} map[string]string "Invalid Skill content or capability kind mismatch"
 //	@Failure		500 {object} map[string]string "Secrets service unavailable"
-//	@Failure		502 {object} map[string]string "Failed to fetch uploaded zip from object storage"
+//	@Failure		502 {object} map[string]string "Failed to read or store Skill ZIP"
 //	@Failure		503 {object} map[string]string "Object storage or database not configured"
 //	@Router			/api/v1/workspaces/{workspaceID}/capabilities/{capabilityID}/versions/import/commit [post]
 func commitCapabilityVersionImport(runtimeStore RuntimeStore, blobStore blob.Store) http.HandlerFunc {
@@ -618,6 +625,12 @@ func commitCapabilityVersionImport(runtimeStore RuntimeStore, blobStore blob.Sto
 		if body.CanonicalSpec.Kind == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "canonical_spec.kind is required"})
 			return
+		}
+		if body.CanonicalSpec.Kind == canonical.KindSkill && strings.TrimSpace(body.OssKey) == "" && strings.TrimSpace(body.UploadSource) == "" {
+			if err := validateMarkdownSkillVersionDestination(r.Context(), runtimeStore, workspaceID, capabilityID); err != nil {
+				writeImportCommitError(w, err)
+				return
+			}
 		}
 
 		// Edit-as-new-version: when the client omits oss_key for a kind that
@@ -714,6 +727,11 @@ func commitCapabilityVersionImport(runtimeStore RuntimeStore, blobStore blob.Sto
 		if skillZipShaped {
 			versionInput.OssKey = body.OssKey
 			versionInput.SHA256 = skillSHA256
+		}
+		versionInput.OssKey, versionInput.SHA256, httpErr = ensureSkillImportArchive(r.Context(), workspaceID, spec, versionInput.OssKey, versionInput.SHA256, blobStore)
+		if httpErr != nil {
+			writeJSON(w, httpErr.status, map[string]string{"error": httpErr.message})
+			return
 		}
 		result, err := runtimeStore.ImportCapabilityVersion(r.Context(), versionInput)
 		if err != nil {


### PR DESCRIPTION
Pasted Markdown Skills were imported successfully without an archive reference or checksum, so the existing runtime could not load them. Markdown imports and new versions now store a SKILL.md archive before committing their version metadata, using the existing blob upload path. Storage and validation failures prevent success; uploaded ZIPs and other capability types keep their current behavior.

Scope is single-file Markdown import and new-version artifacts. Historical versions without bytes need a newly published version. Runtime adapters, marketplace installs and multi-file import remain outside this change.

Validation: `make check`, archive content/checksum regressions and isolated PostgreSQL import/new-version round trips pass. Existing ZIP, cross-workspace validation and registry installation regressions pass. Two unrelated database-test failures reproduce on the unchanged baseline: a query of the removed secrets.workspace_id column and a v1 fixture expecting 1.0.1 rather than v2; tracked separately in Feishu as CHECK-003/CHECK-004. Local Docker remained stopped. Independent blind review completed without blocking findings.
