### PR TITLE
fix(web): show actionable Skill installation failures

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -785,7 +785,12 @@
         "installing": "Installing...",
         "installed": "Installed",
         "success": "{{name}} was imported as a workspace Skill Capability.",
-        "failed": "The Skill could not be installed."
+        "failed": "The Skill could not be installed.",
+        "failureDescription": "Installation of \"{{name}}\" failed. Retry, or share the technical details with your administrator if it keeps failing.",
+        "details": "Technical details",
+        "copy": "Copy details",
+        "copied": "Details copied.",
+        "copyFailed": "Copy failed. Select and copy the details above."
       }
     },
     "mcpDirectory": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -785,7 +785,12 @@
         "installing": "安装中...",
         "installed": "已安装",
         "success": "已将 {{name}} 导入为工作区 Skill Capability。",
-        "failed": "无法安装该 Skill。"
+        "failed": "无法安装该 Skill。",
+        "failureDescription": "「{{name}}」未能完成安装。可以重试；如果仍然失败，请将技术详情交给管理员排查。",
+        "details": "技术详情",
+        "copy": "复制详情",
+        "copied": "详情已复制。",
+        "copyFailed": "复制失败，请选中上方详情手动复制。"
       }
     },
     "mcpDirectory": {

--- a/apps/web/src/lib/clipboard.ts
+++ b/apps/web/src/lib/clipboard.ts
@@ -1,4 +1,4 @@
-export async function copyText(text: string): Promise<boolean> {
+export async function copyText(text: string, options: { fallback?: boolean } = {}): Promise<boolean> {
   try {
     if (navigator.clipboard?.writeText) {
       await navigator.clipboard.writeText(text)
@@ -7,6 +7,8 @@ export async function copyText(text: string): Promise<boolean> {
   } catch {
     // HTTP origins and browser permission policies can reject the modern API.
   }
+
+  if (options.fallback === false) return false
 
   const textarea = document.createElement("textarea")
   textarea.value = text

--- a/apps/web/src/pages/admin/capabilities/SkillInstallErrorDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillInstallErrorDialog.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+import { AlertTriangle, Copy } from "lucide-react"
+
+import { Button } from "../../../components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../../../components/ui/dialog"
+import { VerbatimBlock } from "../../../components/ui/verbatim"
+import { copyText } from "../../../lib/clipboard"
+
+export function SkillInstallErrorDialog({ name, detail, onClose, onRetry }: {
+  name: string
+  detail: string
+  onClose: () => void
+  onRetry: () => void
+}) {
+  const { t } = useTranslation("admin")
+  const { t: common } = useTranslation("common")
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "copyFailed">("idle")
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent showCloseButton={false} className="w-[calc(100%-2rem)] max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-hidden">
+        <DialogHeader className="min-w-0 pr-4">
+          <DialogTitle className="flex items-start gap-2">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-status-failed" aria-hidden="true" />
+            {t("capabilities.skillsDirectory.install.failed")}
+          </DialogTitle>
+          <DialogDescription className="break-words">
+            {t("capabilities.skillsDirectory.install.failureDescription", { name })}
+          </DialogDescription>
+        </DialogHeader>
+        <details className="min-w-0">
+          <summary className="cursor-pointer text-sm text-fg focus-visible:outline-accent">
+            {t("capabilities.skillsDirectory.install.details")}
+          </summary>
+          <VerbatimBlock className="mt-3 max-h-52 w-full">{detail}</VerbatimBlock>
+          <Button variant="outline" size="sm" className="mt-2" onClick={async () => setCopyStatus(await copyText(detail) ? "copied" : "copyFailed")}>
+            <Copy className="h-3.5 w-3.5" aria-hidden="true" />
+            {t("capabilities.skillsDirectory.install.copy")}
+          </Button>
+          {copyStatus !== "idle" && <p role="status" className="mt-2 text-xs text-fg-muted">{t(`capabilities.skillsDirectory.install.${copyStatus}`)}</p>}
+        </details>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>{common("actions.close")}</Button>
+          <Button onClick={onRetry}>{common("actions.retry")}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/pages/admin/capabilities/SkillInstallErrorDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillInstallErrorDialog.tsx
@@ -7,18 +7,23 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { VerbatimBlock } from "../../../components/ui/verbatim"
 import { copyText } from "../../../lib/clipboard"
 
-export function SkillInstallErrorDialog({ name, detail, onClose, onRetry }: {
+export function SkillInstallErrorDialog({ name, detail, onClose, onRetry, onRestoreFocus }: {
   name: string
   detail: string
   onClose: () => void
   onRetry: () => void
+  onRestoreFocus: () => void
 }) {
   const { t } = useTranslation("admin")
   const { t: common } = useTranslation("common")
   const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "copyFailed">("idle")
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
-      <DialogContent showCloseButton={false} className="w-[calc(100%-2rem)] max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-hidden">
+      <DialogContent
+        showCloseButton={false}
+        onCloseAutoFocus={(event) => { event.preventDefault(); onRestoreFocus() }}
+        className="w-[calc(100%-2rem)] max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-hidden"
+      >
         <DialogHeader className="min-w-0 pr-4">
           <DialogTitle className="flex items-start gap-2">
             <AlertTriangle className="h-4 w-4 shrink-0 text-status-failed" aria-hidden="true" />
@@ -33,7 +38,7 @@ export function SkillInstallErrorDialog({ name, detail, onClose, onRetry }: {
             {t("capabilities.skillsDirectory.install.details")}
           </summary>
           <VerbatimBlock className="mt-3 max-h-52 w-full">{detail}</VerbatimBlock>
-          <Button variant="outline" size="sm" className="mt-2" onClick={async () => setCopyStatus(await copyText(detail) ? "copied" : "copyFailed")}>
+          <Button variant="outline" size="sm" className="mt-2" onClick={async () => setCopyStatus(await copyText(detail, { fallback: false }) ? "copied" : "copyFailed")}>
             <Copy className="h-3.5 w-3.5" aria-hidden="true" />
             {t("capabilities.skillsDirectory.install.copy")}
           </Button>

--- a/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type KeyboardEvent } from "react"
+import { useMemo, useRef, useState, type KeyboardEvent } from "react"
 import { useTranslation } from "react-i18next"
 import { ArrowUpRight, Download, PackageCheck } from "lucide-react"
 
@@ -25,6 +25,7 @@ const SKILL_COLUMNS = [col.fixed(40), col.title(), col.id(200, 1), col.num(72), 
 export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDirectoryProps) {
   const { t, i18n } = useTranslation("admin")
   const workspaceID = useWorkspaceId()
+  const directoryRef = useRef<HTMLDivElement>(null)
   const catalogQ = useSkillsCatalog()
   const installMut = useInstallSkill(workspaceID)
   const [installed, setInstalled] = useState<Record<string, string>>({})
@@ -55,7 +56,7 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
   }
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col" data-testid="skills-directory">
+    <div ref={directoryRef} tabIndex={-1} className="flex min-h-0 flex-1 flex-col" data-testid="skills-directory">
       {success ? (
         <InlineNotice
           tone="success"
@@ -87,6 +88,11 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
           detail={installMut.error instanceof Error ? installMut.error.message : String(installMut.error)}
           onClose={() => installMut.reset()}
           onRetry={() => install(failedSkill)}
+          onRestoreFocus={() => {
+            const row = directoryRef.current?.querySelector<HTMLElement>(`[data-catalog-id="${CSS.escape(failedSkill.id)}"]`)
+            const target = row ?? directoryRef.current
+            target?.focus()
+          }}
         />
       ) : null}
 

--- a/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
@@ -11,6 +11,7 @@ import { Skeleton } from "../../../components/ui/skeleton"
 import { useInstallSkill, useSkillsCatalog, type SkillsCatalogItem } from "../../../lib/api-skills"
 import { useWorkspaceId } from "../../../lib/workspace"
 import { InlineNotice } from "./notices"
+import { SkillInstallErrorDialog } from "./SkillInstallErrorDialog"
 
 interface SkillsDirectoryProps {
   query: string
@@ -41,6 +42,7 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
     )
   }, [catalogQ.data?.items, query])
   const pendingID = installMut.isPending ? (installMut.variables?.id ?? null) : null
+  const failedSkill = installMut.error ? installMut.variables : null
 
   const install = (skill: SkillsCatalogItem) => {
     if (!canImport || installed[skill.id]) return
@@ -79,14 +81,13 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
           />
         </div>
       ) : null}
-      {installMut.error ? (
-        <div className="px-4 pt-4">
-          <ErrorState
-            title={t("capabilities.skillsDirectory.install.failed")}
-            detail={installMut.error instanceof Error ? installMut.error.message : undefined}
-            onRetry={() => installMut.reset()}
-          />
-        </div>
+      {failedSkill ? (
+        <SkillInstallErrorDialog
+          name={failedSkill.name || failedSkill.slug}
+          detail={installMut.error instanceof Error ? installMut.error.message : String(installMut.error)}
+          onClose={() => installMut.reset()}
+          onRetry={() => install(failedSkill)}
+        />
       ) : null}
 
       {catalogQ.isLoading ? (


### PR DESCRIPTION
Skill installation failures now open a compact dialog with collapsed diagnostics, truthful copy feedback, and Close/Retry actions. Retry repeats the failed Skill installation; closing restores focus to that Skill in the directory.

Scope: install failure presentation and retry only. Catalog load failures, installation APIs, permissions, successful installs, and existing clipboard callers keep their behavior.

Validation:
- `make check` and production web build passed (Go 1.25.13; local Docker stayed off).
- Real-browser checks covered narrow/dark/light layouts, diagnostics, clipboard success and rejection, keyboard focus, and retry of the same Skill through failure and success using an isolated HTTP fixture.
- A fresh independent blind reviewer found no blocking issues and independently checked the UI and required gate. Database smoke checks were skipped locally; no database behavior changes.
