### PR TITLE
Keep Agent header actions and identity text within their panels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -533,6 +533,10 @@ Three concrete rules:
 When a dialog uses a multi-column grid, give every column `min-w-0` —
 otherwise long children push the grid track wider instead of wrapping.
 
+Pages with a detail rail may opt into wrapping header actions through
+`PageHeader.actionClassName` and an auto-height header. Other pages retain
+the default single-row header layout.
+
 ## Typography contract
 
 The type scale has 7 defined steps. Arbitrary pixel sizes (`text-[Npx]`) are

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -19,6 +19,7 @@ interface PageHeaderProps {
    */
   description?: ReactNode
   action?: ReactNode
+  actionClassName?: string
   backLink?: ReactNode
   className?: string
 }
@@ -28,7 +29,7 @@ interface PageHeaderProps {
  * (the only 600 weight on the screen), actions on the right. Sticks to
  * the top of the scrolling main column and spans its full width.
  */
-export function PageHeader({ title, subtitle, subtitleFor, action, backLink, className }: PageHeaderProps) {
+export function PageHeader({ title, subtitle, subtitleFor, action, actionClassName, backLink, className }: PageHeaderProps) {
   const { t } = useTranslation("admin")
   const english = subtitleFor ? (t(subtitleFor as never, { lng: "en-US" }) as unknown as string) : undefined
   const resolvedSubtitle = subtitle ?? (english && english !== title && english !== subtitleFor ? english : undefined)
@@ -52,7 +53,7 @@ export function PageHeader({ title, subtitle, subtitleFor, action, backLink, cla
           )}
         </h1>
       )}
-      {action && <div className="ml-auto flex shrink-0 items-center gap-2">{action}</div>}
+      {action && <div className={cn("ml-auto flex shrink-0 items-center gap-2", actionClassName)}>{action}</div>}
     </header>
   )
 }

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -173,12 +173,13 @@ export function AgentsPage() {
     <AdminLayout activeMenu="agents" fullBleed>
       <RailLayout rail={agentRail}>
         <PageHeader
-          className="static mx-0 mb-0"
+          className="static mx-0 mb-0 h-auto min-h-16 flex-wrap py-3"
+          actionClassName="min-w-0 max-w-full flex-wrap"
           title={pageTitle}
           subtitleFor="agents.page.title"
           action={
             <>
-              <div className="relative w-72">
+              <div className="relative w-72 min-w-0 max-w-full grow basis-40">
                 <Search
                   className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-fg-muted"
                   strokeWidth={1.5}

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -174,7 +174,7 @@ export function AgentsPage() {
       <RailLayout rail={agentRail}>
         <PageHeader
           className="static mx-0 mb-0 h-auto min-h-16 flex-wrap py-3"
-          actionClassName="min-w-0 max-w-full flex-wrap"
+          actionClassName="min-w-0 max-w-full flex-wrap [&>button]:h-auto [&>button]:min-h-7 [&>button]:max-w-full [&>button]:flex-wrap [&>button]:whitespace-normal [&>button]:py-1"
           title={pageTitle}
           subtitleFor="agents.page.title"
           action={

--- a/apps/web/src/pages/admin/agents/AgentConfigSummary.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigSummary.tsx
@@ -37,11 +37,11 @@ export function AgentConfigSummary({
     <>
       <DetailSection title={t("agents.detail.config.identity.title")}>
         <PropertyList className={CONFIG_PROPERTY_LIST}>
-          <Property label={t("agents.detail.config.identity.slug")} mono>{agent.slug}</Property>
+          <Property label={t("agents.detail.config.identity.slug")} mono className="block h-auto min-h-7 break-all whitespace-normal py-1">{agent.slug}</Property>
           <Property label={t("agents.detail.config.identity.visibility")}>
             {t(`agents.visibility.${agent.visibility ?? "workspace"}`)}
           </Property>
-          <Property label={t("agents.detail.config.identity.agentId")} mono>{agent.id}</Property>
+          <Property label={t("agents.detail.config.identity.agentId")} mono className="block h-auto min-h-7 break-all whitespace-normal py-1">{agent.id}</Property>
           <Property label={t("agents.detail.config.identity.created")} mono>
             {formatDate(agent.created_at, i18n.language)}
           </Property>


### PR DESCRIPTION
Opening a wide Agent detail rail could push the Agents toolbar over the detail title and tabs. Keep the toolbar and its labels inside the list panel as space narrows, and allow the full Agent slug and UUID to wrap in the identity section.

The shared header keeps its existing default layout. This change is limited to Agent header containment and identity values; table-column layout is tracked separately.

Validation: `make check`, production web build, and real-browser checks in both themes at 1024×768 and 1280×720. A fresh independent blind review found no blockers after checking 320/384/640px rails, selected filters, search, creation, detail controls, and the unchanged Models header. Local Docker remained stopped; database smoke checks were skipped.
