### PR TITLE
fix(web): show the capability version used on the next run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,8 +155,9 @@ description and keep ownership on the side listed here.
 ### Server versus daemon ownership
 
 - Agent capability reads retain the stored binding version and expose its
-  pinning mode. Displayed current versions follow the runtime-resolved latest
-  metadata (including deprecation cutoffs) or the pinned version accordingly.
+  pinning mode. Displayed current versions match the daemon's resolver:
+  Skill, Plugin, and Bundle can follow latest metadata (including deprecation
+  cutoffs); MCP and System Prompt currently use the stored binding version.
 
 - Cross-workspace installed capabilities remain visible and removable after
   unpublishing. Their installation metadata reports source visibility and only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,10 @@ description and keep ownership on the side listed here.
 
 ### Server versus daemon ownership
 
+- Agent capability reads retain the stored binding version and expose its
+  pinning mode. Displayed current versions follow the runtime-resolved latest
+  metadata (including deprecation cutoffs) or the pinned version accordingly.
+
 - Cross-workspace installed capabilities remain visible and removable after
   unpublishing. Their installation metadata reports source visibility and only
   bound versions while private; marketplace discovery and new installs still

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -702,7 +702,7 @@
       },
       "add": {
         "title": "{{name}} — add version",
-        "description": "Saving assigns the next version automatically. Unless the capability is deprecated, Agents following latest use it on their next run; pinned Agents keep their selected version.",
+        "description": "Saving assigns the next version automatically. Check each Agent’s Config tab for the version it will use.",
         "prefillFromLatest": "Prefilled from the previous version ({{version}}). Edits become the new version on submit.",
         "inlineSecretLostWarning": "Inline secret(s) from the previous version ({{keys}}) are hidden. Re-enter the plaintext to keep them, or switch to a managed credential."
       },
@@ -1209,7 +1209,8 @@
           "versionDeleted": {
             "warning": "Version unavailable",
             "switchAction": "Switch to an available version"
-          }
+          },
+          "storedVersion": "Using bound version"
         },
         "compatibility": {
           "unsupported": "{{engine}} does not support {{type}} capabilities. Supported engines: {{engines}}.",
@@ -1271,7 +1272,7 @@
           "upgraded": "\"{{cap}}\" upgraded to v{{version}}. Takes effect on the next run."
         },
         "marketplace": {
-          "deprecatedBanner": "This capability is deprecated. This Agent can keep using v{{version}}. Following latest stops at the last version published before deprecation.",
+          "deprecatedBanner": "This capability is deprecated. This Agent can keep using v{{version}}.",
           "upgradeShort": "New version v{{version}}"
         },
         "state": {

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -702,7 +702,7 @@
       },
       "add": {
         "title": "{{name}} — add version",
-        "description": "Saving assigns the next version automatically. Agents using older versions are unaffected until they switch from Agent detail.",
+        "description": "Saving assigns the next version automatically. Agents following latest use it on their next run; pinned Agents keep their selected version.",
         "prefillFromLatest": "Prefilled from the previous version ({{version}}). Edits become the new version on submit.",
         "inlineSecretLostWarning": "Inline secret(s) from the previous version ({{keys}}) are hidden. Re-enter the plaintext to keep them, or switch to a managed credential."
       },
