### PR TITLE
fix(codex): synchronize request timer publication

### DIFF
--- a/apps/parsar-daemon/internal/agent/codex/rpc.go
+++ b/apps/parsar-daemon/internal/agent/codex/rpc.go
@@ -282,12 +282,9 @@ func (c *JSONRPCClient) Request(ctx context.Context, method string, params any) 
 	if err != nil {
 		return nil, fmt.Errorf("codex rpc: id: %w", err)
 	}
-	timer := time.NewTimer(c.cfg.RequestTimeout)
-	defer timer.Stop()
 	pending := &pendingRequest{
 		method: method,
 		resp:   make(chan rpcResponse, 1),
-		timer:  timer,
 	}
 	c.pendingMu.Lock()
 	c.pending[id] = pending
@@ -300,6 +297,17 @@ func (c *JSONRPCClient) Request(ctx context.Context, method string, params any) 
 		c.pendingMu.Unlock()
 		return nil, fmt.Errorf("codex rpc: write %s: %w", method, err)
 	}
+
+	c.pendingMu.Lock()
+	timer := time.NewTimer(c.cfg.RequestTimeout)
+	if c.pending[id] == pending {
+		pending.timer = timer
+	} else {
+		// A response or client shutdown already removed this request.
+		timer.Stop()
+	}
+	c.pendingMu.Unlock()
+	defer timer.Stop()
 
 	select {
 	case r := <-pending.resp:

--- a/apps/parsar-daemon/internal/agent/codex/rpc.go
+++ b/apps/parsar-daemon/internal/agent/codex/rpc.go
@@ -282,9 +282,12 @@ func (c *JSONRPCClient) Request(ctx context.Context, method string, params any) 
 	if err != nil {
 		return nil, fmt.Errorf("codex rpc: id: %w", err)
 	}
+	timer := time.NewTimer(c.cfg.RequestTimeout)
+	defer timer.Stop()
 	pending := &pendingRequest{
 		method: method,
 		resp:   make(chan rpcResponse, 1),
+		timer:  timer,
 	}
 	c.pendingMu.Lock()
 	c.pending[id] = pending
@@ -297,10 +300,6 @@ func (c *JSONRPCClient) Request(ctx context.Context, method string, params any) 
 		c.pendingMu.Unlock()
 		return nil, fmt.Errorf("codex rpc: write %s: %w", method, err)
 	}
-
-	timer := time.NewTimer(c.cfg.RequestTimeout)
-	pending.timer = timer
-	defer timer.Stop()
 
 	select {
 	case r := <-pending.resp:

--- a/apps/parsar-daemon/internal/agent/codex/rpc_process_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/rpc_process_test.go
@@ -43,6 +43,33 @@ func TestJSONRPCClientCloseReapsChildProcess(t *testing.T) {
 	}
 }
 
+func TestJSONRPCClientResponseTimeoutStartsAfterWrite(t *testing.T) {
+	client, server, cleanup := NewTestClient()
+	defer cleanup()
+	client.cfg.RequestTimeout = 100 * time.Millisecond
+	responseDone := make(chan error, 1)
+	go func() {
+		// Block the pipe write for longer than the response timeout.
+		time.Sleep(200 * time.Millisecond)
+		var request JsonRpcRequest
+		if err := json.NewDecoder(server.FromClient).Decode(&request); err != nil {
+			responseDone <- err
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+		responseDone <- json.NewEncoder(server.ToClient).Encode(JsonRpcResponse{
+			JsonRpc: JsonRpcVersion, ID: request.ID, Result: "ok",
+		})
+	}()
+	result, err := client.Request(context.Background(), "echo", nil)
+	if responseErr := <-responseDone; responseErr != nil {
+		t.Fatalf("send response: %v", responseErr)
+	}
+	if err != nil || string(result) != `"ok"` {
+		t.Fatalf("response after blocked write: result=%s error=%v", result, err)
+	}
+}
+
 func TestJSONRPCClientFakeCodexProcess(t *testing.T) {
 	if os.Getenv("CODEX_RPC_FAKE_PROCESS") != "1" {
 		return


### PR DESCRIPTION
Codex JSON-RPC responses and client shutdown can race with publication of a request timer. Publish the timer under the pending-request lock only while the request is still registered, retaining the response timeout start after a successful write.

Scope: request lifecycle synchronization only. No protocol, approval, sandbox, or adapter behavior changes.

Validation:
- `make check` passed (local Docker stayed stopped; the gate skipped PostgreSQL checks).
- Race-enabled lifecycle checks passed 30 repetitions, including immediate response/close, cancellation, timeout, write failure, and delayed writes.
- A fresh independent blind reviewer reported no blocking findings and reproduced the timer races on the baseline.

Tracks CHECK-006 in the QA table.
