### PR TITLE
Align wrapped Agent toolbar with its title

### DIFF
--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -174,7 +174,7 @@ export function AgentsPage() {
       <RailLayout rail={agentRail}>
         <PageHeader
           className="static mx-0 mb-0 h-auto min-h-16 flex-wrap py-3"
-          actionClassName="min-w-0 max-w-full flex-wrap [&>button]:h-auto [&>button]:min-h-7 [&>button]:max-w-full [&>button]:flex-wrap [&>button]:whitespace-normal [&>button]:py-1"
+          actionClassName="ml-0 min-w-0 max-w-full grow basis-128 flex-wrap [&>button]:h-auto [&>button]:min-h-7 [&>button]:max-w-full [&>button]:flex-wrap [&>button]:whitespace-normal [&>button]:py-1"
           title={pageTitle}
           subtitleFor="agents.page.title"
           action={


### PR DESCRIPTION
The Agent toolbar became indented to the right below the page title when the detail pane reduced the available width. Wrapped actions now use the available row width and share the title’s left edge; wider panes retain a single aligned row.

Scope: one Agent page layout configuration. Search, filtering, creation, detail behavior, shared headers and table columns are unchanged.

Validation: `make check`, production web build, real-browser search/filter/create-cancel/detail checks, and an independent blind review of the complete diff passed. The reviewer checked 12 geometry cases and keyboard interactions. Sub-960px table/pane clipping remains outside this change.
