### PR TITLE
fix(audit): record Agent capability changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,6 +156,9 @@ description and keep ownership on the side listed here.
 
 - The server owns auth, workspaces, agent records, runtime bindings, run
   records, audit/usage persistence, and upstream engine session ids.
+- Successful explicit Agent capability enable, upgrade, removal, and built-in
+  toggle requests emit Agent-targeted audit events with the authenticated actor
+  and capability identifiers. Never include configuration or credential values.
 - `parsar-daemon` owns CLI discovery, process spawning, CLI-specific env,
   cwd selection inside its host/container, permission prompts, and translating
   CLI streams into Parsar daemon protocol frames.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -4834,6 +4834,7 @@ paths:
       - application/json
       description: Toggles a runtime-injected built-in on/off for one agent. Workspace
         owners, admins, and members may change it. The key must be a known built-in.
+        Successful requests appear in Agent audit.
       operationId: setDevAgentBuiltinCapability
       parameters:
       - description: Workspace UUID
@@ -4950,7 +4951,7 @@ paths:
       - application/json
       description: Swaps the agent's binding to a new version of the same capability,
         optionally flipping the pinning mode at the same time. Workspace owner, admin,
-        or member only.
+        or member only. Successful requests appear in Agent audit.
       operationId: upgradeDevAgentCapability
       parameters:
       - description: Workspace UUID
@@ -5018,7 +5019,7 @@ paths:
   /api/v1/workspaces/{workspaceID}/agents/{agentID}/capabilities/{capabilityVersionID}:
     delete:
       description: Removes the given capability version from the agent. Workspace
-        owner, admin, or member only.
+        owner, admin, or member only. Successful requests appear in Agent audit.
       operationId: deleteDevAgentCapability
       parameters:
       - description: Workspace UUID
@@ -5074,7 +5075,7 @@ paths:
       - application/json
       description: Enables (installs) a capability version on the agent. Cross-workspace
         enable requires the source capability to be public and non-deprecated. Workspace
-        owner, admin, or member only.
+        owner, admin, or member only. Successful requests appear in Agent audit.
       operationId: enableDevAgentCapability
       parameters:
       - description: Workspace UUID

