### PR TITLE
Count capability usage by effective Agent version

### DIFF
--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -48,7 +48,6 @@ import { useAgents } from "../../../lib/api-agents"
 import {
   KEY_AGENT_CAPABILITIES,
   KEY_CAPABILITY_VERSIONS,
-  agentCapabilityVersionID,
   listCapabilityVersions,
   listAgentCapabilities,
   skillVersionRef,
@@ -83,6 +82,7 @@ import { useRelativeTime } from "../../../lib/relative-time"
 import { requiredCredentialsLabel } from "../../../lib/credential-kind-ui"
 import { CapabilityTypeBadge } from "./CapabilityTypeBadge"
 import { InlineNotice } from "./notices"
+import { useCapabilityEnabledAgents } from "./use-capability-enabled-agents"
 import { MarketplaceCapabilityRail } from "./MarketplaceCapabilityRail"
 import { MarketplaceTab } from "./MarketplaceTab"
 import { DeprecateCapabilityDialog } from "./DeprecateCapabilityDialog"
@@ -96,13 +96,6 @@ export { CapabilityTypeBadge } from "./CapabilityTypeBadge"
 
 type MarketAction = "publish" | "unpublish" | "deprecate" | "undeprecate" | null
 type MarketCapabilityAction = Exclude<MarketAction, null>
-
-interface AgentInstallation {
-  agentID: string
-  agentName: string
-  version: string
-  latest: boolean
-}
 
 /** "" = every type; "bundle" is the server's name for plugin bundles. */
 type CapabilityTypeFilter = "" | "mcp" | "skill" | "bundle"
@@ -1386,34 +1379,6 @@ function useCapabilityVersionSummary(workspaceID: string | null, capabilities: C
   }, [capabilities, queries.map((q) => q.dataUpdatedAt).join(":")])
 }
 
-function useCapabilityEnabledAgents(wid: string | null, agents: Array<{ id: string; name: string }>, capability: Capability | null, versions: CapabilityVersion[]) {
-  const queries = useQueries({
-    queries: agents.map((agent) => ({
-      queryKey: KEY_AGENT_CAPABILITIES(wid ?? "_none", agent.id),
-      queryFn: () => listAgentCapabilities(wid, agent.id),
-      enabled: !!wid && !!capability,
-      retry: noUnreachableRetry,
-      staleTime: 30_000,
-    })),
-  })
-  return useMemo(() => {
-    const latest = versions[0]
-    const versionByID = new Map(versions.map((v) => [v.id, v.version]))
-    const versionCounts = new Map<string, number>()
-    const installations: AgentInstallation[] = []
-    if (!capability) return { installations, versionCounts, isLoading: queries.some((q) => q.isLoading) }
-    queries.forEach((q, idx) => {
-      for (const item of q.data?.installed ?? []) {
-        if (!item.enabled || item.capability_id !== capability.id) continue
-        const versionID = agentCapabilityVersionID(item)
-        versionCounts.set(versionID, (versionCounts.get(versionID) ?? 0) + 1)
-        installations.push({ agentID: agents[idx].id, agentName: agents[idx].name, version: versionByID.get(versionID) ?? "—", latest: versionID === latest?.id })
-      }
-    })
-    return { installations, versionCounts, isLoading: queries.some((q) => q.isLoading) }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [capability, agents, versions, queries.map((q) => q.dataUpdatedAt).join(":")])
-}
 
 function countCapabilityInstalls(groups: AgentCapability[][]) {
   const counts = new Map<string, number>()

--- a/apps/web/src/pages/admin/capabilities/use-capability-enabled-agents.ts
+++ b/apps/web/src/pages/admin/capabilities/use-capability-enabled-agents.ts
@@ -1,0 +1,46 @@
+import { useMemo } from "react"
+import { useQueries } from "@tanstack/react-query"
+import { KEY_AGENT_CAPABILITIES, listAgentCapabilities } from "../../../lib/api-capabilities"
+import { noUnreachableRetry } from "../../../lib/api-client"
+import type { Capability, CapabilityVersion } from "../../../lib/api-types"
+import { agentCapabilityVersion } from "../../../lib/agent-capability-version"
+
+interface AgentInstallation {
+  agentID: string
+  agentName: string
+  version: string
+  latest: boolean
+}
+
+export function useCapabilityEnabledAgents(wid: string | null, agents: Array<{ id: string; name: string }>, capability: Capability | null, versions: CapabilityVersion[]) {
+  const queries = useQueries({
+    queries: agents.map((agent) => ({
+      queryKey: KEY_AGENT_CAPABILITIES(wid ?? "_none", agent.id),
+      queryFn: () => listAgentCapabilities(wid, agent.id),
+      enabled: !!wid && !!capability,
+      retry: noUnreachableRetry,
+      staleTime: 30_000,
+    })),
+  })
+  return useMemo(() => {
+    const latest = versions[0]
+    const versionCounts = new Map<string, number>()
+    const installations: AgentInstallation[] = []
+    if (!capability) return { installations, versionCounts, isLoading: queries.some((q) => q.isLoading) }
+    queries.forEach((q, idx) => {
+      for (const item of q.data?.installed ?? []) {
+        if (!item.enabled || item.capability_id !== capability.id) continue
+        const version = agentCapabilityVersion(item, item.capability, versions)
+        if (version) versionCounts.set(version.id, (versionCounts.get(version.id) ?? 0) + 1)
+        installations.push({
+          agentID: agents[idx].id,
+          agentName: agents[idx].name,
+          version: version?.version ?? "—",
+          latest: !!version && version.id === latest?.id,
+        })
+      }
+    })
+    return { installations, versionCounts, isLoading: queries.some((q) => q.isLoading) }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [capability, agents, versions, queries.map((q) => q.dataUpdatedAt).join(":")])
+}


### PR DESCRIPTION
After publishing a Skill version, capability details counted follow-latest Agents under their original binding version. The Agent usage list and version counts now use the same effective version selection as Agent configuration, including pinning and deprecation cutoffs.

Validation: `make check`, web build, actual server/browser verification with one follow-latest and one pinned Agent, and a fresh independent blind review with 25 resolver cases plus CUA navigation and role checks. Scope is the capability detail's display computation.
