### PR TITLE
Avoid reporting unknown runtime health as Ready

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -504,12 +504,14 @@
           "none": "No action needed."
         },
         "runtimeHealth": {
+          "unknown": "Unknown",
           "noSnapshot": "No snapshot",
           "offline": "Offline or unhealthy",
           "stale": "Stale heartbeat",
           "ready": "Ready"
         },
         "runtimeActions": {
+          "unknown": "Runtime health cannot be confirmed. Check the runtime connection.",
           "noSnapshot": "Check whether this run is bound to an agent_daemon runtime.",
           "offline": "Reconnect the daemon or switch to an available device.",
           "stale": "Confirm the daemon is running and reporting heartbeats.",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -504,12 +504,14 @@
           "none": "无需处理。"
         },
         "runtimeHealth": {
+          "unknown": "未知",
           "noSnapshot": "无快照",
           "offline": "离线或不健康",
           "stale": "心跳过旧",
           "ready": "可用"
         },
         "runtimeActions": {
+          "unknown": "无法确认运行环境是否可用，请检查连接状态。",
           "noSnapshot": "检查这条 Run 是否绑定了 agent_daemon runtime。",
           "offline": "重连 daemon 或切换到可用设备。",
           "stale": "确认 daemon 仍在运行并上报心跳。",

--- a/apps/web/src/lib/run-runtime-diagnosis.ts
+++ b/apps/web/src/lib/run-runtime-diagnosis.ts
@@ -1,0 +1,50 @@
+import type { AgentRunDetail } from "./api-types"
+
+export type AdminText = (key: string, options?: Record<string, unknown>) => string
+export type DiagnosisTone = "success" | "warning" | "error" | "neutral"
+
+interface RuntimeDiagnosis {
+  tone: DiagnosisTone
+  health: string
+  heartbeatAge: string
+  action: string
+}
+
+function fmtAge(value: string | undefined, t: AdminText): string {
+  if (!value) return t("runs.detail.diagnostics.age.unknown")
+  const ms = Date.parse(value)
+  if (Number.isNaN(ms)) return t("runs.detail.diagnostics.age.unknown")
+  const seconds = Math.max(0, Math.round((Date.now() - ms) / 1000))
+  if (seconds < 60) return t("runs.detail.diagnostics.age.seconds", { count: seconds })
+  const minutes = Math.round(seconds / 60)
+  if (minutes < 60) return t("runs.detail.diagnostics.age.minutes", { count: minutes })
+  const hours = Math.round(minutes / 60)
+  if (hours < 48) return t("runs.detail.diagnostics.age.hours", { count: hours })
+  return t("runs.detail.diagnostics.age.days", { count: Math.round(hours / 24) })
+}
+
+export function buildRuntimeDiagnosis(run: AgentRunDetail, t: AdminText): RuntimeDiagnosis {
+  const runtime = run.runtime
+  if (!runtime) {
+    const needsSnapshot = run.connector_type === "agent_daemon" && ["queued", "running", "failed"].includes(run.status)
+    return {
+      tone: needsSnapshot ? "warning" : "neutral",
+      health: t("runs.detail.diagnostics.runtimeHealth.noSnapshot"),
+      heartbeatAge: t("runs.detail.diagnostics.age.unknown"),
+      action: t("runs.detail.diagnostics.runtimeActions.noSnapshot"),
+    }
+  }
+  const live = (runtime.liveness ?? "").toLowerCase()
+  const heartbeatMs = runtime.last_heartbeat_at ? Date.parse(runtime.last_heartbeat_at) : NaN
+  const staleHeartbeat = run.status === "running" && Number.isFinite(heartbeatMs) && Date.now() - heartbeatMs > 120_000
+  if (/offline|unhealthy|error|degraded/.test(live)) {
+    return { tone: "error", health: t("runs.detail.diagnostics.runtimeHealth.offline"), heartbeatAge: fmtAge(runtime.last_heartbeat_at, t), action: t("runs.detail.diagnostics.runtimeActions.offline") }
+  }
+  if (staleHeartbeat) {
+    return { tone: "warning", health: t("runs.detail.diagnostics.runtimeHealth.stale"), heartbeatAge: fmtAge(runtime.last_heartbeat_at, t), action: t("runs.detail.diagnostics.runtimeActions.stale") }
+  }
+  if (live !== "online") {
+    return { tone: "neutral", health: t("runs.detail.diagnostics.runtimeHealth.unknown"), heartbeatAge: fmtAge(runtime.last_heartbeat_at, t), action: t("runs.detail.diagnostics.runtimeActions.unknown") }
+  }
+  return { tone: "success", health: t("runs.detail.diagnostics.runtimeHealth.ready"), heartbeatAge: fmtAge(runtime.last_heartbeat_at, t), action: t("runs.detail.diagnostics.runtimeActions.ready") }
+}

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -57,6 +57,7 @@ import {
 import { VerbatimBlock } from "../../components/ui/verbatim"
 import { useAdminView } from "../../lib/admin-router"
 import { ApiError } from "../../lib/api-client"
+import { buildRuntimeDiagnosis, type AdminText, type DiagnosisTone } from "../../lib/run-runtime-diagnosis"
 import {
   Dialog,
   DialogContent,
@@ -806,9 +807,6 @@ function shortId(s?: string, n = 8): string {
 }
 
 
-type AdminText = (key: string, options?: Record<string, unknown>) => string
-type DiagnosisTone = "success" | "warning" | "error" | "neutral"
-
 interface RunDiagnosis {
   tone: DiagnosisTone
   title: string
@@ -818,12 +816,6 @@ interface RunDiagnosis {
   latest: string
 }
 
-interface RuntimeDiagnosis {
-  tone: DiagnosisTone
-  health: string
-  heartbeatAge: string
-  action: string
-}
 
 function fmtDateTime(value?: string): string {
   if (!value) return "—"
@@ -838,18 +830,6 @@ function runtimeCapabilityEntries(capabilities?: Record<string, boolean>): [stri
     .sort(([a], [b]) => a.localeCompare(b))
 }
 
-function fmtAge(value: string | undefined, t: AdminText): string {
-  if (!value) return t("runs.detail.diagnostics.age.unknown")
-  const ms = Date.parse(value)
-  if (Number.isNaN(ms)) return t("runs.detail.diagnostics.age.unknown")
-  const seconds = Math.max(0, Math.round((Date.now() - ms) / 1000))
-  if (seconds < 60) return t("runs.detail.diagnostics.age.seconds", { count: seconds })
-  const minutes = Math.round(seconds / 60)
-  if (minutes < 60) return t("runs.detail.diagnostics.age.minutes", { count: minutes })
-  const hours = Math.round(minutes / 60)
-  if (hours < 48) return t("runs.detail.diagnostics.age.hours", { count: hours })
-  return t("runs.detail.diagnostics.age.days", { count: Math.round(hours / 24) })
-}
 
 function valueString(value: unknown): string {
   if (typeof value === "string") return value.trim()
@@ -1018,28 +998,6 @@ function buildRunDiagnosis(run: AgentRunDetail, events: AgentRunEvent[], t: Admi
   }
 }
 
-function buildRuntimeDiagnosis(run: AgentRunDetail, t: AdminText): RuntimeDiagnosis {
-  const runtime = run.runtime
-  if (!runtime) {
-    const needsSnapshot = run.connector_type === "agent_daemon" && ["queued", "running", "failed"].includes(run.status)
-    return {
-      tone: needsSnapshot ? "warning" : "neutral",
-      health: t("runs.detail.diagnostics.runtimeHealth.noSnapshot"),
-      heartbeatAge: t("runs.detail.diagnostics.age.unknown"),
-      action: t("runs.detail.diagnostics.runtimeActions.noSnapshot"),
-    }
-  }
-  const live = (runtime.liveness ?? "").toLowerCase()
-  const heartbeatMs = runtime.last_heartbeat_at ? Date.parse(runtime.last_heartbeat_at) : NaN
-  const staleHeartbeat = run.status === "running" && Number.isFinite(heartbeatMs) && Date.now() - heartbeatMs > 120_000
-  if (/offline|unhealthy|error|degraded/.test(live)) {
-    return { tone: "error", health: t("runs.detail.diagnostics.runtimeHealth.offline"), heartbeatAge: fmtAge(runtime.last_heartbeat_at, t), action: t("runs.detail.diagnostics.runtimeActions.offline") }
-  }
-  if (staleHeartbeat) {
-    return { tone: "warning", health: t("runs.detail.diagnostics.runtimeHealth.stale"), heartbeatAge: fmtAge(runtime.last_heartbeat_at, t), action: t("runs.detail.diagnostics.runtimeActions.stale") }
-  }
-  return { tone: "success", health: t("runs.detail.diagnostics.runtimeHealth.ready"), heartbeatAge: fmtAge(runtime.last_heartbeat_at, t), action: t("runs.detail.diagnostics.runtimeActions.ready") }
-}
 
 function RunCancelDialog({ open, loading, onCancel, onConfirm }: { open: boolean; loading: boolean; onCancel: () => void; onConfirm: () => void }) {
   const { t } = useTranslation("admin")


### PR DESCRIPTION
Run details displayed green Ready when runtime metadata had no health status. The health panel now shows Unknown with a connection hint unless the reported state is online; existing offline/error, missing-snapshot and stale-heartbeat handling is preserved.

Validation: `make check`, web build, 24 bilingual diagnosis cases, actual-server CUA verification, and a fresh independent blind review with 242 cases. The change is limited to display computation and its extraction from RunsPage.
