### PR TITLE
fix: keep unpublished marketplace installs manageable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,10 @@ description and keep ownership on the side listed here.
 
 ### Server versus daemon ownership
 
+- Cross-workspace installed capabilities remain visible and removable after
+  unpublishing. Their installation metadata reports source visibility and only
+  bound versions while private; marketplace discovery and new installs still
+  require a published source.
 - Agent capability upgrades accept private capabilities from the Agent's own
   workspace; cross-workspace upgrades still require a public, available source.
 - The server owns auth, workspaces, agent records, runtime bindings, run

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -873,6 +873,10 @@
       "badgeSource": "Deprecated",
       "bannerTarget": "The source workspace marked this capability deprecated. Agents already using it can keep using the pinned version, but cannot upgrade to a newer version."
     },
+    "unpublished": {
+      "badge": "Unpublished",
+      "bannerTarget": "The source workspace unpublished this capability. Existing Agent bindings remain. You can view them or remove the capability from this workspace."
+    },
     "marketStatus": {
       "title": "Market status",
       "published": "Published to market",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -873,6 +873,10 @@
       "badgeSource": "已废弃",
       "bannerTarget": "此能力已被来源工作区标记废弃，建议迁移到其它能力。本工作区已装的 Agent 仍可使用锁定版本，但无法升级到新版本。"
     },
