### PR TITLE
fix(invitations): retain names for newly invited accounts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -411,6 +411,8 @@ description and keep ownership on the side listed here.
   The database smoke gate also runs the cross-workspace secret-disable HTTP
   regression so it cannot silently skip in CI without a test database.
 - Accepting an invitation may set a password only for a newly created user.
+  The saved invitation name initializes that user's name; an empty name keeps
+  the email-prefix fallback. Existing account names are never overwritten.
   Existing users must authenticate as the invited account; acceptance must
   preserve their identities and passwords, and rejected attempts must leave
   the invitation available for its recipient.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -428,6 +428,28 @@ definitions:
         additionalProperties: {}
         type: object
     type: object
+  dev.createInvitationRequest:
+    properties:
+      email:
+        type: string
+      name:
+        type: string
+      role:
+        type: string
+    type: object
+  dev.createInvitationResponse:
+    properties:
+      email:
+        type: string
+      expires_at:
+        type: string
+      invitation_id:
+        type: string
+      invite_link:
+        type: string
+      role:
+        type: string
+    type: object
   dev.createModelBody:
     properties:
       adapter:
@@ -3626,8 +3648,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: New accounts supply a password. Existing accounts must be signed
-        in as the invited user; their password is never changed.
+      description: New accounts supply a password and use the saved invitation name
+        when provided. Existing accounts must be signed in as the invited user; their
+        name and password are never changed.
       parameters:
       - description: Invitation and optional new-account password
         in: body
@@ -7211,6 +7234,64 @@ paths:
       summary: Resolve a pending approval or user question
       tags:
       - interactions
+  /api/v1/workspaces/{workspaceID}/invitations:
+    post:
+      consumes:
+      - application/json
+      description: Stores the optional name for new-account creation. Existing account
+        names are preserved.
+      parameters:
+      - description: Workspace UUID
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: Invitation details
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dev.createInvitationRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/dev.createInvitationResponse'
+        "400":
+          description: Invalid invitation details
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Authentication required
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Invitation not allowed
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Invitation already pending
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Invitation creation failed
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Create a workspace invitation
+      tags:
+      - invitations
   /api/v1/workspaces/{workspaceID}/mcp-directory:
     get:
       parameters:

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -4901,14 +4901,15 @@ where provider = 'email' and subject = @email;
 -- ================================================================
 
 -- name: CreateWorkspaceInvitation :exec
-insert into workspace_invitations(id, token_hash, workspace_id, email, role, invited_by, expires_at, created_at)
-values (@id::uuid, @token_hash::bytea, @workspace_id::uuid, @email, @role, @invited_by::uuid, @expires_at, @created_at);
+insert into workspace_invitations(id, token_hash, workspace_id, email, name, role, invited_by, expires_at, created_at)
+values (@id::uuid, @token_hash::bytea, @workspace_id::uuid, @email, @name, @role, @invited_by::uuid, @expires_at, @created_at);
 
 -- name: GetWorkspaceInvitationByTokenHash :one
 select
   wi.id::text           as id,
   wi.workspace_id::text as workspace_id,
   wi.email,
+  wi.name,
   wi.role,
   wi.invited_by::text   as invited_by,
   wi.expires_at,

