### PR TITLE
fix(codex): handle MCP confirmation requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,6 +276,9 @@ description and keep ownership on the side listed here.
   protocol request and defer the engine response until
   `SubmitPermission` / `SubmitPromptForUserChoice` arrives. Adapters must not
   silently approve, deny, or synthesize empty answers as a fallback.
+- Codex MCP empty-form confirmations use the same permission lifecycle and
+  reply with MCP action/content fields. Decisions grant only that call; structured
+  forms and URL elicitations remain unsupported rather than implicitly approved.
 - Codex agents that may call `request_user_input` use `config.mode=plan`.
   Prompt wording cannot unlock the tool in default mode; the daemon must pass
   the configured mode through app-server `turn/start.collaborationMode`.

--- a/apps/parsar-daemon/internal/agent/codex/server_requests.go
+++ b/apps/parsar-daemon/internal/agent/codex/server_requests.go
@@ -37,6 +37,7 @@ type codexPermissionKind uint8
 const (
 	codexDecisionApproval codexPermissionKind = iota
 	codexPermissionsApproval
+	codexMCPApproval
 )
 
 type pendingCodexInteractions struct {
@@ -230,6 +231,13 @@ func (s *Session) sendCodexPermissionReply(pending pendingCodexPermission, appro
 	value := "decline"
 	if approved {
 		value = "accept"
+	}
+	if pending.kind == codexMCPApproval {
+		var content map[string]any
+		if approved {
+			content = map[string]any{}
+		}
+		return s.rpc.SendServerReply(pending.rpcID, mcpElicitationResponse{Action: value, Content: content})
 	}
 	return s.rpc.SendServerReply(pending.rpcID, ApprovalDecisionResult{Decision: value})
 }

--- a/apps/parsar-daemon/internal/agent/codex/server_requests_mcp.go
+++ b/apps/parsar-daemon/internal/agent/codex/server_requests_mcp.go
@@ -1,0 +1,38 @@
+package codex
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+type mcpElicitationParams struct {
+	ServerName string `json:"serverName"`
+	Mode       string `json:"mode"`
+	Message    string `json:"message"`
+	Schema     struct {
+		Type       string                     `json:"type"`
+		Properties map[string]json.RawMessage `json:"properties"`
+		Required   []string                   `json:"required"`
+	} `json:"requestedSchema"`
+}
+
+type mcpElicitationResponse struct {
+	Action  string         `json:"action"`
+	Content map[string]any `json:"content"`
+}
+
+func (s *Session) handleCodexMCPElicitation(raw json.RawMessage, rpcID any) (any, error) {
+	var params mcpElicitationParams
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, fmt.Errorf("decode MCP elicitation: %w", err)
+	}
+	if params.Mode != "form" || params.Schema.Type != "object" || params.Schema.Properties == nil || len(params.Schema.Properties) != 0 || len(params.Schema.Required) != 0 {
+		return nil, errors.New("MCP elicitation requires unsupported input; only empty confirmation forms are supported")
+	}
+	if strings.TrimSpace(params.ServerName) == "" || strings.TrimSpace(params.Message) == "" {
+		return nil, errors.New("MCP confirmation requires a server name and message")
+	}
+	return s.deferCodexPermission(rpcID, codexMCPApproval, "mcp:"+params.ServerName, params.Message, "", raw, nil)
+}

