### PR TITLE
fix: return to Agent creation after model setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -505,6 +505,9 @@ split relevant pieces out first rather than growing the file further.
 - Inbound messages with `sender_type=external` are user turns. Web conversation
   presenters must not assign them the Agent identity or imply they are from the
   current viewer.
+- Model setup reached from Agent creation must offer a return to the saved
+  name, description, and instructions. Both directions replace the current
+  history entry; closing or completing creation consumes its intent and draft.
 - Cross-page utilities (date/time/duration formatting, status labels,
   etc.) live once in `apps/web/src/lib/`. Do not reimplement inside a page
   component "because it's just a few lines" — that is how

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -13,6 +13,7 @@
     },
     "actions": {
       "addModel": "Add model",
+      "continueAgentCreation": "Continue creating Agent",
       "importModels": "Import models",
       "test": "Test",
       "edit": "Edit",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -13,6 +13,7 @@
     },
     "actions": {
       "addModel": "新建模型",
+      "continueAgentCreation": "继续创建 Agent",
       "importModels": "导入模型",
       "test": "测试连接",
       "edit": "编辑",

--- a/apps/web/src/lib/admin-router.ts
+++ b/apps/web/src/lib/admin-router.ts
@@ -104,6 +104,7 @@ function parseRoute(search: string): AppRoute {
 }
 
 export interface NavigateOptions {
+  replace?: boolean
   id?: string | null
   tab?: string | null
   /** "full" lifts the detail rail into its expanded panel. */
@@ -175,7 +176,7 @@ export function useNavigateAdmin() {
     setOptionalParam(url, "from", opts?.from)
     setOptionalParam(url, "pendingCapability", opts?.pendingCapability)
     setOneShotParam(url, "focus", opts?.focus)
-    window.history.pushState({}, "", url.toString())
+    window.history[opts?.replace ? "replaceState" : "pushState"]({}, "", url.toString())
     window.dispatchEvent(new Event("admin:navigate"))
   }, [])
 }
@@ -220,7 +221,7 @@ export function navigateAdmin(next: AdminView, opts?: NavigateOptions) {
   setOptionalParam(url, "from", opts?.from)
   setOptionalParam(url, "pendingCapability", opts?.pendingCapability)
   setOneShotParam(url, "focus", opts?.focus)
-  window.history.pushState({}, "", url.toString())
+  window.history[opts?.replace ? "replaceState" : "pushState"]({}, "", url.toString())
   window.dispatchEvent(new Event("admin:navigate"))
 }
 

--- a/apps/web/src/lib/agent-create-return.ts
+++ b/apps/web/src/lib/agent-create-return.ts
@@ -1,0 +1,29 @@
+import { useState, type MouseEvent } from "react"
+
+export function replaceAgentModelSetup(event: MouseEvent<HTMLAnchorElement>) {
+  if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+  event.preventDefault()
+  window.location.replace(event.currentTarget.href)
+}
+
+export function hasAgentCreateReturn(): boolean {
+  return new URLSearchParams(window.location.search).get("return_to") === "agents.create"
+}
+
+export function useAgentCreateDialog() {
+  const [open, setOpen] = useState(() =>
+    hasAgentCreateReturn() && new URLSearchParams(window.location.search).get("focus") === "create",
+  )
+
+  function setCreateOpen(next: boolean) {
+    setOpen(next)
+    if (next || !hasAgentCreateReturn()) return
+    const url = new URL(window.location.href)
+    for (const key of ["focus", "return_to", "agent_name", "agent_description", "agent_prompt"]) {
+      url.searchParams.delete(key)
+    }
+    window.history.replaceState(window.history.state, "", url.toString())
+  }
+
+  return [open, setCreateOpen] as const
+}

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -21,6 +21,7 @@ import {
   TabsTrigger,
 } from "../../components/ui/tabs"
 import { useAdminView, useAppRoute } from "../../lib/admin-router"
