### PR TITLE
Restore marketplace capability uninstall and affected Agent preview

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -912,10 +912,10 @@
     "uninstall": {
       "action": "Remove from my workspace",
       "title": "Remove \"{{name}}\" from my workspace?",
-      "description": "After removal, this capability disappears from your capability list and will be disabled on {{count}} Agent(s):",
-      "credentialNote": "Existing my credentials are kept. Only the current workspace is affected.",
+      "description": "Remove this capability from the workspace and from the following {{count}} Agent(s). The Agents and their other capabilities remain available.",
+      "credentialNote": "Your existing credentials are kept. Only the current workspace is affected.",
       "unknownAgent": "Affected Agent",
-      "confirm": "Remove and disable {{count}} Agent(s)",
+      "confirm": "Remove capability",
       "toast": "{{name}} was removed from this workspace."
     },
     "import": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -912,10 +912,10 @@
     "uninstall": {
       "action": "从我的工作区移除",
       "title": "从我的工作区移除「{{name}}」？",
-      "description": "移除后，此能力将从能力列表中消失，当前装着此能力的 {{count}} 个 Agent 会被卸载：",
+      "description": "从当前工作区及以下 {{count}} 个 Agent 中移除此能力。Agent 及其其他能力仍可继续使用。",
       "credentialNote": "已有我的凭据会保留，不会被删除。此操作只影响当前工作区。",
       "unknownAgent": "受影响 Agent",
-      "confirm": "移除（并卸载 {{count}} 个 Agent）",
+      "confirm": "移除能力",
       "toast": "「{{name}}」已从当前工作区移除。"
     },
     "import": {

--- a/apps/web/src/lib/api-marketplace.ts
+++ b/apps/web/src/lib/api-marketplace.ts
@@ -227,7 +227,7 @@ function normalizeMarketplaceCapability(item: MarketplaceCapability): Marketplac
   return { ...item, id, latest_version: item.latest_version ?? item.latest_published_version, created_at: item.created_at ?? item.latest_version_created_at, updated_at: item.updated_at ?? item.latest_version_created_at }
 }
 