--- a/server/internal/dev/agent_capability_audit_test.go
+++ b/server/internal/dev/agent_capability_audit_test.go
@@ -1,0 +1,76 @@
+package dev
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+func (stubRuntimeStore) RecordAgentCapabilityAudit(store.AgentCapabilityAuditInput) {}
+
+func TestAgentCapabilityRequestsAppearInAgentAudit(t *testing.T) {
+	roles := map[string]string{testUserAID: "member", testUserBID: "viewer"}
+	_, db := capabilityTestRouter(t, roles, nil)
+	s, ingester := newDevRouteAuditStore(t, db)
+	r := chi.NewRouter()
+	RegisterRoutesWithStore(r, capabilityRBACStore{RuntimeStore: s, workspaceRoles: roles})
+	workspaceID := store.DefaultDevFixtureIDs().WorkspaceID
+	capabilityID, v1, v2 := insertCapabilityVersions(t, db, workspaceID, "Audit MCP")
+	publishForeignCapability(t, db, capabilityID)
+	agentID := insertAgentForOwner(t, db, testUserBID, "audit-capability-agent")
+	base := "/api/v1/workspaces/" + workspaceID + "/agents/" + agentID
+	tests := []struct {
+		method, path, body, action string
+		status                     int
+		payload                    map[string]any
+	}{
+		{http.MethodPost, "/capabilities/" + v1 + "/enable", `{"configuration":{"note":"private configuration"},"pinning_mode":"pinned"}`, "enabled", 200,
+			map[string]any{"capability_id": capabilityID, "capability_version_id": v1, "pinning_mode": "pinned", "enabled": true}},
+		{http.MethodPost, "/capabilities/" + v1 + "/enable", `{"configuration":{"note":"updated private configuration"},"pinning_mode":"latest"}`, "enabled", 200,
+			map[string]any{"capability_id": capabilityID, "capability_version_id": v1, "pinning_mode": "latest", "enabled": true}},
+		{http.MethodPost, "/capabilities/" + capabilityID + "/upgrade", `{"new_version_id":"` + v2 + `","pinning_mode":"pinned"}`, "upgraded", 200,
+			map[string]any{"capability_id": capabilityID, "capability_version_id": v2, "pinning_mode": "pinned", "enabled": true}},
+		{http.MethodPut, "/builtin-capabilities/parsar_chat_history", `{"enabled":false}`, "builtin.updated", 200,
+			map[string]any{"builtin_key": "parsar_chat_history", "enabled": false}},
+		{http.MethodDelete, "/capabilities/" + v2, "", "removed", 204,
+			map[string]any{"capability_reference": v2, "enabled": false}},
+	}
+	for index, tc := range tests {
+		response := serveCapabilityRoute(t, r, tc.method, base+tc.path, tc.body, testUserAID)
+		if response.Code != tc.status {
+			t.Fatalf("%s: status %d: %s", tc.action, response.Code, response.Body.String())
+		}
+		flushDevRouteAudit(t, ingester)
+		response = serveCapabilityRoute(t, r, http.MethodGet,
+			"/api/v1/workspaces/"+workspaceID+"/audit-records?target_type=agent&target_id="+agentID, "", testUserAID)
+		var body struct {
+			Records []store.AuditRecordRead `json:"audit_records"`
+		}
+		if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil || response.Code != http.StatusOK || len(body.Records) != index+1 {
+			t.Fatalf("audit response %d: %s", response.Code, response.Body.String())
+		}
+		event := body.Records[0]
+		if event.EventType != "agent.capability."+tc.action || event.ActorType != "user" || event.ActorID != testUserAID || event.TargetID != agentID || event.WorkspaceID != workspaceID || event.OccurredAt.IsZero() {
+			t.Fatalf("incorrect audit identity: %+v", event)
+		}
+		if !reflect.DeepEqual(event.Payload, tc.payload) {
+			t.Fatalf("audit payload = %#v, want %#v", event.Payload, tc.payload)
+		}
+	}
+	// Neither a rejected caller nor a failed mutation should claim success.
+	response := serveCapabilityRoute(t, r, http.MethodPost, base+"/capabilities/"+v1+"/enable", `{}`, testUserBID)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf("viewer enable: %d", response.Code)
+	}
+	response = serveCapabilityRoute(t, r, http.MethodDelete, base+"/capabilities/"+v2, "", testUserAID)
+	if response.Code != http.StatusNotFound {
+		t.Fatalf("missing binding deletion: %d", response.Code)
+	}
+	flushDevRouteAudit(t, ingester)
+	assertAuditEventCount(t, db, "agent.capability.enabled", 2)
+	assertAuditEventCount(t, db, "agent.capability.removed", 1)
+}

--- a/server/internal/dev/agent_capability_store.go
+++ b/server/internal/dev/agent_capability_store.go
@@ -1,0 +1,17 @@
+package dev
+
+import (
+	"context"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+type agentCapabilityStore interface {
+	ListAgentCapabilities(ctx context.Context, agentID string) ([]store.AgentCapabilityRead, error)
+	GetEnabledMarketplaceCapabilitiesForAgent(ctx context.Context, agentID string) ([]store.EnabledCapabilityRead, error)
+	EnableAgentCapability(ctx context.Context, agentID string, versionID string, configuration map[string]any, pinningMode string) (store.AgentCapabilityRead, error)
+	UpgradeAgentCapability(ctx context.Context, agentID string, capabilityID string, newVersionID string, pinningMode string) (store.AgentCapabilityRead, error)
+	UninstallWorkspaceMarketplaceCapability(ctx context.Context, targetWorkspaceID string, sourceCapabilityID string) (int64, error)
+	DeleteAgentCapability(ctx context.Context, agentID string, capabilityVersionID string) error
+	RecordAgentCapabilityAudit(input store.AgentCapabilityAuditInput)
+}

--- a/server/internal/dev/capability_routes.go
+++ b/server/internal/dev/capability_routes.go
@@ -1370,7 +1370,7 @@ func listAgentCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 // Cross-workspace requires the source capability to be public + non-deprecated.
 //
 //	@Summary		Enable a capability on an agent
-//	@Description	Enables (installs) a capability version on the agent. Cross-workspace enable requires the source capability to be public and non-deprecated. Workspace owner, admin, or member only.
+//	@Description	Enables (installs) a capability version on the agent. Cross-workspace enable requires the source capability to be public and non-deprecated. Workspace owner, admin, or member only. Successful requests appear in Agent audit.
 //	@Tags			capabilities
 //	@ID				enableDevAgentCapability
 //	@Accept			json
@@ -1451,6 +1451,11 @@ func enableAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeCapabilityError(w, err, "failed to enable agent capability")
 			return
 		}
