### PR TITLE
fix: reject ambiguous paths in Skill ZIP imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,8 @@ description and keep ownership on the side listed here.
 - Skill ZIP preview and commit must reject duplicate paths, including
   normalized separator/dot-segment and case aliases, so approved file contents
   cannot differ because an extractor chooses a different duplicate entry.
+  Reject filenames outside Unicode stream-safe normalization rather than
+  adding a separate unbounded normalizer.
 
 ### Plugin Bundle (KindBundle) architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,6 +200,9 @@ description and keep ownership on the side listed here.
 - Markdown Skill imports and new versions must store an engine-neutral ZIP
   containing `SKILL.md`, with its storage reference and SHA-256 persisted before
   reporting success. Existing versions without archives require a new import.
+- Skill ZIP preview and commit must reject duplicate paths, including
+  normalized separator/dot-segment and case aliases, so approved file contents
+  cannot differ because an extractor chooses a different duplicate entry.
 
 ### Plugin Bundle (KindBundle) architecture
 

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/text v0.41.0 // indirect
+	golang.org/x/text v0.41.0
 	golang.org/x/time v0.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260720211330-0afa2a65878a // indirect

--- a/server/internal/capability/parser/skill_zip_parser.go
+++ b/server/internal/capability/parser/skill_zip_parser.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/unicode/norm"
 )
 
 // MaxSkillZipBytes caps a single Skill upload. 8 MiB carries a Skill with
@@ -76,11 +78,13 @@ func ParseSkillZip(buf []byte) (SkillParseResult, error) {
 		entry *zip.File
 	}
 	stripped := make([]strippedEntry, 0, len(zr.File))