-function normalizeMarketplaceInstall(item: TargetMarketplaceInstall): TargetMarketplaceInstall {
+export function normalizeMarketplaceInstall(item: TargetMarketplaceInstall): TargetMarketplaceInstall {
   return normalizeMarketplaceCapability(item) as TargetMarketplaceInstall
 }
 

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -61,6 +61,7 @@ import {
   useDeprecate,
   useInstallCount,
   useMarketplaceEnabledAgents,
+  normalizeMarketplaceInstall,
   useMCPDirectory,
   usePublish,
   useTargetMarketplaceInstalls,
@@ -207,7 +208,7 @@ export function CapabilitiesPage() {
   // the separate full-list endpoint. The standalone endpoint stays mounted to
   // compute totals (and as a fallback if paginated mode is off).
   const pageInstalls = useMemo(
-    () => (capsQ.data?.marketplace_installs ?? []) as TargetMarketplaceInstall[],
+    () => ((capsQ.data?.marketplace_installs ?? []) as TargetMarketplaceInstall[]).map(normalizeMarketplaceInstall),
     [capsQ.data?.marketplace_installs],
   )
   const allInstalls = marketplaceInstallsQ.data ?? []

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -3765,7 +3765,7 @@ join agents a on a.id = ac.agent_id
 join capability_version cv on cv.id = ac.capability_version_id
 where a.workspace_id = @target_workspace_id::uuid
   and ac.capability_id = @source_capability_id::uuid
-order by a.name asc, a.id asc;
+order by agent_name asc, agent_id asc;
 
 -- name: UninstallWorkspaceMarketplaceCapability :execrows
 delete from agent_capabilities ac

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -8142,7 +8142,7 @@ join agents a on a.id = ac.agent_id
 join capability_version cv on cv.id = ac.capability_version_id
 where a.workspace_id = $1::uuid
   and ac.capability_id = $2::uuid
-order by a.name asc, a.id asc
+order by agent_name asc, agent_id asc
 `
 
 type ListEnabledAgentsForMarketplaceCapabilityParams struct {

--- a/server/internal/store/marketplace_uninstall_test.go
+++ b/server/internal/store/marketplace_uninstall_test.go
@@ -1,0 +1,72 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestMarketplaceUninstallListsAffectedAgentsAndPreservesSource(t *testing.T) {
+	ctx := context.Background()
+	st := New(openTestDB(t))
+	ids := mustSeedDevFixture(t, ctx, st)
+	source, err := st.CreateWorkspace(ctx, CreateWorkspaceInput{Name: "Marketplace source", CreatedBy: ids.UserID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	capability, err := st.CreateCapability(ctx, CreateCapabilityInput{
+		WorkspaceID: source.Workspace.ID, CreatorID: ids.UserID,
+		Type: "mcp", Name: "Shared test tool", Visibility: "public",
+		InitialVersion: &CreateCapabilityVersionInput{Version: "1.0.0", CreatorID: ids.UserID, Content: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	versions, err := st.ListCapabilityVersions(ctx, capability.ID)
+	if err != nil || len(versions) != 1 {
+		t.Fatalf("versions = %+v, error = %v", versions, err)
+	}
+	versionID := versions[0].ID
+	sourceAgent, err := st.CreateAgent(ctx, CreateAgentInput{
+		WorkspaceID: source.Workspace.ID, Name: "Source agent", ConnectorType: "agent_daemon", CreatedBy: ids.UserID,
+		AgentConfig:         map[string]any{"agent_kind": "claude_code", "daemon_mode": "sandbox"},
+		InitialCapabilities: []InitialAgentCapabilityInput{{CapabilityVersionID: versionID, PinningMode: PinningModePinned}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{ids.ProductAgentID, ids.BackendAgentID} {
+		if _, err := st.EnableAgentCapability(ctx, id, versionID, nil, PinningModePinned); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rows, err := st.ListEnabledAgents(ctx, ids.WorkspaceID, capability.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 || rows[0].AgentID != ids.BackendAgentID || rows[1].AgentID != ids.ProductAgentID {
+		t.Fatalf("affected agents = %+v, want target workspace agents in name order", rows)
+	}
+	for _, row := range rows {
+		if row.AgentName == "" || !row.Enabled || row.CapabilityVersionID != versionID || row.Version != "1.0.0" {
+			t.Fatalf("incomplete affected agent: %+v", row)
+		}
+	}
+	removed, err := st.UninstallWorkspaceMarketplaceCapability(ctx, ids.WorkspaceID, capability.ID)
+	if err != nil || removed != 2 {
+		t.Fatalf("removed = %d, error = %v", removed, err)
+	}
+	rows, err = st.ListEnabledAgents(ctx, ids.WorkspaceID, capability.ID)
+	if err != nil || len(rows) != 0 {
+		t.Fatalf("remaining target bindings = %+v, error = %v", rows, err)
+	}
+	rows, err = st.ListEnabledAgents(ctx, source.Workspace.ID, capability.ID)
+	if err != nil || len(rows) != 1 || rows[0].AgentID != sourceAgent.Agent.ID {
+		t.Fatalf("source binding changed: %+v, error = %v", rows, err)
+	}
+	for _, id := range []string{ids.BackendAgentID, ids.ProductAgentID} {
+		agent, err := st.GetAgent(ctx, id)
+		if err != nil || agent.Status != "active" {
+			t.Fatalf("target agent changed: %+v, error = %v", agent, err)
+		}
+	}
+}


### PR DESCRIPTION
Removing a marketplace capability from the paginated workspace list sent an undefined capability ID. Its affected-Agent preview also failed in PostgreSQL. Reuse the existing marketplace normalizer for paginated rows and order the DISTINCT query by selected aliases. The confirmation names the affected Agents and explicitly removes only the capability.

Validation: `make check`, regenerated sqlc, web build, isolated PostgreSQL regression, and a fresh independent blind review passed. Real browser testing covered detail navigation, affected-Agent names, keyboard navigation to Agent Config, cancel, and successful uninstall in light/dark themes. API comparisons verified that the source capability, active Agent and unrelated bindings were preserved.

Scope: marketplace uninstall identity, affected-Agent preview and confirmation copy. Installation, permissions, pinning and runtime behavior are unchanged.