--- a/server/internal/db/sqlc/models.go
+++ b/server/internal/db/sqlc/models.go
@@ -859,6 +859,7 @@ type WorkspaceInvitation struct {
 	AcceptedAt  pgtype.Timestamptz `json:"accepted_at"`
 	RevokedAt   pgtype.Timestamptz `json:"revoked_at"`
 	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	Name        string             `json:"name"`
 }
 
 // Workspace members and roles (with join-request state machine)

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -3099,8 +3099,8 @@ func (q *Queries) CreateWorkspaceConversation(ctx context.Context, arg CreateWor
 
 const createWorkspaceInvitation = `-- name: CreateWorkspaceInvitation :exec
 
-insert into workspace_invitations(id, token_hash, workspace_id, email, role, invited_by, expires_at, created_at)
-values ($1::uuid, $2::bytea, $3::uuid, $4, $5, $6::uuid, $7, $8)
+insert into workspace_invitations(id, token_hash, workspace_id, email, name, role, invited_by, expires_at, created_at)
+values ($1::uuid, $2::bytea, $3::uuid, $4, $5, $6, $7::uuid, $8, $9)
 `
 
 type CreateWorkspaceInvitationParams struct {
@@ -3108,6 +3108,7 @@ type CreateWorkspaceInvitationParams struct {
 	TokenHash   []byte             `json:"token_hash"`
 	WorkspaceID pgtype.UUID        `json:"workspace_id"`
 	Email       string             `json:"email"`
+	Name        string             `json:"name"`
 	Role        string             `json:"role"`
 	InvitedBy   pgtype.UUID        `json:"invited_by"`
 	ExpiresAt   pgtype.Timestamptz `json:"expires_at"`
@@ -3123,6 +3124,7 @@ func (q *Queries) CreateWorkspaceInvitation(ctx context.Context, arg CreateWorks
 		arg.TokenHash,
 		arg.WorkspaceID,
 		arg.Email,
+		arg.Name,
 		arg.Role,
 		arg.InvitedBy,
 		arg.ExpiresAt,
@@ -6407,6 +6409,7 @@ select
   wi.id::text           as id,
   wi.workspace_id::text as workspace_id,
   wi.email,
+  wi.name,
   wi.role,
   wi.invited_by::text   as invited_by,
   wi.expires_at,
@@ -6423,6 +6426,7 @@ type GetWorkspaceInvitationByTokenHashRow struct {
 	ID            string             `json:"id"`
 	WorkspaceID   string             `json:"workspace_id"`
 	Email         string             `json:"email"`
+	Name          string             `json:"name"`
 	Role          string             `json:"role"`
 	InvitedBy     string             `json:"invited_by"`
 	ExpiresAt     pgtype.Timestamptz `json:"expires_at"`
@@ -6439,6 +6443,7 @@ func (q *Queries) GetWorkspaceInvitationByTokenHash(ctx context.Context, tokenHa
 		&i.ID,
 		&i.WorkspaceID,
 		&i.Email,
+		&i.Name,
 		&i.Role,
 		&i.InvitedBy,
 		&i.ExpiresAt,

--- a/server/internal/dev/routes_invitation_accept.go
+++ b/server/internal/dev/routes_invitation_accept.go
@@ -26,7 +26,7 @@ type acceptInvitationResponse struct {
 // acceptInvitation consumes an invitation for a new or authenticated existing account.
 //
 // @Summary Accept a workspace invitation
-// @Description New accounts supply a password. Existing accounts must be signed in as the invited user; their password is never changed.
+// @Description New accounts supply a password and use the saved invitation name when provided. Existing accounts must be signed in as the invited user; their name and password are never changed.
 // @Tags invitations
 // @Accept json
 // @Produce json
@@ -78,6 +78,7 @@ func acceptInvitation(runtimeStore RuntimeStore, cfg *routerConfig) http.Handler
 		result, err := runtimeStore.AcceptInvitation(r.Context(), store.AcceptInvitationInput{
 			TokenHash:    authinvite.TokenHash(req.Token),
 			Email:        inv.Email,
+			Name:         inv.Name,
 			Role:         inv.Role,
 			WorkspaceID:  inv.WorkspaceID,
 			PasswordHash: hash,

--- a/server/internal/dev/routes_invitation_create.go
+++ b/server/internal/dev/routes_invitation_create.go
@@ -1,0 +1,115 @@
+package dev
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	authinvite "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/invite"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+type createInvitationRequest struct {
+	Email string `json:"email"`
+	Name  string `json:"name,omitempty"`
+	Role  string `json:"role"`
+}
+
+type createInvitationResponse struct {
+	InvitationID string `json:"invitation_id"`
+	InviteLink   string `json:"invite_link"`
+	Email        string `json:"email"`
+	Role         string `json:"role"`
+	ExpiresAt    string `json:"expires_at"`
+}
+
+// createInvitation saves a workspace invitation and an optional new-account name.
+//
+// @Summary Create a workspace invitation
+// @Description Stores the optional name for new-account creation. Existing account names are preserved.
+// @Tags invitations
+// @Accept json
+// @Produce json
+// @Param workspaceID path string true "Workspace UUID"
+// @Param body body createInvitationRequest true "Invitation details"
+// @Success 201 {object} createInvitationResponse
+// @Failure 400 {object} map[string]string "Invalid invitation details"
+// @Failure 401 {object} map[string]string "Authentication required"
+// @Failure 403 {object} map[string]string "Invitation not allowed"
+// @Failure 409 {object} map[string]string "Invitation already pending"
+// @Failure 500 {object} map[string]string "Invitation creation failed"
+// @Router /api/v1/workspaces/{workspaceID}/invitations [post]
+func createInvitation(runtimeStore RuntimeStore, cfg *routerConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
+		if !isUUID(workspaceID) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
+			return
+		}
+		if err := requireWorkspaceMemberNotViewer(r, runtimeStore, workspaceID); err != nil {
+			writeRBACError(w, err)
+			return
+		}
+		var req createInvitationRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
+			return
+		}
+		req.Email = strings.TrimSpace(req.Email)
+		req.Role = strings.TrimSpace(req.Role)
+		if req.Email == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is required"})
+			return
+		}
+		if !store.IsValidMemberRole(req.Role) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "role must be one of owner|admin|member|viewer"})
+			return
+		}
+
+		now := time.Now().UTC()
+		expiresAt := now.Add(authinvite.MaxLifetime)
+		invID := uuid.New().String()
+		token := invID
+
+		callerID, callerRole, err := invitationCallerRole(r, runtimeStore, workspaceID)
+		if err != nil {
+			writeRBACError(w, err)
+			return
+		}
+		if callerRole == "member" && req.Role != "member" {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "members can only invite new members with the member role"})
+			return
+		}
+
+		if err := runtimeStore.CreateInvitation(r.Context(), store.CreateInvitationInput{
+			ID:          invID,
+			TokenHash:   authinvite.TokenHash(token),
+			WorkspaceID: workspaceID,
+			Email:       req.Email,
+			Name:        req.Name,
+			Role:        req.Role,
+			InvitedBy:   callerID,
+			ExpiresAt:   expiresAt,
+			Now:         now,
+		}); err != nil {
+			if strings.Contains(err.Error(), "uk_workspace_invitations_pending_email") {
+				writeJSON(w, http.StatusConflict, map[string]string{"error": "an invitation is already pending for this email"})
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create invitation"})
+			return
+		}
+
+		link := cfg.publicURL + "/invite/" + token
+		writeJSON(w, http.StatusCreated, createInvitationResponse{
+			InvitationID: invID,
+			InviteLink:   link,
+			Email:        store.NormalizeEmail(req.Email),
+			Role:         req.Role,
+			ExpiresAt:    expiresAt.Format(time.RFC3339),
+		})
+	}
+}

--- a/server/internal/dev/routes_workspace_invitations_test.go
+++ b/server/internal/dev/routes_workspace_invitations_test.go
@@ -100,7 +100,7 @@ func TestCreateInvitationUsesStableUUIDTokenAndConfiguredPublicURL(t *testing.T)
 	req := withTestUser(httptest.NewRequest(
 		http.MethodPost,
 		"/api/v1/workspaces/"+testWorkspaceID+"/invitations",
-		strings.NewReader(`{"email":"new@example.com","role":"member"}`),
+		strings.NewReader(`{"email":"new@example.com","name":"QA Employee","role":"member"}`),
 	))
 	req.Header.Set("Content-Type", "application/json")
 	res := httptest.NewRecorder()
@@ -124,6 +124,9 @@ func TestCreateInvitationUsesStableUUIDTokenAndConfiguredPublicURL(t *testing.T)
 	}
 	if !bytes.Equal(st.created.TokenHash, authinvite.TokenHash(token)) {
 		t.Fatal("stored token hash does not match generated token")
+	}
+	if st.created.Name != "QA Employee" {
+		t.Fatalf("invitation name = %q", st.created.Name)
 	}
 }
 