+	seenPaths := make(map[string]string, len(zr.File))
+	caseFolder := cases.Fold()
 	for i, p := range rawPaths {
-		if isMacOSMetadata(p) {
-			continue
-		}
 		if root != "" {
+			if p+"/" == root && zr.File[i].FileInfo().IsDir() {
+				continue
+			}
 			p = strings.TrimPrefix(p, root)
 		}
 		if p == "" {
@@ -93,6 +97,17 @@ func ParseSkillZip(buf []byte) (SkillParseResult, error) {
 		// in a way we don't understand; sanitising could mask intent.
 		if hasParentTraversal(p) {
 			return SkillParseResult{}, fmt.Errorf("%w: zip entry %q contains parent-directory reference (..)", ErrInvalidSkillZip, zr.File[i].Name)
+		}
+		// Extraction cleans dot segments and repeated separators. Reject aliases
+		// before preview can select different bytes from the installed archive.
+		p = path.Clean(p)
+		key := norm.NFC.String(caseFolder.String(norm.NFC.String(p)))
+		if previous, exists := seenPaths[key]; exists {
+			return SkillParseResult{}, fmt.Errorf("%w: duplicate zip path %q conflicts with %q", ErrInvalidSkillZip, zr.File[i].Name, previous)
+		}
+		seenPaths[key] = zr.File[i].Name
+		if isMacOSMetadata(p) {
+			continue
 		}
 		stripped = append(stripped, strippedEntry{rel: p, entry: zr.File[i]})
 	}

--- a/server/internal/capability/parser/skill_zip_parser.go
+++ b/server/internal/capability/parser/skill_zip_parser.go
@@ -101,7 +101,15 @@ func ParseSkillZip(buf []byte) (SkillParseResult, error) {
 		// Extraction cleans dot segments and repeated separators. Reject aliases
 		// before preview can select different bytes from the installed archive.
 		p = path.Clean(p)
-		key := norm.NFC.String(caseFolder.String(norm.NFC.String(p)))
+		normalized := norm.NFC.String(p)
+		folded := caseFolder.String(normalized)
+		key := norm.NFC.String(folded)
+		// Stream-safe normalization inserts CGJ into long combining sequences,
+		// which can make equivalent filesystem names compare differently.
+		// Reject such names instead of implementing unbounded normalization.
+		if strings.Count(normalized, "\u034f") != strings.Count(p, "\u034f") || strings.Count(key, "\u034f") != strings.Count(folded, "\u034f") {
+			return SkillParseResult{}, fmt.Errorf("%w: zip entry %q has an unsupported combining sequence", ErrInvalidSkillZip, zr.File[i].Name)
+		}
 		if previous, exists := seenPaths[key]; exists {
 			return SkillParseResult{}, fmt.Errorf("%w: duplicate zip path %q conflicts with %q", ErrInvalidSkillZip, zr.File[i].Name, previous)
 		}

--- a/server/internal/capability/parser/skill_zip_paths_test.go
+++ b/server/internal/capability/parser/skill_zip_paths_test.go
@@ -55,6 +55,19 @@ func TestParseSkillZipNormalizesUniqueReferencePath(t *testing.T) {
 	}
 }
 
+func TestParseSkillZipRejectsNonStreamSafePaths(t *testing.T) {
+	for _, root := range []string{"", "wrapped/"} {
+		_, err := ParseSkillZip(buildZip(t, []struct{ name, content string }{
+			{root + "SKILL.md", minimalSkillMd},
+			{root + "references/a" + strings.Repeat("\u0301", 30) + "\u0323.md", "PREVIEW-188"},
+			{root + "references/a\u0323" + strings.Repeat("\u0301", 30) + ".md", "RUNTIME-299"},
+		}))
+		if !errors.Is(err, ErrInvalidSkillZip) || !strings.Contains(err.Error(), "unsupported combining sequence") {
+			t.Fatalf("ambiguous long combining sequence accepted or wrong error: %v", err)
+		}
+	}
+}
+
 func TestParseSkillZipWrapperDirectoryIsNotAnEntry(t *testing.T) {
 	_, err := ParseSkillZip(buildZip(t, []struct{ name, content string }{
 		{"wrapped/", ""},

--- a/server/internal/capability/parser/skill_zip_paths_test.go
+++ b/server/internal/capability/parser/skill_zip_paths_test.go
@@ -1,0 +1,68 @@
+package parser
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestParseSkillZipRejectsDuplicatePaths(t *testing.T) {
+	for _, names := range [][2]string{
+		{"SKILL.md", "SKILL.md"},
+		{"SKILL.md", "skill.md"},
+		{"SKILL.md", "ſKILL.md"},
+		{"SKILL.md", "./SKILL.md"},
+		{"policy.md", "policy.md"},
+		{"references/policy.md", "references/./policy.md"},
+		{"references/policy.md", "references//policy.md"},
+		{"references/policy.md", `references\policy.md`},
+		{"references/policy.md", "References/POLICY.md"},
+		{"references/S.md", "references/ſ.md"},
+		{"references/Σ.md", "references/ς.md"},
+		{"references/café.md", "references/cafe\u0301.md"},
+		{"references/\u03b1\u0345\u0301.md", "references/\u03b1\u0301\u0345.md"},
+		{"references/.DS_Store/.", "references/.DS_Store"},
+		{"references/.DS_Store", "references/.ds_store"},
+	} {
+		for _, root := range []string{"", "wrapped/"} {
+			t.Run(root+names[0]+" and "+names[1], func(t *testing.T) {
+				entries := []struct{ name, content string }{
+					{root + names[0], minimalSkillMd + "PREVIEW-188"},
+					{root + names[1], minimalSkillMd + "RUNTIME-299"},
+				}
+				if names[0] != "SKILL.md" {
+					entries = append(entries, struct{ name, content string }{root + "SKILL.md", minimalSkillMd})
+				}
+				_, err := ParseSkillZip(buildZip(t, entries))
+				if !errors.Is(err, ErrInvalidSkillZip) || !strings.Contains(err.Error(), "duplicate zip path") {
+					t.Fatalf("ambiguous archive accepted or wrong error: %v", err)
+				}
+			})
+		}
+	}
+}
+
+func TestParseSkillZipNormalizesUniqueReferencePath(t *testing.T) {
+	parsed, err := ParseSkillZip(buildZip(t, []struct{ name, content string }{
+		{"SKILL.md", minimalSkillMd},
+		{"references/./policy.md", "pickup on day 3"},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(parsed.Spec.Skill.Files) != 1 || parsed.Spec.Skill.Files[0].Path != "references/policy.md" {
+		t.Fatalf("unexpected reference paths: %+v", parsed.Spec.Skill.Files)
+	}
+}
+
+func TestParseSkillZipWrapperDirectoryIsNotAnEntry(t *testing.T) {
+	_, err := ParseSkillZip(buildZip(t, []struct{ name, content string }{
+		{"wrapped/", ""},
+		{"wrapped/SKILL.md", minimalSkillMd},
+		{"wrapped/wrapped/", ""},
+		{"wrapped/wrapped/policy.md", "pickup on day 3"},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/server/internal/dev/capability_import_duplicate_zip_test.go
+++ b/server/internal/dev/capability_import_duplicate_zip_test.go
@@ -1,0 +1,58 @@
+package dev
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func TestCapabilityImportRejectsDuplicateZipAtEveryEntryPoint(t *testing.T) {
+	r, db, blobs := skillsInstallTestRouter(t, &fakeSkillInstallRunner{t: t})
+	ids := store.DefaultDevFixtureIDs()
+	base := "/api/v1/workspaces/" + ids.WorkspaceID + "/capabilities"
+	storeZip := func(entries []struct{ name, content string }) string {
+		t.Helper()
+		ref, err := blobs.NewRef("skill", ids.WorkspaceID, "skill.zip")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := blobs.PutBytes(t.Context(), ref, ids.WorkspaceID, makeSkillZip(t, entries)); err != nil {
+			t.Fatal(err)
+		}
+		return ref
+	}
+	validRef := storeZip([]struct{ name, content string }{{"SKILL.md", goodSkillMd}})
+	res := serveCapabilityRoute(t, r, http.MethodPost, base+"/import/commit", mustJSON(t, map[string]any{
+		"kind": "skill", "name": "ZIP path test", "oss_key": validRef,
+	}), ids.UserID)
+	if res.Code != http.StatusCreated {
+		t.Fatalf("valid import: %d %s", res.Code, res.Body.String())
+	}
+	var created commitCapabilityImportResponse
+	if err := json.Unmarshal(res.Body.Bytes(), &created); err != nil {
+		t.Fatal(err)
+	}
+	duplicateRef := storeZip([]struct{ name, content string }{
+		{"SKILL.md", goodSkillMd + "PREVIEW-188"},
+		{"SKILL.md", goodSkillMd + "RUNTIME-299"},
+	})
+	for _, endpoint := range []string{"/import/preview", "/import/commit", "/" + created.Capability.ID + "/versions/import/commit"} {
+		res := serveCapabilityRoute(t, r, http.MethodPost, base+endpoint, mustJSON(t, map[string]any{
+			"kind": "skill", "name": "Duplicate ZIP", "source_format": "zip", "oss_key": duplicateRef,
+			"canonical_spec": created.CapabilityVersion.CanonicalSpec,
+		}), ids.UserID)
+		if res.Code < 400 || res.Code >= 500 || !strings.Contains(res.Body.String(), "duplicate zip path") {
+			t.Fatalf("%s accepted duplicate ZIP: %d %s", endpoint, res.Code, res.Body.String())
+		}
+	}
+	var count int
+	if err := db.QueryRow(t.Context(), "SELECT count(*) FROM capability_version").Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("rejected imports created versions: count=%d", count)
+	}
+}


### PR DESCRIPTION
Skill ZIP imports can contain duplicate or equivalent paths, allowing previewed instructions to differ from the extracted files. Reject these ambiguous archives before preview or either import commit, while preserving valid root and wrapped archives.

Scope is limited to Skill ZIP import validation, regression tests, and its contributor contract. Plugin parsing, runtime extractors, and previously stored archives are unchanged.

Validation: `make check` and parser regressions passed with local Docker stopped; the new preview/create/version HTTP regression and existing ZIP import regressions passed against a separate PostgreSQL database on the remote test host. A fresh independent blind review of the final diff found no blocking findings. CI passed.
