### PR TITLE
Redact authentication queries from Feishu connection logs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -642,8 +642,8 @@ Go toolchain; do not use `@latest` for that build-time tool.
   the reference style.
 - Feishu WebSocket SDK and lifecycle logs must redact connection URL query
   strings before writing them, without changing the URLs used to connect.
-  Omit the URL-bearing field's tail after `?`, including malformed query text;
-  preserve separate SDK correlation fields and structured route context.
+  Omit each field's tail after its first `?`, without requiring a valid URL
+  prefix; preserve separate SDK correlation fields and structured route context.
 - Use `internal/obs/log` for all logging — never `slog.Default()`,
   `log.Println`, `fmt.Println`, or a hand-rolled `*slog.Logger`. The
   linter (`forbidigo`) rejects direct `slog.Default()` outside

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -640,6 +640,8 @@ Go toolchain; do not use `@latest` for that build-time tool.
   the build on any drift. See `server/internal/api/health.go:livenessHandler`
   and `server/internal/dev/routes.go:listWorkspaceEnabledAgents` for
   the reference style.
+- Feishu WebSocket SDK and lifecycle logs must redact connection URL query
+  strings before writing them, without changing the URLs used to connect.
 - Use `internal/obs/log` for all logging — never `slog.Default()`,
   `log.Println`, `fmt.Println`, or a hand-rolled `*slog.Logger`. The
   linter (`forbidigo`) rejects direct `slog.Default()` outside

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -642,6 +642,8 @@ Go toolchain; do not use `@latest` for that build-time tool.
   the reference style.
 - Feishu WebSocket SDK and lifecycle logs must redact connection URL query
   strings before writing them, without changing the URLs used to connect.
+  Omit the URL-bearing field's tail after `?`, including malformed query text;
+  preserve separate SDK correlation fields and structured route context.
 - Use `internal/obs/log` for all logging — never `slog.Default()`,
   `log.Println`, `fmt.Println`, or a hand-rolled `*slog.Logger`. The
   linter (`forbidigo`) rejects direct `slog.Default()` outside

--- a/server/internal/gateway/inbound/manager.go
+++ b/server/internal/gateway/inbound/manager.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/gateway"
 	sharedrouter "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/router"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/interaction"