@@ -330,6 +333,7 @@ func TestAcceptInvitationUsesDatabaseFields(t *testing.T) {
 		invitation: store.InvitationRead{
 			WorkspaceID: testWorkspaceID,
 			Email:       "invitee@example.com",
+			Name:        "Database Employee",
 			Role:        "member",
 			ExpiresAt:   time.Now().UTC().Add(time.Hour),
 		},
@@ -347,6 +351,7 @@ func TestAcceptInvitationUsesDatabaseFields(t *testing.T) {
 
 	if st.accepted.WorkspaceID != st.invitation.WorkspaceID ||
 		st.accepted.Email != st.invitation.Email ||
+		st.accepted.Name != st.invitation.Name ||
 		st.accepted.Role != st.invitation.Role {
 		t.Fatalf("accept input = %#v, want database invitation fields", st.accepted)
 	}

--- a/server/internal/dev/routes_workspace_members.go
+++ b/server/internal/dev/routes_workspace_members.go
@@ -14,7 +14,6 @@ import (
 	authinvite "github.com/MiniMax-AI-Dev/parsar/server/internal/auth/invite"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 	"github.com/go-chi/chi/v5"
-	"github.com/google/uuid"
 )
 
 // listWorkspaceMembers lists members of a workspace.
@@ -130,20 +129,6 @@ func addWorkspaceMember(runtimeStore RuntimeStore) http.HandlerFunc {
 
 // ── Invitation handlers ─────────────────────────────────────────
 
-type createInvitationRequest struct {
-	Email string `json:"email"`
-	Name  string `json:"name,omitempty"`
-	Role  string `json:"role"`
-}
-
-type createInvitationResponse struct {
-	InvitationID string `json:"invitation_id"`
-	InviteLink   string `json:"invite_link"`
-	Email        string `json:"email"`
-	Role         string `json:"role"`
-	ExpiresAt    string `json:"expires_at"`
-}
-
 func invitationCallerRole(r *http.Request, runtimeStore RuntimeStore, workspaceID string) (string, string, error) {
 	ctx := requestContextForRBAC(r)
 	callerID := auth.UserIDFromContext(ctx)
@@ -155,77 +140,6 @@ func invitationCallerRole(r *http.Request, runtimeStore RuntimeStore, workspaceI
 		return "", "", err
 	}
 	return callerID, role, nil
-}
-
-func createInvitation(runtimeStore RuntimeStore, cfg *routerConfig) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		workspaceID := strings.TrimSpace(chi.URLParam(r, "workspaceID"))
-		if !isUUID(workspaceID) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "workspace_id must be a valid uuid"})
-			return
-		}
-		if err := requireWorkspaceMemberNotViewer(r, runtimeStore, workspaceID); err != nil {
-			writeRBACError(w, err)
-			return
-		}
-		var req createInvitationRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json body"})
-			return
-		}
-		req.Email = strings.TrimSpace(req.Email)
-		req.Role = strings.TrimSpace(req.Role)
-		if req.Email == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "email is required"})
-			return
-		}
-		if !store.IsValidMemberRole(req.Role) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "role must be one of owner|admin|member|viewer"})
-			return
-		}
-
-		now := time.Now().UTC()
-		expiresAt := now.Add(authinvite.MaxLifetime)
-		invID := uuid.New().String()
-		token := invID
-
-		callerID, callerRole, err := invitationCallerRole(r, runtimeStore, workspaceID)
-		if err != nil {
-			writeRBACError(w, err)
-			return
-		}
-		if callerRole == "member" && req.Role != "member" {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "members can only invite new members with the member role"})
-			return
-		}
-
-		if err := runtimeStore.CreateInvitation(r.Context(), store.CreateInvitationInput{
-			ID:          invID,
-			TokenHash:   authinvite.TokenHash(token),
-			WorkspaceID: workspaceID,
-			Email:       req.Email,
-			Role:        req.Role,
-			InvitedBy:   callerID,
-			ExpiresAt:   expiresAt,
-			Now:         now,
-		}); err != nil {
-			if strings.Contains(err.Error(), "uk_workspace_invitations_pending_email") {
-				writeJSON(w, http.StatusConflict, map[string]string{"error": "an invitation is already pending for this email"})
-				return
-			}
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create invitation"})
-			return
-		}
-
-		link := cfg.publicURL + "/invite/" + token
-		writeJSON(w, http.StatusCreated, createInvitationResponse{
-			InvitationID: invID,
-			InviteLink:   link,
-			Email:        store.NormalizeEmail(req.Email),
-			Role:         req.Role,
-			ExpiresAt:    expiresAt.Format(time.RFC3339),
-		})
-	}
 }
 
 type pendingInvitationResponse struct {

--- a/server/internal/store/invitation.go
+++ b/server/internal/store/invitation.go
@@ -1,0 +1,76 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
+)
+
+type CreateInvitationInput struct {
+	ID          string
+	TokenHash   []byte
+	WorkspaceID string
+	Email       string
+	Name        string
+	Role        string
+	InvitedBy   string
+	ExpiresAt   time.Time
+	Now         time.Time
+}
+
+type InvitationRead struct {
+	ID            string     `json:"id"`
+	WorkspaceID   string     `json:"workspace_id"`
+	Email         string     `json:"email"`
+	Name          string     `json:"name"`
+	Role          string     `json:"role"`
+	InvitedBy     string     `json:"invited_by"`
+	ExpiresAt     time.Time  `json:"expires_at"`
+	AcceptedAt    *time.Time `json:"accepted_at"`
+	RevokedAt     *time.Time `json:"revoked_at"`
+	CreatedAt     time.Time  `json:"created_at"`
+	WorkspaceName string     `json:"workspace_name"`
+}
+
+func (s *Store) CreateInvitation(ctx context.Context, input CreateInvitationInput) error {
+	q := sqlc.New(s.db)
+	return q.CreateWorkspaceInvitation(ctx, sqlc.CreateWorkspaceInvitationParams{
+		ID:          mustUUID(input.ID),
+		TokenHash:   input.TokenHash,
+		WorkspaceID: mustUUID(input.WorkspaceID),
+		Email:       normalizeEmail(input.Email),
+		Name:        strings.TrimSpace(input.Name),
+		Role:        input.Role,
+		InvitedBy:   mustUUID(input.InvitedBy),
+		ExpiresAt:   timestamptz(input.ExpiresAt),
+		CreatedAt:   timestamptz(input.Now),
+	})
+}
+
+func (s *Store) GetInvitationByTokenHash(ctx context.Context, tokenHash []byte) (InvitationRead, error) {
+	q := sqlc.New(s.db)
+	row, err := q.GetWorkspaceInvitationByTokenHash(ctx, tokenHash)
+	if err != nil {
+		return InvitationRead{}, err
+	}
+	inv := InvitationRead{
+		ID:            row.ID,
+		WorkspaceID:   row.WorkspaceID,
+		Email:         row.Email,
+		Name:          row.Name,
+		Role:          row.Role,
+		InvitedBy:     row.InvitedBy,
+		ExpiresAt:     row.ExpiresAt.Time,
+		CreatedAt:     row.CreatedAt.Time,
+		WorkspaceName: row.WorkspaceName,
+	}
+	if row.AcceptedAt.Valid {
+		inv.AcceptedAt = &row.AcceptedAt.Time
+	}
+	if row.RevokedAt.Valid {
+		inv.RevokedAt = &row.RevokedAt.Time
+	}
+	return inv, nil
+}