--- a/apps/parsar-daemon/internal/agent/codex/server_requests_mcp_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/server_requests_mcp_test.go
@@ -1,0 +1,100 @@
+package codex
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestCodexMCPConfirmationUsesPermissionLifecycle(t *testing.T) {
+	for _, action := range []string{"approve", "deny", "expire"} {
+		t.Run(action, func(t *testing.T) {
+			tc, srv, cleanup := NewTestClient()
+			defer cleanup()
+			s, out := newInteractionTestSession(tc.JSONRPCClient)
+			defer s.stopCodexInteractionTimers()
+			params := json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","serverName":"qa-service-desk","mode":"form","message":"Allow get_test_ticket?","requestedSchema":{"type":"object","properties":{}},"_meta":{"codex_approval_kind":"mcp_tool_call","persist":["session","always"]}}`)
+			if err := SendServerRequest(srv, "rpc-mcp", "mcpServer/elicitation/request", params); err != nil {
+				t.Fatal(err)
+			}
+			var env proto.Envelope
+			select {
+			case env = <-out:
+			case <-time.After(2 * time.Second):
+				t.Fatal("MCP confirmation was not surfaced")
+			}
+			var request proto.PermissionRequestPayload
+			if err := env.DecodePayload(&request); err != nil {
+				t.Fatal(err)
+			}
+			if env.Type != proto.TypePermissionRequest || env.ID != "run-test" || request.RequestID == "" || request.Tool != "mcp:qa-service-desk" || request.Title != "Allow get_test_ticket?" {
+				t.Fatalf("incorrect confirmation: %+v / %+v", env, request)
+			}
+			done := make(chan error, 1)
+			go func() {
+				if action == "expire" {
+					s.expireCodexPermission(request.RequestID)
+					done <- nil
+					return
+				}
+				done <- s.SubmitPermission(t.Context(), request.RequestID, proto.PermissionDecisionPayload{Approved: action == "approve"})
+			}()
+			var reply struct {
+				ID     string                     `json:"id"`
+				Result map[string]json.RawMessage `json:"result"`
+			}
+			decodeCodexReply(t, srv, &reply)
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			wantAction, wantContent := `"decline"`, `null`
+			if action == "approve" {
+				wantAction, wantContent = `"accept"`, `{}`
+			}
+			if reply.ID != "rpc-mcp" || len(reply.Result) != 2 || string(reply.Result["action"]) != wantAction || string(reply.Result["content"]) != wantContent {
+				t.Fatalf("incorrect MCP response: %+v", reply)
+			}
+			if err := s.SubmitPermission(t.Context(), request.RequestID, proto.PermissionDecisionPayload{Approved: true}); !errors.Is(err, agent.ErrUnknownPermission) {
+				t.Fatalf("resolved confirmation accepted again: %v", err)
+			}
+		})
+	}
+}
+
+func TestCodexMCPElicitationRejectsUnsupportedInputWithoutApproval(t *testing.T) {
+	for _, params := range []string{
+		`{"serverName":"qa","mode":"form","message":"Enter name","requestedSchema":{"type":"object","properties":{"name":{"type":"string"}}}}`,
+		`{"serverName":"qa","mode":"url","message":"Sign in","url":"https://example.test/login","elicitationId":"login"}`,
+		`{"serverName":"qa","mode":"form","message":"Confirm","requestedSchema":{"type":"object","properties":{},"required":["name"]}}`,
+		`{"serverName":"qa","mode":"form","message":"Confirm","requestedSchema":{"type":"object"}}`,
+		`{"mode":"form","requestedSchema":{"type":"object","properties":{}}}`,
+	} {
+		t.Run(params, func(t *testing.T) {
+			tc, srv, cleanup := NewTestClient()
+			defer cleanup()
+			s, out := newInteractionTestSession(tc.JSONRPCClient)
+			defer s.stopCodexInteractionTimers()
+			if err := SendServerRequest(srv, "rpc-unsupported", "mcpServer/elicitation/request", json.RawMessage(params)); err != nil {
+				t.Fatal(err)
+			}
+			var reply struct {
+				Error *struct {
+					Code int `json:"code"`
+				} `json:"error"`
+			}
+			decodeCodexReply(t, srv, &reply)
+			if reply.Error == nil || reply.Error.Code != -32603 {
+				t.Fatalf("unsupported input was not rejected: %+v", reply)
+			}
+			select {
+			case env := <-out:
+				t.Fatalf("unsupported input became an approval: %+v", env)
+			default:
+			}
+		})
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -360,6 +360,7 @@ func (s *Session) registerHandlers() {
 	// Older app-server releases used this unseparated method name.
 	rpc.OnServerRequest("item/permissionsRequestApproval", s.handleCodexPermissionsApproval)
 	rpc.OnServerRequest("item/tool/requestUserInput", s.handleCodexUserInput)
+	rpc.OnServerRequest("mcpServer/elicitation/request", s.handleCodexMCPElicitation)
 }
 
 func (s *Session) onThreadStarted(raw json.RawMessage) {


### PR DESCRIPTION
Codex MCP calls that request confirmation currently fail because the app-server request has no handler. Route empty form confirmations through the existing run approval flow, returning the user's allow or deny decision to Codex; expired confirmations decline.

This change covers confirmations without input fields. General forms, URL authorization and persistent grants remain outside this PR. Existing command, file and permissions approvals keep their current responses.

Validation: `make check` passed; focused MCP and existing interaction tests passed 25 race-enabled runs in an independent blind review. A real Codex 0.141.0 turn using MiniMax M3 requested approval, accepted the explicit decision and returned the synthetic MCP ticket. The blind review found no blocking issue. Local Docker remained stopped; the live check ran in the remote test runtime.