+		runtimeStore.RecordAgentCapabilityAudit(store.AgentCapabilityAuditInput{
+			WorkspaceID: agent.WorkspaceID, AgentID: agentID, ActorID: actorIDFromRequest(r),
+			Action: "enabled", CapabilityID: enabled.CapabilityID, VersionID: enabled.CapabilityVersionID,
+			PinningMode: enabled.PinningMode, Enabled: enabled.Enabled,
+		})
 		writeJSON(w, http.StatusOK, enabled)
 	}
 }
@@ -1458,7 +1463,7 @@ func enableAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 // deleteAgentCapability uninstalls a capability version from the agent.
 //
 //	@Summary		Uninstall a capability from an agent
-//	@Description	Removes the given capability version from the agent. Workspace owner, admin, or member only.
+//	@Description	Removes the given capability version from the agent. Workspace owner, admin, or member only. Successful requests appear in Agent audit.
 //	@Tags			capabilities
 //	@ID				deleteDevAgentCapability
 //	@Produce		json
@@ -1473,7 +1478,7 @@ func enableAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 //	@Router			/api/v1/workspaces/{workspaceID}/agents/{agentID}/capabilities/{capabilityVersionID} [delete]
 func deleteAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_, agentID, _, ok := requireAgentWritableMember(w, r, runtimeStore)
+		workspaceID, agentID, _, ok := requireAgentWritableMember(w, r, runtimeStore)
 		if !ok {
 			return
 		}
@@ -1486,6 +1491,10 @@ func deleteAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeCapabilityError(w, err, "failed to delete agent capability")
 			return
 		}
+		runtimeStore.RecordAgentCapabilityAudit(store.AgentCapabilityAuditInput{
+			WorkspaceID: workspaceID, AgentID: agentID, ActorID: actorIDFromRequest(r),
+			Action: "removed", ReferenceID: versionID,
+		})
 		w.WriteHeader(http.StatusNoContent)
 	}
 }
@@ -1495,7 +1504,7 @@ func deleteAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 // registry so callers can't create arbitrary rows.
 //
 //	@Summary		Toggle a built-in capability on an agent
-//	@Description	Toggles a runtime-injected built-in on/off for one agent. Workspace owners, admins, and members may change it. The key must be a known built-in.
+//	@Description	Toggles a runtime-injected built-in on/off for one agent. Workspace owners, admins, and members may change it. The key must be a known built-in. Successful requests appear in Agent audit.
 //	@Tags			capabilities
 //	@ID				setDevAgentBuiltinCapability
 //	@Accept			json
@@ -1512,7 +1521,7 @@ func deleteAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 //	@Router			/api/v1/workspaces/{workspaceID}/agents/{agentID}/builtin-capabilities/{key} [put]
 func setBuiltinCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		_, agentID, _, ok := requireAgentWritableMember(w, r, runtimeStore)
+		workspaceID, agentID, _, ok := requireAgentWritableMember(w, r, runtimeStore)
 		if !ok {
 			return
 		}
@@ -1530,6 +1539,10 @@ func setBuiltinCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeCapabilityError(w, err, "failed to set builtin capability")
 			return
 		}
+		runtimeStore.RecordAgentCapabilityAudit(store.AgentCapabilityAuditInput{
+			WorkspaceID: workspaceID, AgentID: agentID, ActorID: actorIDFromRequest(r),
+			Action: "builtin.updated", BuiltinKey: key, Enabled: body.Enabled,
+		})
 		writeJSON(w, http.StatusOK, map[string]any{"agent_id": agentID, "builtin_key": key, "enabled": body.Enabled})
 	}
 }
@@ -1538,7 +1551,7 @@ func setBuiltinCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 // same capability, optionally flipping the pinning mode at the same time.
 //
 //	@Summary		Upgrade an agent's capability version
-//	@Description	Swaps the agent's binding to a new version of the same capability, optionally flipping the pinning mode at the same time. Workspace owner, admin, or member only.
+//	@Description	Swaps the agent's binding to a new version of the same capability, optionally flipping the pinning mode at the same time. Workspace owner, admin, or member only. Successful requests appear in Agent audit.
 //	@Tags			capabilities
 //	@ID				upgradeDevAgentCapability
 //	@Accept			json