@@ -1204,6 +1204,8 @@
           "missingShort": "Requires {{kind}}, not set"
         },
         "bindings": {
+          "followingLatest": "Following latest",
+          "pinnedVersion": "Pinned version",
           "versionDeleted": {
             "warning": "Version unavailable",
             "switchAction": "Switch to an available version"
@@ -1245,7 +1247,7 @@
         },
         "switchDialog": {
           "title": "Switch \"{{cap}}\" version",
-          "description": "The Agent uses the new version on its next run; in-flight runs are unchanged.",
+          "description": "Selecting a version pins this Agent to it for future runs. In-flight runs are unchanged.",
           "latest": "latest",
           "current": "current",
           "notice": "Only this Agent ({{agent}}) is affected. Other Agents using this capability are unchanged. Takes effect on the next run."
@@ -1269,7 +1271,7 @@
           "upgraded": "\"{{cap}}\" upgraded to v{{version}}. Takes effect on the next run."
         },
         "marketplace": {
-          "deprecatedBanner": "The source workspace marked this capability deprecated. This Agent can keep using pinned v{{version}}, but cannot upgrade.",
+          "deprecatedBanner": "The source workspace deprecated this capability. This Agent can keep using v{{version}}, but cannot upgrade.",
           "upgradeShort": "New version v{{version}}"
         },
         "state": {

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1271,7 +1271,7 @@
           "upgraded": "\"{{cap}}\" upgraded to v{{version}}. Takes effect on the next run."
         },
         "marketplace": {
-          "deprecatedBanner": "The source workspace deprecated this capability. This Agent can keep using v{{version}}, but cannot upgrade.",
+          "deprecatedBanner": "This capability is deprecated. This Agent can keep using v{{version}}. Following latest stops at the last version published before deprecation.",
           "upgradeShort": "New version v{{version}}"
         },
         "state": {

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -702,7 +702,7 @@
       },
       "add": {
         "title": "{{name}} — add version",
-        "description": "Saving assigns the next version automatically. Agents following latest use it on their next run; pinned Agents keep their selected version.",
+        "description": "Saving assigns the next version automatically. Unless the capability is deprecated, Agents following latest use it on their next run; pinned Agents keep their selected version.",
         "prefillFromLatest": "Prefilled from the previous version ({{version}}). Edits become the new version on submit.",
         "inlineSecretLostWarning": "Inline secret(s) from the previous version ({{keys}}) are hidden. Re-enter the plaintext to keep them, or switch to a managed credential."
       },

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -702,7 +702,7 @@
       },
       "add": {
         "title": "{{name}} — 添加新版本",
-        "description": "保存时会自动分配下一个版本号。能力未弃用时，跟随最新版的 Agent 将在下次运行时使用新版本；固定版本的 Agent 保持原版本。",
+        "description": "保存后会自动生成下一个版本。请在各 Agent 的配置页查看实际使用的版本。",
         "prefillFromLatest": "已用上一版（{{version}}）的内容预填。修改后会作为新版本提交。",
         "inlineSecretLostWarning": "上一版的 inline secret（{{keys}}）已隐藏。如需保留，请重新输入明文；或改成已托管的凭据。"
       },
@@ -1209,7 +1209,8 @@
           "versionDeleted": {
             "warning": "版本已下线",
             "switchAction": "请切到可用版本"
-          }
+          },
+          "storedVersion": "使用绑定版本"
         },
         "compatibility": {
           "unsupported": "{{engine}} 不支持 {{type}} 能力。支持的 Agent 引擎：{{engines}}。",
@@ -1271,7 +1272,7 @@
           "upgraded": "「{{cap}}」已升级到 v{{version}}，下次运行生效。"
         },
         "marketplace": {
-          "deprecatedBanner": "此能力已弃用。此 Agent 可以继续使用 v{{version}}；跟随最新版的绑定会停留在弃用前发布的最后一个版本。",
+          "deprecatedBanner": "此能力已弃用。此 Agent 仍可继续使用 v{{version}}。",
           "upgradeShort": "有新版本 v{{version}}"
         },
         "state": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1271,7 +1271,7 @@
           "upgraded": "「{{cap}}」已升级到 v{{version}}，下次运行生效。"
         },
         "marketplace": {
-          "deprecatedBanner": "来源工作区已弃用此能力。此 Agent 可以继续使用 v{{version}}，但不能升级。",
+          "deprecatedBanner": "此能力已弃用。此 Agent 可以继续使用 v{{version}}；跟随最新版的绑定会停留在弃用前发布的最后一个版本。",
           "upgradeShort": "有新版本 v{{version}}"
         },
         "state": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -702,7 +702,7 @@
       },
       "add": {
         "title": "{{name}} — 添加新版本",
-        "description": "保存时会自动生成下一个版本。已启用旧版本的 Agent 不受影响，需在 Agent 详情中手动切换。",
+        "description": "保存时会自动分配下一个版本号。跟随最新版的 Agent 将在下次运行时使用新版本；固定版本的 Agent 保持原版本。",
         "prefillFromLatest": "已用上一版（{{version}}）的内容预填。修改后会作为新版本提交。",
         "inlineSecretLostWarning": "上一版的 inline secret（{{keys}}）已隐藏。如需保留，请重新输入明文；或改成已托管的凭据。"
       },
