### PR TITLE
Fix persisted Skills.sh installation status

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -422,6 +422,8 @@ description and keep ownership on the side listed here.
 - Skills.sh installed state is read from persisted version provenance within
   the workspace, including older versions and deprecated capabilities. Deleting
   the capability removes that installed state; names are not registry identities.
+  Refresh it on directory entry and after installation; mutation responses do
+  not establish the current installed mapping.
 - Secret disabling is authorized by `secrets.management_workspace_id`, set
   from the creation workspace. This ownership must not restrict shared reads
   or runtime use. Legacy rows inherit unambiguous creation metadata or runtime

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -419,6 +419,9 @@ description and keep ownership on the side listed here.
 - Workspace run search matches run IDs, Agent names/slugs, and conversation IDs
   as case-insensitive literal text before pagination. Page rows and totals use
   the same search, status, and workspace filters.
+- Skills.sh installed state is read from persisted version provenance within
+  the workspace, including older versions and deprecated capabilities. Deleting
+  the capability removes that installed state; names are not registry identities.
 - Secret disabling is authorized by `secrets.management_workspace_id`, set
   from the creation workspace. This ownership must not restrict shared reads
   or runtime use. Legacy rows inherit unambiguous creation metadata or runtime

--- a/apps/web/src/lib/api-skills.ts
+++ b/apps/web/src/lib/api-skills.ts
@@ -137,6 +137,8 @@ export function useInstalledSkills(workspaceID: string | null) {
       ? apiRequest<Record<string, string>>(`/api/v1/workspaces/${encodeURIComponent(workspaceID)}/skills/installed`)
       : Promise.resolve({} as Record<string, string>),
     retry: noUnreachableRetry,
+    // Recheck on entry, including changes made from another page or session.
+    staleTime: 0,
   })
 }
 
@@ -148,12 +150,9 @@ export function useInstallSkill(workspaceID: string | null) {
       return installSkill(workspaceID, skill)
     },
     retry: noUnreachableRetry,