+    "unpublished": {
+      "badge": "已下架",
+      "bannerTarget": "来源工作区已取消发布此能力。已有 Agent 绑定仍保留，可查看使用者或从本工作区卸载。"
+    },
     "marketStatus": {
       "title": "市场状态",
       "published": "已发布到市场",

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -362,7 +362,7 @@ export function CreateAgentDialog({
       requiredCredentials: RequiredCredential[]
     }
     const ownCaps = capabilitiesQ.data?.capabilities ?? []
-    const installedCaps = capabilitiesQ.data?.marketplace_installs ?? []
+    const installedCaps = (capabilitiesQ.data?.marketplace_installs ?? []).filter((cap) => cap.visibility !== "workspace")
     const availableCaps = capabilitiesQ.data?.marketplace_available ?? []
     const workspace: PickerOption[] = [...ownCaps, ...installedCaps].map((cap) => ({
       id: cap.id,
@@ -462,7 +462,7 @@ export function CreateAgentDialog({
   const allCapabilitiesPool = useMemo<Capability[]>(() => {
     const data = allCapabilitiesQ.data
     const own = data?.capabilities ?? []
-    const installed = data?.marketplace_installs ?? []
+    const installed = (data?.marketplace_installs ?? []).filter((cap) => cap.visibility !== "workspace")
     // Map MarketplaceCapability into the minimum Capability shape
     // aggregate/required-credentials helpers and submit lookup expect.
     const available: Capability[] = (data?.marketplace_available ?? []).map((cap) => ({

--- a/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityRail.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityRail.tsx
@@ -79,6 +79,7 @@ export function MarketplaceCapabilityRail({ id, open, onClose, onClosed }: {
 
   const source = marketplaceSourceName(capability)
   const deprecated = !!capability.deprecated_at
+  const unpublished = capability.visibility === "workspace"
   const latest = capability.latest_version ?? capability.latest_published_version
   const agentCount = agents.length || capability.enabled_agent_count
 
@@ -98,19 +99,21 @@ export function MarketplaceCapabilityRail({ id, open, onClose, onClosed }: {
               deprecation is one word here — the banner below it already gives
               the advice the longer badge was repeating. */}
           {deprecated && <Badge variant="neutral" dot>{t("capabilities.deprecated.badgeSource")}</Badge>}
+          {unpublished && <Badge variant="neutral" dot>{t("capabilities.unpublished.badge")}</Badge>}
         </>
       }
       footer={<Button variant="outline" onClick={() => setUninstallOpen(true)}>{t("capabilities.uninstall.action")}</Button>}
     >
       <>
         {deprecated && <InlineNotice tone="warning" className="mb-4">{t("capabilities.deprecated.bannerTarget")}</InlineNotice>}
+        {unpublished && <InlineNotice tone="warning" className="mb-4">{t("capabilities.unpublished.bannerTarget")}</InlineNotice>}
         {capability.description && <p className="mb-4 text-sm text-fg">{capability.description}</p>}
 
         <RailSection title={t("capabilities.marketplaceDetail.source.title")}>
           <PropertyList>
             <Property label={t("capabilities.marketplaceDetail.source.workspace")}>{source || t("capabilities.none")}</Property>
             <Property label={t("capabilities.marketplaceDetail.source.pinnedVersion")} mono>{capability.pinned_version ? `v${capability.pinned_version}` : t("capabilities.none")}</Property>
-            <Property label={t("capabilities.marketplaceDetail.source.latestVersion")} mono>{latest ? `v${latest}` : t("capabilities.none")}</Property>
+            {!unpublished && <Property label={t("capabilities.marketplaceDetail.source.latestVersion")} mono>{latest ? `v${latest}` : t("capabilities.none")}</Property>}
             <Property label={t("capabilities.table.credentials")}>{requiredCredentialsLabel(capability.required_credentials, i18n.language, t("capabilities.credentials.none"))}</Property>
           </PropertyList>
         </RailSection>

--- a/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityRail.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityRail.tsx
@@ -90,21 +90,15 @@ export function MarketplaceCapabilityRail({ id, open, onClose, onClosed }: {
       onClosed={onClosed}
       closeLabel={closeLabel}
       aria-label={capability.name}
-      header={
-        <>
-          <span className="min-w-0 truncate text-base font-medium text-fg">{capability.name}</span>
-          <CapabilityTypeBadge type={capability.type} />
-          {/* No "from market" badge: this rail only ever shows capabilities
-              that came from the market, so it never varied. And the
-              deprecation is one word here — the banner below it already gives
-              the advice the longer badge was repeating. */}
-          {deprecated && <Badge variant="neutral" dot>{t("capabilities.deprecated.badgeSource")}</Badge>}
-          {unpublished && <Badge variant="neutral" dot>{t("capabilities.unpublished.badge")}</Badge>}
-        </>
-      }
+      header={<span className="min-w-0 flex-1 line-clamp-2 break-words text-base font-medium text-fg" title={capability.name}>{capability.name}</span>}
       footer={<Button variant="outline" onClick={() => setUninstallOpen(true)}>{t("capabilities.uninstall.action")}</Button>}
     >
       <>
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <CapabilityTypeBadge type={capability.type} />
+          {deprecated && <Badge variant="neutral" dot>{t("capabilities.deprecated.badgeSource")}</Badge>}
+          {unpublished && <Badge variant="neutral" dot>{t("capabilities.unpublished.badge")}</Badge>}
+        </div>
         {deprecated && <InlineNotice tone="warning" className="mb-4">{t("capabilities.deprecated.bannerTarget")}</InlineNotice>}
         {unpublished && <InlineNotice tone="warning" className="mb-4">{t("capabilities.unpublished.bannerTarget")}</InlineNotice>}
         {capability.description && <p className="mb-4 text-sm text-fg">{capability.description}</p>}

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -116,7 +116,7 @@ const TYPE_FILTERS: { value: CapabilityTypeFilter; label: string }[] = [
 ]
 
 /** name (+type, +description) · version · source · enabled agents · credentials · updated · actions */
-const LEDGER_COLUMNS = [col.title(), col.id(96, 0.4), col.meta(104), col.num(96), col.meta(120), col.age(80), col.actions(2)]
+const LEDGER_COLUMNS = [col.title(280), col.id(96, 0.4), col.meta(104), col.num(96), col.meta(120), col.age(80), col.actions(2)]
 
 export function CapabilitiesPage() {
   const { t, i18n } = useTranslation("admin")
@@ -308,7 +308,9 @@ export function CapabilitiesPage() {
         // not missing, it is redundant with the group header — and a dash in
         // this ledger means "unknown".
         source={fromMarketplace ? marketplaceSourceName(marketCap) : ""}
-        deprecatedLabel={fromMarketplace ? t("capabilities.deprecated.badgeTarget") : t("capabilities.deprecated.badgeSource")}
+        availabilityLabel={fromMarketplace && cap.visibility === "workspace"
+          ? t("capabilities.unpublished.badge")
+          : cap.deprecated_at ? t(fromMarketplace ? "capabilities.deprecated.badgeTarget" : "capabilities.deprecated.badgeSource") : ""}
         enabledCount={enabledCount}
         credentials={requiredCredentialsLabel(cap.required_credentials, i18n.language, t("capabilities.credentials.none"))}
         age={fmtAgo(cap.updated_at ?? cap.created_at)}
@@ -584,7 +586,7 @@ function CapabilityRow({
   capability,
   version,
   source,
-  deprecatedLabel,
+  availabilityLabel,
   enabledCount,
   credentials,
   age,
@@ -595,7 +597,7 @@ function CapabilityRow({
   capability: Capability
   version?: string
   source: string
-  deprecatedLabel: string
+  availabilityLabel: string
   enabledCount: number
   credentials: string
   age: string
@@ -613,11 +615,11 @@ function CapabilityRow({
   return (
     <LedgerRow selected={selected} onClick={onOpen} onKeyDown={onKeyDown}>
       <span className="flex min-w-0 items-center gap-2">
-        <span className="shrink-0 truncate font-medium">{capability.name}</span>
+        <span className="min-w-0 truncate font-medium" title={capability.name}>{capability.name}</span>
         <CapabilityTypeBadge type={capability.type} />
-        {capability.deprecated_at && <Badge variant="neutral" dot>{deprecatedLabel}</Badge>}
+        {availabilityLabel && <Badge variant="neutral" className="shrink-0" dot>{availabilityLabel}</Badge>}
         {capability.description && (
-          <span className="min-w-0 truncate text-xs text-fg-muted">· {capability.description}</span>
+          <span className="min-w-0 flex-1 truncate text-xs text-fg-muted">· {capability.description}</span>
         )}
       </span>
       <span className={cnMono(!!version)}>{version ?? "—"}</span>

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -310,7 +310,7 @@ export function CapabilitiesPage() {
         source={fromMarketplace ? marketplaceSourceName(marketCap) : ""}
         availabilityLabel={fromMarketplace && cap.visibility === "workspace"
           ? t("capabilities.unpublished.badge")
-          : cap.deprecated_at ? t(fromMarketplace ? "capabilities.deprecated.badgeTarget" : "capabilities.deprecated.badgeSource") : ""}
+          : cap.deprecated_at ? t("capabilities.deprecated.badgeSource") : ""}
         enabledCount={enabledCount}
         credentials={requiredCredentialsLabel(cap.required_credentials, i18n.language, t("capabilities.credentials.none"))}
         age={fmtAgo(cap.updated_at ?? cap.created_at)}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -6622,8 +6622,9 @@ paths:
       - capabilities
   /api/v1/workspaces/{workspaceID}/capabilities/marketplace-installs:
     get:
-      description: Returns the marketplace capabilities the workspace has installed
-        (as opposed to authored).
+      description: Returns installed capabilities, including unpublished sources,
+        with visibility and bound version metadata. Unpublished sources do not expose
+        later private versions.
       operationId: listDevWorkspaceMarketplaceInstalls
       parameters:
       - description: Workspace UUID

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -3702,6 +3702,7 @@ select distinct
   c.name,
   c.description,
   c.type,
+  c.visibility,
   cv.required_credentials,
   c.workspace_id::text as source_workspace_id,
   src_ws.name as source_workspace_name,
@@ -3727,12 +3728,12 @@ join lateral (
   select id, version, created_at
   from capability_version
   where capability_id = c.id
+    and (c.visibility = 'public' or id = ac.capability_version_id)
   order by created_at desc, version desc
   limit 1
 ) latest on true
 where a.workspace_id = @target_workspace_id::uuid
   and c.workspace_id != @target_workspace_id::uuid
-  and c.visibility = 'public'
   and c.deleted_at is null
 order by c.name asc, cv.version asc;
 

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -10044,6 +10044,7 @@ select distinct
   c.name,
   c.description,
   c.type,
+  c.visibility,
   cv.required_credentials,
   c.workspace_id::text as source_workspace_id,
   src_ws.name as source_workspace_name,
@@ -10069,12 +10070,12 @@ join lateral (
   select id, version, created_at
   from capability_version
   where capability_id = c.id
+    and (c.visibility = 'public' or id = ac.capability_version_id)
   order by created_at desc, version desc
   limit 1
 ) latest on true
 where a.workspace_id = $1::uuid
   and c.workspace_id != $1::uuid
-  and c.visibility = 'public'
   and c.deleted_at is null
 order by c.name asc, cv.version asc
 `
@@ -10084,6 +10085,7 @@ type ListWorkspaceMarketplaceInstallsRow struct {
 	Name                   string             `json:"name"`
 	Description            string             `json:"description"`
 	Type                   string             `json:"type"`
+	Visibility             string             `json:"visibility"`
 	RequiredCredentials    []byte             `json:"required_credentials"`
 	SourceWorkspaceID      string             `json:"source_workspace_id"`
 	SourceWorkspaceName    string             `json:"source_workspace_name"`
@@ -10110,6 +10112,7 @@ func (q *Queries) ListWorkspaceMarketplaceInstalls(ctx context.Context, targetWo
 			&i.Name,
 			&i.Description,
 			&i.Type,
+			&i.Visibility,
 			&i.RequiredCredentials,
 			&i.SourceWorkspaceID,
 			&i.SourceWorkspaceName,

--- a/server/internal/dev/capability_routes.go
+++ b/server/internal/dev/capability_routes.go
@@ -555,7 +555,7 @@ func previewMarketplaceMCP(spec *canonical.MCPSpec) *marketplaceMCPPreview {
 // workspace has installed (as opposed to authored).
 //
 //	@Summary		List workspace marketplace installs
-//	@Description	Returns the marketplace capabilities the workspace has installed (as opposed to authored).
+//	@Description	Returns installed capabilities, including unpublished sources, with visibility and bound version metadata. Unpublished sources do not expose later private versions.
 //	@Tags			capabilities
 //	@ID				listDevWorkspaceMarketplaceInstalls
 //	@Produce		json

--- a/server/internal/store/capabilities.go
+++ b/server/internal/store/capabilities.go
@@ -156,6 +156,7 @@ type MarketplaceInstallRead struct {
 	Name                   string               `json:"name"`
 	Description            string               `json:"description"`
 	Type                   string               `json:"type"`
+	Visibility             string               `json:"visibility"`
 	RequiredCredentials    []RequiredCredential `json:"required_credentials"`
 	SourceWorkspaceID      string               `json:"-"`
 	SourceWorkspaceName    string               `json:"source_workspace_name"`
@@ -1024,7 +1025,7 @@ func marketplaceCapabilityFromRow(row sqlc.ListMarketplaceCapabilitiesRow) Marke
 }
 
 func marketplaceInstallFromRow(row sqlc.ListWorkspaceMarketplaceInstallsRow) MarketplaceInstallRead {
-	return MarketplaceInstallRead{CapabilityID: row.CapabilityID, Name: row.Name, Description: row.Description, Type: row.Type, RequiredCredentials: decodeRequiredCredentials(row.RequiredCredentials), SourceWorkspaceID: row.SourceWorkspaceID, SourceWorkspaceName: row.SourceWorkspaceName, PinnedVersionID: row.PinnedVersionID, PinnedVersion: row.PinnedVersion, DeprecatedAt: pgOptionalTime(row.DeprecatedAt), LatestVersionID: row.LatestVersionID, LatestPublishedVersion: row.LatestPublishedVersion, LatestVersionCreatedAt: pgTime(row.LatestVersionCreatedAt), EnabledAgentCount: row.EnabledAgentCount, FromMarketplace: true}
+	return MarketplaceInstallRead{CapabilityID: row.CapabilityID, Name: row.Name, Description: row.Description, Type: row.Type, Visibility: row.Visibility, RequiredCredentials: decodeRequiredCredentials(row.RequiredCredentials), SourceWorkspaceID: row.SourceWorkspaceID, SourceWorkspaceName: row.SourceWorkspaceName, PinnedVersionID: row.PinnedVersionID, PinnedVersion: row.PinnedVersion, DeprecatedAt: pgOptionalTime(row.DeprecatedAt), LatestVersionID: row.LatestVersionID, LatestPublishedVersion: row.LatestPublishedVersion, LatestVersionCreatedAt: pgTime(row.LatestVersionCreatedAt), EnabledAgentCount: row.EnabledAgentCount, FromMarketplace: true}
 }
 
 func decodeRequiredCredentials(raw []byte) []RequiredCredential {

--- a/server/internal/store/marketplace_unpublished_test.go
+++ b/server/internal/store/marketplace_unpublished_test.go
@@ -1,0 +1,75 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestUnpublishedMarketplaceInstallRemainsManageable(t *testing.T) {
+	ctx := context.Background()
+	st := New(openTestDB(t))
+	ids := mustSeedDevFixture(t, ctx, st)
+	source, err := st.CreateWorkspace(ctx, CreateWorkspaceInput{Name: "Unpublished source", CreatedBy: ids.UserID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	capability, err := st.CreateCapability(ctx, CreateCapabilityInput{
+		WorkspaceID: source.Workspace.ID, CreatorID: ids.UserID,
+		Type: "mcp", Name: "Installed tool", Visibility: "public",
+		InitialVersion: &CreateCapabilityVersionInput{Version: "1.0.0", CreatorID: ids.UserID, Content: map[string]any{}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	versions, err := st.ListCapabilityVersions(ctx, capability.ID)
+	if err != nil || len(versions) != 1 {
+		t.Fatalf("versions = %+v, error = %v", versions, err)
+	}
+	versionID := versions[0].ID
+	if _, err := st.EnableAgentCapability(ctx, ids.ProductAgentID, versionID, nil, PinningModePinned); err != nil {
+		t.Fatal(err)
+	}
+	for _, visibility := range []string{"public", "workspace"} {
+		if visibility == "workspace" {
+			if _, err := st.UnpublishCapability(ctx, source.Workspace.ID, capability.ID); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := st.CreateCapabilityVersion(ctx, CreateCapabilityVersionInput{
+				CapabilityID: capability.ID, Version: "2.0.0", CreatorID: ids.UserID, Content: map[string]any{},
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		installs, err := st.ListWorkspaceMarketplaceInstalls(ctx, ids.WorkspaceID)
+		if err != nil || len(installs) != 1 {
+			t.Fatalf("%s installs = %+v, error = %v", visibility, installs, err)
+		}
+		item := installs[0]
+		if item.CapabilityID != capability.ID || item.Visibility != visibility || item.PinnedVersionID != versionID || item.LatestVersionID != versionID || item.LatestPublishedVersion != "1.0.0" || item.EnabledAgentCount != 1 {
+			t.Fatalf("unexpected %s install metadata: %+v", visibility, item)
+		}
+	}
+	market, err := st.ListMarketplaceCapabilities(ctx, ids.WorkspaceID)
+	if err != nil || len(market) != 0 {
+		t.Fatalf("unpublished source exposed in marketplace: %+v, error = %v", market, err)
+	}
+	unrelated, err := st.ListWorkspaceMarketplaceInstalls(ctx, source.Workspace.ID)
+	if err != nil || len(unrelated) != 0 {
+		t.Fatalf("install exposed outside consuming workspace: %+v, error = %v", unrelated, err)
+	}
+	agents, err := st.ListEnabledAgents(ctx, ids.WorkspaceID, capability.ID)
+	if err != nil || len(agents) != 1 || agents[0].AgentID != ids.ProductAgentID || agents[0].CapabilityVersionID != versionID {
+		t.Fatalf("binding changed after unpublishing: %+v, error = %v", agents, err)
+	}
+	removed, err := st.UninstallWorkspaceMarketplaceCapability(ctx, ids.WorkspaceID, capability.ID)
+	if err != nil || removed != 1 {
+		t.Fatalf("uninstall = %d, error = %v", removed, err)
+	}
+	installs, err := st.ListWorkspaceMarketplaceInstalls(ctx, ids.WorkspaceID)
+	if err != nil || len(installs) != 0 {
+		t.Fatalf("install remains after removal: %+v, error = %v", installs, err)
+	}
+	if _, err := st.GetCapability(ctx, capability.ID); err != nil {
+		t.Fatalf("uninstall changed source capability: %v", err)
+	}
+}


### PR DESCRIPTION
When a publisher unpublished a capability, a workspace that already depended on it lost the marketplace entry and its removal controls. Keep that existing dependency visible with an Unpublished state, its bound version, named Agents and uninstall action. Newly created Agents cannot select the unavailable source.

This PR changes existing-install management only. Public discovery and install/upgrade authorization stay unchanged, newer private versions remain hidden, and runtime bindings are preserved.

Validation:
- `make check`, the production web build, OpenAPI regeneration and SQLC checks passed.
- Isolated remote PostgreSQL tests passed for unpublish/version visibility and uninstall/source preservation; local Docker stayed stopped.
- CUA verified the real candidate removal flow and readable unpublished MCP/Skill/Bundle details at the supported 320px width.
- Fresh independent blind review found no blockers after reviewing the full diff and testing English/Chinese layouts, published/deprecated states, Agent navigation and removal on isolated fixtures. Its own PostgreSQL checks skipped; the separate database run above passed.
