### PR TITLE
fix: count conversation message limits in Unicode characters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,8 @@ description and keep ownership on the side listed here.
   unpublishing. Their installation metadata reports source visibility and only
   bound versions while private; marketplace discovery and new installs still
   require a published source.
+- Conversation user-message limits count Unicode code points after trimming
+  surrounding whitespace, not UTF-8 bytes. Keep route and store validation aligned.
 - Agent capability upgrades accept private capabilities from the Agent's own
   workspace; cross-workspace upgrades still require a public, available source.
 - The server owns auth, workspaces, agent records, runtime bindings, run

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -414,6 +414,15 @@ definitions:
       plaintext:
         type: string
     type: object
+  dev.createConversationUserMessageBody:
+    properties:
+      content:
+        type: string
+      mentioned_agent_ids:
+        items:
+          type: string
+        type: array
+    type: object
   dev.createCredentialKindBody:
     properties:
       code:
@@ -3431,6 +3440,71 @@ paths:
               type: string
             type: object
       summary: Configure a conversation's external reference
+      tags:
+      - conversations
+  /api/v1/conversations/{conversationID}/messages:
+    post:
+      consumes:
+      - application/json
+      description: Accepts 1-32000 Unicode code points after trimming surrounding
+        whitespace.
+      parameters:
+      - description: Conversation UUID
+        in: path
+        name: conversationID
+        required: true
+        type: string
+      - description: Message and optional Agent mentions
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dev.createConversationUserMessageBody'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Message and dispatched Agent run
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Invalid body or UUID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Workspace membership required
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Conversation not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "422":
+          description: Invalid content or Agent mention
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Message could not be sent
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Conversation messages unavailable
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Send a conversation message
       tags:
       - conversations
   /api/v1/conversations/{conversationID}/runs/{runID}/start:

--- a/server/internal/dev/conversation_message_length_test.go
+++ b/server/internal/dev/conversation_message_length_test.go
@@ -1,0 +1,50 @@
+package dev
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestConversationUserMessageUnicodeLength(t *testing.T) {
+	router := chi.NewRouter()
+	RegisterRoutesWithStore(router, stubRuntimeStore{})
+	for _, tc := range []struct {
+		name, content string
+		status        int
+	}{
+		{"ASCII limit", strings.Repeat("a", 32000), http.StatusCreated},
+		{"reported Chinese message", strings.Repeat("中", 11000), http.StatusCreated},
+		{"Chinese limit", " \n" + strings.Repeat("中", 32000) + "\t", http.StatusCreated},
+		{"emoji limit", strings.Repeat("😀", 32000), http.StatusCreated},
+		{"ASCII over limit", strings.Repeat("a", 32001), http.StatusUnprocessableEntity},
+		{"Chinese over limit", strings.Repeat("中", 32001), http.StatusUnprocessableEntity},
+		{"blank", " \n\t", http.StatusUnprocessableEntity},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(createConversationUserMessageBody{Content: tc.content})
+			if err != nil {
+				t.Fatal(err)
+			}
+			res := serveDevRoute(t, router, http.MethodPost, "/api/v1/conversations/"+testConversationID+"/messages", string(body))
+			if res.Code != tc.status {
+				t.Fatalf("status = %d, want %d", res.Code, tc.status)
+			}
+			if tc.status == http.StatusCreated {
+				var result struct {
+					Message store.MessageRead `json:"message"`
+				}
+				if err := json.Unmarshal(res.Body.Bytes(), &result); err != nil {
+					t.Fatal(err)
+				}
+				if result.Message.Content != strings.TrimSpace(tc.content) {
+					t.Fatal("accepted message content changed")
+				}
+			}
+		})
+	}
+}