+import { useAgentCreateDialog } from "../../lib/agent-create-return"
 import { ApiError } from "../../lib/api-client"
 import { createAgentConversation } from "../../lib/api-conversations"
 import {
@@ -93,7 +94,7 @@ export function AgentsPage() {
   const wid = useWorkspaceId()
   const [keyword, setKeyword] = useState("")
   const [connectorFilter, setConnectorFilter] = useState("")
-  const [createOpen, setCreateOpen] = useState(false)
+  const [createOpen, setCreateOpen] = useAgentCreateDialog()
   const [editAgent, setEditAgent] = useState<Agent | null>(null)
   const [cloneAgent, setCloneAgent] = useState<Agent | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<Agent | null>(null)

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -21,6 +21,7 @@ import { AgentInstructionsField } from "./agents/AgentInstructionsField"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
 import { cn } from "../../lib/utils"
+import { replaceAgentModelSetup } from "../../lib/agent-create-return"
 import { agentCodexModeOf, type CodexCollaborationMode } from "../../lib/agent-view-model"
 import {
   modelProtocols,
@@ -739,9 +740,9 @@ export function CreateAgentDialog({
     url.searchParams.set("admin", target)
     url.searchParams.delete("id")
     url.searchParams.set("return_to", "agents.create")
-    if (name.trim()) url.searchParams.set("agent_name", name.trim())
-    if (description.trim()) url.searchParams.set("agent_description", description.trim())
-    if (systemPrompt.trim()) url.searchParams.set("agent_prompt", systemPrompt.trim())
+    url.searchParams.set("agent_name", name)
+    url.searchParams.set("agent_description", description)
+    url.searchParams.set("agent_prompt", systemPrompt)
     return `${url.pathname}${url.search}${url.hash}`
   }
 
@@ -1736,7 +1737,7 @@ function DependencyCard({ title, description, href, cta }: { title: string; desc
       <p className="text-sm font-medium text-fg">{title}</p>
       <p className="text-xs text-fg-muted">{description}</p>
       <Button variant="link" size="sm" className="mt-1 px-0" asChild>
-        <a href={href}>
+        <a href={href} onClick={replaceAgentModelSetup}>
           {cta} <ArrowUpRight strokeWidth={1.5} aria-hidden="true" />
         </a>
       </Button>

--- a/apps/web/src/pages/admin/ModelsPage.tsx
+++ b/apps/web/src/pages/admin/ModelsPage.tsx
@@ -6,7 +6,7 @@
  */
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { AlertTriangle, Database, Download, Loader2, Plus } from "lucide-react"
+import { AlertTriangle, ArrowLeft, Database, Download, Loader2, Plus } from "lucide-react"
 
 import { AdminLayout } from "../../components/layout/AdminLayout"
 import { PageHeader } from "../../components/layout/PageHeader"
@@ -24,6 +24,8 @@ import { EmptyState } from "../../components/ui/empty-state"
 import { ErrorState } from "../../components/ui/error-state"
 import { Skeleton } from "../../components/ui/skeleton"
 import { ApiError } from "../../lib/api-client"
+import { navigateAdmin } from "../../lib/admin-router"
+import { hasAgentCreateReturn } from "../../lib/agent-create-return"
 import {
   useBackgroundTestModels,
   useBulkDeleteModels,
@@ -307,16 +309,24 @@ export function ModelsPage() {
 
   const pageTitle = t("models.page.title")
   const hasModels = allModels.length > 0
+  const returningToAgent = hasAgentCreateReturn()
 
   return (
     <AdminLayout activeMenu="models" fullBleed>
       <div className="flex min-h-0 flex-1 flex-col">
         <PageHeader
-          className="static mx-0 mb-0"
+          className={returningToAgent ? "static mx-0 mb-0 h-auto min-h-16 flex-wrap py-3" : "static mx-0 mb-0"}
+          actionClassName={returningToAgent ? "min-w-0 shrink flex-wrap justify-end" : undefined}
           title={pageTitle}
           subtitleFor="models.page.title"
           action={
             <>
+              {returningToAgent && (
+                <Button variant="outline" onClick={() => navigateAdmin("agents", { focus: "create", replace: true })}>
+                  <ArrowLeft strokeWidth={1.5} aria-hidden="true" />
+                  {t("models.actions.continueAgentCreation")}
+                </Button>
+              )}
               {/* A filter, not a navigation control: every other ledger page
                   narrows itself with `FilterMenu`, and the action slot is for
                   what you can do here. */}


### PR DESCRIPTION
Agent creation currently sends users to Models when a model is missing, but offers no explicit way back to the draft. This candidate adds a return action and preserves the existing name, description, and instructions, including empty and multiline values.

Draft: **do not merge**. The independent review reproduced completed drafts returning through older browser-history entries after an intermediate Settings visit. Replacing the immediate history entry does not provide reliable consumption of the creation intent. The draft lifetime needs a bounded design before this change is ready.

Scope is limited to the missing-model detour and draft consumption. Model configuration, credentials, probing, runtimes, and ordinary edit/clone behavior are excluded. Avoid extending this into a general router rewrite.

Validation: `make check` and the web build pass. Browser checks cover direct returns, repeated detours, empty/multiline fields, cancel/Escape, and successful creation with a synthetic model. The independent blind review has one unresolved history/draft blocker. No live model inference was needed; database checks skip locally with Docker stopped.