--- a/server/internal/store/invitation_accept.go
+++ b/server/internal/store/invitation_accept.go
@@ -17,6 +17,7 @@ var ErrInvitationSignInRequired = errors.New("sign in as the invited account bef
 type AcceptInvitationInput struct {
 	TokenHash    []byte
 	Email        string
+	Name         string
 	Role         string
 	WorkspaceID  string
 	PasswordHash string
@@ -60,9 +61,12 @@ func (s *Store) AcceptInvitation(ctx context.Context, input AcceptInvitationInpu
 	}
 
 	// Upsert user by email.
-	name := email
-	if at := strings.Index(email, "@"); at > 0 {
-		name = email[:at]
+	name := strings.TrimSpace(input.Name)
+	if name == "" {
+		name = email
+		if at := strings.Index(email, "@"); at > 0 {
+			name = email[:at]
+		}
 	}
 	userRow, err := q.UpsertUserByEmail(ctx, sqlc.UpsertUserByEmailParams{
 		ID:    mustUUID(newID()),

--- a/server/internal/store/invitation_accept_test.go
+++ b/server/internal/store/invitation_accept_test.go
@@ -19,26 +19,31 @@ func TestAcceptInvitationPreservesExistingAccount(t *testing.T) {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()
-	invite := func(workspace, email, hash string) AcceptInvitationInput {
+	invite := func(workspace, email, name, hash string) AcceptInvitationInput {
 		t.Helper()
 		token := sha256.Sum256([]byte(newID()))
 		in := AcceptInvitationInput{TokenHash: token[:], Email: email, Role: "member", WorkspaceID: workspace, PasswordHash: hash, Now: now}
-		err := st.CreateInvitation(ctx, CreateInvitationInput{ID: newID(), TokenHash: in.TokenHash, WorkspaceID: workspace, Email: email, Role: in.Role, InvitedBy: ids.UserID, ExpiresAt: now.Add(time.Hour), Now: now})
+		err := st.CreateInvitation(ctx, CreateInvitationInput{ID: newID(), TokenHash: in.TokenHash, WorkspaceID: workspace, Email: email, Name: name, Role: in.Role, InvitedBy: ids.UserID, ExpiresAt: now.Add(time.Hour), Now: now})
 		if err != nil {
 			t.Fatal(err)
 		}
+		saved, err := st.GetInvitationByTokenHash(ctx, in.TokenHash)
+		if err != nil {
+			t.Fatal(err)
+		}
+		in.Name = saved.Name
 		return in
 	}
-	first := invite(ids.WorkspaceID, "invitee@example.com", "original-hash")
+	first := invite(ids.WorkspaceID, "invitee@example.com", " QA 员工 ", "original-hash")
 	created, err := st.AcceptInvitation(ctx, first)
-	if err != nil || !created.UserCreated {
+	if err != nil || !created.UserCreated || created.Member.UserName != "QA 员工" {
 		t.Fatalf("new account: %+v, %v", created, err)
 	}
 	target, err := st.CreateWorkspace(ctx, CreateWorkspaceInput{Name: "Invitation target", CreatedBy: ids.UserID, Now: now})
 	if err != nil {
 		t.Fatal(err)
 	}
-	second := invite(target.Workspace.ID, first.Email, "replacement-hash")
+	second := invite(target.Workspace.ID, first.Email, "Replacement name", "replacement-hash")
 	q := sqlc.New(db)
 	assertUnchanged := func() {
 		t.Helper()
@@ -64,7 +69,7 @@ func TestAcceptInvitationPreservesExistingAccount(t *testing.T) {
 	}
 	second.ActorUserID = created.Member.UserID
 	accepted, err := st.AcceptInvitation(ctx, second)
-	if err != nil || accepted.UserCreated || accepted.Member.UserID != created.Member.UserID {
+	if err != nil || accepted.UserCreated || accepted.Member.UserID != created.Member.UserID || accepted.Member.UserName != created.Member.UserName {
 		t.Fatalf("authenticated acceptance: %+v, %v", accepted, err)
 	}
 	assertUnchanged()
@@ -72,13 +77,13 @@ func TestAcceptInvitationPreservesExistingAccount(t *testing.T) {
 		t.Fatalf("replay: %v", err)
 	}
 
-	third := invite(target.Workspace.ID, "missing-password@example.com", "")
+	third := invite(target.Workspace.ID, "missing-password@example.com", "", "")
 	third.ActorUserID = ids.UserID
 	if _, err := st.AcceptInvitation(ctx, third); !errors.Is(err, ErrInvalidInput) {
 		t.Fatalf("missing new-account password: %v", err)
 	}
 	third.PasswordHash = "new-account-hash"
-	if result, err := st.AcceptInvitation(ctx, third); err != nil || !result.UserCreated {
+	if result, err := st.AcceptInvitation(ctx, third); err != nil || !result.UserCreated || result.Member.UserName != "missing-password" {
 		t.Fatalf("new account retry: %+v, %v", result, err)
 	}
 }

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -5147,17 +5147,6 @@ func (s *Store) AddWorkspaceMember(ctx context.Context, input AddWorkspaceMember
 
 // ── Invitation CRUD ─────────────────────────────────────────────
 
-type CreateInvitationInput struct {
-	ID          string
-	TokenHash   []byte
-	WorkspaceID string
-	Email       string
-	Role        string
-	InvitedBy   string
-	ExpiresAt   time.Time
-	Now         time.Time
-}
-
 type PendingInvitationRead struct {
 	ID            string    `json:"id"`
 	TokenHash     []byte    `json:"-"`
@@ -5167,33 +5156,6 @@ type PendingInvitationRead struct {
 	InvitedByName string    `json:"invited_by_name"`
 	ExpiresAt     time.Time `json:"expires_at"`
 	CreatedAt     time.Time `json:"created_at"`
-}
-
-type InvitationRead struct {
-	ID            string     `json:"id"`
-	WorkspaceID   string     `json:"workspace_id"`
-	Email         string     `json:"email"`
-	Role          string     `json:"role"`
-	InvitedBy     string     `json:"invited_by"`
-	ExpiresAt     time.Time  `json:"expires_at"`
-	AcceptedAt    *time.Time `json:"accepted_at"`
-	RevokedAt     *time.Time `json:"revoked_at"`
-	CreatedAt     time.Time  `json:"created_at"`
-	WorkspaceName string     `json:"workspace_name"`
-}
-
-func (s *Store) CreateInvitation(ctx context.Context, input CreateInvitationInput) error {
-	q := sqlc.New(s.db)
-	return q.CreateWorkspaceInvitation(ctx, sqlc.CreateWorkspaceInvitationParams{
-		ID:          mustUUID(input.ID),
-		TokenHash:   input.TokenHash,
-		WorkspaceID: mustUUID(input.WorkspaceID),
-		Email:       normalizeEmail(input.Email),
-		Role:        input.Role,
-		InvitedBy:   mustUUID(input.InvitedBy),
-		ExpiresAt:   timestamptz(input.ExpiresAt),
-		CreatedAt:   timestamptz(input.Now),
-	})
 }
 
 func (s *Store) ListPendingInvitations(ctx context.Context, workspaceID string) ([]PendingInvitationRead, error) {
@@ -5276,31 +5238,6 @@ func (s *Store) RevokeOwnInvitation(ctx context.Context, workspaceID, invitation
 		InvitedBy:   mustUUID(invitedBy),
 		Now:         timestamptz(time.Now().UTC()),
 	})
-}
-
-func (s *Store) GetInvitationByTokenHash(ctx context.Context, tokenHash []byte) (InvitationRead, error) {
-	q := sqlc.New(s.db)
-	row, err := q.GetWorkspaceInvitationByTokenHash(ctx, tokenHash)
-	if err != nil {
-		return InvitationRead{}, err
-	}
-	inv := InvitationRead{
-		ID:            row.ID,
-		WorkspaceID:   row.WorkspaceID,
-		Email:         row.Email,
-		Role:          row.Role,
-		InvitedBy:     row.InvitedBy,
-		ExpiresAt:     row.ExpiresAt.Time,
-		CreatedAt:     row.CreatedAt.Time,
-		WorkspaceName: row.WorkspaceName,
-	}
-	if row.AcceptedAt.Valid {
-		inv.AcceptedAt = &row.AcceptedAt.Time
-	}
-	if row.RevokedAt.Valid {
-		inv.RevokedAt = &row.RevokedAt.Time
-	}
-	return inv, nil
 }
 
 // UpdateWorkspaceMemberRole flips an existing member's role. Returns

--- a/server/migrations/000015_workspace_invitation_name.sql
+++ b/server/migrations/000015_workspace_invitation_name.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE workspace_invitations ADD COLUMN name text NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE workspace_invitations DROP COLUMN name;


### PR DESCRIPTION
Inviting a new member with a name previously created their account using the email prefix. Save the invitation name and use it when creating the recipient's account. Blank and older invitations keep the existing fallback; accepting an invitation for an existing account preserves its name and login information.

Scope: one invitation column, its create/read/accept path and generated contracts. The touched invitation functions are extracted from oversized files; member-management behavior is unchanged.

Validation: `make check`, regenerated sqlc/OpenAPI, fresh HTTP tests and isolated PostgreSQL acceptance tests covering the saved name, blank-name fallback, existing-account preservation and single-use authorization. Fresh independent blind review found no blocking issues.