@@ -1621,6 +1634,11 @@ func upgradeAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeCapabilityError(w, err, "failed to upgrade agent capability")
 			return
 		}
+		runtimeStore.RecordAgentCapabilityAudit(store.AgentCapabilityAuditInput{
+			WorkspaceID: agent.WorkspaceID, AgentID: agentID, ActorID: actorIDFromRequest(r),
+			Action: "upgraded", CapabilityID: upgraded.CapabilityID, VersionID: upgraded.CapabilityVersionID,
+			PinningMode: upgraded.PinningMode, Enabled: upgraded.Enabled,
+		})
 		writeJSON(w, http.StatusOK, upgraded)
 	}
 }

--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -77,12 +77,7 @@ type RuntimeStore interface {
 	GetUserCredential(ctx context.Context, credentialID string) (store.UserCredentialRead, error)
 	UpdateUserCredential(ctx context.Context, input store.UpdateUserCredentialInput) (store.UserCredentialRead, error)
 	SoftDeleteUserCredential(ctx context.Context, credentialID string) (store.UserCredentialRead, error)
-	ListAgentCapabilities(ctx context.Context, agentID string) ([]store.AgentCapabilityRead, error)
-	GetEnabledMarketplaceCapabilitiesForAgent(ctx context.Context, agentID string) ([]store.EnabledCapabilityRead, error)
-	EnableAgentCapability(ctx context.Context, agentID string, versionID string, configuration map[string]any, pinningMode string) (store.AgentCapabilityRead, error)
-	UpgradeAgentCapability(ctx context.Context, agentID string, capabilityID string, newVersionID string, pinningMode string) (store.AgentCapabilityRead, error)
-	UninstallWorkspaceMarketplaceCapability(ctx context.Context, targetWorkspaceID string, sourceCapabilityID string) (int64, error)
-	DeleteAgentCapability(ctx context.Context, agentID string, capabilityVersionID string) error
+	agentCapabilityStore
 	CreateAgent(ctx context.Context, input store.CreateAgentInput) (store.CreateAgentResult, error)
 	GetAgent(ctx context.Context, agentID string) (store.AgentSummary, error)
 	UpdateAgent(ctx context.Context, input store.UpdateAgentInput) (store.AgentSummary, []string, error)

--- a/server/internal/store/agent_capability_audit.go
+++ b/server/internal/store/agent_capability_audit.go
@@ -1,0 +1,30 @@
+package store
+
+import "time"
+
+// AgentCapabilityAuditInput deliberately excludes configuration and credentials.
+type AgentCapabilityAuditInput struct {
+	WorkspaceID, AgentID, ActorID string
+	Action                        string
+	CapabilityID, VersionID       string
+	ReferenceID, BuiltinKey       string
+	PinningMode                   string
+	Enabled                       bool
+}
+
+// RecordAgentCapabilityAudit records a successful explicit capability operation.
+// ReferenceID preserves the DELETE route's version-or-capability identifier.
+func (s *Store) RecordAgentCapabilityAudit(input AgentCapabilityAuditInput) {
+	payload := map[string]any{"enabled": input.Enabled}
+	for key, value := range map[string]string{
+		"capability_id": input.CapabilityID, "capability_version_id": input.VersionID,
+		"capability_reference": input.ReferenceID, "builtin_key": input.BuiltinKey,
+		"pinning_mode": input.PinningMode,
+	} {
+		if value != "" {
+			payload[key] = value
+		}
+	}
+	s.emitAgentAudit(time.Now().UTC(), input.ActorID, "agent.capability."+input.Action,
+		"agent", input.AgentID, input.WorkspaceID, payload)
+}


### PR DESCRIPTION
Explicit Agent capability enable/reconfiguration, upgrade, removal and built-in toggle requests now appear in Agent audit. Successful operations identify the authenticated caller and affected Agent/capability without recording configuration or credential values.

Scope: audit emission after the existing mutations; authorization and response behavior are unchanged.

Validation: make check, regenerated OpenAPI, and an isolated PostgreSQL route regression covering success, rejected callers, failed mutations and safe payloads. Fresh independent blind review found no blocking issues. A separate existing failure when upgrading workspace-private capabilities is tracked independently as BUG-024.
