### PR TITLE
Fix OpenCode execution for managed Anthropic models

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,9 @@ description and keep ownership on the side listed here.
 
 - Agent creation and editing store behavior instructions in `system_prompt`.
   Preserve saved text when opening the form; clearing it sends an empty string.
+- OpenCode model selectors use `provider/model`. Its Anthropic SDK base URL
+  derives from the same endpoint resolver as model probes; explicit provider
+  SDK options retain precedence over generated defaults.
 - Claude Code streaming deltas and their per-block assistant copies must be
   emitted once; preserve separate text blocks even when their content matches.
 - Every daemon-side agent adapter must use a shared process runner for CLI

--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -330,6 +330,9 @@ func injectOpenCodeManagedModel(opts map[string]any, modelID string, mr store.Mo
 	if providerSlug == "" || modelKey == "" || adapter == "" {
 		return fmt.Errorf("%w: model_id=%s provider_slug=%q model_key=%q adapter=%q", ErrManagedModelConfigInvalid, modelID, mr.ProviderType, mr.ModelKey, mr.Adapter)
 	}
+	if adapter == "@ai-sdk/anthropic" {
+		mr.BaseURL = modelEndpointBaseURL(mr, "anthropic")
+	}
 	configJSON, err := runtimeopencode.RenderConfig(mr, apiKey, runtimeopencode.RenderInput{})
 	if err != nil {
 		return fmt.Errorf("agent_daemon: render opencode config for model %s: %w", modelID, err)
@@ -338,7 +341,7 @@ func injectOpenCodeManagedModel(opts map[string]any, modelID string, mr store.Mo
 		return fmt.Errorf("%w: model_id=%s provider_slug=%q model_key=%q adapter=%q", ErrManagedModelConfigInvalid, modelID, mr.ProviderType, mr.ModelKey, mr.Adapter)
 	}
 	opts["model"] = modelKey
-	opts["model_selector"] = modelKey
+	opts["model_selector"] = providerSlug + "/" + modelKey
 	opts["opencode_json"] = string(configJSON)
 	return nil
 }

--- a/server/internal/connector/agentdaemon/model_injection_test.go
+++ b/server/internal/connector/agentdaemon/model_injection_test.go
@@ -262,8 +262,8 @@ func TestStreamPrompt_ManagedOpenCodeModelInjection(t *testing.T) {
 	if payload.AgentOptions["model"] != "gpt-4o-mini" {
 		t.Fatalf("agent_options.model=%v, want platform model key", payload.AgentOptions["model"])
 	}
-	if payload.AgentOptions["model_selector"] != "gpt-4o-mini" {
-		t.Fatalf("agent_options.model_selector=%v, want platform model key", payload.AgentOptions["model_selector"])
+	if payload.AgentOptions["model_selector"] != "openai/gpt-4o-mini" {
+		t.Fatalf("agent_options.model_selector=%v, want provider/model selector", payload.AgentOptions["model_selector"])
 	}
 	envMap, ok := payload.AgentOptions["env"].(map[string]any)
 	if !ok {

--- a/server/internal/connector/agentdaemon/opencode_endpoint_test.go
+++ b/server/internal/connector/agentdaemon/opencode_endpoint_test.go
@@ -1,0 +1,46 @@
+package agentdaemon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func TestOpenCodeManagedAnthropicEndpoint(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		endpoints any
+		override  string
+		want      string
+	}{
+		{"JSON map", map[string]any{"anthropic": "https://gateway.test/anthropic"}, "", "https://gateway.test/anthropic/v1"},
+		{"typed map alias", map[string]string{"messages": "https://gateway.test/anthropic"}, "", "https://gateway.test/anthropic/v1"},
+		{"explicit SDK override", map[string]any{"anthropic": "https://gateway.test/anthropic"}, "https://override.test/api", "https://override.test/api"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := store.ModelRuntime{
+				ProviderType: "qa", ModelKey: "qa-model", Adapter: "@ai-sdk/anthropic", BaseURL: "https://gateway.test/v1",
+				ProviderConfig: map[string]any{"endpoint_base_urls": tc.endpoints},
+			}
+			if tc.override != "" {
+				mr.ProviderConfig["options"] = map[string]any{"baseURL": tc.override}
+			}
+			opts := map[string]any{}
+			if err := injectOpenCodeManagedModel(opts, "qa-model", mr, "synthetic-key"); err != nil {
+				t.Fatal(err)
+			}
+			var config struct {
+				Provider map[string]struct {
+					Options map[string]any `json:"options"`
+				} `json:"provider"`
+			}
+			if err := json.Unmarshal([]byte(opts["opencode_json"].(string)), &config); err != nil {
+				t.Fatal(err)
+			}
+			if got := config.Provider["qa"].Options["baseURL"]; got != tc.want {
+				t.Fatalf("baseURL = %v, want %s", got, tc.want)
+			}
+		})
+	}
+}

--- a/server/internal/dev/routes_model_health.go
+++ b/server/internal/dev/routes_model_health.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/modelendpoint"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 	"github.com/go-chi/chi/v5"
@@ -35,18 +36,6 @@ func isAnthropicMessagesAdapter(adapter string) bool {
 		return true
 	default:
 		return false
-	}
-}
-
-func anthropicMessagesURL(baseURL string) string {
-	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
-	switch {
-	case strings.HasSuffix(base, "/v1/messages"), strings.HasSuffix(base, "/messages"):
-		return base
-	case strings.HasSuffix(base, "/v1"):
-		return base + "/messages"
-	default:
-		return base + "/v1/messages"
 	}
 }
 
@@ -420,7 +409,7 @@ func probeModelEndpoint(ctx context.Context, mr store.ModelRuntime, endpointType
 func modelProbeRequestSpec(mr store.ModelRuntime, endpointType string) (string, map[string]any) {
 	switch endpointType {
 	case "anthropic":
-		return anthropicMessagesURL(endpointBaseURLFromConfig(mr.ProviderConfig, "anthropic", mr.BaseURL)), map[string]any{
+		return modelendpoint.AnthropicMessagesURL(endpointBaseURLFromConfig(mr.ProviderConfig, "anthropic", mr.BaseURL)), map[string]any{
 			"model":      mr.ModelKey,
 			"messages":   []map[string]any{{"role": "user", "content": "ping"}},
 			"max_tokens": modelProbeMaxTokens,

--- a/server/internal/dev/routes_models.go
+++ b/server/internal/dev/routes_models.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/modelendpoint"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 	"github.com/go-chi/chi/v5"
@@ -648,7 +649,7 @@ func endpointProbeRequest(ctx context.Context, baseURL, modelKey, apiKey, endpoi
 	url := ""
 	switch normalizeEndpointType(endpointType) {
 	case "anthropic":
-		url = anthropicMessagesURL(endpointBaseURLFromConfig(config, "anthropic", baseURL))
+		url = modelendpoint.AnthropicMessagesURL(endpointBaseURLFromConfig(config, "anthropic", baseURL))
 		body = map[string]any{
 			"model":      modelKey,
 			"messages":   []map[string]any{{"role": "user", "content": "ping"}},

--- a/server/internal/modelendpoint/anthropic.go
+++ b/server/internal/modelendpoint/anthropic.go
@@ -1,0 +1,17 @@
+// Package modelendpoint resolves model API endpoints shared by probes and runtimes.
+package modelendpoint
+
+import "strings"
+
+// AnthropicMessagesURL accepts a service root, versioned base, or messages endpoint.
+func AnthropicMessagesURL(baseURL string) string {
+	base := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	switch {
+	case strings.HasSuffix(base, "/v1/messages"), strings.HasSuffix(base, "/messages"):
+		return base
+	case strings.HasSuffix(base, "/v1"):
+		return base + "/messages"
+	default:
+		return base + "/v1/messages"
+	}
+}

--- a/server/internal/runtime/opencode/adapter.go
+++ b/server/internal/runtime/opencode/adapter.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/modelendpoint"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
 )
 
@@ -58,6 +59,9 @@ func RenderConfig(modelRuntime store.ModelRuntime, apiKey string, in RenderInput
 	providerOptions := map[string]any{"apiKey": apiKey}
 	if modelRuntime.BaseURL != "" {
 		providerOptions["baseURL"] = modelRuntime.BaseURL
+		if modelRuntime.Adapter == "@ai-sdk/anthropic" {
+			providerOptions["baseURL"] = strings.TrimSuffix(modelendpoint.AnthropicMessagesURL(modelRuntime.BaseURL), "/messages")
+		}
 	}
 	if extra, ok := modelRuntime.ProviderConfig["options"].(map[string]any); ok {
 		for k, v := range extra {

--- a/server/internal/runtime/opencode/adapter_url_test.go
+++ b/server/internal/runtime/opencode/adapter_url_test.go
@@ -1,0 +1,47 @@
+package opencode_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/runtime/opencode"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func TestRenderAnthropicSDKBaseURL(t *testing.T) {
+	for _, tc := range []struct {
+		name, adapter, base, override, want string
+	}{
+		{"service root", "@ai-sdk/anthropic", "https://example.test/anthropic", "", "https://example.test/anthropic/v1"},
+		{"versioned base", "@ai-sdk/anthropic", "https://example.test/v1/", "", "https://example.test/v1"},
+		{"messages endpoint", "@ai-sdk/anthropic", "https://example.test/anthropic/v1/messages", "", "https://example.test/anthropic/v1"},
+		{"custom messages endpoint", "@ai-sdk/anthropic", "https://example.test/custom/messages", "", "https://example.test/custom"},
+		{"explicit SDK override", "@ai-sdk/anthropic", "https://example.test/anthropic", "https://override.test/api", "https://override.test/api"},
+		{"other adapter", "@ai-sdk/openai", "https://example.test/custom", "", "https://example.test/custom"},
+		{"default SDK endpoint", "@ai-sdk/anthropic", "", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := store.ModelRuntime{ProviderType: "qa-provider", ModelKey: "qa-model", Adapter: tc.adapter, BaseURL: tc.base}
+			if tc.override != "" {
+				mr.ProviderConfig = map[string]any{"options": map[string]any{"baseURL": tc.override}}
+			}
+			raw, err := opencode.RenderConfig(mr, "synthetic-key", opencode.RenderInput{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var config struct {
+				Providers map[string]struct {
+					Options struct {
+						BaseURL string `json:"baseURL"`
+					} `json:"options"`
+				} `json:"provider"`
+			}
+			if err := json.Unmarshal(raw, &config); err != nil {
+				t.Fatal(err)
+			}
+			if got := config.Providers["qa-provider"].Options.BaseURL; got != tc.want {
+				t.Fatalf("baseURL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Managed MiniMax M3 runs exited before producing an answer in OpenCode. Generate a native `provider/model` selector and resolve Anthropic SDK URLs from the configured endpoint, while preserving explicit SDK options and model-probe behavior.

Scope: managed Anthropic execution and the OpenCode selector contract. Non-Anthropic endpoint mapping, framework entry points, and sandbox policies are separate issues.

Validation: `make check`; affected Go tests; native OpenCode 1.18.29 with real MiniMax M3 returned the exact expected text. A fresh independent blind review found no blockers and verified five native Anthropic fixture cases. Local Docker remained stopped; DB smoke checks were skipped because this change does not alter persistence.
