### PR TITLE
feat(web): edit Agent behavior instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,8 @@ description and keep ownership on the side listed here.
 
 ### Agent CLI adapter contract
 
+- Agent creation and editing store behavior instructions in `system_prompt`.
+  Preserve saved text when opening the form; clearing it sends an empty string.
 - Claude Code streaming deltas and their per-block assistant copies must be
   emitted once; preserve separate text blocks even when their content matches.
 - Every daemon-side agent adapter must use a shared process runner for CLI

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1364,6 +1364,10 @@
         "modelSearch": "Search models in this Workspace",
         "capabilitySearch": "Search capabilities"
       },
+      "instructions": {
+        "label": "Instructions",
+        "hint": "Describe what this Agent should do, how it should respond, and when it should ask for clarification."
+      },
       "defaults": {
         "workspaceName": "My Workspace",
         "name": "{{workspace}}'s agent",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1364,6 +1364,10 @@
         "modelSearch": "搜索当前 Workspace 的模型",
         "capabilitySearch": "搜索能力"
       },
+      "instructions": {
+        "label": "行为指令",
+        "hint": "说明这个 Agent 应该做什么、如何回答，以及什么时候需要向用户确认。"
+      },
       "defaults": {
         "workspaceName": "当前 Workspace",
         "name": "{{workspace}} 的 Agent",

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -17,6 +17,7 @@ import {
 import { Input } from "../../components/ui/input"
 import { Label } from "../../components/ui/label"
 import { Select } from "../../components/ui/select"
+import { AgentInstructionsField } from "./agents/AgentInstructionsField"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
 import { cn } from "../../lib/utils"
@@ -895,6 +896,7 @@ export function CreateAgentDialog({
     const body = {
       name: name.trim(),
       description: description.trim() || undefined,
+      system_prompt: systemPrompt.trim(),
       connector_type: connector,
       ...(requiresModel ? { default_model_id: selectedModelID } : {}),
       capabilities: capabilityNames,
@@ -1068,6 +1070,7 @@ export function CreateAgentDialog({
                 <Field label={t("agents.form.fields.description")}>
                   <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t("agents.form.placeholders.description")} />
                 </Field>
+                <AgentInstructionsField value={systemPrompt} onChange={setSystemPrompt} disabled={pending} />
               </section>
               <section className="flex flex-col gap-3">
               {showExecutionChoices ? (

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -558,7 +558,7 @@ export function CreateAgentDialog({
       setModelSearch("")
       setModelDropdownOpen(false)
       setHighlightedModelID(null)
-      setSystemPrompt(promptFromAgent(agent, defaultSystemPrompt))
+      setSystemPrompt(promptFromAgent(agent, ""))
       setCapabilities(capabilitiesFromAgent(agent))
       setSelectedCapabilityIDs([])
       // capabilityVersionChoices for edit mode is hydrated by a separate

--- a/apps/web/src/pages/admin/agents/AgentInstructionsField.tsx
+++ b/apps/web/src/pages/admin/agents/AgentInstructionsField.tsx
@@ -1,0 +1,27 @@
+import { useId } from "react"
+import { useTranslation } from "react-i18next"
+import { Label } from "../../../components/ui/label"
+import { Textarea } from "../../../components/ui/textarea"
+
+export function AgentInstructionsField({ value, onChange, disabled }: {
+  value: string
+  onChange: (value: string) => void
+  disabled: boolean
+}) {
+  const { t } = useTranslation("admin")
+  const id = useId()
+  return (
+    <div className="flex flex-col">
+      <Label htmlFor={id}>{t("agents.form.instructions.label")}</Label>
+      <Textarea
+        id={id}
+        aria-describedby={`${id}-hint`}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        rows={4}
+        disabled={disabled}
+      />
+      <span id={`${id}-hint`} className="mt-1 text-xs text-fg-muted">{t("agents.form.instructions.hint")}</span>
+    </div>
+  )
+}

--- a/tests/e2e/agent-instructions.spec.ts
+++ b/tests/e2e/agent-instructions.spec.ts
@@ -18,20 +18,31 @@ for (const instructions of ["Existing instructions", "Updated instructions\nAsk 
   });
 }
 
-test("creation saves the instructions entered in the form", async ({ page }) => {
-  const writes = await mockAgents(page);
-  await page.goto(`/?ws=${workspace}&admin=agents`);
-  await page.getByRole("button", { name: "New Agent", exact: true }).click();
-  const dialog = page.getByRole("dialog", { name: "New Agent" });
-  await dialog.getByRole("textbox", { name: "Instructions", exact: true }).fill("Answer from the approved policy.");
-  await dialog.getByRole("radio", { name: /Cloud isolation/ }).check();
-  await dialog.getByPlaceholder("Search models in this Workspace").click();
-  await dialog.getByRole("option", { name: /QA Model/ }).click();
-  await dialog.getByRole("button", { name: "Next", exact: true }).click();
-  await dialog.getByRole("button", { name: "Create Agent", exact: true }).click();
-  await expect.poll(() => writes.creates.length).toBe(1);
-  expect(writes.creates[0].system_prompt).toBe("Answer from the approved policy.");
-});
+for (const instructions of ["Answer from the approved policy.", ""]) {
+  test(`creation saves instructions: ${instructions || "empty"}`, async ({ page }) => {
+    const writes = await mockAgents(page);
+    await page.goto(`/?ws=${workspace}&admin=agents`);
+    await page.getByRole("button", { name: "New Agent", exact: true }).click();
+    const dialog = page.getByRole("dialog", { name: "New Agent" });
+    await dialog.getByRole("textbox", { name: "Instructions", exact: true }).fill(instructions);
+    await dialog.getByRole("radio", { name: /Cloud isolation/ }).check();
+    await dialog.getByPlaceholder("Search models in this Workspace").click();
+    await dialog.getByRole("option", { name: /QA Model/ }).click();
+    await dialog.getByRole("button", { name: "Next", exact: true }).click();
+    await dialog.getByRole("button", { name: "Create Agent", exact: true }).click();
+    await expect.poll(() => writes.creates.length).toBe(1);
+    expect(writes.creates[0].system_prompt).toBe(instructions);
+    await expect(dialog).not.toBeVisible();
+    await page.goto(`/?ws=${workspace}&admin=agents&id=${agentID}&tab=config`);
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    const edit = page.getByRole("dialog", { name: "Edit Agent" });
+    await expect(edit.getByRole("textbox", { name: "Instructions", exact: true })).toHaveValue(instructions);
+    await edit.getByRole("button", { name: "Next", exact: true }).click();
+    await edit.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(edit).not.toBeVisible();
+    expect(writes.updates[0].system_prompt).toBe(instructions);
+  });
+}
 
 async function mockAgents(page: Page) {
   const writes = { updates: [] as Record<string, unknown>[], creates: [] as Record<string, unknown>[] };
@@ -40,7 +51,7 @@ async function mockAgents(page: Page) {
   const agent = {
     id: agentID, workspace_id: workspace, name: "Instruction test", slug: "instruction-test", status: "active",
     connector_type: "agent_daemon", visibility: "workspace", capabilities: [],
-    config: { agent_kind: "opencode", daemon_mode: "sandbox", system_prompt: "Existing instructions" },
+    config: { agent_kind: "opencode", daemon_mode: "sandbox", system_prompt: "Existing instructions" } as Record<string, unknown>,
   };
   await page.addInitScript(() => localStorage.setItem("i18nextLng", "en-US"));
   await page.route("**/api/v1/**", async (route) => {
@@ -49,7 +60,14 @@ async function mockAgents(page: Page) {
     if (path === "/api/v1/me") return json(route, { user_id: "user-1", name: "User", email: "user@example.test" });
     if (path === "/api/v1/me/workspaces") return json(route, { workspaces: [{ id: workspace, name: "Instruction test", role: "owner" }] });
     if (path === `${base}/agents`) {
-      if (method === "POST") { writes.creates.push(route.request().postDataJSON()); return json(route, { agent }, 201); }
+      if (method === "POST") {
+        const input = route.request().postDataJSON();
+        writes.creates.push(input);
+        // Agent creation omits an empty prompt in the persisted config.
+        if (input.system_prompt) agent.config.system_prompt = input.system_prompt;
+        else delete agent.config.system_prompt;
+        return json(route, { agent }, 201);
+      }
       return json(route, { agents: [agent] });
     }
     if (path === agentURL || path === `/api/v1/agents/${agentID}`) {

--- a/tests/e2e/agent-instructions.spec.ts
+++ b/tests/e2e/agent-instructions.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test, type Page } from "@playwright/test";
+import { json, WORKSPACE_ID as workspace, AGENT_ID as agentID } from "./helpers/conversation-app";
+
+for (const instructions of ["Existing instructions", "Updated instructions\nAsk when context is missing.", ""]) {
+  test(`edit instructions: ${instructions || "clear"}`, async ({ page }) => {
+    const writes = await mockAgents(page);
+    await page.goto(`/?ws=${workspace}&admin=agents&id=${agentID}&tab=config`);
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    const dialog = page.getByRole("dialog", { name: "Edit Agent" });
+    const field = dialog.getByRole("textbox", { name: "Instructions", exact: true });
+    await expect(field).toHaveValue("Existing instructions");
+    if (instructions !== "Existing instructions") await field.fill(instructions);
+    await dialog.getByRole("button", { name: "Next", exact: true }).click();
+    await dialog.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(dialog).not.toBeVisible();
+    expect(writes.updates).toHaveLength(1);
+    expect(writes.updates[0].system_prompt).toBe(instructions);
+  });
+}
+
+test("creation saves the instructions entered in the form", async ({ page }) => {
+  const writes = await mockAgents(page);
+  await page.goto(`/?ws=${workspace}&admin=agents`);
+  await page.getByRole("button", { name: "New Agent", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "New Agent" });
+  await dialog.getByRole("textbox", { name: "Instructions", exact: true }).fill("Answer from the approved policy.");
+  await dialog.getByRole("radio", { name: /Cloud isolation/ }).check();
+  await dialog.getByPlaceholder("Search models in this Workspace").click();
+  await dialog.getByRole("option", { name: /QA Model/ }).click();
+  await dialog.getByRole("button", { name: "Next", exact: true }).click();
+  await dialog.getByRole("button", { name: "Create Agent", exact: true }).click();
+  await expect.poll(() => writes.creates.length).toBe(1);
+  expect(writes.creates[0].system_prompt).toBe("Answer from the approved policy.");
+});
+
+async function mockAgents(page: Page) {
+  const writes = { updates: [] as Record<string, unknown>[], creates: [] as Record<string, unknown>[] };
+  const base = `/api/v1/workspaces/${workspace}`;
+  const agentURL = `${base}/agents/${agentID}`;
+  const agent = {
+    id: agentID, workspace_id: workspace, name: "Instruction test", slug: "instruction-test", status: "active",
+    connector_type: "agent_daemon", visibility: "workspace", capabilities: [],
+    config: { agent_kind: "opencode", daemon_mode: "sandbox", system_prompt: "Existing instructions" },
+  };
+  await page.addInitScript(() => localStorage.setItem("i18nextLng", "en-US"));
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const method = route.request().method();
+    if (path === "/api/v1/me") return json(route, { user_id: "user-1", name: "User", email: "user@example.test" });
+    if (path === "/api/v1/me/workspaces") return json(route, { workspaces: [{ id: workspace, name: "Instruction test", role: "owner" }] });
+    if (path === `${base}/agents`) {
+      if (method === "POST") { writes.creates.push(route.request().postDataJSON()); return json(route, { agent }, 201); }
+      return json(route, { agents: [agent] });
+    }
+    if (path === agentURL || path === `/api/v1/agents/${agentID}`) {
+      if (method !== "GET") writes.updates.push(route.request().postDataJSON());
+      return json(route, agent);
+    }
+    if (path === `${agentURL}/capabilities`) return json(route, { available: [], installed: [] });
+    if (path === `${base}/capabilities`) return json(route, { capabilities: [] });
+    if (path.endsWith("/models")) return json(route, { models: [{
+      id: "model-1", name: "QA Model", model_key: "qa-model", status: "active", provider_type: "anthropic", adapter: "anthropic", credential_mode: "inline_secret", config: {},
+    }] });
+    return json(route, {});
+  });
+  return writes;
+}


### PR DESCRIPTION
Agent creation and editing now expose behavior instructions with bilingual guidance. Multiline text is saved through the existing system_prompt field; empty instructions remain empty when reopening and saving an Agent.

Scope: the instruction field and its persistence through the existing form. Model selection, capability management and execution behavior retain their existing paths.

Validation: make check, five Playwright create/edit cases, a production build, and real browser save/clear/reopen checks against an isolated server. A fresh independent blind review found no blocking issues.