@@ -482,12 +483,13 @@ func (m *Manager) startClientWithSecret(ctx context.Context, route store.FeishuA
 
 	clientOpts := []ws.ClientOption{
 		ws.WithEventHandler(eventDispatcher),
+		ws.WithLogger(feishuSDKLogger{logger: log.With("component", "feishu_websocket", "agent_id", route.AgentID, "app_id", cfg.AppID)}),
 		ws.WithOnReady(func() {
 			m.logger.Info("feishu websocket inbound client ready", "source", source, "agent_id", route.AgentID, "app_id", cfg.AppID)
 		}),
 		ws.WithOnError(func(err error) {
 			if err != nil {
-				m.logger.Warn("feishu websocket inbound client error", "source", source, "agent_id", route.AgentID, "app_id", cfg.AppID, "err", err.Error())
+				m.logger.Warn("feishu websocket inbound client error", "source", source, "agent_id", route.AgentID, "app_id", cfg.AppID, "err", redactFeishuConnectionLog(err.Error()))
 			}
 		}),
 		ws.WithOnReconnecting(func() {
@@ -518,7 +520,7 @@ func (m *Manager) startClientWithSecret(ctx context.Context, route store.FeishuA
 
 	go func() {
 		if err := client.Start(clientCtx); err != nil && !errors.Is(err, context.Canceled) {
-			m.logger.Warn("feishu websocket inbound client exited", "source", source, "agent_id", route.AgentID, "app_id", cfg.AppID, "err", err.Error())
+			m.logger.Warn("feishu websocket inbound client exited", "source", source, "agent_id", route.AgentID, "app_id", cfg.AppID, "err", redactFeishuConnectionLog(err.Error()))
 		}
 	}()
 	m.logger.Info("feishu websocket inbound client started", "source", source, "agent_id", route.AgentID, "app_id", cfg.AppID)

--- a/server/internal/gateway/inbound/sdk_logger.go
+++ b/server/internal/gateway/inbound/sdk_logger.go
@@ -8,10 +8,9 @@ import (
 	"strings"
 )
 
-// Connection query strings contain short-lived credentials. Redact only the
-// log copy, retaining the host and path for connection diagnostics.
-// RawQuery may contain quotes; they must not terminate redaction early.
-var feishuLogURLQuery = regexp.MustCompile(`(?i)(\b(?:https?|wss?)://[^\s?]+\?)[^\s]+`)
+// SDK fields may embed malformed URLs. Keep the operation and URL path, but
+// omit the entire field tail after the query rather than guess its delimiter.
+var feishuLogURLQuery = regexp.MustCompile(`(?is)(\b(?:https?|wss?)://[^?]*\?).*`)
 
 func redactFeishuConnectionLog(message string) string {
 	return feishuLogURLQuery.ReplaceAllString(message, "${1}[REDACTED]")
@@ -39,6 +38,10 @@ func (l feishuSDKLogger) Error(ctx context.Context, args ...any) {
 }
 
 func (l feishuSDKLogger) write(ctx context.Context, level slog.Level, args ...any) {
-	message := strings.TrimSuffix(fmt.Sprintln(args...), "\n")
-	l.logger.Log(ctx, level, redactFeishuConnectionLog(message))
+	fields := make([]any, len(args))
+	for i, arg := range args {
+		fields[i] = redactFeishuConnectionLog(fmt.Sprint(arg))
+	}
+	message := strings.TrimSuffix(fmt.Sprintln(fields...), "\n")
+	l.logger.Log(ctx, level, message)
 }

--- a/server/internal/gateway/inbound/sdk_logger.go
+++ b/server/internal/gateway/inbound/sdk_logger.go
@@ -1,0 +1,43 @@
+package inbound
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+)
+
+// Connection query strings contain short-lived credentials. Redact only the
+// log copy, retaining the host and path for connection diagnostics.
+var feishuLogURLQuery = regexp.MustCompile(`(?i)(\b(?:https?|wss?)://[^\s?<>"']+\?)[^\s<>"']+`)
+
+func redactFeishuConnectionLog(message string) string {
+	return feishuLogURLQuery.ReplaceAllString(message, "${1}[REDACTED]")
+}
+
+type feishuSDKLogger struct {
+	logger interface {
+		Log(context.Context, slog.Level, string, ...any)
+	}
+}
+
+// The SDK's default minimum level is Info; keep payload debug logs disabled.
+func (feishuSDKLogger) Debug(context.Context, ...any) {}
+
+func (l feishuSDKLogger) Info(ctx context.Context, args ...any) {
+	l.write(ctx, slog.LevelInfo, args...)
+}
+
+func (l feishuSDKLogger) Warn(ctx context.Context, args ...any) {
+	l.write(ctx, slog.LevelWarn, args...)
+}
+
+func (l feishuSDKLogger) Error(ctx context.Context, args ...any) {
+	l.write(ctx, slog.LevelError, args...)
+}
+
+func (l feishuSDKLogger) write(ctx context.Context, level slog.Level, args ...any) {
+	message := strings.TrimSuffix(fmt.Sprintln(args...), "\n")
+	l.logger.Log(ctx, level, redactFeishuConnectionLog(message))
+}

--- a/server/internal/gateway/inbound/sdk_logger.go
+++ b/server/internal/gateway/inbound/sdk_logger.go
@@ -4,16 +4,15 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"regexp"
 	"strings"
 )
 
-// SDK fields may embed malformed URLs. Keep the operation and URL path, but
-// omit the entire field tail after the query rather than guess its delimiter.
-var feishuLogURLQuery = regexp.MustCompile(`(?is)(\b(?:https?|wss?)://[^?]*\?).*`)
-
+// SDK fields may embed malformed URLs. Do not rely on parsing their prefix.
 func redactFeishuConnectionLog(message string) string {
-	return feishuLogURLQuery.ReplaceAllString(message, "${1}[REDACTED]")
+	if prefix, _, found := strings.Cut(message, "?"); found {
+		return prefix + "?[REDACTED]"
+	}
+	return message
 }
 
 type feishuSDKLogger struct {

--- a/server/internal/gateway/inbound/sdk_logger.go
+++ b/server/internal/gateway/inbound/sdk_logger.go
@@ -10,7 +10,8 @@ import (
 
 // Connection query strings contain short-lived credentials. Redact only the
 // log copy, retaining the host and path for connection diagnostics.
-var feishuLogURLQuery = regexp.MustCompile(`(?i)(\b(?:https?|wss?)://[^\s?<>"']+\?)[^\s<>"']+`)
+// RawQuery may contain quotes; they must not terminate redaction early.
+var feishuLogURLQuery = regexp.MustCompile(`(?i)(\b(?:https?|wss?)://[^\s?]+\?)[^\s]+`)
 
 func redactFeishuConnectionLog(message string) string {
 	return feishuLogURLQuery.ReplaceAllString(message, "${1}[REDACTED]")

--- a/server/internal/gateway/inbound/sdk_logger_test.go
+++ b/server/internal/gateway/inbound/sdk_logger_test.go
@@ -15,6 +15,10 @@ func TestFeishuConnectionLogsOmitAuthenticationQuery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	_, malformedErr := url.Parse("wss://frontier.example/ws/v2/%zz?extra=two words&access-key=synthetic-access&ticket=synthetic-ticket")
+	if malformedErr == nil {
+		t.Fatal("expected invalid URL escape")
+	}
 	for _, args := range [][]any{
 		{"connected to", parsed, "[conn_id=connection-1]"},
 		{"disconnected to " + address},
@@ -23,6 +27,8 @@ func TestFeishuConnectionLogsOmitAuthenticationQuery(t *testing.T) {
 		{"retry " + address + " then " + address},
 		{"connected to wss://frontier.example/ws/v2?extra='value'&access-key=synthetic-access&ticket=synthetic-ticket"},
 		{&url.Error{Op: "dial", URL: `wss://frontier.example/ws/v2?extra="value"&access-key=synthetic-access&ticket=synthetic-ticket`, Err: errors.New("connection refused")}},
+		{"connect failed:", malformedErr},
+		{"connected to wss://frontier.example/ws/v2?extra=two\nwords&access-key=synthetic-access&ticket=synthetic-ticket"},
 	} {
 		sink := &sdkLogRecorder{}
 		logger := feishuSDKLogger{logger: sink}
@@ -37,6 +43,11 @@ func TestFeishuConnectionLogsOmitAuthenticationQuery(t *testing.T) {
 		if !strings.Contains(message, "frontier.example/ws/v2") || !strings.Contains(message, "[REDACTED]") {
 			t.Fatalf("connection diagnostics missing: %s", message)
 		}
+	}
+	sink := &sdkLogRecorder{}
+	feishuSDKLogger{logger: sink}.Info(t.Context(), "connected to "+address, "[conn_id=connection-1]")
+	if got := sink.messages[0]; got != "connected to wss://frontier.example/ws/v2?[REDACTED] [conn_id=connection-1]" {
+		t.Fatalf("SDK correlation field changed: %s", got)
 	}
 }
 

--- a/server/internal/gateway/inbound/sdk_logger_test.go
+++ b/server/internal/gateway/inbound/sdk_logger_test.go
@@ -49,6 +49,19 @@ func TestFeishuConnectionLogsOmitAuthenticationQuery(t *testing.T) {
 	if got := sink.messages[0]; got != "connected to wss://frontier.example/ws/v2?[REDACTED] [conn_id=connection-1]" {
 		t.Fatalf("SDK correlation field changed: %s", got)
 	}
+	for _, address := range []string{
+		"\nwss://frontier.example/ws/v2?access-key=synthetic-access&ticket=synthetic-ticket",
+		"wss:/frontier.example/%zz?access-key=synthetic-access&ticket=synthetic-ticket",
+	} {
+		_, err := url.Parse(address)
+		if err == nil {
+			t.Fatal("expected malformed connection URL")
+		}
+		message := redactFeishuConnectionLog(err.Error())
+		if strings.Contains(message, "synthetic-") || !strings.Contains(message, "[REDACTED]") {
+			t.Fatalf("malformed connection credentials leaked: %s", message)
+		}
+	}
 }
 
 func TestFeishuSDKLoggerPreservesDiagnosticsAndLevels(t *testing.T) {

--- a/server/internal/gateway/inbound/sdk_logger_test.go
+++ b/server/internal/gateway/inbound/sdk_logger_test.go
@@ -1,0 +1,67 @@
+package inbound
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestFeishuConnectionLogsOmitAuthenticationQuery(t *testing.T) {
+	const address = "wss://frontier.example/ws/v2?device_id=device&access-key=synthetic-access&ticket=synthetic-ticket"
+	parsed, err := url.Parse(address)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]any{
+		{"connected to", parsed, "[conn_id=connection-1]"},
+		{"disconnected to " + address},
+		{&url.Error{Op: "dial", URL: address, Err: errors.New("connection refused")}},
+		{"connect failed: https://frontier.example/ws/v2?access%2Dkey=synthetic-access&ticket=synthetic-ticket"},
+		{"retry " + address + " then " + address},
+	} {
+		sink := &sdkLogRecorder{}
+		logger := feishuSDKLogger{logger: sink}
+		logger.Info(t.Context(), args...)
+		if len(sink.messages) != 1 {
+			t.Fatalf("got %d log records", len(sink.messages))
+		}
+		message := sink.messages[0]
+		if strings.Contains(message, "synthetic-access") || strings.Contains(message, "synthetic-ticket") {
+			t.Fatalf("authentication query leaked: %s", message)
+		}
+		if !strings.Contains(message, "frontier.example/ws/v2") || !strings.Contains(message, "[REDACTED]") {
+			t.Fatalf("connection diagnostics missing: %s", message)
+		}
+	}
+}
+
+func TestFeishuSDKLoggerPreservesDiagnosticsAndLevels(t *testing.T) {
+	sink := &sdkLogRecorder{}
+	logger := feishuSDKLogger{logger: sink}
+	logger.Debug(t.Context(), "debug payload remains disabled")
+	logger.Info(t.Context(), "trying to reconnect: 2", "[conn_id=connection-1]")
+	logger.Warn(t.Context(), "ping failed:", errors.New("connection is closed"))
+	logger.Error(t.Context(), "handle message failed")
+	want := []string{"trying to reconnect: 2 [conn_id=connection-1]", "ping failed: connection is closed", "handle message failed"}
+	if len(sink.messages) != len(want) {
+		t.Fatalf("records = %v", sink.messages)
+	}
+	for i, message := range want {
+		if sink.messages[i] != message || sink.levels[i] != []slog.Level{slog.LevelInfo, slog.LevelWarn, slog.LevelError}[i] {
+			t.Fatalf("record %d = %s: %s", i, sink.levels[i], sink.messages[i])
+		}
+	}
+}
+
+type sdkLogRecorder struct {
+	messages []string
+	levels   []slog.Level
+}
+
+func (r *sdkLogRecorder) Log(_ context.Context, level slog.Level, message string, _ ...any) {
+	r.messages = append(r.messages, message)
+	r.levels = append(r.levels, level)
+}

--- a/server/internal/gateway/inbound/sdk_logger_test.go
+++ b/server/internal/gateway/inbound/sdk_logger_test.go
@@ -21,6 +21,8 @@ func TestFeishuConnectionLogsOmitAuthenticationQuery(t *testing.T) {
 		{&url.Error{Op: "dial", URL: address, Err: errors.New("connection refused")}},
 		{"connect failed: https://frontier.example/ws/v2?access%2Dkey=synthetic-access&ticket=synthetic-ticket"},
 		{"retry " + address + " then " + address},
+		{"connected to wss://frontier.example/ws/v2?extra='value'&access-key=synthetic-access&ticket=synthetic-ticket"},
+		{&url.Error{Op: "dial", URL: `wss://frontier.example/ws/v2?extra="value"&access-key=synthetic-access&ticket=synthetic-ticket`, Err: errors.New("connection refused")}},
 	} {
 		sink := &sdkLogRecorder{}
 		logger := feishuSDKLogger{logger: sink}


### PR DESCRIPTION
Feishu SDK connection and disconnect logs included authentication query parameters. Route the SDK through the existing project logger and redact query tails in SDK fields and lifecycle errors before logging. Preserve log levels, the SDK's Info minimum, connection ID fields and route context; wire URLs and connection behavior are unchanged.

Fields are conservatively truncated after their first `?`, including malformed addresses, so credentials cannot escape through URL parsing or delimiter assumptions. This can omit trailing diagnostic text within that field; separate correlation fields remain.

Validation: inbound package regression tests, `make check`, and a fresh independent blind review passed. Coverage includes URL/error formatting, malformed prefixes, whitespace, quoting, encoded query names, correlation fields and log levels. No local Docker was started.