-    onSuccess: async (result, skill) => {
+    onSuccess: async (result) => {
       const installedWorkspaceID = result.capability.workspace_id
       await qc.cancelQueries({ queryKey: KEY_INSTALLED_SKILLS(installedWorkspaceID) })
-      qc.setQueryData<Record<string, string>>(KEY_INSTALLED_SKILLS(installedWorkspaceID), (current) => ({
-        ...current, [skill.id]: result.capability.id,
-      }))
       void qc.invalidateQueries({ queryKey: KEY_CAPABILITIES_WORKSPACE(installedWorkspaceID) })
       void qc.invalidateQueries({ queryKey: ["admin", "capability"] })
       void qc.invalidateQueries({

--- a/apps/web/src/lib/api-skills.ts
+++ b/apps/web/src/lib/api-skills.ts
@@ -148,8 +148,9 @@ export function useInstallSkill(workspaceID: string | null) {
       return installSkill(workspaceID, skill)
     },
     retry: noUnreachableRetry,
-    onSuccess: (result, skill) => {
+    onSuccess: async (result, skill) => {
       const installedWorkspaceID = result.capability.workspace_id
+      await qc.cancelQueries({ queryKey: KEY_INSTALLED_SKILLS(installedWorkspaceID) })
       qc.setQueryData<Record<string, string>>(KEY_INSTALLED_SKILLS(installedWorkspaceID), (current) => ({
         ...current, [skill.id]: result.capability.id,
       }))

--- a/apps/web/src/lib/api-skills.ts
+++ b/apps/web/src/lib/api-skills.ts
@@ -39,6 +39,7 @@ export interface InstallSkillResponse {
 }
 
 export const KEY_SKILLS_CATALOG = ["admin", "skillsCatalog", "v2"] as const
+const KEY_INSTALLED_SKILLS = (workspaceID: string) => [...KEY_CAPABILITIES_WORKSPACE(workspaceID), "skillsInstalled"] as const
 
 async function listSkillsCatalog(): Promise<SkillsCatalogResponse> {
   const res = await fetch(SKILLS_CATALOG_URL, { headers: { Accept: "application/json" } })
@@ -129,6 +130,16 @@ export function useSkillsCatalog() {
   })
 }
 
+export function useInstalledSkills(workspaceID: string | null) {
+  return useQuery({
+    queryKey: KEY_INSTALLED_SKILLS(workspaceID ?? "_none"),
+    queryFn: () => workspaceID
+      ? apiRequest<Record<string, string>>(`/api/v1/workspaces/${encodeURIComponent(workspaceID)}/skills/installed`)
+      : Promise.resolve({} as Record<string, string>),
+    retry: noUnreachableRetry,
+  })
+}
+
 export function useInstallSkill(workspaceID: string | null) {
   const qc = useQueryClient()
   return useMutation({
@@ -137,8 +148,11 @@ export function useInstallSkill(workspaceID: string | null) {
       return installSkill(workspaceID, skill)
     },
     retry: noUnreachableRetry,
-    onSuccess: (result) => {
+    onSuccess: (result, skill) => {
       if (!workspaceID) return
+      qc.setQueryData<Record<string, string>>(KEY_INSTALLED_SKILLS(workspaceID), (current) => ({
+        ...current, [skill.id]: result.capability.id,
+      }))
       void qc.invalidateQueries({ queryKey: KEY_CAPABILITIES_WORKSPACE(workspaceID) })
       void qc.invalidateQueries({ queryKey: ["admin", "capability"] })
       void qc.invalidateQueries({

--- a/apps/web/src/lib/api-skills.ts
+++ b/apps/web/src/lib/api-skills.ts
@@ -149,14 +149,14 @@ export function useInstallSkill(workspaceID: string | null) {
     },
     retry: noUnreachableRetry,
     onSuccess: (result, skill) => {
-      if (!workspaceID) return
-      qc.setQueryData<Record<string, string>>(KEY_INSTALLED_SKILLS(workspaceID), (current) => ({
+      const installedWorkspaceID = result.capability.workspace_id
+      qc.setQueryData<Record<string, string>>(KEY_INSTALLED_SKILLS(installedWorkspaceID), (current) => ({
         ...current, [skill.id]: result.capability.id,
       }))
-      void qc.invalidateQueries({ queryKey: KEY_CAPABILITIES_WORKSPACE(workspaceID) })
+      void qc.invalidateQueries({ queryKey: KEY_CAPABILITIES_WORKSPACE(installedWorkspaceID) })
       void qc.invalidateQueries({ queryKey: ["admin", "capability"] })
       void qc.invalidateQueries({
-        queryKey: KEY_CAPABILITY_VERSIONS(workspaceID, result.capability.id),
+        queryKey: KEY_CAPABILITY_VERSIONS(installedWorkspaceID, result.capability.id),
       })
     },
   })

--- a/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
@@ -30,7 +30,7 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
   const installedQ = useInstalledSkills(workspaceID)
   const installMut = useInstallSkill(workspaceID)
   const installed = installedQ.data ?? {}
-  const loading = catalogQ.isLoading || installedQ.isLoading
+  const loading = catalogQ.isPending || installedQ.isPending
   const loadError = catalogQ.error ?? installedQ.error
   const [success, setSuccess] = useState<{ name: string; capabilityID: string } | null>(null)
   const numberFormatter = useMemo(() => new Intl.NumberFormat(i18n.language), [i18n.language])

--- a/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
@@ -30,7 +30,7 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
   const installedQ = useInstalledSkills(workspaceID)
   const installMut = useInstallSkill(workspaceID)
   const installed = installedQ.data ?? {}
-  const loading = catalogQ.isPending || installedQ.isPending
+  const loading = catalogQ.isPending || installedQ.isPending || installedQ.isFetching || installedQ.isPaused
   const loadError = catalogQ.error ?? installedQ.error
   const [success, setSuccess] = useState<{ name: string; capabilityID: string } | null>(null)
   const numberFormatter = useMemo(() => new Intl.NumberFormat(i18n.language), [i18n.language])

--- a/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
@@ -8,7 +8,7 @@ import { EmptyState } from "../../../components/ui/empty-state"
 import { ErrorState } from "../../../components/ui/error-state"
 import { Ledger, LedgerHeader, LedgerId, LedgerNum, LedgerRow, col } from "../../../components/ui/ledger"
 import { Skeleton } from "../../../components/ui/skeleton"
-import { useInstallSkill, useSkillsCatalog, type SkillsCatalogItem } from "../../../lib/api-skills"
+import { useInstalledSkills, useInstallSkill, useSkillsCatalog, type SkillsCatalogItem } from "../../../lib/api-skills"
 import { useWorkspaceId } from "../../../lib/workspace"
 import { InlineNotice } from "./notices"
 import { SkillInstallErrorDialog } from "./SkillInstallErrorDialog"
@@ -27,8 +27,11 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
   const workspaceID = useWorkspaceId()
   const directoryRef = useRef<HTMLDivElement>(null)
   const catalogQ = useSkillsCatalog()
+  const installedQ = useInstalledSkills(workspaceID)
   const installMut = useInstallSkill(workspaceID)
-  const [installed, setInstalled] = useState<Record<string, string>>({})
+  const installed = installedQ.data ?? {}
+  const loading = catalogQ.isLoading || installedQ.isLoading
+  const loadError = catalogQ.error ?? installedQ.error
   const [success, setSuccess] = useState<{ name: string; capabilityID: string } | null>(null)
   const numberFormatter = useMemo(() => new Intl.NumberFormat(i18n.language), [i18n.language])
 
@@ -46,10 +49,9 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
   const failedSkill = installMut.error ? installMut.variables : null
 
   const install = (skill: SkillsCatalogItem) => {
-    if (!canImport || installed[skill.id]) return
+    if (!canImport || loading || loadError || installed[skill.id]) return
     installMut.mutate(skill, {
       onSuccess: (result) => {
-        setInstalled((current) => ({ ...current, [skill.id]: result.capability.id }))
         setSuccess({ name: result.capability.name, capabilityID: result.capability.id })
       },
     })
@@ -57,7 +59,7 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
 
   return (
     <div ref={directoryRef} tabIndex={-1} className="flex min-h-0 flex-1 flex-col" data-testid="skills-directory">
-      {success ? (
+      {success && Object.values(installed).includes(success.capabilityID) ? (
         <InlineNotice
           tone="success"
           className="border-b border-line px-4 py-2"
@@ -72,13 +74,13 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
         </InlineNotice>
       ) : null}
 
-      {catalogQ.error ? (
+      {loadError ? (
         <div className="px-4 pt-4">
           <ErrorState
             title={t("capabilities.skillsDirectory.loadError.title")}
             description={t("capabilities.skillsDirectory.loadError.description")}
-            detail={catalogQ.error instanceof Error ? catalogQ.error.message : undefined}
-            onRetry={() => void catalogQ.refetch()}
+            detail={loadError instanceof Error ? loadError.message : undefined}
+            onRetry={() => { void catalogQ.refetch(); void installedQ.refetch() }}
           />
         </div>
       ) : null}
@@ -96,7 +98,7 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
         />
       ) : null}
 
-      {catalogQ.isLoading ? (
+      {loading ? (
         <div className="px-4 pt-3" data-testid="skills-directory-loading">
           <div className="mb-3 h-7 border-b border-line" />
           {Array.from({ length: 6 }).map((_, index) => (
@@ -108,13 +110,13 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
             </div>
           ))}
         </div>
-      ) : filtered.length === 0 && !catalogQ.error ? (
+      ) : filtered.length === 0 && !loadError ? (
         <EmptyState
           icon={PackageCheck}
           title={t("capabilities.skillsDirectory.empty.title")}
           description={t("capabilities.skillsDirectory.empty.description")}
         />
-      ) : filtered.length > 0 ? (
+      ) : filtered.length > 0 && !loadError ? (
         <Ledger columns={SKILL_COLUMNS} role="listbox" aria-label={t("capabilities.tabs.skills")} data-testid="skills-marketplace-grid">
           <LedgerHeader>
             <span className="text-right">#</span>

--- a/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
@@ -59,7 +59,7 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
 
   return (
     <div ref={directoryRef} tabIndex={-1} className="flex min-h-0 flex-1 flex-col" data-testid="skills-directory">
-      {success && Object.values(installed).includes(success.capabilityID) ? (
+      {success && !loading && !loadError && Object.values(installed).includes(success.capabilityID) ? (
         <InlineNotice
           tone="success"
           className="border-b border-line px-4 py-2"

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -8850,6 +8850,63 @@ paths:
       summary: Install a Skills.sh Skill as a capability
       tags:
       - capabilities
+  /api/v1/workspaces/{workspaceID}/skills/installed:
+    get:
+      operationId: listSkillsDirectoryInstalls
+      parameters:
+      - description: Workspace UUID
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Registry ID to workspace capability ID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Service Unavailable
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: List installed Skills.sh skills
+      tags:
+      - capabilities
   /api/v1/workspaces/{workspaceID}/spec/fragments:
     get:
       description: Returns spec fragments visible to the workspace. Optional source/tag

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -3608,6 +3608,19 @@ where c.workspace_id = @workspace_id::uuid
   and coalesce(cv.source_payload->>'catalog_id', '') <> ''
 order by cv.source_payload->>'catalog_id', cv.created_at desc, cv.id desc;
 
+-- name: ListSkillsDirectoryInstalls :many
+select distinct on (cv.source_payload->>'registry_id')
+  coalesce(cv.source_payload->>'registry_id', '')::text as registry_id,
+  c.id::text as capability_id
+from capability c
+join capability_version cv on cv.capability_id = c.id
+where c.workspace_id = @workspace_id::uuid
+  and c.type = 'skill'
+  and c.deleted_at is null
+  and cv.source_payload->>'registry' = 'skills.sh'
+  and coalesce(cv.source_payload->>'registry_id', '') <> ''
+order by cv.source_payload->>'registry_id', cv.created_at desc, cv.id desc;
+
 -- name: UpdateCapability :one
 update capability
 set name = @name,

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -9103,6 +9103,45 @@ func (q *Queries) ListSecretsForWorkspace(ctx context.Context, arg ListSecretsFo
 	return items, nil
 }
 
+const listSkillsDirectoryInstalls = `-- name: ListSkillsDirectoryInstalls :many
+select distinct on (cv.source_payload->>'registry_id')
+  coalesce(cv.source_payload->>'registry_id', '')::text as registry_id,
+  c.id::text as capability_id
+from capability c
+join capability_version cv on cv.capability_id = c.id
+where c.workspace_id = $1::uuid
+  and c.type = 'skill'
+  and c.deleted_at is null
+  and cv.source_payload->>'registry' = 'skills.sh'
+  and coalesce(cv.source_payload->>'registry_id', '') <> ''
+order by cv.source_payload->>'registry_id', cv.created_at desc, cv.id desc
+`
+
+type ListSkillsDirectoryInstallsRow struct {
+	RegistryID   string `json:"registry_id"`
+	CapabilityID string `json:"capability_id"`
+}
+
+func (q *Queries) ListSkillsDirectoryInstalls(ctx context.Context, workspaceID pgtype.UUID) ([]ListSkillsDirectoryInstallsRow, error) {
+	rows, err := q.db.Query(ctx, listSkillsDirectoryInstalls, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListSkillsDirectoryInstallsRow{}
+	for rows.Next() {
+		var i ListSkillsDirectoryInstallsRow
+		if err := rows.Scan(&i.RegistryID, &i.CapabilityID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listStaleFeishuPermissionInflightCards = `-- name: ListStaleFeishuPermissionInflightCards :many
 select id::text                  as conversation_id,
        workspace_id::text        as workspace_id,

--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -45,6 +45,7 @@ type RuntimeStore interface {
 	RegisterWorkspaceRuntimeCredential(ctx context.Context, input store.RegisterWorkspaceRuntimeCredentialInput) (store.SecretRead, error)
 	PatchWorkspaceSettings(ctx context.Context, workspaceID string) (store.WorkspaceSettingsRead, error)
 	ListCapabilities(ctx context.Context, workspaceID string, filter store.ListCapabilityFilter) ([]store.CapabilityRead, error)
+	ListSkillsDirectoryInstalls(ctx context.Context, workspaceID string) (map[string]string, error)
 	ListMarketplaceCapabilities(ctx context.Context, targetWorkspaceID string) ([]store.MarketplaceCapabilityRead, error)
 	ListWorkspaceMarketplaceInstalls(ctx context.Context, targetWorkspaceID string) ([]store.MarketplaceInstallRead, error)
 	CountInstalls(ctx context.Context, sourceCapabilityID string) (int64, error)
@@ -648,6 +649,7 @@ func RegisterRoutesWithStore(r chi.Router, runtimeStore RuntimeStore, opts ...Ro
 			// the all-or-nothing materialization.
 			r.Post("/workspaces/{workspaceID}/capabilities/import/preview", previewCapabilityImport(runtimeStore, cfg.blobStore))
 			r.Post("/workspaces/{workspaceID}/capabilities/import/commit", commitCapabilityImport(runtimeStore, cfg.blobStore))
+			r.Get("/workspaces/{workspaceID}/skills/installed", listSkillsDirectoryInstalls(runtimeStore))
 			r.Post("/workspaces/{workspaceID}/skills/install", installSkillFromRegistry(runtimeStore, cfg.blobStore, cfg.skillInstallRunner, cfg.skillInstallHTTPClient))
 			r.Post("/workspaces/{workspaceID}/capabilities/plugins/install", installPlugin(runtimeStore))
 			// Plugin client bundle serving — browser fetches the built

--- a/server/internal/dev/skills_directory_routes.go
+++ b/server/internal/dev/skills_directory_routes.go
@@ -1,0 +1,33 @@
+package dev
+
+import "net/http"
+
+// listSkillsDirectoryInstalls returns persisted Skills.sh installation identities.
+//
+//	@Summary	List installed Skills.sh skills
+//	@Tags		capabilities
+//	@ID			listSkillsDirectoryInstalls
+//	@Produce	json
+//	@Param		workspaceID	path	string	true	"Workspace UUID"
+//	@Success	200	{object}	map[string]string	"Registry ID to workspace capability ID"
+//	@Failure	400	{object}	map[string]string
+//	@Failure	401	{object}	map[string]string
+//	@Failure	403	{object}	map[string]string
+//	@Failure	404	{object}	map[string]string
+//	@Failure	500	{object}	map[string]string
+//	@Failure	503	{object}	map[string]string
+//	@Router		/api/v1/workspaces/{workspaceID}/skills/installed [get]
+func listSkillsDirectoryInstalls(runtimeStore RuntimeStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		workspaceID, ok := requireWorkspaceCapabilityRead(w, r, runtimeStore)
+		if !ok {
+			return
+		}
+		installs, err := runtimeStore.ListSkillsDirectoryInstalls(r.Context(), workspaceID)
+		if err != nil {
+			writeCapabilityError(w, err, "failed to list installed skills")
+			return
+		}
+		writeJSON(w, http.StatusOK, installs)
+	}
+}

--- a/server/internal/dev/skills_directory_routes_test.go
+++ b/server/internal/dev/skills_directory_routes_test.go
@@ -1,0 +1,82 @@
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func (stubRuntimeStore) ListSkillsDirectoryInstalls(context.Context, string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+func TestSkillsDirectoryInstalledStatePersists(t *testing.T) {
+	runner := &fakeSkillInstallRunner{t: t, writeSkill: true}
+	installRouter, db, _ := skillsInstallTestRouter(t, runner)
+	ids := store.DefaultDevFixtureIDs()
+	prefix := "/api/v1/workspaces/" + ids.WorkspaceID + "/skills/"
+	registryID := "googleworkspace/cli/gws-gmail-triage"
+	res := serveCapabilityRoute(t, installRouter, http.MethodPost, prefix+"install", mustJSON(t, map[string]string{
+		"source": "googleworkspace/cli", "slug": "gws-gmail-triage", "registry_id": registryID, "registry": "skills.sh",
+	}), ids.UserID)
+	if res.Code != http.StatusCreated {
+		t.Fatalf("install: %d %s", res.Code, res.Body.String())
+	}
+	var installed commitCapabilityImportResponse
+	if err := json.Unmarshal(res.Body.Bytes(), &installed); err != nil {
+		t.Fatal(err)
+	}
+	st := store.New(db)
+	r := chi.NewRouter()
+	RegisterRoutesWithStore(r, st)
+	read := func(wantID string) {
+		t.Helper()
+		res := serveCapabilityRoute(t, r, http.MethodGet, prefix+"installed", "", ids.UserID)
+		var got map[string]string
+		if res.Code != http.StatusOK || json.Unmarshal(res.Body.Bytes(), &got) != nil {
+			t.Fatalf("read installs: %d %s", res.Code, res.Body.String())
+		}
+		if wantID == "" && len(got) != 0 || wantID != "" && (len(got) != 1 || got[registryID] != wantID) {
+			t.Fatalf("installs = %v, want capability %q", got, wantID)
+		}
+	}
+	read(installed.Capability.ID)
+	ctx := context.Background()
+	renamed := "Renamed installed skill"
+	if _, err := st.UpdateCapability(ctx, store.UpdateCapabilityInput{CapabilityID: installed.Capability.ID, Name: &renamed}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateCapabilityVersion(ctx, store.CreateCapabilityVersionInput{
+		CapabilityID: installed.Capability.ID, Version: "1.0.1", CreatorID: ids.UserID,
+		CanonicalSpec: installed.CapabilityVersion.CanonicalSpec,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.DeprecateCapability(ctx, ids.WorkspaceID, installed.Capability.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.CreateCapability(ctx, store.CreateCapabilityInput{
+		WorkspaceID: ids.WorkspaceID, Name: installed.Capability.Name, Type: "skill", CreatorID: ids.UserID,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	read(installed.Capability.ID)
+	for _, test := range []struct{ workspaceID, userID string }{
+		{ids.WorkspaceID, "22222222-2222-4222-8222-222222222222"},
+		{"11111111-1111-4111-8111-111111111111", ids.UserID},
+	} {
+		res := serveCapabilityRoute(t, r, http.MethodGet, "/api/v1/workspaces/"+test.workspaceID+"/skills/installed", "", test.userID)
+		if res.Code != http.StatusNotFound {
+			t.Fatalf("unauthorized read: %d %s", res.Code, res.Body.String())
+		}
+	}
+	if _, err := st.SoftDeleteCapability(ctx, ids.WorkspaceID, installed.Capability.ID); err != nil {
+		t.Fatal(err)
+	}
+	read("")
+}

--- a/server/internal/store/skills_directory.go
+++ b/server/internal/store/skills_directory.go
@@ -1,0 +1,23 @@
+package store
+
+import (
+	"context"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
+)
+
+func (s *Store) ListSkillsDirectoryInstalls(ctx context.Context, workspaceID string) (map[string]string, error) {
+	wid, err := uuid(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := sqlc.New(s.db).ListSkillsDirectoryInstalls(ctx, wid)
+	if err != nil {
+		return nil, err
+	}
+	installs := make(map[string]string, len(rows))
+	for _, row := range rows {
+		installs[row.RegistryID] = row.CapabilityID
+	}
+	return installs, nil
+}


### PR DESCRIPTION
The Skills.sh directory forgot installed state after navigation and offered Install again. It now reads installation provenance from the workspace, opens the corresponding imported capability, and makes installation available again after that capability is removed.

Installed status is confirmed through a fresh read on entry and after installation. Pending or failed reads do not offer an unverified install action, and late installation responses cannot replace newer confirmed status. The change is limited to the directory, its read endpoint and cache plumbing; installer execution is unchanged.

Validation: `make check`, web build, regenerated OpenAPI/sqlc, and an isolated PostgreSQL install/read/remove route test. Actual CUA browser checks cover persistence, correct capability links, workspace switching, pending reads and delayed install/removal responses. A fresh independent blind review found no blocking issues. GitHub checks passed.