@@ -1204,6 +1204,8 @@
           "missingShort": "需要「{{kind}}」，未设置"
         },
         "bindings": {
+          "followingLatest": "跟随最新版",
+          "pinnedVersion": "固定版本",
           "versionDeleted": {
             "warning": "版本已下线",
             "switchAction": "请切到可用版本"
@@ -1245,7 +1247,7 @@
         },
         "switchDialog": {
           "title": "切换「{{cap}}」版本",
-          "description": "切换后，该 Agent 下一次运行使用新版本（已在跑的运行不变）。",
+          "description": "选择一个版本后，此 Agent 的后续运行将固定使用它；进行中的运行不受影响。",
           "latest": "最新",
           "current": "当前",
           "notice": "切换仅影响本 Agent（{{agent}}）；其它装配此能力的 Agent 不受影响。下次运行生效。"
@@ -1269,7 +1271,7 @@
           "upgraded": "「{{cap}}」已升级到 v{{version}}，下次运行生效。"
         },
         "marketplace": {
-          "deprecatedBanner": "此能力已被来源工作区标记废弃。本 Agent 可以继续使用锁定的 v{{version}}，但无法升级到新版本。",
+          "deprecatedBanner": "来源工作区已弃用此能力。此 Agent 可以继续使用 v{{version}}，但不能升级。",
           "upgradeShort": "有新版本 v{{version}}"
         },
         "state": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -702,7 +702,7 @@
       },
       "add": {
         "title": "{{name}} — 添加新版本",
-        "description": "保存时会自动分配下一个版本号。跟随最新版的 Agent 将在下次运行时使用新版本；固定版本的 Agent 保持原版本。",
+        "description": "保存时会自动分配下一个版本号。能力未弃用时，跟随最新版的 Agent 将在下次运行时使用新版本；固定版本的 Agent 保持原版本。",
         "prefillFromLatest": "已用上一版（{{version}}）的内容预填。修改后会作为新版本提交。",
         "inlineSecretLostWarning": "上一版的 inline secret（{{keys}}）已隐藏。如需保留，请重新输入明文；或改成已托管的凭据。"
       },

--- a/apps/web/src/lib/agent-capability-version.ts
+++ b/apps/web/src/lib/agent-capability-version.ts
@@ -1,0 +1,26 @@
+import type { AgentCapability, Capability, CapabilityVersion } from "./api-types"
+
+export function agentCapabilityVersion(
+  binding: AgentCapability | undefined,
+  capability: Capability | undefined,
+  versions: CapabilityVersion[],
+): CapabilityVersion | undefined {
+  if (!binding) return undefined
+  const followsLatest = binding.pinning_mode === "latest"
+  // The binding response's latest version respects the runtime's deprecation cutoff.
+  const id = followsLatest
+    ? capability?.latest_version_id ?? binding.latest_version_id
+    : binding.capability_version_id
+  const version = versions.find((item) => item.id === id)
+  if (version) return version
+  const label = followsLatest
+    ? capability?.latest_version ?? binding.latest_version
+    : capability?.pinned_version ?? binding.version
+  return id && label ? {
+    id,
+    capability_id: binding.capability_id,
+    version: label,
+    creator_id: "",
+    created_at: binding.updated_at,
+  } : undefined
+}

--- a/apps/web/src/lib/agent-capability-version.ts
+++ b/apps/web/src/lib/agent-capability-version.ts
@@ -1,12 +1,22 @@
 import type { AgentCapability, Capability, CapabilityVersion } from "./api-types"
 
