### PR TITLE
Fix workspace switcher identity and action alignment

### DIFF
--- a/apps/web/src/components/layout/WorkspaceMenuItem.tsx
+++ b/apps/web/src/components/layout/WorkspaceMenuItem.tsx
@@ -6,10 +6,9 @@ import type { UserWorkspace } from "../../lib/api-types"
 import { cn } from "../../lib/utils"
 import { setWorkspaceId } from "../../lib/workspace"
 
-export function WorkspaceMenuItem({ workspace, active, showSlug, onRename, onArchive }: {
+export function WorkspaceMenuItem({ workspace, active, onRename, onArchive }: {
   workspace: UserWorkspace
   active: boolean
-  showSlug: boolean
   onRename: () => void
   onArchive: () => void
 }) {
@@ -28,7 +27,7 @@ export function WorkspaceMenuItem({ workspace, active, showSlug, onRename, onArc
       >
         <span className="min-w-0 flex-1 break-words">
           {workspace.name}
-          {showSlug && <span className="block break-all font-mono text-xs font-normal text-fg-faint">{workspace.slug}</span>}
+          <span className="block break-all font-mono text-xs font-normal text-fg-faint">{workspace.slug}</span>
         </span>
         <span className="w-14 shrink-0 text-right text-xs font-medium text-fg-faint">{workspace.role}</span>
         <span className="h-3.5 w-3.5 shrink-0" aria-hidden="true">

--- a/apps/web/src/components/layout/WorkspaceMenuItem.tsx
+++ b/apps/web/src/components/layout/WorkspaceMenuItem.tsx
@@ -1,0 +1,61 @@
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
+import { Archive, Check, Pencil } from "lucide-react"
+import type { ReactNode } from "react"
+import { useTranslation } from "react-i18next"
+import type { UserWorkspace } from "../../lib/api-types"
+import { cn } from "../../lib/utils"
+import { setWorkspaceId } from "../../lib/workspace"
+
+export function WorkspaceMenuItem({ workspace, active, onRename, onArchive }: {
+  workspace: UserWorkspace
+  active: boolean
+  onRename: () => void
+  onArchive: () => void
+}) {
+  const { t } = useTranslation("common")
+  const canManage = workspace.role === "owner" || workspace.role === "admin"
+  return (
+    <div className="group/row grid grid-cols-[minmax(0,1fr)_1.75rem_1.75rem] items-center gap-1">
+      <DropdownMenu.Item
+        onSelect={() => { if (!active) setWorkspaceId(workspace.id) }}
+        aria-current={active ? "true" : undefined}
+        title={`${workspace.name}\n${workspace.slug}`}
+        className={cn(
+          "flex min-w-0 cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 outline-none data-[highlighted]:bg-surface-muted",
+          active && "font-medium text-fg",
+        )}
+      >
+        <span className="min-w-0 flex-1 break-words">{workspace.name}</span>
+        <span className="w-14 shrink-0 text-right text-xs font-medium text-fg-faint">{workspace.role}</span>
+        <span className="h-3.5 w-3.5 shrink-0" aria-hidden="true">
+          {active && <Check className="h-3.5 w-3.5 text-fg-muted" strokeWidth={2} />}
+        </span>
+      </DropdownMenu.Item>
+      {canManage && <>
+        <RowAction title={t("workspaceCrud.workspace.renameTitle")} onSelect={onRename} icon={<Pencil className="h-3.5 w-3.5" strokeWidth={1.75} />} />
+        <RowAction title={t("workspaceCrud.workspace.archiveTitle")} onSelect={onArchive} icon={<Archive className="h-3.5 w-3.5" strokeWidth={1.75} />} danger />
+      </>}
+    </div>
+  )
+}
+
+function RowAction({ title, icon, onSelect, danger }: {
+  title: string
+  icon: ReactNode
+  onSelect: () => void
+  danger?: boolean
+}) {
+  return (
+    <DropdownMenu.Item
+      onSelect={(e) => { e.preventDefault(); onSelect() }}
+      title={title}
+      aria-label={title}
+      className={cn(
+        "invisible flex h-7 w-7 cursor-pointer items-center justify-center rounded outline-none text-fg-faint hover:text-fg-muted data-[highlighted]:text-fg-muted group-hover/row:visible group-focus-within/row:visible",
+        danger && "hover:text-danger data-[highlighted]:text-danger",
+      )}
+    >
+      {icon}
+    </DropdownMenu.Item>
+  )
+}

--- a/apps/web/src/components/layout/WorkspaceMenuItem.tsx
+++ b/apps/web/src/components/layout/WorkspaceMenuItem.tsx
@@ -6,9 +6,10 @@ import type { UserWorkspace } from "../../lib/api-types"
 import { cn } from "../../lib/utils"
 import { setWorkspaceId } from "../../lib/workspace"
 
-export function WorkspaceMenuItem({ workspace, active, onRename, onArchive }: {
+export function WorkspaceMenuItem({ workspace, active, showSlug, onRename, onArchive }: {
   workspace: UserWorkspace
   active: boolean
+  showSlug: boolean
   onRename: () => void
   onArchive: () => void
 }) {
@@ -25,7 +26,10 @@ export function WorkspaceMenuItem({ workspace, active, onRename, onArchive }: {
           active && "font-medium text-fg",
         )}
       >
-        <span className="min-w-0 flex-1 break-words">{workspace.name}</span>
+        <span className="min-w-0 flex-1 break-words">
+          {workspace.name}
+          {showSlug && <span className="block break-all font-mono text-xs font-normal text-fg-faint">{workspace.slug}</span>}
+        </span>
         <span className="w-14 shrink-0 text-right text-xs font-medium text-fg-faint">{workspace.role}</span>
         <span className="h-3.5 w-3.5 shrink-0" aria-hidden="true">
           {active && <Check className="h-3.5 w-3.5 text-fg-muted" strokeWidth={2} />}

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -1,21 +1,17 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu"
 import {
-  Archive,
-  Check,
   ChevronsUpDown,
   Clock,
   Globe,
   Layers,
-  Pencil,
   Plus,
   Send,
   X,
 } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
-import type { ReactNode } from "react"
 import { useTranslation } from "react-i18next"
-import { cn } from "../../lib/utils"
 import { BrandMark } from "../ui/brand-mark"
+import { WorkspaceMenuItem } from "./WorkspaceMenuItem"
 import {
   setWorkspaceId,
   useWorkspaceId,
@@ -113,6 +109,7 @@ export function WorkspaceSwitcher() {
           <button
             type="button"
             aria-label={t("workspaceSwitcher.triggerAriaLabel")}
+            title={triggerLabel}
             className="flex h-8 w-full items-center gap-1.5 rounded-md px-2 text-left text-sm hover:app-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 data-[state=open]:app-pressed"
           >
             <BrandMark size={14} />
@@ -135,7 +132,7 @@ export function WorkspaceSwitcher() {
           <DropdownMenu.Content
             align="start"
             sideOffset={6}
-            className="app-shadow-floating z-50 min-w-[300px] overflow-hidden rounded-lg border border-line bg-surface p-1 text-sm text-fg-muted animate-pop-in data-[state=closed]:animate-pop-out"
+            className="app-shadow-floating z-50 w-96 max-w-[calc(100vw-1rem)] overflow-hidden rounded-lg border border-line bg-surface p-1 text-sm text-fg-muted animate-pop-in data-[state=closed]:animate-pop-out"
           >
             <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium text-fg-subtle">
               <Layers className="h-3 w-3" strokeWidth={1.75} />
@@ -150,55 +147,15 @@ export function WorkspaceSwitcher() {
               </div>
             )}
 
-            {workspaces.map((ws) => {
-              const isActive = ws.id === wsId
-              const canManage = ws.role === "owner" || ws.role === "admin"
-              return (
-                <div
-                  key={ws.id}
-                  className="group/row flex items-center gap-1"
-                >
-                  <DropdownMenu.Item
-                    onSelect={() => {
-                      if (ws.id === wsId) return
-                      setWorkspaceId(ws.id)
-                    }}
-                    className={cn(
-                      "flex flex-1 cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 outline-none data-[highlighted]:bg-surface-muted",
-                      isActive && "font-medium text-fg"
-                    )}
-                  >
-                    <div className="flex flex-1 flex-col min-w-0">
-                      <span className="truncate">{ws.name}</span>
-                      <span className="truncate font-mono text-xs text-fg-faint">
-                        {ws.slug}
-                      </span>
-                    </div>
-                    <span className="text-xs font-medium text-fg-faint">
-                      {ws.role}
-                    </span>
-                    {isActive && (
-                      <Check className="h-3.5 w-3.5 text-fg-muted" strokeWidth={2} />
-                    )}
-                  </DropdownMenu.Item>
-                  {canManage && (
-                    <>
-                      <RowAction
-                        title={t("workspaceCrud.workspace.renameTitle")}
-                        onSelect={() => setRenameWs(ws)}
-                        icon={<Pencil className="h-3.5 w-3.5" strokeWidth={1.75} />}
-                      />
-                      <RowAction
-                        title={t("workspaceCrud.workspace.archiveTitle")}
-                        onSelect={() => setArchiveWs(ws)}
-                        icon={<Archive className="h-3.5 w-3.5" strokeWidth={1.75} />}
-                        danger
-                      />
-                    </>
-                  )}
-                </div>
-              )
-            })}
+            {workspaces.map((ws) => (
+              <WorkspaceMenuItem
+                key={ws.id}
+                workspace={ws}
+                active={ws.id === wsId}
+                onRename={() => setRenameWs(ws)}
+                onArchive={() => setArchiveWs(ws)}
+              />
+            ))}
 
             <DropdownMenu.Item
               onSelect={(e) => {
@@ -223,7 +180,7 @@ export function WorkspaceSwitcher() {
                     key={ws.id}
                     className="group/row flex items-center gap-1"
                   >
-                    <div className="flex flex-1 items-center gap-2 rounded-sm px-2 py-1.5">
+                    <div className="flex min-w-0 flex-1 items-center gap-2 rounded-sm px-2 py-1.5">
                       <div className="flex flex-1 flex-col min-w-0">
                         <span className="truncate">{ws.name}</span>
                         <span className="truncate font-mono text-xs text-fg-faint">
@@ -424,31 +381,5 @@ export function WorkspaceSwitcher() {
         }}
       />
     </>
-  )
-}
-
-interface RowActionProps {
-  title: string
-  icon: ReactNode
-  onSelect: () => void
-  danger?: boolean
-}
-
-function RowAction({ title, icon, onSelect, danger }: RowActionProps) {
-  return (
-    <DropdownMenu.Item
-      onSelect={(e) => {
-        e.preventDefault()
-        onSelect()
-      }}
-      title={title}
-      aria-label={title}
-      className={cn(
-        "invisible flex h-7 w-7 cursor-pointer items-center justify-center rounded outline-none text-fg-faint hover:text-fg-muted data-[highlighted]:text-fg-muted group-hover/row:visible",
-        danger && "hover:text-danger data-[highlighted]:text-danger"
-      )}
-    >
-      {icon}
-    </DropdownMenu.Item>
   )
 }

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -152,7 +152,6 @@ export function WorkspaceSwitcher() {
                 key={ws.id}
                 workspace={ws}
                 active={ws.id === wsId}
-                showSlug={workspaces.some((other) => other.id !== ws.id && other.name === ws.name)}
                 onRename={() => setRenameWs(ws)}
                 onArchive={() => setArchiveWs(ws)}
               />

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -152,6 +152,7 @@ export function WorkspaceSwitcher() {
                 key={ws.id}
                 workspace={ws}
                 active={ws.id === wsId}
+                showSlug={workspaces.some((other) => other.id !== ws.id && other.name === ws.name)}
                 onRename={() => setRenameWs(ws)}
                 onArchive={() => setArchiveWs(ws)}
               />

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -132,7 +132,7 @@ export function WorkspaceSwitcher() {
           <DropdownMenu.Content
             align="start"
             sideOffset={6}
-            className="app-shadow-floating z-50 w-96 max-w-[calc(100vw-1rem)] overflow-hidden rounded-lg border border-line bg-surface p-1 text-sm text-fg-muted animate-pop-in data-[state=closed]:animate-pop-out"
+            className="app-shadow-floating z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] w-96 max-w-[calc(100vw-1rem)] overflow-x-hidden overflow-y-auto rounded-lg border border-line bg-surface p-1 text-sm text-fg-muted animate-pop-in data-[state=closed]:animate-pop-out"
           >
             <DropdownMenu.Label className="flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium text-fg-subtle">
               <Layers className="h-3 w-3" strokeWidth={1.75} />
@@ -178,21 +178,19 @@ export function WorkspaceSwitcher() {
                 {discoverable.map((ws) => (
                   <div
                     key={ws.id}
-                    className="group/row flex items-center gap-1"
+                    className="group/row grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 gap-y-1 px-2 py-1.5"
                   >
-                    <div className="flex min-w-0 flex-1 items-center gap-2 rounded-sm px-2 py-1.5">
-                      <div className="flex flex-1 flex-col min-w-0">
-                        <span className="truncate">{ws.name}</span>
-                        <span className="truncate font-mono text-xs text-fg-faint">
-                          {ws.slug}
-                        </span>
-                      </div>
-                      <span className="text-xs text-fg-faint">
-                        {t("workspaceSwitcher.memberCount", {
-                          count: ws.member_count,
-                        })}
+                    <div className="col-span-2 flex min-w-0 flex-col">
+                      <span className="break-words">{ws.name}</span>
+                      <span className="truncate font-mono text-xs text-fg-faint">
+                        {ws.slug}
                       </span>
                     </div>
+                    <span className="text-xs text-fg-faint">
+                      {t("workspaceSwitcher.memberCount", {
+                        count: ws.member_count,
+                      })}
+                    </span>
                     {ws.has_pending_request ? (
                       <div className="flex items-center gap-1">
                         <span


### PR DESCRIPTION
Workspace switcher rows placed role labels and selection marks at different positions, and long names crowded management actions. The menu now aligns these fields, keeps names and identifiers readable, and contains overflow while preserving workspace permissions and actions.

Validation: `make check`, web build, actual CUA checks for desktop/mobile layout, duplicate names, keyboard navigation, rename and workspace switching. Independent blind review found no blocking issues. An unverified edge case involving exceptionally long names in a 320×200 viewport is tracked separately as a low-priority follow-up.
