### PR TITLE
Open Agent configuration from capability usage links

### DIFF
--- a/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityRail.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityRail.tsx
@@ -126,7 +126,7 @@ export function MarketplaceCapabilityRail({ id, open, onClose, onClosed }: {
                 {agents.map((agent) => {
                   const agentID = agent.agent_id ?? agent.id
                   const name = agent.name ?? agent.agent_name ?? "—"
-                  const openAgent = () => agentID && navigateAdmin("agents", { id: agentID, tab: "capabilities" })
+                  const openAgent = () => agentID && navigateAdmin("agents", { id: agentID, tab: "config" })
                   const onKeyDown = (e: KeyboardEvent<HTMLLIElement>) => {
                     if (e.key === "Enter" || e.key === " ") {
                       e.preventDefault()

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -1071,7 +1071,7 @@ export function CapabilityRail({ id, open, onClose, onClosed }: {
                   name={item.agentName}
                   version={item.version}
                   oldLabel={item.latest ? undefined : t("capabilities.detail.enabledAgents.old")}
-                  onOpen={() => navigateAdmin("agents", { id: item.agentID, tab: "capabilities" })}
+                  onOpen={() => navigateAdmin("agents", { id: item.agentID, tab: "config" })}
                 />
               ))}
             </ul>


### PR DESCRIPTION
Clicking an Agent in a capability's usage list opened an empty panel because the link selected a removed tab. Both workspace and marketplace capability detail links now open that Agent's Config tab, preserving the workspace and existing keyboard behavior.

Validation: `make check`, web build, independent blind review, and browser click/Enter navigation for a workspace capability passed. Marketplace end-to-end navigation remains blocked by the separately tracked installation ID / enabled-agent API issue (BUG-016). This PR changes only the two link destinations.
