### PR TITLE
Retain readable history after deleting an Agent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,9 @@ description and keep ownership on the side listed here.
   workspace; cross-workspace upgrades still require a public, available source.
 - The server owns auth, workspaces, agent records, runtime bindings, run
   records, audit/usage persistence, and upstream engine session ids.
+- Soft-deleting an Agent preserves workspace-authorized conversation and run
+  history, including its identity. History reads expose deletion state; they
+  must not allow new messages or retries to execute the deleted Agent.
 - Successful explicit Agent capability enable, upgrade, removal, and built-in
   toggle requests emit Agent-targeted audit events with the authenticated actor
   and capability identifiers. Never include configuration or credential values.

--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -197,7 +197,7 @@ function ConversationMainInner(p: MainProps & { err: unknown; isUnreachable: boo
     )
   }
 
-  if (p.messageCount === 0) {
+  if (p.messageCount === 0 && !p.conv.primary_agent_deleted) {
     // 0 messages: same empty surface as the no-conversation state until
     // the first send; interaction cards still show for this conv.
     return (
@@ -360,6 +360,8 @@ function ChatStream({
   // without threading the id through every parent prop bag.
   const convInfoQ = useConversation(conversationId, null)
   const convWorkspaceId = convInfoQ.data?.workspace_id ?? null
+  const agentDeleted = convInfoQ.data?.primary_agent_deleted === true
+  const agentName = agent?.name || convInfoQ.data?.primary_agent_name || ""
   const cancelRunMut = useCancelRun(convWorkspaceId)
 
   // SSE state: ComposerForm hands us a run_id after send; we open the
@@ -560,7 +562,7 @@ function ChatStream({
                   metadata={m.metadata}
                   outputRuns={runsByOutputMessage.get(m.id)}
                   stamp={fmtAgo(m.created_at)}
-                  agentName={agent?.name ?? ""}
+                  agentName={agentName}
                   conversationId={conversationId}
                   onOpenRun={openRun}
                 />
@@ -588,7 +590,7 @@ function ChatStream({
               senderType="agent"
               content={stream.deltaText}
               stamp={t("conversations.stream.caretHint")}
-              agentName={agent?.name ?? ""}
+              agentName={agentName}
               conversationId={conversationId}
             />
           )}
@@ -660,9 +662,9 @@ function ChatStream({
         ) : (
           <ComposerForm
             conversationId={conversationId}
-            agentName={agent?.name}
-            placeholder={t("conversations.composer.placeholder", { agent: agent?.name ?? "" })}
-            disabled={!canWrite || !agent || sandboxGuard?.blocked}
+            agentName={agentName}
+            placeholder={agentDeleted ? t("agents.deletedLabel") : t("conversations.composer.placeholder", { agent: agentName })}
+            disabled={!canWrite || !agent || agentDeleted || sandboxGuard?.blocked}
             onRunStarted={startRun}
             onStartError={(message: string) => setChatToast({ text: message })}
             activeRunId={activeRunId}
@@ -682,7 +684,7 @@ function ChatStream({
                 : undefined
             }
             cancelling={cancelRunMut.isPending}
-            blockReason={!canWrite ? t("conversations.composer.readOnly") : sandboxGuard?.blocked ? sandboxGuard.message : undefined}
+            blockReason={agentDeleted ? t("conversations.composer.agentDeleted") : !canWrite ? t("conversations.composer.readOnly") : sandboxGuard?.blocked ? sandboxGuard.message : undefined}
           />
         )}
       </ComposerFooter>

--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -562,7 +562,7 @@ function ChatStream({
                   metadata={m.metadata}
                   outputRuns={runsByOutputMessage.get(m.id)}
                   stamp={fmtAgo(m.created_at)}
-                  agentName={agentName}
+                  agentName={agent?.name || (m.sender_id === convInfoQ.data?.primary_agent_id ? agentName : "")}
                   conversationId={conversationId}
                   onOpenRun={openRun}
                 />

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -498,6 +498,7 @@
           "runtime": "Check daemon device, liveness, and latest heartbeat.",
           "model": "Check model provider, model config, and opencode_json.",
           "inspect": "Inspect events and audit records to locate the cause.",
+          "agentDeleted": "This Agent was deleted. Its historical runs cannot be retried.",
           "requeueIfNeeded": "Requeue after confirming the context is still valid.",
           "waitOrCancel": "Wait for dispatch or cancel if no longer needed.",
           "inspectRuntime": "Open runtime status and check heartbeat and availability.",

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -299,6 +299,7 @@
     },
     "composer": {
       "readOnly": "Read-only access. You cannot send messages.",
+      "agentDeleted": "This Agent was deleted. You can read this conversation, but cannot send new messages.",
       "label": "Send message",
       "placeholder": "Chat with {{agent}}…",
       "send": "Send",
@@ -977,6 +978,7 @@
     }
   },
   "agents": {
+    "deletedLabel": "Deleted Agent",
     "page": {
       "title": "Agents"
     },

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -299,6 +299,7 @@
     },
     "composer": {
       "readOnly": "当前为只读权限，无法发送消息。",
+      "agentDeleted": "这个 Agent 已删除。你仍可查看历史对话，但无法继续发送消息。",
       "label": "发送消息",
       "placeholder": "和 {{agent}} 聊聊…",
       "send": "发送",
@@ -977,6 +978,7 @@
     }
   },
   "agents": {
+    "deletedLabel": "Agent 已删除",
     "page": {
       "title": "Agent"
     },

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -498,6 +498,7 @@
           "runtime": "检查 daemon 设备、liveness 和最近心跳。",
           "model": "检查模型 provider、model 配置和 opencode_json。",
           "inspect": "查看事件和审计记录定位原因。",
+          "agentDeleted": "Agent 已删除，历史运行记录不能重试。",
           "requeueIfNeeded": "确认上下文仍有效后可重新入队。",
           "waitOrCancel": "可等待调度；不再需要时取消。",
           "inspectRuntime": "打开运行环境状态检查心跳和可用性。",

--- a/apps/web/src/lib/api-agents.ts
+++ b/apps/web/src/lib/api-agents.ts
@@ -698,6 +698,10 @@ export function useDeleteAgent(workspaceID: string | null) {
     mutationFn: async (agentID: string) => deleteAgentRequest(agentID),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: KEY_AGENTS(workspaceID ?? "_none") })
+      void qc.invalidateQueries({ queryKey: ["admin", "conversations"] })
+      void qc.invalidateQueries({ queryKey: ["admin", "conversation"] })
+      void qc.invalidateQueries({ queryKey: ["admin", "agentRuns"] })
+      void qc.invalidateQueries({ queryKey: ["admin", "agentRun"] })
     },
   })
 }

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -438,6 +438,7 @@ export interface AgentRunSummary {
   agent_id?: string
   agent_name?: string
   agent_slug?: string
+  agent_deleted?: boolean
   connector_type: string
   status: AgentRunStatus
   error_summary?: string
@@ -734,10 +735,11 @@ export interface Conversation {
   metadata: Record<string, unknown>
   /**
    * Derived from metadata.primary_agent_id via a JOIN. Empty string when no
-   * primary agent is bound or the bound agent has been soft-deleted.
+   * primary agent is bound. Deleted Agents remain identifiable in history.
    */
   primary_agent_id?: string
   primary_agent_name?: string
+  primary_agent_deleted?: boolean
   created_at: string
   updated_at: string
 }
@@ -803,6 +805,7 @@ export interface ConversationTimelineRun {
   user_facing_reason?: string
   agent_name?: string
   agent_slug?: string
+  agent_deleted?: boolean
   trigger_message_id?: string
   output_message_id?: string
   connector_type?: string

--- a/apps/web/src/pages/SharedConversationPage.tsx
+++ b/apps/web/src/pages/SharedConversationPage.tsx
@@ -79,8 +79,13 @@ export function SharedConversationPage({ conversationId }: { conversationId: str
     )
   }
 
+  const headerAgent = agent ?? (conv.primary_agent_name ? {
+    name: conv.primary_agent_name,
+    description: conv.primary_agent_deleted ? t("conversations.composer.agentDeleted") : "",
+  } : undefined)
+
   return (
-    <SharedShell agent={agent ? { name: agent.name, description: agent.description } : undefined}>
+    <SharedShell agent={headerAgent}>
       <ConversationMain
         conv={conv}
         canWrite={canWrite}

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -341,6 +341,7 @@ function RunRow({
   age: string
   onSelect: () => void
 }) {
+  const { t } = useTranslation("admin")
   const agent = run.agent_name ?? run.agent_slug ?? "—"
   const errorSummary = run.error_summary ?? run.user_facing_reason
   const onKeyDown = (e: KeyboardEvent<HTMLLIElement>) => {
@@ -355,7 +356,8 @@ function RunRow({
       <LedgerId>{shortId(run.id, 16)}</LedgerId>
       <span className="flex min-w-0 items-center gap-1.5">
         <InitialTile name={agent} />
-        <span className="shrink-0 truncate font-medium">{agent}</span>
+        <span className="min-w-0 truncate font-medium">{agent}</span>
+        {run.agent_deleted && <span className="shrink-0 text-xs text-fg-muted">{t("agents.deletedLabel")}</span>}
         {errorSummary && (
           <span className="min-w-0 truncate text-xs text-fg-muted max-[1360px]:hidden">· {errorSummary}</span>
         )}
@@ -466,7 +468,7 @@ function RunDetailRail({
   }
 
   const run = runData
-  const agent = run.agent_name ?? run.agent_slug ?? "—"
+  const agent = (run.agent_name ?? run.agent_slug ?? "—") + (run.agent_deleted ? ` · ${t("agents.deletedLabel")}` : "")
   const errorSummary = run.error_summary ?? run.user_facing_reason
   const translateDetail = (key: string, options?: Record<string, unknown>) => t(key as never, options as never) as unknown as string
   const diagnosis = buildRunDiagnosis(run, events, translateDetail)
@@ -475,7 +477,7 @@ function RunDetailRail({
   const role = workspacesQ.data?.workspaces.find((w) => w.id === run.workspace_id)?.role
   const canCancel = role === "owner" || role === "admin" || role === "member"
   const isCancellable = canCancel && (run.status === "running" || run.status === "queued")
-  const isRetryable = run.status === "failed" || run.status === "interrupted" || run.status === "cancelled"
+  const isRetryable = !run.agent_deleted && (run.status === "failed" || run.status === "interrupted" || run.status === "cancelled")
 
   function handleRetry() {
     setCancelError(null)

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -472,6 +472,7 @@ function RunDetailRail({
   const errorSummary = run.error_summary ?? run.user_facing_reason
   const translateDetail = (key: string, options?: Record<string, unknown>) => t(key as never, options as never) as unknown as string
   const diagnosis = buildRunDiagnosis(run, events, translateDetail)
+  if (run.agent_deleted) diagnosis.action = t("runs.detail.diagnostics.actions.agentDeleted")
   const runtimeDiagnosis = buildRuntimeDiagnosis(run, translateDetail)
   // Viewers may watch a run but not stop it (main #234ef56).
   const role = workspacesQ.data?.workspaces.find((w) => w.id === run.workspace_id)?.role

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1910,8 +1910,8 @@ paths:
       - agent-daemon
   /api/v1/agent-runs/{runID}:
     get:
-      description: Returns the full record for a single agent run. Caller must belong
-        to the run's workspace.
+      description: Returns a run, including retained history and agent_deleted state
+        after Agent deletion. Caller must belong to the run's workspace.
       operationId: getDevAgentRun
       parameters:
       - description: Agent run UUID
@@ -3346,6 +3346,46 @@ paths:
       summary: Start GitHub personal OAuth connection
       tags:
       - connections
+  /api/v1/conversations/{conversationID}:
+    get:
+      description: Returns a conversation with primary_agent_deleted when its retained
+        primary Agent has been deleted. Caller must belong to the workspace.
+      operationId: getDevConversation
+      parameters:
+      - description: Conversation UUID
+        in: path
+        name: conversationID
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Conversation
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Invalid UUID
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Caller lacks permission
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Conversation not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get a conversation
+      tags:
+      - conversations
   /api/v1/conversations/{conversationID}/cancel-all:
     post:
       consumes:
@@ -3633,8 +3673,8 @@ paths:
       - agent-runs
   /api/v1/conversations/{conversationID}/timeline:
     get:
-      description: Returns the ordered timeline (messages, tool calls, events) for
-        a conversation.
+      description: Returns the ordered timeline, including run history and Agent identity
+        retained after Agent deletion.
       operationId: getDevConversationTimeline
       parameters:
       - description: Conversation UUID
@@ -4692,8 +4732,8 @@ paths:
       - workspaces
   /api/v1/workspaces/{workspaceID}/agent-runs:
     get:
-      description: Returns agent-run rows for the workspace. Caller must be a workspace
-        member.
+      description: Returns agent-run rows, including retained history and agent_deleted
+        state after Agent deletion. Caller must be a workspace member.
       operationId: listDevWorkspaceAgentRuns
       parameters:
       - description: Workspace UUID

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -536,12 +536,13 @@ select
     limit 1
   ), '')::text as last_message_sender_type,
   coalesce(a.id::text, '')::text as primary_agent_id,
-  coalesce(a.name, '')::text as primary_agent_name
+  coalesce(a.name, '')::text as primary_agent_name,
+  (a.deleted_at is not null)::boolean as primary_agent_deleted
 from conversations c
 left join agents a
   on a.id = nullif(c.metadata->>'primary_agent_id', '')::uuid
-  and a.deleted_at is null
-  and a.status = 'active'
+  and a.workspace_id = c.workspace_id
+  and (a.status = 'active' or a.deleted_at is not null)
 where c.workspace_id = @workspace_id::uuid
   and c.deleted_at is null
   and (@agent_id::text = '' or c.metadata->>'primary_agent_id' = @agent_id::text)
@@ -566,12 +567,13 @@ select
   c.created_at,
   c.updated_at,
   coalesce(a.id::text, '')::text as primary_agent_id,
-  coalesce(a.name, '')::text as primary_agent_name
+  coalesce(a.name, '')::text as primary_agent_name,
+  (a.deleted_at is not null)::boolean as primary_agent_deleted
 from conversations c
 left join agents a
   on a.id = nullif(c.metadata->>'primary_agent_id', '')::uuid
-  and a.deleted_at is null
-  and a.status = 'active'
+  and a.workspace_id = c.workspace_id
+  and (a.status = 'active' or a.deleted_at is not null)
 where c.id = @id::uuid
   and c.deleted_at is null;
 
@@ -809,6 +811,16 @@ set status = 'queued',
     updated_at = @now
 where id = @id::uuid
   and status = 'failed'
+  and exists (
+    select 1 from agents a
+    join conversations c on c.id = agent_runs.conversation_id
+    where a.id = agent_runs.agent_id
+      and a.workspace_id = agent_runs.workspace_id
+      and c.workspace_id = agent_runs.workspace_id
+      and a.deleted_at is null
+      and c.deleted_at is null
+      and c.status = 'active'
+  )
 returning
   id::text,
   workspace_id::text,
@@ -970,6 +982,7 @@ select
   r.agent_id::text,
   a.name as agent_name,
   a.slug as agent_slug,
+  (a.deleted_at is not null)::boolean as agent_deleted,
   r.connector_type,
   r.status,
   r.metadata,
@@ -984,7 +997,6 @@ where r.conversation_id = @conversation_id::uuid
   and r.workspace_id = a.workspace_id
   and c.status = 'active'
   and c.deleted_at is null
-  and a.deleted_at is null
 order by r.created_at asc, r.id asc
 limit @item_limit;
 
@@ -1019,6 +1031,7 @@ select
   r.agent_id::text,
   a.name as agent_name,
   a.slug as agent_slug,
+  (a.deleted_at is not null)::boolean as agent_deleted,
   r.connector_type,
   r.external_run_id,
   r.status,
@@ -1053,8 +1066,7 @@ where r.id = @id::uuid
   and r.workspace_id = c.workspace_id
   and r.workspace_id = a.workspace_id
   and c.status = 'active'
-  and c.deleted_at is null
-  and a.deleted_at is null;
+  and c.deleted_at is null;
 
 -- name: GetOutputMessageByRunID :one
 select
@@ -1866,6 +1878,7 @@ select
   r.agent_id::text,
   a.name as agent_name,
   a.slug as agent_slug,
+  (a.deleted_at is not null)::boolean as agent_deleted,
   r.connector_type,
   r.status,
   r.metadata,
@@ -1879,7 +1892,6 @@ where r.workspace_id = @workspace_id::uuid
   and r.workspace_id = c.workspace_id
   and r.workspace_id = a.workspace_id
   and c.deleted_at is null
-  and a.deleted_at is null
   and (@search::text = '' or strpos(lower(concat_ws(' ', a.name, a.slug, r.id::text, r.conversation_id::text)), lower(@search::text)) > 0)
   and (cardinality(@statuses::text[]) = 0
        or r.status = ANY(@statuses::text[]))
@@ -1899,7 +1911,6 @@ where r.workspace_id = @workspace_id::uuid
   and r.workspace_id = c.workspace_id
   and r.workspace_id = a.workspace_id
   and c.deleted_at is null
-  and a.deleted_at is null
   and (@search::text = '' or strpos(lower(concat_ws(' ', a.name, a.slug, r.id::text, r.conversation_id::text)), lower(@search::text)) > 0)
   and (cardinality(@statuses::text[]) = 0
        or r.status = ANY(@statuses::text[]));

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -1616,7 +1616,6 @@ where r.workspace_id = $1::uuid
   and r.workspace_id = c.workspace_id
   and r.workspace_id = a.workspace_id
   and c.deleted_at is null
-  and a.deleted_at is null
   and ($2::text = '' or strpos(lower(concat_ws(' ', a.name, a.slug, r.id::text, r.conversation_id::text)), lower($2::text)) > 0)
   and (cardinality($3::text[]) = 0
        or r.status = ANY($3::text[]))
@@ -4528,6 +4527,7 @@ select
   r.agent_id::text,
   a.name as agent_name,
   a.slug as agent_slug,
+  (a.deleted_at is not null)::boolean as agent_deleted,
   r.connector_type,
   r.external_run_id,
   r.status,
@@ -4563,7 +4563,6 @@ where r.id = $1::uuid
   and r.workspace_id = a.workspace_id
   and c.status = 'active'
   and c.deleted_at is null
-  and a.deleted_at is null
 `
 
 type GetAgentRunForReadRow struct {
@@ -4577,6 +4576,7 @@ type GetAgentRunForReadRow struct {
 	RAgentID         string             `json:"r_agent_id"`
 	AgentName        string             `json:"agent_name"`
 	AgentSlug        string             `json:"agent_slug"`
+	AgentDeleted     bool               `json:"agent_deleted"`
 	ConnectorType    string             `json:"connector_type"`
 	ExternalRunID    string             `json:"external_run_id"`
 	Status           string             `json:"status"`
@@ -4614,6 +4614,7 @@ func (q *Queries) GetAgentRunForRead(ctx context.Context, id pgtype.UUID) (GetAg
 		&i.RAgentID,
 		&i.AgentName,
 		&i.AgentSlug,
+		&i.AgentDeleted,
 		&i.ConnectorType,
 		&i.ExternalRunID,
 		&i.Status,
@@ -5095,28 +5096,30 @@ select
   c.created_at,
   c.updated_at,
   coalesce(a.id::text, '')::text as primary_agent_id,
-  coalesce(a.name, '')::text as primary_agent_name
+  coalesce(a.name, '')::text as primary_agent_name,
+  (a.deleted_at is not null)::boolean as primary_agent_deleted
 from conversations c
 left join agents a
   on a.id = nullif(c.metadata->>'primary_agent_id', '')::uuid
-  and a.deleted_at is null
-  and a.status = 'active'
+  and a.workspace_id = c.workspace_id
+  and (a.status = 'active' or a.deleted_at is not null)
 where c.id = $1::uuid
   and c.deleted_at is null
 `
 
 type GetConversationRow struct {
-	ID               string             `json:"id"`
-	WorkspaceID      string             `json:"workspace_id"`
-	Surface          string             `json:"surface"`
-	Form             string             `json:"form"`
-	Title            string             `json:"title"`
-	Status           string             `json:"status"`
-	Metadata         []byte             `json:"metadata"`
-	CreatedAt        pgtype.Timestamptz `json:"created_at"`
-	UpdatedAt        pgtype.Timestamptz `json:"updated_at"`
-	PrimaryAgentID   string             `json:"primary_agent_id"`
-	PrimaryAgentName string             `json:"primary_agent_name"`
+	ID                  string             `json:"id"`
+	WorkspaceID         string             `json:"workspace_id"`
+	Surface             string             `json:"surface"`
+	Form                string             `json:"form"`
+	Title               string             `json:"title"`
+	Status              string             `json:"status"`
+	Metadata            []byte             `json:"metadata"`
+	CreatedAt           pgtype.Timestamptz `json:"created_at"`
+	UpdatedAt           pgtype.Timestamptz `json:"updated_at"`
+	PrimaryAgentID      string             `json:"primary_agent_id"`
+	PrimaryAgentName    string             `json:"primary_agent_name"`
+	PrimaryAgentDeleted bool               `json:"primary_agent_deleted"`
 }
 
 func (q *Queries) GetConversation(ctx context.Context, id pgtype.UUID) (GetConversationRow, error) {
@@ -5134,6 +5137,7 @@ func (q *Queries) GetConversation(ctx context.Context, id pgtype.UUID) (GetConve
 		&i.UpdatedAt,
 		&i.PrimaryAgentID,
 		&i.PrimaryAgentName,
+		&i.PrimaryAgentDeleted,
 	)
 	return i, err
 }
@@ -7873,6 +7877,7 @@ select
   r.agent_id::text,
   a.name as agent_name,
   a.slug as agent_slug,
+  (a.deleted_at is not null)::boolean as agent_deleted,
   r.connector_type,
   r.status,
   r.metadata,
@@ -7887,7 +7892,6 @@ where r.conversation_id = $1::uuid
   and r.workspace_id = a.workspace_id
   and c.status = 'active'
   and c.deleted_at is null
-  and a.deleted_at is null
 order by r.created_at asc, r.id asc
 limit $2
 `
@@ -7906,6 +7910,7 @@ type ListConversationAgentRunsRow struct {
 	RAgentID         string             `json:"r_agent_id"`
 	AgentName        string             `json:"agent_name"`
 	AgentSlug        string             `json:"agent_slug"`
+	AgentDeleted     bool               `json:"agent_deleted"`
 	ConnectorType    string             `json:"connector_type"`
 	Status           string             `json:"status"`
 	Metadata         []byte             `json:"metadata"`
@@ -7932,6 +7937,7 @@ func (q *Queries) ListConversationAgentRuns(ctx context.Context, arg ListConvers
 			&i.RAgentID,
 			&i.AgentName,
 			&i.AgentSlug,
+			&i.AgentDeleted,
 			&i.ConnectorType,
 			&i.Status,
 			&i.Metadata,
@@ -9567,6 +9573,7 @@ select
   r.agent_id::text,
   a.name as agent_name,
   a.slug as agent_slug,
+  (a.deleted_at is not null)::boolean as agent_deleted,
   r.connector_type,
   r.status,
   r.metadata,
@@ -9580,7 +9587,6 @@ where r.workspace_id = $1::uuid
   and r.workspace_id = c.workspace_id
   and r.workspace_id = a.workspace_id
   and c.deleted_at is null
-  and a.deleted_at is null
   and ($2::text = '' or strpos(lower(concat_ws(' ', a.name, a.slug, r.id::text, r.conversation_id::text)), lower($2::text)) > 0)
   and (cardinality($3::text[]) = 0
        or r.status = ANY($3::text[]))
@@ -9605,6 +9611,7 @@ type ListWorkspaceAgentRunsPageRow struct {
 	RAgentID         string             `json:"r_agent_id"`
 	AgentName        string             `json:"agent_name"`
 	AgentSlug        string             `json:"agent_slug"`
+	AgentDeleted     bool               `json:"agent_deleted"`
 	ConnectorType    string             `json:"connector_type"`
 	Status           string             `json:"status"`
 	Metadata         []byte             `json:"metadata"`
@@ -9646,6 +9653,7 @@ func (q *Queries) ListWorkspaceAgentRunsPage(ctx context.Context, arg ListWorksp
 			&i.RAgentID,
 			&i.AgentName,
 			&i.AgentSlug,
+			&i.AgentDeleted,
 			&i.ConnectorType,
 			&i.Status,
 			&i.Metadata,
@@ -9855,12 +9863,13 @@ select
     limit 1
   ), '')::text as last_message_sender_type,
   coalesce(a.id::text, '')::text as primary_agent_id,
-  coalesce(a.name, '')::text as primary_agent_name
+  coalesce(a.name, '')::text as primary_agent_name,
+  (a.deleted_at is not null)::boolean as primary_agent_deleted
 from conversations c
 left join agents a
   on a.id = nullif(c.metadata->>'primary_agent_id', '')::uuid
-  and a.deleted_at is null
-  and a.status = 'active'
+  and a.workspace_id = c.workspace_id
+  and (a.status = 'active' or a.deleted_at is not null)
 where c.workspace_id = $1::uuid
   and c.deleted_at is null
   and ($2::text = '' or c.metadata->>'primary_agent_id' = $2::text)
@@ -9896,6 +9905,7 @@ type ListWorkspaceConversationsRow struct {
 	LastMessageSenderType string             `json:"last_message_sender_type"`
 	PrimaryAgentID        string             `json:"primary_agent_id"`
 	PrimaryAgentName      string             `json:"primary_agent_name"`
+	PrimaryAgentDeleted   bool               `json:"primary_agent_deleted"`
 }
 
 func (q *Queries) ListWorkspaceConversations(ctx context.Context, arg ListWorkspaceConversationsParams) ([]ListWorkspaceConversationsRow, error) {
@@ -9923,6 +9933,7 @@ func (q *Queries) ListWorkspaceConversations(ctx context.Context, arg ListWorksp
 			&i.LastMessageSenderType,
 			&i.PrimaryAgentID,
 			&i.PrimaryAgentName,
+			&i.PrimaryAgentDeleted,
 		); err != nil {
 			return nil, err
 		}
@@ -10711,6 +10722,16 @@ set status = 'queued',
     updated_at = $2
 where id = $3::uuid
   and status = 'failed'
+  and exists (
+    select 1 from agents a
+    join conversations c on c.id = agent_runs.conversation_id
+    where a.id = agent_runs.agent_id
+      and a.workspace_id = agent_runs.workspace_id
+      and c.workspace_id = agent_runs.workspace_id
+      and a.deleted_at is null
+      and c.deleted_at is null
+      and c.status = 'active'
+  )
 returning
   id::text,
   workspace_id::text,

--- a/server/internal/dev/routes_conversations.go
+++ b/server/internal/dev/routes_conversations.go
@@ -89,7 +89,7 @@ func configureConversationExternalRef(runtimeStore RuntimeStore) http.HandlerFun
 // getConversationTimeline returns the ordered timeline for a conversation.
 //
 //	@Summary		Get a conversation's timeline
-//	@Description	Returns the ordered timeline (messages, tool calls, events) for a conversation.
+//	@Description	Returns the ordered timeline, including run history and Agent identity retained after Agent deletion.
 //	@Tags			conversations
 //	@ID				getDevConversationTimeline
 //	@Produce		json
@@ -304,6 +304,19 @@ func createWorkspaceConversation(runtimeStore RuntimeStore) http.HandlerFunc {
 	}
 }
 
+// getConversation reads a conversation and its retained primary Agent identity.
+//
+//	@Summary		Get a conversation
+//	@Description	Returns a conversation with primary_agent_deleted when its retained primary Agent has been deleted. Caller must belong to the workspace.
+//	@Tags			conversations
+//	@ID				getDevConversation
+//	@Produce		json
+//	@Param			conversationID	path	string	true	"Conversation UUID"
+//	@Success		200 {object} map[string]interface{} "Conversation"
+//	@Failure		400 {object} map[string]string "Invalid UUID"
+//	@Failure		403 {object} map[string]string "Caller lacks permission"
+//	@Failure		404 {object} map[string]string "Conversation not found"
+//	@Router			/api/v1/conversations/{conversationID} [get]
 func getConversation(runtimeStore RuntimeStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if runtimeStore == nil {

--- a/server/internal/dev/routes_runs.go
+++ b/server/internal/dev/routes_runs.go
@@ -91,7 +91,7 @@ func requeueAgentRun(runtimeStore RuntimeStore) http.HandlerFunc {
 // getAgentRun returns details for a single agent run.
 //
 //	@Summary		Get an agent run
-//	@Description	Returns the full record for a single agent run. Caller must belong to the run's workspace.
+//	@Description	Returns a run, including retained history and agent_deleted state after Agent deletion. Caller must belong to the run's workspace.
 //	@Tags			agent-runs
 //	@ID				getDevAgentRun
 //	@Produce		json
@@ -130,7 +130,7 @@ func getAgentRun(runtimeStore RuntimeStore) http.HandlerFunc {
 // listWorkspaceAgentRuns lists agent runs within a workspace.
 //
 //	@Summary		List workspace agent runs
-//	@Description	Returns agent-run rows for the workspace. Caller must be a workspace member.
+//	@Description	Returns agent-run rows, including retained history and agent_deleted state after Agent deletion. Caller must be a workspace member.
 //	@Tags			agent-runs
 //	@ID				listDevWorkspaceAgentRuns
 //	@Produce		json

--- a/server/internal/store/deleted_agent_history_test.go
+++ b/server/internal/store/deleted_agent_history_test.go
@@ -1,0 +1,100 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestDeletedAgentRetainsReadOnlyHistory(t *testing.T) {
+	ctx := context.Background()
+	st := New(openTestDB(t))
+	ids := mustSeedDevFixture(t, ctx, st)
+	conv, err := st.CreateWorkspaceConversation(ctx, CreateWorkspaceConversationInput{
+		WorkspaceID: ids.WorkspaceID, Title: "Retained history", PrimaryAgentID: ids.ProductAgentID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	send := func() string {
+		t.Helper()
+		result, err := st.SendUserMessageToConversation(ctx, SendUserMessageToConversationInput{
+			ConversationID: conv.ID, UserID: ids.UserID, Content: "History fixture",
+		})
+		if err != nil || len(result.RunIDs) != 1 {
+			t.Fatalf("send: runs=%v error=%v", result.RunIDs, err)
+		}
+		return result.RunIDs[0]
+	}
+	completedID := send()
+	if _, err := st.CompleteAgentRun(ctx, CompleteAgentRunInput{RunID: completedID, Content: "Retained answer"}); err != nil {
+		t.Fatal(err)
+	}
+	failedID := send()
+	fail := func() {
+		t.Helper()
+		if err := st.FailAgentRun(ctx, FailAgentRunInput{RunID: failedID, Reason: "fixture"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fail()
+	if _, err := st.RequeueFailedAgentRun(ctx, RequeueAgentRunInput{RunID: failedID}); err != nil {
+		t.Fatalf("live Agent retry: %v", err)
+	}
+	fail()
+	if _, _, err := st.DeleteAgent(ctx, ids.ProductAgentID, ids.UserID); err != nil {
+		t.Fatal(err)
+	}
+	for _, runID := range []string{completedID, failedID} {
+		run, err := st.GetAgentRun(ctx, runID)
+		if err != nil || !run.AgentDeleted || run.AgentName != conv.PrimaryAgentName {
+			t.Fatalf("retained run %s: %+v, %v", runID, run.AgentRunBriefRead, err)
+		}
+		if runID == completedID && (run.OutputMessage == nil || run.OutputMessage.Content != "Retained answer") {
+			t.Fatal("completed output was not retained")
+		}
+	}
+	page, err := st.ListWorkspaceAgentRuns(ctx, ids.WorkspaceID, nil, 1, 0, conv.PrimaryAgentName)
+	if err != nil || page.Total != 2 || len(page.Runs) != 1 || !page.Runs[0].AgentDeleted {
+		t.Fatalf("retained search and pagination: %+v, %v", page, err)
+	}
+	history, err := st.GetConversation(ctx, conv.ID)
+	if err != nil || !history.PrimaryAgentDeleted || history.PrimaryAgentID != ids.ProductAgentID || history.PrimaryAgentName != conv.PrimaryAgentName {
+		t.Fatalf("retained conversation identity: %+v, %v", history, err)
+	}
+	timeline, err := st.GetConversationTimeline(ctx, conv.ID, 100)
+	if err != nil || len(timeline.AgentRuns) != 2 || len(timeline.Messages) != 3 {
+		t.Fatalf("retained timeline: runs=%d messages=%d error=%v", len(timeline.AgentRuns), len(timeline.Messages), err)
+	}
+	if _, err := st.RequeueFailedAgentRun(ctx, RequeueAgentRunInput{RunID: failedID}); !errors.Is(err, ErrAgentRunNotCompletable) {
+		t.Fatalf("deleted Agent retry must be rejected: %v", err)
+	}
+	run, err := st.GetAgentRun(ctx, failedID)
+	if err != nil || run.Status != "failed" {
+		t.Fatalf("rejected retry changed history: status=%s error=%v", run.Status, err)
+	}
+	sent, err := st.SendUserMessageToConversation(ctx, SendUserMessageToConversationInput{
+		ConversationID: conv.ID, UserID: ids.UserID, Content: "Must not execute the deleted Agent",
+	})
+	if err != nil || len(sent.RunIDs) != 0 {
+		t.Fatalf("deleted Agent received a new run: %v, %v", sent.RunIDs, err)
+	}
+	other, err := st.CreateWorkspace(ctx, CreateWorkspaceInput{Name: "Other history workspace", CreatedBy: ids.UserID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err = st.ListWorkspaceAgentRuns(ctx, other.Workspace.ID, nil, 20, 0, completedID)
+	if err != nil || page.Total != 0 || len(page.Runs) != 0 {
+		t.Fatalf("history crossed workspaces: %+v, %v", page, err)
+	}
+	if err := st.SoftDeleteConversation(ctx, conv.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := st.GetAgentRun(ctx, completedID); !errors.Is(err, ErrUnknownAgentRun) {
+		t.Fatalf("deleted conversation must remain hidden: %v", err)
+	}
+	page, err = st.ListWorkspaceAgentRuns(ctx, ids.WorkspaceID, nil, 20, 0, conv.PrimaryAgentName)
+	if err != nil || page.Total != 0 {
+		t.Fatalf("deleted conversation remained in history: %+v, %v", page, err)
+	}
+}

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -496,10 +496,11 @@ type ConversationRead struct {
 	Metadata    map[string]any `json:"metadata"`
 	// PrimaryAgentID / PrimaryAgentName are derived fields, hydrated from
 	// metadata.primary_agent_id + a JOIN against agents.
-	PrimaryAgentID   string    `json:"primary_agent_id,omitempty"`
-	PrimaryAgentName string    `json:"primary_agent_name,omitempty"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	PrimaryAgentID      string    `json:"primary_agent_id,omitempty"`
+	PrimaryAgentName    string    `json:"primary_agent_name,omitempty"`
+	PrimaryAgentDeleted bool      `json:"primary_agent_deleted,omitempty"`
+	CreatedAt           time.Time `json:"created_at"`
+	UpdatedAt           time.Time `json:"updated_at"`
 }
 
 type ConversationListItem struct {
@@ -582,6 +583,7 @@ type AgentRunBriefRead struct {
 	AgentID          string         `json:"agent_id"`
 	AgentName        string         `json:"agent_name"`
 	AgentSlug        string         `json:"agent_slug"`
+	AgentDeleted     bool           `json:"agent_deleted,omitempty"`
 	ConnectorType    string         `json:"connector_type"`
 	Status           string         `json:"status"`
 	UserFacingReason string         `json:"user_facing_reason,omitempty"`
@@ -2806,17 +2808,18 @@ func (s *Store) ListWorkspaceConversations(ctx context.Context, workspaceID stri
 	for _, row := range rows {
 		item := ConversationListItem{
 			ConversationRead: ConversationRead{
-				ID:               row.ID,
-				WorkspaceID:      row.WorkspaceID,
-				Surface:          row.Surface,
-				Form:             row.Form,
-				Title:            row.Title,
-				Status:           row.Status,
-				Metadata:         decodeJSONMap(row.Metadata),
-				PrimaryAgentID:   row.PrimaryAgentID,
-				PrimaryAgentName: row.PrimaryAgentName,
-				CreatedAt:        pgTime(row.CreatedAt),
-				UpdatedAt:        pgTime(row.UpdatedAt),
+				ID:                  row.ID,
+				WorkspaceID:         row.WorkspaceID,
+				Surface:             row.Surface,
+				Form:                row.Form,
+				Title:               row.Title,
+				Status:              row.Status,
+				Metadata:            decodeJSONMap(row.Metadata),
+				PrimaryAgentID:      row.PrimaryAgentID,
+				PrimaryAgentName:    row.PrimaryAgentName,
+				PrimaryAgentDeleted: row.PrimaryAgentDeleted,
+				CreatedAt:           pgTime(row.CreatedAt),
+				UpdatedAt:           pgTime(row.UpdatedAt),
 			},
 			MessageCount:          row.MessageCount,
 			LastMessagePreview:    row.LastMessagePreview,
@@ -2845,17 +2848,18 @@ func (s *Store) GetConversation(ctx context.Context, conversationID string) (Con
 		return ConversationRead{}, err
 	}
 	return ConversationRead{
-		ID:               row.ID,
-		WorkspaceID:      row.WorkspaceID,
-		Surface:          row.Surface,
-		Form:             row.Form,
-		Title:            row.Title,
-		Status:           row.Status,
-		Metadata:         decodeJSONMap(row.Metadata),
-		PrimaryAgentID:   row.PrimaryAgentID,
-		PrimaryAgentName: row.PrimaryAgentName,
-		CreatedAt:        pgTime(row.CreatedAt),
-		UpdatedAt:        pgTime(row.UpdatedAt),
+		ID:                  row.ID,
+		WorkspaceID:         row.WorkspaceID,
+		Surface:             row.Surface,
+		Form:                row.Form,
+		Title:               row.Title,
+		Status:              row.Status,
+		Metadata:            decodeJSONMap(row.Metadata),
+		PrimaryAgentID:      row.PrimaryAgentID,
+		PrimaryAgentName:    row.PrimaryAgentName,
+		PrimaryAgentDeleted: row.PrimaryAgentDeleted,
+		CreatedAt:           pgTime(row.CreatedAt),
+		UpdatedAt:           pgTime(row.UpdatedAt),
 	}, nil
 }
 
@@ -3544,6 +3548,7 @@ func (s *Store) GetAgentRun(ctx context.Context, runID string) (AgentRunDetailRe
 			AgentID:          row.RAgentID,
 			AgentName:        row.AgentName,
 			AgentSlug:        row.AgentSlug,
+			AgentDeleted:     row.AgentDeleted,
 			ConnectorType:    row.ConnectorType,
 			Status:           row.Status,
 			CreatedAt:        pgTime(row.CreatedAt),
@@ -7926,6 +7931,7 @@ func agentRunBriefFromRow(row agentRunBriefRow) AgentRunBriefRead {
 		AgentID:          row.RAgentID,
 		AgentName:        row.AgentName,
 		AgentSlug:        row.AgentSlug,
+		AgentDeleted:     row.AgentDeleted,
 		ConnectorType:    row.ConnectorType,
 		Status:           row.Status,
 		CreatedAt:        pgTime(row.CreatedAt),


### PR DESCRIPTION
Deleting an Agent now preserves its authorized conversation and run history, including identity, messages and run details. Deleted-Agent views explain the retained state, disable new chat input and hide retry; the retry store gate also rejects deleted Agents.

Validation: `make check`, web build, regenerated OpenAPI/sqlc contracts, isolated PostgreSQL history/authorization/retry tests, actual-server browser checks, and a fresh independent blind review of the full diff. Scope is historical reads and the corresponding deletion state and execution guards.