+export function agentCapabilityFollowsLatest(
+  binding: AgentCapability | undefined,
+  capability: Capability | undefined,
+): boolean {
+  const kind = capability?.type ?? binding?.type
+  // Match the daemon resolvers: MCP and System Prompt still use stored fields.
+  return binding?.pinning_mode === "latest"
+    && (kind === "skill" || kind === "plugin" || kind === "bundle")
+}
+
 export function agentCapabilityVersion(
   binding: AgentCapability | undefined,
   capability: Capability | undefined,
   versions: CapabilityVersion[],
 ): CapabilityVersion | undefined {
   if (!binding) return undefined
-  const followsLatest = binding.pinning_mode === "latest"
+  const followsLatest = agentCapabilityFollowsLatest(binding, capability)
   // The binding response's latest version respects the runtime's deprecation cutoff.
   const id = followsLatest
     ? capability?.latest_version_id ?? binding.latest_version_id

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -335,7 +335,7 @@ export interface AgentCapability {
   latest_version_created_at?: string
   enabled: boolean
   configuration: Record<string, unknown>
-  /** "latest" tracks newest version on every dispatch; "pinned" locks capability_version_id. */
+  /** Stored mode; effective version selection also depends on the capability resolver. */
   pinning_mode?: "latest" | "pinned"
   created_at: string
   updated_at: string

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -40,6 +40,7 @@ import {
 } from "../../../lib/api-capabilities"
 import { useMyCredentials } from "../../../lib/api-credentials"
 import { useSecrets } from "../../../lib/api-secrets"
+import { agentCapabilityVersion } from "../../../lib/agent-capability-version"
 import { agentExecutionPlacement } from "../../../lib/agent-runtime"
 import { agentEngineLabel, agentEngineOf, agentEngineSupportsCapability, agentEnginesSupportingCapability } from "../../../lib/agent-view-model"
 import { credentialBinding, hasCredentialKind, sharedSecretsForKind } from "../../../lib/credential-bindings"
@@ -381,7 +382,7 @@ function CapabilityCard({
   const capability = item.capability
   const binding = item.binding
   const { latest, versions, versionsQ } = useCapabilityVersions(workspaceID, capability, mode === "enabled")
-  const boundVersion = versions.find((version) => version.id === binding?.capability_version_id) ?? (binding?.capability_version_id && capability?.pinned_version ? { id: binding.capability_version_id, capability_id: capability.id, version: capability.pinned_version, created_at: capability.latest_version_created_at ?? capability.created_at } as CapabilityVersion : undefined)
+  const boundVersion = agentCapabilityVersion(binding, capability, versions)
   const catalogID = catalogIDFromVersion(boundVersion ?? latest)
   const versionDeleted = !!binding && !versionsQ.isLoading && !boundVersion && !capability?.latest_version_id
   const fromMarketplace = !!capability?.from_marketplace || (!!capability?.source_workspace_id && capability.source_workspace_id !== workspaceID)
@@ -410,7 +411,7 @@ function CapabilityCard({
 
   const agentEngine = agentEngineOf(agent)
   const incompatible = !agentEngineSupportsCapability(agentEngine, capability.type)
-  const upgradable = mode === "enabled" && fromMarketplace && !!binding && !!latest && latest.id !== binding.capability_version_id
+  const upgradable = mode === "enabled" && fromMarketplace && !!binding && binding.pinning_mode !== "latest" && !!latest && latest.id !== binding.capability_version_id
 
   // One line per credential the capability needs and the reader has not set.
   // A credential that *is* set says nothing: the row's glyph already reports
@@ -420,7 +421,10 @@ function CapabilityCard({
     (rc) => !hasUsableCredential(agent, binding, credentials, sharedSecrets, rc.kind, catalogID),
   )
 
-  const notes: { key: string; text: React.ReactNode; action?: React.ReactNode }[] = []
+  const notes: { key: string; text: React.ReactNode; action?: React.ReactNode }[] = binding ? [{
+    key: "version-mode",
+    text: t(`agents.detail.capabilities.bindings.${binding.pinning_mode === "latest" ? "followingLatest" : "pinnedVersion"}`),
+  }] : []
   for (const rc of missingKinds) {
     notes.push({
       key: `cred:${rc.kind}`,
@@ -468,7 +472,7 @@ function CapabilityCard({
     notes.push({
       key: "deprecated",
       text: t("agents.detail.capabilities.marketplace.deprecatedBanner", {
-        version: boundVersion?.version ?? capability.pinned_version ?? "—",
+        version: boundVersion?.version ?? "—",
       }),
     })
   }
@@ -521,11 +525,7 @@ function CapabilityCard({
         </>
       }
       description={capability.description}
-      // The version the agent is actually pinned to. It used to be told three
-      // times over — a mono `v—`, a "current v2.0.0" in prose, a "published
-      // v2.0.0" in a banner — so it lives in one slot now, and says nothing
-      // rather than an em dash when there is nothing to say.
-      version={versionOf(boundVersion?.version ?? binding?.version ?? capability.pinned_version) ?? (mode === "available" ? versionOf(latest?.version) : undefined)}
+      version={versionOf(boundVersion?.version) ?? (mode === "available" ? versionOf(latest?.version) : undefined)}
       notes={notes}
       // In the add dialog the verb is the reason the list exists, so it does
       // not wait for a hover to appear.
@@ -595,9 +595,15 @@ function CapabilityVersionDialog({
   const { t } = useTranslation("admin")
   const [open, setOpen] = useState(false)
   const mut = useEnableAgentCapabilityMutation(workspaceID, agent.id)
-  const [selected, setSelected] = useState(binding?.capability_version_id ?? "")
+  const [selection, setSelected] = useState("")
+  const changeOpen = (next: boolean) => {
+    setOpen(next)
+    setSelected("")
+  }
   const [credentialBindingChoices, setCredentialBindingChoices] = useState<Record<string, string>>({})
   const { latest, versions, versionsQ } = useCapabilityVersions(workspaceID, capability, open)
+  const currentVersion = agentCapabilityVersion(binding, capability, versions)
+  const selected = selection || currentVersion?.id || ""
   const selectedVersion = selected
     ? versions.find((version) => version.id === selected) ?? (mode === "enable" ? latest : versions[0])
     : mode === "enable" ? latest : versions[0]
@@ -627,7 +633,7 @@ function CapabilityVersionDialog({
   const canSubmit = !!selectedVersion
     && !mut.isPending
     && !disabled
-    && (mode === "enable" ? !missingRequiredCredential : selectedVersion.id !== binding?.capability_version_id)
+    && (mode === "enable" ? !missingRequiredCredential : binding?.pinning_mode === "latest" || selectedVersion.id !== currentVersion?.id)
 
   const submit = () => {
     if (!selectedVersion) return
@@ -646,7 +652,7 @@ function CapabilityVersionDialog({
         : binding?.configuration,
     }, {
       onSuccess: () => {
-        setOpen(false)
+        changeOpen(false)
         onToast(mode === "enable"
           ? t("agents.detail.capabilities.toast.enabled", { cap: capability.name, agent: agent.name, version: selectedVersion.version })
           : t("agents.detail.capabilities.toast.switched", { cap: capability.name, version: selectedVersion.version }))
@@ -661,18 +667,18 @@ function CapabilityVersionDialog({
     : t("agents.detail.capabilities.actions.enableConfirm")
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={changeOpen}>
       {trigger ? (
-        trigger(() => setOpen(true))
+        trigger(() => changeOpen(true))
       ) : isSwitch ? (
         <ActionIconButton
           icon={Replace}
           label={t("agents.detail.capabilities.actions.switchVersion")}
           disabled={disabled}
-          onClick={() => setOpen(true)}
+          onClick={() => changeOpen(true)}
         />
       ) : (
-        <Button variant="outline" size="sm" disabled={disabled} onClick={() => setOpen(true)}>
+        <Button variant="outline" size="sm" disabled={disabled} onClick={() => changeOpen(true)}>
           {t("agents.detail.capabilities.actions.enable")}
         </Button>
       )}
@@ -691,7 +697,7 @@ function CapabilityVersionDialog({
                       <input type="radio" name="capability-version" className="h-3.5 w-3.5 accent-accent" checked={selected === version.id} onChange={() => setSelected(version.id)} />
                       <span className="font-mono text-xs">v{version.version}</span>
                       {index === 0 && <span className="text-xs text-fg-muted">· {t("agents.detail.capabilities.switchDialog.latest")}</span>}
-                      {version.id === binding?.capability_version_id && <span className="text-xs text-fg-muted">· {t("agents.detail.capabilities.switchDialog.current")}</span>}
+                      {version.id === currentVersion?.id && <span className="text-xs text-fg-muted">· {t("agents.detail.capabilities.switchDialog.current")}</span>}
                     </label>
                   </li>
                 ))}
@@ -724,7 +730,7 @@ function CapabilityVersionDialog({
           <MutationError error={mut.error} />
         </div>
         <DialogFooter>
-          <Button variant="outline" onClick={() => setOpen(false)} disabled={mut.isPending}>{t("agents.detail.capabilities.actions.cancel")}</Button>
+          <Button variant="outline" onClick={() => changeOpen(false)} disabled={mut.isPending}>{t("agents.detail.capabilities.actions.cancel")}</Button>
           <Button disabled={!canSubmit} onClick={submit}>{mut.isPending && <Loader2 className="animate-spin" strokeWidth={1.5} aria-hidden="true" />}{confirmLabel}</Button>
         </DialogFooter>
       </DialogContent>

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -40,7 +40,7 @@ import {
 } from "../../../lib/api-capabilities"
 import { useMyCredentials } from "../../../lib/api-credentials"
 import { useSecrets } from "../../../lib/api-secrets"
-import { agentCapabilityVersion } from "../../../lib/agent-capability-version"
+import { agentCapabilityFollowsLatest, agentCapabilityVersion } from "../../../lib/agent-capability-version"
 import { agentExecutionPlacement } from "../../../lib/agent-runtime"
 import { agentEngineLabel, agentEngineOf, agentEngineSupportsCapability, agentEnginesSupportingCapability } from "../../../lib/agent-view-model"
 import { credentialBinding, hasCredentialKind, sharedSecretsForKind } from "../../../lib/credential-bindings"
@@ -411,7 +411,8 @@ function CapabilityCard({
 
   const agentEngine = agentEngineOf(agent)
   const incompatible = !agentEngineSupportsCapability(agentEngine, capability.type)
-  const upgradable = mode === "enabled" && fromMarketplace && !!binding && binding.pinning_mode !== "latest" && !!latest && latest.id !== binding.capability_version_id
+  const followsLatest = agentCapabilityFollowsLatest(binding, capability)
+  const upgradable = mode === "enabled" && fromMarketplace && !!binding && !followsLatest && !!latest && latest.id !== binding.capability_version_id
 
   // One line per credential the capability needs and the reader has not set.
   // A credential that *is* set says nothing: the row's glyph already reports
@@ -423,7 +424,7 @@ function CapabilityCard({
 
   const notes: { key: string; text: React.ReactNode; action?: React.ReactNode }[] = binding ? [{
     key: "version-mode",
-    text: t(`agents.detail.capabilities.bindings.${binding.pinning_mode === "latest" ? "followingLatest" : "pinnedVersion"}`),
+    text: t(`agents.detail.capabilities.bindings.${followsLatest ? "followingLatest" : binding.pinning_mode === "latest" ? "storedVersion" : "pinnedVersion"}`),
   }] : []
   for (const rc of missingKinds) {
     notes.push({

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -476,8 +476,7 @@ function CapabilityCard({
       }),
     })
   }
-  // Not when deprecated: the note above already says the source was retired
-  // and that this binding cannot move off its pinned version.
+  // Deprecated marketplace sources cannot be upgraded.
   if (upgradable && !deprecated) {
     notes.push({
       key: "upgrade",
@@ -544,7 +543,7 @@ function CapabilityCard({
           />
         ) : binding ? (
           <>
-            {versions.length > 1 && !versionDeleted && !fromMarketplace && (
+            {(versions.length > 1 || (versions.length === 1 && binding.pinning_mode === "latest")) && !versionDeleted && !fromMarketplace && (
               <CapabilityVersionDialog
                 mode="switch"
                 agent={agent}

--- a/apps/web/src/pages/admin/capabilities/api.ts
+++ b/apps/web/src/pages/admin/capabilities/api.ts
@@ -186,6 +186,7 @@ export function useImportCapabilityVersionMutation(
       return postImportCapabilityVersionCommit(workspaceID, capabilityID, body)
     },
     onSuccess: (res) => {
+      void qc.invalidateQueries({ queryKey: ["admin", "agentCapabilities"] })
       void qc.invalidateQueries({ queryKey: KEY_CAPABILITIES_WORKSPACE(workspaceID ?? "_none") })
       void qc.invalidateQueries({ queryKey: ["admin", "capability"] })
       if (workspaceID) {

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -5011,9 +5011,9 @@ paths:
       - capabilities
   /api/v1/workspaces/{workspaceID}/agents/{agentID}/capabilities:
     get:
-      description: Returns the capabilities installed on the agent (own + marketplace
-        + built-ins) and what else is available to install from the workspace and
-        the marketplace.
+      description: Returns installed capabilities, their pinning_mode and bound/latest
+        version metadata, plus available workspace and marketplace capabilities. Latest
+        metadata respects the runtime deprecation cutoff.
       operationId: listDevAgentCapabilities
       parameters:
       - description: Workspace UUID

--- a/server/internal/dev/agent_capability_version_test.go
+++ b/server/internal/dev/agent_capability_version_test.go
@@ -1,0 +1,51 @@
+package dev
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func TestAgentCapabilitiesExposeVersionMode(t *testing.T) {
+	r, db := capabilityTestRouter(t, map[string]string{testUserAID: "member"}, nil)
+	workspaceID := store.DefaultDevFixtureIDs().WorkspaceID
+	capabilityID, v1, v2 := insertCapabilityVersions(t, db, workspaceID, "Version mode")
+	agentID := insertAgentForOwner(t, db, testUserAID, "version-mode-agent")
+	base := "/api/v1/workspaces/" + workspaceID + "/agents/" + agentID + "/capabilities"
+	for _, mode := range []string{"latest", "pinned"} {
+		enabled := serveCapabilityRoute(t, r, http.MethodPost, base+"/"+v1+"/enable",
+			`{"pinning_mode":"`+mode+`"}`, testUserAID)
+		if enabled.Code != http.StatusOK {
+			t.Fatalf("enable %s: %d %s", mode, enabled.Code, enabled.Body.String())
+		}
+		response := serveCapabilityRoute(t, r, http.MethodGet, base, "", testUserAID)
+		var body struct {
+			Installed []struct {
+				store.AgentCapabilityRead
+				Capability struct {
+					LatestVersionID string `json:"latest_version_id"`
+					PinnedVersionID string `json:"pinned_version_id"`
+				} `json:"capability"`
+			} `json:"installed"`
+		}
+		if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil || response.Code != http.StatusOK {
+			t.Fatalf("list: %d %s", response.Code, response.Body.String())
+		}
+		found := false
+		for _, binding := range body.Installed {
+			if binding.CapabilityID != capabilityID {
+				continue
+			}
+			found = true
+			if binding.PinningMode != mode || binding.CapabilityVersionID != v1 ||
+				binding.Capability.LatestVersionID != v2 || binding.Capability.PinnedVersionID != v1 {
+				t.Fatalf("mode %s: unexpected version metadata: %+v", mode, binding)
+			}
+		}
+		if !found {
+			t.Fatal("installed capability missing")
+		}
+	}
+}

--- a/server/internal/dev/capability_routes.go
+++ b/server/internal/dev/capability_routes.go
@@ -1243,7 +1243,7 @@ func deleteMyCredential(runtimeStore RuntimeStore) http.HandlerFunc {
 // (including built-ins) plus what else is available to install.
 //
 //	@Summary		List agent capabilities
-//	@Description	Returns the capabilities installed on the agent (own + marketplace + built-ins) and what else is available to install from the workspace and the marketplace.
+//	@Description	Returns installed capabilities, their pinning_mode and bound/latest version metadata, plus available workspace and marketplace capabilities. Latest metadata respects the runtime deprecation cutoff.
 //	@Tags			capabilities
 //	@ID				listDevAgentCapabilities
 //	@Produce		json
@@ -1307,6 +1307,7 @@ func listAgentCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 				"agent_id":              binding.AgentID,
 				"capability_id":         binding.CapabilityID,
 				"capability_version_id": binding.CapabilityVersionID,
+				"pinning_mode":          binding.PinningMode,
 				"enabled":               binding.Enabled,
 				"configuration":         binding.Configuration,
 				"created_at":            binding.CreatedAt,


### PR DESCRIPTION
Agent Config could display the stored Skill version even when the next run follows a newer version. It now shows the version selected by the existing runtime resolver and marks that version as current in the chooser. Explicit version selection pins only the selected Agent; publication feedback and capability refreshes stay consistent with that behavior.

The change adds existing pinning metadata to the read response and keeps current runtime and permission rules. MCP and System Prompt continue displaying their stored runtime version. Capability usage counts and runtime version policy changes are outside this PR.

Validation: `make check`, regenerated OpenAPI, an isolated PostgreSQL route test, and actual browser checks for version publication, current-version selection and explicit MCP switching. Independent blind review found no blockers; focused helper and component checks passed.