--- a/server/internal/dev/routes_conversations.go
+++ b/server/internal/dev/routes_conversations.go
@@ -7,6 +7,7 @@ import (
 
 	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
 
@@ -135,6 +136,23 @@ type createConversationUserMessageBody struct {
 	MentionedAgentIDs []string `json:"mentioned_agent_ids"`
 }
 
+// createConversationUserMessage sends a user message to a conversation.
+//
+// @Summary Send a conversation message
+// @Description Accepts 1-32000 Unicode code points after trimming surrounding whitespace.
+// @Tags conversations
+// @Accept json
+// @Produce json
+// @Param conversationID path string true "Conversation UUID"
+// @Param body body createConversationUserMessageBody true "Message and optional Agent mentions"
+// @Success 201 {object} map[string]interface{} "Message and dispatched Agent run"
+// @Failure 400 {object} map[string]string "Invalid body or UUID"
+// @Failure 403 {object} map[string]string "Workspace membership required"
+// @Failure 404 {object} map[string]string "Conversation not found"
+// @Failure 422 {object} map[string]string "Invalid content or Agent mention"
+// @Failure 500 {object} map[string]string "Message could not be sent"
+// @Failure 503 {object} map[string]string "Conversation messages unavailable"
+// @Router /api/v1/conversations/{conversationID}/messages [post]
 func createConversationUserMessage(runtimeStore RuntimeStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if runtimeStore == nil {
@@ -154,7 +172,7 @@ func createConversationUserMessage(runtimeStore RuntimeStore) http.HandlerFunc {
 			}
 		}
 		content := strings.TrimSpace(req.Content)
-		if content == "" || len(content) > 32000 {
+		if content == "" || utf8.RuneCountInString(content) > 32000 {
 			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": "content must be 1-32000 characters"})
 			return
 		}

--- a/server/internal/store/conversation_message_length_test.go
+++ b/server/internal/store/conversation_message_length_test.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestConversationUserMessageUnicodeLength(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	s := New(db)
+	ids := mustSeedDevFixture(t, ctx, s)
+	accepted := 0
+	for _, tc := range []struct {
+		name, content string
+		valid         bool
+	}{
+		{"ASCII limit", strings.Repeat("a", 32000), true},
+		{"reported Chinese message", strings.Repeat("中", 11000), true},
+		{"Chinese limit", " \n" + strings.Repeat("中", 32000) + "\t", true},
+		{"emoji limit", strings.Repeat("😀", 32000), true},
+		{"ASCII over limit", strings.Repeat("a", 32001), false},
+		{"Chinese over limit", strings.Repeat("中", 32001), false},
+		{"blank", " \n\t", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := s.SendUserMessageToConversation(ctx, SendUserMessageToConversationInput{
+				ConversationID: ids.ConversationID, UserID: ids.UserID, Content: tc.content,
+			})
+			if !tc.valid {
+				if !errors.Is(err, ErrInvalidInput) {
+					t.Fatalf("error = %v, want ErrInvalidInput", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Message.Content != strings.TrimSpace(tc.content) || len(result.RunIDs) != 0 {
+				t.Fatal("accepted message changed or unexpectedly dispatched an Agent")
+			}
+			accepted++
+		})
+	}
+	var persisted int
+	if err := db.QueryRow(ctx, "SELECT count(*) FROM messages WHERE conversation_id = $1", ids.ConversationID).Scan(&persisted); err != nil {
+		t.Fatal(err)
+	}
+	if persisted != accepted {
+		t.Fatalf("persisted %d messages, want %d", persisted, accepted)
+	}
+}

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/audit"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
@@ -6685,7 +6686,7 @@ func (s *Store) SendUserMessageToConversation(ctx context.Context, input SendUse
 		return result, err
 	}
 	content := strings.TrimSpace(input.Content)
-	if content == "" || len(content) > 32000 {
+	if content == "" || utf8.RuneCountInString(content) > 32000 {
 		return result, ErrInvalidInput
 	}
 


### PR DESCRIPTION
A Chinese message of 11,000 characters was rejected by the documented 32,000-character limit because both the HTTP route and store counted UTF-8 bytes. Count Unicode code points after the existing whitespace trim so all writing systems use the same limit.

This PR only changes conversation user-message length validation. ASCII limits, blank rejection, content, mention handling, authorization, persistence and error responses retain their existing behavior. Scheduled tasks and token budgets are outside scope.

Validation:
- `make check`, OpenAPI regeneration and focused HTTP tests passed.
- Isolated remote PostgreSQL tests passed for 32,000-character ASCII/Chinese/emoji messages, 11,000 Chinese characters, whitespace, over-limit rejection and exact persistence.
- Fresh independent blind review found no blockers. It independently passed migrations, the full store suite, and supplementary HTTP/store Unicode, mention and authorization checks using Docker-free PostgreSQL 16.4.
- A supplementary full database-backed HTTP suite had the same 29 failing tests/subtests on the candidate and baseline; no candidate-only failures. Local Docker remained stopped.
