### PR TITLE
fix(web): identify inbound IM messages as user turns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -495,6 +495,9 @@ split relevant pieces out first rather than growing the file further.
 
 ### Frontend shared logic
 
+- Inbound messages with `sender_type=external` are user turns. Web conversation
+  presenters must not assign them the Agent identity or imply they are from the
+  current viewer.
 - Cross-page utilities (date/time/duration formatting, status labels,
   etc.) live once in `apps/web/src/lib/`. Do not reimplement inside a page
   component "because it's just a few lines" — that is how

--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -42,6 +42,7 @@ import type {
   Agent,
   ToolStep,
 } from "../../lib/api-types"
+import { isUserMessageSender } from "../../lib/message-sender"
 import { useRelativeTime } from "../../lib/relative-time"
 import { credentialKindLabel } from "../../pages/admin/capability-ui"
 import { ToolCardSlot, SingleSlot, ListSlot } from "../plugin/SlotRenderer"
@@ -477,7 +478,7 @@ function ChatStream({
   const turns = useMemo(
     () =>
       messages
-        .filter((m) => m.sender_type === "user")
+        .filter((m) => isUserMessageSender(m.sender_type))
         .map((m) => ({ key: m.id, preview: turnPreview(m.content) })),
     [messages],
   )
@@ -564,7 +565,7 @@ function ChatStream({
                   onOpenRun={openRun}
                 />
               )
-              if (m.sender_type === "user") {
+              if (isUserMessageSender(m.sender_type)) {
                 // The turn and the work it triggered share one anchor.
                 return (
                   <div key={m.id} data-turn-key={m.id} className="flex flex-col gap-3">
@@ -835,7 +836,7 @@ const MessageRow = memo(function MessageRow({
   onOpenRun?: (runID: string) => void
 }) {
   const { i18n, t } = useTranslation("admin")
-  const isUser = senderType === "user"
+  const isUser = isUserMessageSender(senderType)
   if (isUser) {
     return (
       <div className="flex justify-end">
@@ -843,7 +844,9 @@ const MessageRow = memo(function MessageRow({
           <div className="rounded-md bg-surface-muted px-3 py-2 text-base text-fg">
             <p className="m-0 whitespace-pre-wrap break-words">{content}</p>
           </div>
-          <div className="mt-1 text-xs text-fg-muted">{stamp}</div>
+          <div className="mt-1 text-xs text-fg-muted">
+            {senderType === "external" && <>{t("conversations.detail.externalUser")} · </>}{stamp}
+          </div>
         </div>
       </div>
     )

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -281,7 +281,8 @@
     "detail": {
       "unnamed": "Untitled conversation",
       "emptyTimeline": "No messages yet",
-      "viewRunLink": "View run details"
+      "viewRunLink": "View run details",
+      "externalUser": "IM user"
     },
     "runtime_error": {
       "badge": "Run failed",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -281,7 +281,8 @@
     "detail": {
       "unnamed": "未命名对话",
       "emptyTimeline": "暂无消息",
-      "viewRunLink": "查看运行详情"
+      "viewRunLink": "查看运行详情",
+      "externalUser": "IM 用户"
     },
     "runtime_error": {
       "badge": "运行失败",

--- a/apps/web/src/lib/message-sender.ts
+++ b/apps/web/src/lib/message-sender.ts
@@ -1,0 +1,3 @@
+export function isUserMessageSender(senderType: string): boolean {
+  return senderType === "user" || senderType === "external"
+}

--- a/apps/web/src/lib/parsar-chat-runtime.ts
+++ b/apps/web/src/lib/parsar-chat-runtime.ts
@@ -23,6 +23,7 @@ import type {
   ToolStep,
 } from "./api-types"
 import { startAgentRun } from "./api-conversations"
+import { isUserMessageSender } from "./message-sender"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -106,7 +107,7 @@ export function convertTimelineMessage(
   msg: ConversationTimelineMessage,
   runs: ConversationTimelineRun[],
 ): ThreadMessageLike {
-  if (msg.sender_type === "user") {
+  if (isUserMessageSender(msg.sender_type)) {
     return {
       id: msg.id,
       role: "user",


### PR DESCRIPTION
Inbound IM messages were displayed under the Agent name and omitted from user-turn navigation. Treat persisted external senders as user turns and label them “IM user” / “IM 用户”; do not attribute them to the current viewer.

This changes web presentation only. Message persistence, sender IDs, connector execution, and ordinary web-user/Agent behavior remain unchanged.

Validation:
- `make check` and the production web build passed; local Docker stayed stopped.
- CUA with actual history confirmed three IM user turns and three Agent replies in English/light and Chinese/dark. Existing sender metadata remained unchanged.
- An ordinary web conversation retained its single user turn, Agent reply, and execution trace.
- Fresh independent blind review found no blockers and verified 21 converter cases plus isolated CUA console/shared views and turn navigation.
