### PR TITLE
fix: avoid duplicate Claude Code streamed replies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,8 @@ description and keep ownership on the side listed here.
 
 ### Agent CLI adapter contract
 
+- Claude Code streaming deltas and their per-block assistant copies must be
+  emitted once; preserve separate text blocks even when their content matches.
 - Every daemon-side agent adapter must use a shared process runner for CLI
   subprocesses. New adapters must not hand-roll separate `Start`, stdin,
   cancellation, timeout, and `Wait` loops.

--- a/apps/parsar-daemon/internal/agent/claudecode/parser.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/parser.go
@@ -215,6 +215,13 @@ func (t *translator) translateAssistant(line []byte) (translation, error) {
 
 	var envs []proto.Envelope
 	for index, raw := range msg.Message.Content {
+		partialIndex := index
+		// Claude's per-block assistant frames restart content indexes at zero.
+		if len(msg.Message.Content) == 1 && len(t.partialBlocks) == 1 {
+			for streamedIndex := range t.partialBlocks {
+				partialIndex = streamedIndex
+			}
+		}
 		var head struct {
 			Type string `json:"type"`
 		}
@@ -223,7 +230,7 @@ func (t *translator) translateAssistant(line []byte) (translation, error) {
 		}
 		switch head.Type {
 		case "text":
-			if t.partialBlocks[index] == "text" {
+			if t.partialBlocks[partialIndex] == "text" {
 				continue
 			}
 			var item struct {
@@ -241,7 +248,7 @@ func (t *translator) translateAssistant(line []byte) (translation, error) {
 			}
 			envs = append(envs, env)
 		case "thinking":
-			if t.partialBlocks[index] == "thinking" {
+			if t.partialBlocks[partialIndex] == "thinking" {
 				continue
 			}
 			var item struct {

--- a/apps/parsar-daemon/internal/agent/claudecode/parser_partial_block_test.go
+++ b/apps/parsar-daemon/internal/agent/claudecode/parser_partial_block_test.go
@@ -1,0 +1,56 @@
+package claudecode_test
+
+import (
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/claudecode"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestTranslatePerBlockAssistantPreservesStreamWithoutCopies(t *testing.T) {
+	tr := claudecode.NewTranslatorForTest("run_blocks", nil, counterMinter())
+	frames := []string{
+		`{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Checking."}}}`,
+		`{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"Checking."}]}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+		`{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"PARSAR"}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"-IM-OK"}}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"PARSAR-IM-OK"}]}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":1}}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","id":"tool_1","name":"Read","input":{"path":"policy.md"}}]}}`,
+		`{"type":"stream_event","event":{"type":"content_block_start","index":3,"content_block":{"type":"text","text":""}}}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":3,"delta":{"type":"text_delta","text":"PARSAR-IM-OK"}}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"PARSAR-IM-OK"}]}}`,
+		`{"type":"stream_event","event":{"type":"content_block_stop","index":3}}`,
+		`{"type":"result","subtype":"success","result":"PARSAR-IM-OK"}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"complete-only"}]}}`,
+	}
+	var text, thinking string
+	var tools, done int
+	for _, frame := range frames {
+		out, err := tr.Translate([]byte(frame))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, env := range out.Envelopes {
+			switch env.Type {
+			case proto.TypeDelta:
+				text += mustDecode[proto.DeltaPayload](t, env.Payload).Delta
+			case proto.TypeThinking:
+				thinking += mustDecode[proto.ThinkingPayload](t, env.Payload).Text
+			case proto.TypeToolCall:
+				tools++
+			case proto.TypeDone:
+				done++
+				if got := mustDecode[proto.DonePayload](t, env.Payload).Content; got != "PARSAR-IM-OK" {
+					t.Fatalf("final content = %q", got)
+				}
+			}
+		}
+	}
+	if text != "PARSAR-IM-OKPARSAR-IM-OKcomplete-only" || thinking != "Checking." || tools != 1 || done != 1 {
+		t.Fatalf("text=%q thinking=%q tools=%d done=%d", text, thinking, tools, done)
+	}
+}


### PR DESCRIPTION
Claude Code can emit a complete assistant frame for each content block, restarting its content array at index zero. After a Thinking block, the text deltas use a different stream index, so the adapter could emit the full text again and Feishu displayed the answer twice.

Match a single-block assistant copy to its outstanding streamed block. Preserve full-message translation, Thinking, tool events, final content, complete-only replies, and identical text emitted in separate blocks. This PR changes only the Claude Code adapter, a regression test, and its contributor contract.

Validation: the observed Thinking/text frame sequence reproduced duplication before the change; the new replay and existing adapter tests pass. `make check` passed with local Docker stopped. Independent blind review found no blocking issues. The full adapter suite has a pre-existing intermittent plugin-cache test failure, reproduced by the reviewer on the unchanged baseline; it is tracked separately. Deployed IM regression will follow the combined test-instance update.
