### PR TITLE
WIP: align MCP execution with selected capability versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,10 @@ description and keep ownership on the side listed here.
   pinning mode. Displayed current versions match the daemon's resolver:
   Skill, Plugin, Bundle, MCP, and System Prompt follow their binding mode and
   the existing deprecation cutoff. MCP content and required credentials must
-  come from the same selected version, including legacy content.
+  come from the same selected version, including legacy content. Installed
+  credential hints and binding validation use that selection too. Advancing
+  a public Agent's latest binding must not fall back to personal credentials
+  for a newly required kind; require a shared binding before delivery.
 
 - Cross-workspace installed capabilities remain visible and removable after
   unpublishing. Their installation metadata reports source visibility and only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,8 +156,9 @@ description and keep ownership on the side listed here.
 
 - Agent capability reads retain the stored binding version and expose its
   pinning mode. Displayed current versions match the daemon's resolver:
-  Skill, Plugin, and Bundle can follow latest metadata (including deprecation
-  cutoffs); MCP and System Prompt currently use the stored binding version.
+  Skill, Plugin, Bundle, MCP, and System Prompt follow their binding mode and
+  the existing deprecation cutoff. MCP content and required credentials must
+  come from the same selected version, including legacy content.
 
 - Cross-workspace installed capabilities remain visible and removable after
   unpublishing. Their installation metadata reports source visibility and only

--- a/apps/web/src/lib/agent-capability-version.ts
+++ b/apps/web/src/lib/agent-capability-version.ts
@@ -5,9 +5,8 @@ export function agentCapabilityFollowsLatest(
   capability: Capability | undefined,
 ): boolean {
   const kind = capability?.type ?? binding?.type
-  // Match the daemon resolvers: MCP and System Prompt still use stored fields.
   return binding?.pinning_mode === "latest"
-    && (kind === "skill" || kind === "plugin" || kind === "bundle")
+    && (kind === "skill" || kind === "plugin" || kind === "bundle" || kind === "mcp" || kind === "system_prompt")
 }
 
 export function agentCapabilityVersion(

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -5013,7 +5013,8 @@ paths:
     get:
       description: Returns installed capabilities, their pinning_mode and bound/latest
         version metadata, plus available workspace and marketplace capabilities. Latest
-        metadata respects the runtime deprecation cutoff.
+        metadata respects the runtime deprecation cutoff. Installed MCP credential
+        requirements match the selected runtime version.
       operationId: listDevAgentCapabilities
       parameters:
       - description: Workspace UUID

--- a/server/internal/connector/agentdaemon/capability_content.go
+++ b/server/internal/connector/agentdaemon/capability_content.go
@@ -1,0 +1,71 @@
+package agentdaemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/render"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+// resolveCapabilityMCPContent picks the right content source for an MCP
+// capability and renders it via the Claude Code renderer.
+//
+// Precedence:
+//  1. CanonicalSpec (M1+ imports) → render through TargetClaudeCode
+//  2. Content (legacy hand-authored) → returned verbatim
+func resolveCapabilityMCPContent(cap store.EnabledCapabilityRead, renderer render.Renderer) ([]byte, error) {
+	if len(cap.CanonicalSpec) > 0 {
+		var spec canonical.Spec
+		if err := json.Unmarshal(cap.CanonicalSpec, &spec); err != nil {
+			return nil, fmt.Errorf("agent_daemon: capability %s canonical_spec decode: %w", cap.CapabilityID, err)
+		}
+		out, err := renderer.Render(context.Background(), spec)
+		if err != nil {
+			return nil, fmt.Errorf("agent_daemon: capability %s render: %w", cap.CapabilityID, err)
+		}
+		return out.Content, nil
+	}
+	return cap.Content, nil
+}
+
+// resolveSystemPromptCapability decodes a capability_version.canonical_spec
+// into a ResolvedSystemPrompt. The render call is kept for wire-shape
+// consistency only (mirrors resolveSkillCapability); the prompt text is
+// read straight from the canonical spec because the daemon consumes
+// agent_options.system_prompt / override_system_prompt, not a rendered
+// capability blob.
+func (c *Connector) resolveSystemPromptCapability(
+	ctx context.Context,
+	cap store.EnabledCapabilityRead,
+	renderer render.Renderer,
+) (*ResolvedSystemPrompt, error) {
+	resolved := resolveVersionFields(cap)
+	if len(resolved.CanonicalSpec) == 0 {
+		c.log.Warn("agent_daemon: system_prompt capability has empty canonical_spec, skipping",
+			"capability_id", cap.CapabilityID,
+			"capability_name", cap.Name)
+		return nil, nil
+	}
+	var spec canonical.Spec
+	if err := json.Unmarshal(resolved.CanonicalSpec, &spec); err != nil {
+		return nil, fmt.Errorf("agent_daemon: system_prompt capability %s canonical_spec decode: %w", cap.CapabilityID, err)
+	}
+	if spec.Kind != canonical.KindSystemPrompt {
+		return nil, fmt.Errorf("agent_daemon: capability %s has type=system_prompt but canonical_spec.kind=%q", cap.CapabilityID, spec.Kind)
+	}
+	if spec.SystemPrompt == nil {
+		return nil, fmt.Errorf("agent_daemon: capability %s canonical_spec.system_prompt is nil", cap.CapabilityID)
+	}
+	if _, err := renderer.Render(ctx, spec); err != nil {
+		return nil, fmt.Errorf("agent_daemon: render system_prompt %s: %w", cap.CapabilityID, err)
+	}
+	return &ResolvedSystemPrompt{
+		Name:    strings.TrimSpace(cap.Name),
+		Mode:    spec.SystemPrompt.ResolvedMode(),
+		Content: spec.SystemPrompt.Prompt,
+	}, nil
+}

--- a/server/internal/connector/agentdaemon/capability_content_test.go
+++ b/server/internal/connector/agentdaemon/capability_content_test.go
@@ -1,0 +1,92 @@
+package agentdaemon
+
+import (
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func TestCapabilityContentVersionSelection(t *testing.T) {
+	for _, kind := range []string{"mcp", "legacy_mcp", "system_prompt"} {
+		for _, mode := range []string{"", store.PinningModePinned, store.PinningModeLatest} {
+			t.Run(kind+"/"+mode, func(t *testing.T) {
+				row := store.EnabledCapabilityRead{CapabilityID: "cap", Name: "versioned", Type: "mcp", PinningMode: mode}
+				if kind == "system_prompt" {
+					row.Type = kind
+					row.CanonicalSpec = []byte(`{"schema_version":1,"kind":"system_prompt","system_prompt":{"prompt":"v1","mode":"append"}}`)
+					row.LatestCanonicalSpec = []byte(`{"schema_version":1,"kind":"system_prompt","system_prompt":{"prompt":"v2","mode":"override"}}`)
+				} else if kind == "legacy_mcp" {
+					row.Content = []byte(`{"mcpServers":{"versioned":{"command":"v1"}}}`)
+					row.LatestContent = []byte(`{"mcpServers":{"versioned":{"command":"v2"}}}`)
+				} else {
+					row.CanonicalSpec = newMCPRow(t, "cap", "versioned", []canonical.MCPServer{{Name: "versioned", Command: "v1"}}, nil).CanonicalSpec
+					row.LatestCanonicalSpec = newMCPRow(t, "cap", "versioned", []canonical.MCPServer{{Name: "versioned", Command: "v2"}}, nil).CanonicalSpec
+				}
+				c := &Connector{capabilities: stubCapabilityStore{rows: []store.EnabledCapabilityRead{row}}, log: discardLogger()}
+				got, err := c.resolveCapabilityAdditions(t.Context(), defaultPromptInput(), "claude_code")
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := "v1"
+				if mode == store.PinningModeLatest {
+					want = "v2"
+				}
+				if kind == "system_prompt" {
+					if len(got.SystemPrompts) != 1 || got.SystemPrompts[0].Content != want {
+						t.Fatalf("system prompt = %+v, want %s", got.SystemPrompts, want)
+					}
+					wantMode := canonical.SystemPromptModeAppend
+					if mode == store.PinningModeLatest {
+						wantMode = canonical.SystemPromptModeOverride
+					}
+					if got.SystemPrompts[0].Mode != wantMode {
+						t.Fatalf("prompt mode = %s, want %s", got.SystemPrompts[0].Mode, wantMode)
+					}
+				} else if server, ok := got.MCPServers["versioned"].(map[string]any); !ok || server["command"] != want {
+					t.Fatalf("MCP servers = %+v, want %s", got.MCPServers, want)
+				}
+			})
+		}
+	}
+}
+
+func TestMCPLatestVersionCredentials(t *testing.T) {
+	svc := testSecretsService(t)
+	v2 := newMCPRow(t, "cap", "versioned", []canonical.MCPServer{{Name: "versioned", Command: "echo", Env: map[string]canonical.EnvValue{
+		"TOKEN": {Mode: canonical.EnvModeCredentialRef, CredentialKindCode: "new_token"},
+	}}}, []store.RequiredCredential{{Kind: "new_token", Required: true}})
+	row := newMCPRow(t, "cap", "versioned", []canonical.MCPServer{{Name: "old", Command: "echo"}}, []store.RequiredCredential{{Kind: "old_token", Required: true}})
+	row.PinningMode, row.CapabilityVersionID, row.LatestVersionID = store.PinningModeLatest, "v1", "v2"
+	row.LatestCanonicalSpec, row.LatestRequiredCredentials = v2.CanonicalSpec, v2.RequiredCredentials
+	for _, missing := range []bool{false, true} {
+		t.Run(map[bool]string{false: "available", true: "missing"}[missing], func(t *testing.T) {
+			creds := map[string]store.UserCredentialRead{}
+			if !missing {
+				creds["user-1:new_token"] = store.UserCredentialRead{ID: "credential-new", UserID: "user-1", Kind: "new_token", Ciphertext: encryptPayload(t, svc, map[string]any{"token": "synthetic-token"})}
+			}
+			c := &Connector{capabilities: stubCapabilityStore{rows: []store.EnabledCapabilityRead{row}, credentials: creds}, secrets: svc, log: discardLogger()}
+			got, err := c.resolveCapabilityAdditions(t.Context(), defaultPromptInput(), "claude_code")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if missing {
+				if len(got.MCPServers) != 0 || len(got.Disabled) != 1 || len(got.Disabled[0].MissingCredentials) != 1 || got.Disabled[0].CapabilityVersionID != "v2" || got.Disabled[0].MissingCredentials[0].Kind != "new_token" {
+					t.Fatalf("missing credential result = %+v", got)
+				}
+				return
+			}
+			server, ok := got.MCPServers["versioned"].(map[string]any)
+			if !ok {
+				t.Fatalf("MCP server missing: %+v", got.MCPServers)
+			}
+			env, ok := server["env"].(map[string]string)
+			if !ok || env["TOKEN"] != "synthetic-token" {
+				t.Fatalf("new credential was not resolved")
+			}
+			if len(got.CredentialEmits) != 1 || got.CredentialEmits[0].CapabilityVersionID != "v2" || got.CredentialEmits[0].CredentialKind != "new_token" {
+				t.Fatalf("credential audit = %+v", got.CredentialEmits)
+			}
+		})
+	}
+}

--- a/server/internal/connector/agentdaemon/capability_content_test.go
+++ b/server/internal/connector/agentdaemon/capability_content_test.go
@@ -90,3 +90,56 @@ func TestMCPLatestVersionCredentials(t *testing.T) {
 		})
 	}
 }
+
+func TestMCPLatestPublicCredentials(t *testing.T) {
+	svc := testSecretsService(t)
+	v2 := newMCPRow(t, "cap", "versioned", []canonical.MCPServer{{Name: "versioned", Command: "echo", Env: map[string]canonical.EnvValue{
+		"TOKEN": {Mode: canonical.EnvModeCredentialRef, CredentialKindCode: "github_pat"},
+	}}}, []store.RequiredCredential{{Kind: "github_pat", Required: true}})
+	for _, tc := range []struct {
+		name, visibility, mode, token string
+		shared, disabled              bool
+	}{
+		{name: "workspace latest", visibility: "workspace", mode: store.PinningModeLatest, token: "private-token"},
+		{name: "public latest unbound", visibility: "public", mode: store.PinningModeLatest, disabled: true},
+		{name: "public latest shared", visibility: "public", mode: store.PinningModeLatest, shared: true, token: "sk-shared"},
+		{name: "public pinned", visibility: "public", mode: store.PinningModePinned},
+		{name: "public omitted mode", visibility: "public"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			row := newMCPRow(t, "cap", "versioned", []canonical.MCPServer{{Name: "versioned", Command: "echo"}}, nil)
+			row.AgentVisibility, row.PinningMode = tc.visibility, tc.mode
+			row.CapabilityVersionID, row.LatestVersionID = "v1", "v2"
+			row.LatestCanonicalSpec, row.LatestRequiredCredentials = v2.CanonicalSpec, v2.RequiredCredentials
+			if tc.shared {
+				row.Configuration = map[string]any{"credential_bindings": map[string]any{"github_pat": map[string]any{"source": "shared", "secret_id": "secret-shared"}}}
+			}
+			c := &Connector{capabilities: stubCapabilityStore{rows: []store.EnabledCapabilityRead{row}, credentials: map[string]store.UserCredentialRead{
+				"user-1:github_pat": {ID: "personal", UserID: "user-1", Kind: "github_pat", Ciphertext: encryptPayload(t, svc, map[string]any{"token": "private-token"})},
+			}}, secrets: svc, modelResolver: sharedBindingResolver(t, svc), log: discardLogger()}
+			got, err := c.resolveCapabilityAdditions(t.Context(), defaultPromptInput(), "claude_code")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.disabled {
+				if len(got.MCPServers) != 0 || len(got.CredentialEmits) != 0 || len(got.Disabled) != 1 || got.Disabled[0].CapabilityVersionID != "v2" {
+					t.Fatalf("public MCP with an unbound required credential was not disabled: %+v", got)
+				}
+				return
+			}
+			if len(got.Disabled) != 0 || len(got.MCPServers) != 1 {
+				t.Fatalf("expected available MCP: %+v", got)
+			}
+			if tc.token == "" {
+				if len(got.CredentialEmits) != 0 {
+					t.Fatal("credential-free stored version emitted a credential")
+				}
+				return
+			}
+			server := got.MCPServers["versioned"].(map[string]any)
+			if server["env"].(map[string]string)["TOKEN"] != tc.token || len(got.CredentialEmits) != 1 || got.CredentialEmits[0].CapabilityVersionID != "v2" {
+				t.Fatal("selected version credential or audit did not match")
+			}
+		})
+	}
+}

--- a/server/internal/connector/agentdaemon/capability_runtime.go
+++ b/server/internal/connector/agentdaemon/capability_runtime.go
@@ -741,10 +741,15 @@ func (c *Connector) resolveCredentialValues(
 	var (
 		personalKinds []store.RequiredCredential
 		sharedTargets []sharedTarget
+		missing       []MissingCredentialRef
 	)
 	for _, rc := range cap.RequiredCredentials {
 		if b, ok := bindings[rc.Kind]; ok && b.IsShared() {
 			sharedTargets = append(sharedTargets, sharedTarget{Kind: rc.Kind, SecretID: b.SecretID})
+			continue
+		}
+		if strings.TrimSpace(cap.AgentVisibility) == "public" && rc.Required {
+			missing = append(missing, MissingCredentialRef{Kind: rc.Kind})
 			continue
 		}
 		personalKinds = append(personalKinds, rc)
@@ -758,7 +763,6 @@ func (c *Connector) resolveCredentialValues(
 
 	values := map[string]string{}
 	sharedSecretIDs := map[string]string{}
-	var missing []MissingCredentialRef
 
 	// Shared bindings: resolve once via the model resolver's secret
 	// payload reader (already wired for inline_secret models).

--- a/server/internal/connector/agentdaemon/capability_runtime.go
+++ b/server/internal/connector/agentdaemon/capability_runtime.go
@@ -207,16 +207,19 @@ func disabledForUnavailableVersion(cap store.EnabledCapabilityRead) DisabledCapa
 	}
 }
 
-// resolvedVersionFields collects the four storage-relevant fields the
+// resolvedVersionFields collects the version fields the
 // daemon resolver needs from cap, picking either the pinned-column
 // fields or the joined latest-* fields based on cap.PinningMode.
 // Centralising the switch keeps the per-kind resolve functions free of
 // pinning_mode awareness.
 type resolvedVersionFields struct {
-	OssKey        string
-	SHA256        string
-	CanonicalSpec []byte
-	Version       string // capability_version.version literal, surfaced to the daemon for log / wire purposes
+	ID                  string
+	Content             []byte
+	RequiredCredentials []store.RequiredCredential
+	OssKey              string
+	SHA256              string
+	CanonicalSpec       []byte
+	Version             string // capability_version.version literal, surfaced to the daemon for log / wire purposes
 }
 
 // resolveVersionFields returns the storage / version fields to use for
@@ -227,17 +230,23 @@ type resolvedVersionFields struct {
 func resolveVersionFields(cap store.EnabledCapabilityRead) resolvedVersionFields {
 	if strings.TrimSpace(cap.PinningMode) == store.PinningModeLatest {
 		return resolvedVersionFields{
-			OssKey:        cap.LatestOssKey,
-			SHA256:        cap.LatestSHA256,
-			CanonicalSpec: cap.LatestCanonicalSpec,
-			Version:       cap.LatestVersion,
+			ID:                  cap.LatestVersionID,
+			Content:             cap.LatestContent,
+			RequiredCredentials: cap.LatestRequiredCredentials,
+			OssKey:              cap.LatestOssKey,
+			SHA256:              cap.LatestSHA256,
+			CanonicalSpec:       cap.LatestCanonicalSpec,
+			Version:             cap.LatestVersion,
 		}
 	}
 	return resolvedVersionFields{
-		OssKey:        cap.OssKey,
-		SHA256:        cap.SHA256,
-		CanonicalSpec: cap.CanonicalSpec,
-		Version:       cap.Version,
+		ID:                  cap.CapabilityVersionID,
+		Content:             cap.Content,
+		RequiredCredentials: cap.RequiredCredentials,
+		OssKey:              cap.OssKey,
+		SHA256:              cap.SHA256,
+		CanonicalSpec:       cap.CanonicalSpec,
+		Version:             cap.Version,
 	}
 }
 
@@ -561,8 +570,11 @@ func (c *Connector) resolveMCPCapability(
 	renderer render.Renderer,
 	credentialCache map[string]store.UserCredentialRead,
 ) (map[string]any, *DisabledCapability, []CredentialEmit, error) {
-	// Render canonical spec (or legacy content) into the Claude Code
-	// MCP JSON shape: {"mcpServers": {"name": {"command","args","env"}}}
+	version := resolveVersionFields(cap)
+	cap.CapabilityVersionID = version.ID
+	cap.CanonicalSpec = version.CanonicalSpec
+	cap.Content = version.Content
+	cap.RequiredCredentials = version.RequiredCredentials
 	content, err := resolveCapabilityMCPContent(cap, renderer)
 	if err != nil {
 		return nil, nil, nil, err
@@ -893,27 +905,6 @@ func credentialPayloadValue(payload map[string]any) string {
 	return ""
 }
 
-// resolveCapabilityMCPContent picks the right content source for an MCP
-// capability and renders it via the Claude Code renderer.
-//
-// Precedence:
-//  1. CanonicalSpec (M1+ imports) → render through TargetClaudeCode
-//  2. Content (legacy hand-authored) → returned verbatim
-func resolveCapabilityMCPContent(cap store.EnabledCapabilityRead, renderer render.Renderer) ([]byte, error) {
-	if len(cap.CanonicalSpec) > 0 {
-		var spec canonical.Spec
-		if err := json.Unmarshal(cap.CanonicalSpec, &spec); err != nil {
-			return nil, fmt.Errorf("agent_daemon: capability %s canonical_spec decode: %w", cap.CapabilityID, err)
-		}
-		out, err := renderer.Render(context.Background(), spec)
-		if err != nil {
-			return nil, fmt.Errorf("agent_daemon: capability %s render: %w", cap.CapabilityID, err)
-		}
-		return out.Content, nil
-	}
-	return cap.Content, nil
-}
-
 // claudeCodeMCPDocument mirrors the JSON shape emitted by
 // render.claudeCodeRenderer for KindMCP.
 type claudeCodeMCPDocument struct {
@@ -1024,43 +1015,6 @@ func (c *Connector) resolveSkillCapability(
 		Version:     resolved.Version,
 		DownloadURL: url,
 		SHA256:      sha256,
-	}, nil
-}
-
-// resolveSystemPromptCapability decodes a capability_version.canonical_spec
-// into a ResolvedSystemPrompt. The render call is kept for wire-shape
-// consistency only (mirrors resolveSkillCapability); the prompt text is
-// read straight from the canonical spec because the daemon consumes
-// agent_options.system_prompt / override_system_prompt, not a rendered
-// capability blob.
-func (c *Connector) resolveSystemPromptCapability(
-	ctx context.Context,
-	cap store.EnabledCapabilityRead,
-	renderer render.Renderer,
-) (*ResolvedSystemPrompt, error) {
-	if len(cap.CanonicalSpec) == 0 {
-		c.log.Warn("agent_daemon: system_prompt capability has empty canonical_spec, skipping",
-			"capability_id", cap.CapabilityID,
-			"capability_name", cap.Name)
-		return nil, nil
-	}
-	var spec canonical.Spec
-	if err := json.Unmarshal(cap.CanonicalSpec, &spec); err != nil {
-		return nil, fmt.Errorf("agent_daemon: system_prompt capability %s canonical_spec decode: %w", cap.CapabilityID, err)
-	}
-	if spec.Kind != canonical.KindSystemPrompt {
-		return nil, fmt.Errorf("agent_daemon: capability %s has type=system_prompt but canonical_spec.kind=%q", cap.CapabilityID, spec.Kind)
-	}
-	if spec.SystemPrompt == nil {
-		return nil, fmt.Errorf("agent_daemon: capability %s canonical_spec.system_prompt is nil", cap.CapabilityID)
-	}
-	if _, err := renderer.Render(ctx, spec); err != nil {
-		return nil, fmt.Errorf("agent_daemon: render system_prompt %s: %w", cap.CapabilityID, err)
-	}
-	return &ResolvedSystemPrompt{
-		Name:    strings.TrimSpace(cap.Name),
-		Mode:    spec.SystemPrompt.ResolvedMode(),
-		Content: spec.SystemPrompt.Prompt,
 	}, nil
 }
 

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -3986,6 +3986,7 @@ where id = @id::uuid;
 select
   ac.id::text as agent_capability_id,
   ac.agent_id::text as agent_id,
+  a.visibility as agent_visibility,
   ac.enabled,
   ac.configuration,
   ac.pinning_mode,
@@ -4030,6 +4031,7 @@ select
   -- lets the runtime fail closed if a legacy row slips through.
   coalesce(c.creator_id::text, '')::text as capability_creator_id
 from agent_capabilities ac
+join agents a on a.id = ac.agent_id
 join capability c on c.id = ac.capability_id
 join capability_version cv on cv.id = ac.capability_version_id
 join workspaces src_ws on src_ws.id = c.workspace_id

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -4010,6 +4010,8 @@ select
   latest.oss_key        as latest_oss_key,
   latest.sha256         as latest_sha256,
   latest.canonical_spec as latest_canonical_spec,
+  latest.content as latest_content,
+  latest.required_credentials as latest_required_credentials,
   latest.schema_version as latest_schema_version,
   cv.git_repo_url,
   cv.git_ref,
@@ -4033,7 +4035,7 @@ join capability_version cv on cv.id = ac.capability_version_id
 join workspaces src_ws on src_ws.id = c.workspace_id
 join lateral (
   select id, version, created_at,
-    oss_key, sha256, canonical_spec, schema_version
+    oss_key, sha256, canonical_spec, content, required_credentials, schema_version
   from capability_version
   where capability_id = c.id
     -- After a capability is deprecated, latest bindings should freeze

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -5247,6 +5247,8 @@ select
   latest.oss_key        as latest_oss_key,
   latest.sha256         as latest_sha256,
   latest.canonical_spec as latest_canonical_spec,
+  latest.content as latest_content,
+  latest.required_credentials as latest_required_credentials,
   latest.schema_version as latest_schema_version,
   cv.git_repo_url,
   cv.git_ref,
@@ -5270,7 +5272,7 @@ join capability_version cv on cv.id = ac.capability_version_id
 join workspaces src_ws on src_ws.id = c.workspace_id
 join lateral (
   select id, version, created_at,
-    oss_key, sha256, canonical_spec, schema_version
+    oss_key, sha256, canonical_spec, content, required_credentials, schema_version
   from capability_version
   where capability_id = c.id
     -- After a capability is deprecated, latest bindings should freeze
@@ -5291,40 +5293,42 @@ order by c.name asc
 `
 
 type GetEnabledCapabilitiesForAgentRow struct {
-	AgentCapabilityID      string             `json:"agent_capability_id"`
-	AgentID                string             `json:"agent_id"`
-	Enabled                bool               `json:"enabled"`
-	Configuration          []byte             `json:"configuration"`
-	PinningMode            string             `json:"pinning_mode"`
-	CapabilityID           string             `json:"capability_id"`
-	WorkspaceID            string             `json:"workspace_id"`
-	SourceWorkspaceName    string             `json:"source_workspace_name"`
-	Type                   string             `json:"type"`
-	Name                   string             `json:"name"`
-	Description            string             `json:"description"`
-	Visibility             string             `json:"visibility"`
-	Status                 string             `json:"status"`
-	DeprecatedAt           pgtype.Timestamptz `json:"deprecated_at"`
-	RequiredCredentials    []byte             `json:"required_credentials"`
-	CapabilityVersionID    string             `json:"capability_version_id"`
-	Version                string             `json:"version"`
-	LatestVersionID        string             `json:"latest_version_id"`
-	LatestVersion          string             `json:"latest_version"`
-	LatestVersionCreatedAt pgtype.Timestamptz `json:"latest_version_created_at"`
-	LatestOssKey           string             `json:"latest_oss_key"`
-	LatestSha256           string             `json:"latest_sha256"`
-	LatestCanonicalSpec    []byte             `json:"latest_canonical_spec"`
-	LatestSchemaVersion    int16              `json:"latest_schema_version"`
-	GitRepoUrl             pgtype.Text        `json:"git_repo_url"`
-	GitRef                 pgtype.Text        `json:"git_ref"`
-	Path                   pgtype.Text        `json:"path"`
-	Content                []byte             `json:"content"`
-	CanonicalSpec          []byte             `json:"canonical_spec"`
-	SchemaVersion          int16              `json:"schema_version"`
-	OssKey                 string             `json:"oss_key"`
-	Sha256                 string             `json:"sha256"`
-	Tags                   []byte             `json:"tags"`
-	CapabilityCreatorID    string             `json:"capability_creator_id"`
+	AgentCapabilityID         string             `json:"agent_capability_id"`
+	AgentID                   string             `json:"agent_id"`
+	Enabled                   bool               `json:"enabled"`
+	Configuration             []byte             `json:"configuration"`
+	PinningMode               string             `json:"pinning_mode"`
+	CapabilityID              string             `json:"capability_id"`
+	WorkspaceID               string             `json:"workspace_id"`
+	SourceWorkspaceName       string             `json:"source_workspace_name"`
+	Type                      string             `json:"type"`
+	Name                      string             `json:"name"`
+	Description               string             `json:"description"`
+	Visibility                string             `json:"visibility"`
+	Status                    string             `json:"status"`
+	DeprecatedAt              pgtype.Timestamptz `json:"deprecated_at"`
+	RequiredCredentials       []byte             `json:"required_credentials"`
+	CapabilityVersionID       string             `json:"capability_version_id"`
+	Version                   string             `json:"version"`
+	LatestVersionID           string             `json:"latest_version_id"`
+	LatestVersion             string             `json:"latest_version"`
+	LatestVersionCreatedAt    pgtype.Timestamptz `json:"latest_version_created_at"`
+	LatestOssKey              string             `json:"latest_oss_key"`
+	LatestSha256              string             `json:"latest_sha256"`
+	LatestCanonicalSpec       []byte             `json:"latest_canonical_spec"`
+	LatestContent             []byte             `json:"latest_content"`
+	LatestRequiredCredentials []byte             `json:"latest_required_credentials"`
+	LatestSchemaVersion       int16              `json:"latest_schema_version"`
+	GitRepoUrl                pgtype.Text        `json:"git_repo_url"`
+	GitRef                    pgtype.Text        `json:"git_ref"`
+	Path                      pgtype.Text        `json:"path"`
+	Content                   []byte             `json:"content"`
+	CanonicalSpec             []byte             `json:"canonical_spec"`
+	SchemaVersion             int16              `json:"schema_version"`
+	OssKey                    string             `json:"oss_key"`
+	Sha256                    string             `json:"sha256"`
+	Tags                      []byte             `json:"tags"`
+	CapabilityCreatorID       string             `json:"capability_creator_id"`
 }
 
 func (q *Queries) GetEnabledCapabilitiesForAgent(ctx context.Context, agentID pgtype.UUID) ([]GetEnabledCapabilitiesForAgentRow, error) {
@@ -5360,6 +5364,8 @@ func (q *Queries) GetEnabledCapabilitiesForAgent(ctx context.Context, agentID pg
 			&i.LatestOssKey,
 			&i.LatestSha256,
 			&i.LatestCanonicalSpec,
+			&i.LatestContent,
+			&i.LatestRequiredCredentials,
 			&i.LatestSchemaVersion,
 			&i.GitRepoUrl,
 			&i.GitRef,

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -5223,6 +5223,7 @@ const getEnabledCapabilitiesForAgent = `-- name: GetEnabledCapabilitiesForAgent 
 select
   ac.id::text as agent_capability_id,
   ac.agent_id::text as agent_id,
+  a.visibility as agent_visibility,
   ac.enabled,
   ac.configuration,
   ac.pinning_mode,
@@ -5267,6 +5268,7 @@ select
   -- lets the runtime fail closed if a legacy row slips through.
   coalesce(c.creator_id::text, '')::text as capability_creator_id
 from agent_capabilities ac
+join agents a on a.id = ac.agent_id
 join capability c on c.id = ac.capability_id
 join capability_version cv on cv.id = ac.capability_version_id
 join workspaces src_ws on src_ws.id = c.workspace_id
@@ -5295,6 +5297,7 @@ order by c.name asc
 type GetEnabledCapabilitiesForAgentRow struct {
 	AgentCapabilityID         string             `json:"agent_capability_id"`
 	AgentID                   string             `json:"agent_id"`
+	AgentVisibility           string             `json:"agent_visibility"`
 	Enabled                   bool               `json:"enabled"`
 	Configuration             []byte             `json:"configuration"`
 	PinningMode               string             `json:"pinning_mode"`
@@ -5343,6 +5346,7 @@ func (q *Queries) GetEnabledCapabilitiesForAgent(ctx context.Context, agentID pg
 		if err := rows.Scan(
 			&i.AgentCapabilityID,
 			&i.AgentID,
+			&i.AgentVisibility,
 			&i.Enabled,
 			&i.Configuration,
 			&i.PinningMode,

--- a/server/internal/dev/agent_capability_response.go
+++ b/server/internal/dev/agent_capability_response.go
@@ -1,0 +1,46 @@
+package dev
+
+import (
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func installedAgentCapabilityResponse(binding store.AgentCapabilityRead, capability store.EnabledCapabilityRead, workspaceID string) map[string]any {
+	requiredCredentials := capability.RequiredCredentials
+	if capability.Type == "mcp" && strings.TrimSpace(binding.PinningMode) == store.PinningModeLatest {
+		requiredCredentials = capability.LatestRequiredCredentials
+	}
+	return map[string]any{
+		"id":                    binding.ID,
+		"agent_id":              binding.AgentID,
+		"capability_id":         binding.CapabilityID,
+		"capability_version_id": binding.CapabilityVersionID,
+		"pinning_mode":          binding.PinningMode,
+		"enabled":               binding.Enabled,
+		"configuration":         binding.Configuration,
+		"created_at":            binding.CreatedAt,
+		"updated_at":            binding.UpdatedAt,
+		"capability": map[string]any{
+			"id":                        capability.CapabilityID,
+			"workspace_id":              capability.WorkspaceID,
+			"type":                      capability.Type,
+			"name":                      capability.Name,
+			"description":               capability.Description,
+			"visibility":                capability.Visibility,
+			"status":                    capability.Status,
+			"required_credentials":      requiredCredentials,
+			"deprecated_at":             capability.DeprecatedAt,
+			"from_marketplace":          capability.WorkspaceID != workspaceID,
+			"source_workspace_id":       capability.WorkspaceID,
+			"source_workspace_name":     capability.SourceWorkspaceName,
+			"latest_version_id":         capability.LatestVersionID,
+			"latest_version":            capability.LatestVersion,
+			"latest_version_created_at": capability.LatestVersionCreatedAt,
+			"pinned_version_id":         binding.CapabilityVersionID,
+			"pinned_version":            capability.Version,
+			"created_at":                capability.LatestVersionCreatedAt,
+			"updated_at":                capability.LatestVersionCreatedAt,
+		},
+	}
+}

--- a/server/internal/dev/capability_binding_version.go
+++ b/server/internal/dev/capability_binding_version.go
@@ -15,6 +15,7 @@ type capabilityBindingVersionStore interface {
 }
 
 func validateBoundCapabilityCredentials(ctx context.Context, source capabilityBindingVersionStore, input capabilityCredentialBindingValidationInput) error {
+	boundVersionID := input.Version.ID
 	if strings.TrimSpace(input.PinningMode) == store.PinningModeLatest {
 		capability, err := source.GetCapability(ctx, input.Version.CapabilityID)
 		if err != nil {
@@ -37,5 +38,7 @@ func validateBoundCapabilityCredentials(ctx context.Context, source capabilityBi
 			}
 		}
 	}
+	// A newer version may retire credentials retained in an existing binding.
+	input.AllowUnusedBindings = input.AllowUnusedBindings && input.Version.ID != boundVersionID
 	return validateCapabilityCredentialBindings(ctx, source, input)
 }

--- a/server/internal/dev/capability_binding_version.go
+++ b/server/internal/dev/capability_binding_version.go
@@ -1,0 +1,41 @@
+package dev
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+type capabilityBindingVersionStore interface {
+	credentialBindingSecretStore
+	GetCapability(context.Context, string) (store.CapabilityRead, error)
+	ListCapabilityVersions(context.Context, string) ([]store.CapabilityVersionRead, error)
+}
+
+func validateBoundCapabilityCredentials(ctx context.Context, source capabilityBindingVersionStore, input capabilityCredentialBindingValidationInput) error {
+	if strings.TrimSpace(input.PinningMode) == store.PinningModeLatest {
+		capability, err := source.GetCapability(ctx, input.Version.CapabilityID)
+		if err != nil {
+			return err
+		}
+		if capability.Type == "mcp" {
+			versions, err := source.ListCapabilityVersions(ctx, capability.ID)
+			if err != nil {
+				return err
+			}
+			found := false
+			for _, version := range versions {
+				if capability.DeprecatedAt == nil || !version.CreatedAt.After(*capability.DeprecatedAt) {
+					input.Version, found = version, true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("no available version for capability %s", capability.ID)
+			}
+		}
+	}
+	return validateCapabilityCredentialBindings(ctx, source, input)
+}

--- a/server/internal/dev/capability_credential_binding.go
+++ b/server/internal/dev/capability_credential_binding.go
@@ -31,12 +31,13 @@ func (e *capabilityCredentialValidationError) Error() string {
 }
 
 type capabilityCredentialBindingValidationInput struct {
-	PinningMode     string
-	WorkspaceID     string
-	AgentVisibility string
-	AgentConfig     map[string]any
-	Version         store.CapabilityVersionRead
-	Configuration   map[string]any
+	PinningMode         string
+	AllowUnusedBindings bool
+	WorkspaceID         string
+	AgentVisibility     string
+	AgentConfig         map[string]any
+	Version             store.CapabilityVersionRead
+	Configuration       map[string]any
 }
 
 func validateCapabilityCredentialBindings(
@@ -56,7 +57,7 @@ func validateCapabilityCredentialBindings(
 		}
 	}
 	for kind := range bindings {
-		if !requiredKinds[kind] {
+		if !requiredKinds[kind] && !input.AllowUnusedBindings {
 			return errors.New("credential binding kind is not required by this capability")
 		}
 	}
@@ -105,12 +106,13 @@ func validateAgentCapabilityBindingsForVisibility(
 			return fmt.Errorf("get capability version %s: %w", binding.CapabilityVersionID, err)
 		}
 		if err := validateBoundCapabilityCredentials(ctx, credentialStore, capabilityCredentialBindingValidationInput{
-			PinningMode:     binding.PinningMode,
-			WorkspaceID:     agent.WorkspaceID,
-			AgentVisibility: visibility,
-			AgentConfig:     agent.Config,
-			Version:         version,
-			Configuration:   binding.Configuration,
+			PinningMode:         binding.PinningMode,
+			AllowUnusedBindings: true,
+			WorkspaceID:         agent.WorkspaceID,
+			AgentVisibility:     visibility,
+			AgentConfig:         agent.Config,
+			Version:             version,
+			Configuration:       binding.Configuration,
 		}); err != nil {
 			return &capabilityCredentialValidationError{err: err}
 		}

--- a/server/internal/dev/capability_credential_binding.go
+++ b/server/internal/dev/capability_credential_binding.go
@@ -17,7 +17,7 @@ type credentialBindingSecretStore interface {
 }
 
 type agentCapabilityCredentialBindingStore interface {
-	credentialBindingSecretStore
+	capabilityBindingVersionStore
 	ListAgentCapabilities(ctx context.Context, agentID string) ([]store.AgentCapabilityRead, error)
 	GetCapabilityVersion(ctx context.Context, capabilityVersionID string) (store.CapabilityVersionRead, error)
 }
@@ -31,6 +31,7 @@ func (e *capabilityCredentialValidationError) Error() string {
 }
 
 type capabilityCredentialBindingValidationInput struct {
+	PinningMode     string
 	WorkspaceID     string
 	AgentVisibility string
 	AgentConfig     map[string]any
@@ -103,7 +104,8 @@ func validateAgentCapabilityBindingsForVisibility(
 		if err != nil {
 			return fmt.Errorf("get capability version %s: %w", binding.CapabilityVersionID, err)
 		}
-		if err := validateCapabilityCredentialBindings(ctx, credentialStore, capabilityCredentialBindingValidationInput{
+		if err := validateBoundCapabilityCredentials(ctx, credentialStore, capabilityCredentialBindingValidationInput{
+			PinningMode:     binding.PinningMode,
 			WorkspaceID:     agent.WorkspaceID,
 			AgentVisibility: visibility,
 			AgentConfig:     agent.Config,

--- a/server/internal/dev/capability_latest_credentials_test.go
+++ b/server/internal/dev/capability_latest_credentials_test.go
@@ -1,0 +1,74 @@
+package dev
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func TestLatestMCPCredentialBinding(t *testing.T) {
+	r, db := capabilityTestRouter(t, map[string]string{testUserAID: "member"}, nil)
+	workspaceID := store.DefaultDevFixtureIDs().WorkspaceID
+	capID, v1, _ := insertCapabilityVersions(t, db, workspaceID, "Latest credentials")
+	if _, err := db.Exec(t.Context(), `update capability_version set required_credentials = '[]' where id = $1`, v1); err != nil {
+		t.Fatal(err)
+	}
+	agentID := insertAgentForOwner(t, db, testUserAID, "latest-credentials")
+	if _, err := db.Exec(t.Context(), `update agents set visibility = 'public', config = '{"agent_kind":"claude_code"}' where id = $1`, agentID); err != nil {
+		t.Fatal(err)
+	}
+	base := "/api/v1/workspaces/" + workspaceID + "/agents/" + agentID + "/capabilities"
+	for _, mode := range []string{"pinned", "", "latest"} {
+		response := serveCapabilityRoute(t, r, http.MethodPost, base+"/"+v1+"/enable", fmt.Sprintf(`{"pinning_mode":%q}`, mode), testUserAID)
+		want := http.StatusOK
+		if mode == "latest" {
+			want = http.StatusUnprocessableEntity
+		}
+		if response.Code != want {
+			t.Fatalf("public %q: %d %s", mode, response.Code, response.Body.String())
+		}
+	}
+	secretID := "00000000-0000-0000-0000-000000000099"
+	if _, err := db.Exec(t.Context(), `insert into secrets(id, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_by, created_at, updated_at)
+		values ($1, 'latest-shared', 'Latest shared credential', 'capability_inline', 'inline', 'literal', '{}'::jsonb, 'v1', 'active', $2::jsonb, $3, now(), now())`,
+		secretID, `{"credential_kind_code":"github_pat"}`, testUserAID); err != nil {
+		t.Fatal(err)
+	}
+	shared := serveCapabilityRoute(t, r, http.MethodPost, base+"/"+v1+"/enable",
+		`{"pinning_mode":"latest","configuration":{"credential_bindings":{"github_pat":{"source":"shared","secret_id":"`+secretID+`"}}}}`, testUserAID)
+	if shared.Code != http.StatusOK {
+		t.Fatalf("shared binding for the selected version: %d %s", shared.Code, shared.Body.String())
+	}
+	if _, err := db.Exec(t.Context(), `update agents set visibility = 'workspace' where id = $1`, agentID); err != nil {
+		t.Fatal(err)
+	}
+	response := serveCapabilityRoute(t, r, http.MethodPost, base+"/"+v1+"/enable", `{"pinning_mode":"latest"}`, testUserAID)
+	if response.Code != http.StatusOK {
+		t.Fatalf("workspace latest: %d %s", response.Code, response.Body.String())
+	}
+	response = serveCapabilityRoute(t, r, http.MethodGet, base, "", testUserAID)
+	var body struct {
+		Installed []struct {
+			store.AgentCapabilityRead
+			Capability struct {
+				RequiredCredentials []store.RequiredCredential `json:"required_credentials"`
+			} `json:"capability"`
+		} `json:"installed"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil || response.Code != http.StatusOK {
+		t.Fatalf("list: %d %s", response.Code, response.Body.String())
+	}
+	for _, binding := range body.Installed {
+		if binding.CapabilityID != capID {
+			continue
+		}
+		if binding.CapabilityVersionID != v1 || binding.PinningMode != "latest" || len(binding.Capability.RequiredCredentials) != 1 || binding.Capability.RequiredCredentials[0].Kind != "github_pat" {
+			t.Fatalf("selected credential declaration or stored identity changed: %+v", binding)
+		}
+		return
+	}
+	t.Fatal("installed MCP missing")
+}

--- a/server/internal/dev/capability_latest_credentials_test.go
+++ b/server/internal/dev/capability_latest_credentials_test.go
@@ -72,3 +72,47 @@ func TestLatestMCPCredentialBinding(t *testing.T) {
 	}
 	t.Fatal("installed MCP missing")
 }
+
+func TestLatestMCPRetiredCredentialVisibility(t *testing.T) {
+	r, db := capabilityTestRouter(t, map[string]string{testUserAID: "admin"}, nil)
+	workspaceID := store.DefaultDevFixtureIDs().WorkspaceID
+	capID, v1, v2 := insertCapabilityVersions(t, db, workspaceID, "Retired credential")
+	agentID := insertAgentForOwner(t, db, testUserAID, "retired-credential")
+	secretID := "00000000-0000-0000-0000-000000000099"
+	if _, err := db.Exec(t.Context(), `insert into secrets(id, slug, name, kind, provider, auth_type, encrypted_payload, key_version, status, metadata, created_by, created_at, updated_at)
+		values ($1, 'retired-shared', 'Retired shared credential', 'capability_inline', 'inline', 'literal', '{}'::jsonb, 'v1', 'active', '{"credential_kind_code":"github_pat"}', $2, now(), now())`, secretID, testUserAID); err != nil {
+		t.Fatal(err)
+	}
+	base := "/api/v1/workspaces/" + workspaceID + "/agents/" + agentID + "/capabilities"
+	body := `{"pinning_mode":"latest","configuration":{"credential_bindings":{"github_pat":{"source":"shared","secret_id":"` + secretID + `"}}}}`
+	enabled := serveCapabilityRoute(t, r, http.MethodPost, base+"/"+v1+"/enable", body, testUserAID)
+	if enabled.Code != http.StatusOK {
+		t.Fatalf("enable before retiring credential: %d %s", enabled.Code, enabled.Body.String())
+	}
+	if _, err := db.Exec(t.Context(), `update capability_version set required_credentials = '[]' where id = $1`, v2); err != nil {
+		t.Fatal(err)
+	}
+	visibilityPath := "/api/v1/agents/" + agentID + "/visibility"
+	published := serveCapabilityRoute(t, r, http.MethodPatch, visibilityPath, `{"visibility":"public"}`, testUserAID)
+	if published.Code != http.StatusOK {
+		t.Fatalf("publish with retired stored credential: %d %s", published.Code, published.Body.String())
+	}
+	var retainedSecret string
+	if err := db.QueryRow(t.Context(), `select configuration->'credential_bindings'->'github_pat'->>'secret_id' from agent_capabilities where agent_id = $1 and capability_id = $2`, agentID, capID).Scan(&retainedSecret); err != nil || retainedSecret != secretID {
+		t.Fatalf("stored binding changed: %q, %v", retainedSecret, err)
+	}
+	resubmitted := serveCapabilityRoute(t, r, http.MethodPost, base+"/"+v1+"/enable", body, testUserAID)
+	if resubmitted.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("new configuration containing an unused credential: %d %s", resubmitted.Code, resubmitted.Body.String())
+	}
+	if _, err := db.Exec(t.Context(), `update agents set visibility = 'workspace' where id = $1`, agentID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(t.Context(), `update capability_version set required_credentials = '[{"kind":"notion_token","required":true}]' where id = $1`, v2); err != nil {
+		t.Fatal(err)
+	}
+	published = serveCapabilityRoute(t, r, http.MethodPatch, visibilityPath, `{"visibility":"public"}`, testUserAID)
+	if published.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("publish without the new required shared credential: %d %s", published.Code, published.Body.String())
+	}
+}

--- a/server/internal/dev/capability_routes.go
+++ b/server/internal/dev/capability_routes.go
@@ -1243,7 +1243,7 @@ func deleteMyCredential(runtimeStore RuntimeStore) http.HandlerFunc {
 // (including built-ins) plus what else is available to install.
 //
 //	@Summary		List agent capabilities
-//	@Description	Returns installed capabilities, their pinning_mode and bound/latest version metadata, plus available workspace and marketplace capabilities. Latest metadata respects the runtime deprecation cutoff.
+//	@Description	Returns installed capabilities, their pinning_mode and bound/latest version metadata, plus available workspace and marketplace capabilities. Latest metadata respects the runtime deprecation cutoff. Installed MCP credential requirements match the selected runtime version.
 //	@Tags			capabilities
 //	@ID				listDevAgentCapabilities
 //	@Produce		json
@@ -1302,38 +1302,7 @@ func listAgentCapabilities(runtimeStore RuntimeStore) http.HandlerFunc {
 				installedAny = append(installedAny, binding)
 				continue
 			}
-			installedAny = append(installedAny, map[string]any{
-				"id":                    binding.ID,
-				"agent_id":              binding.AgentID,
-				"capability_id":         binding.CapabilityID,
-				"capability_version_id": binding.CapabilityVersionID,
-				"pinning_mode":          binding.PinningMode,
-				"enabled":               binding.Enabled,
-				"configuration":         binding.Configuration,
-				"created_at":            binding.CreatedAt,
-				"updated_at":            binding.UpdatedAt,
-				"capability": map[string]any{
-					"id":                        capability.CapabilityID,
-					"workspace_id":              capability.WorkspaceID,
-					"type":                      capability.Type,
-					"name":                      capability.Name,
-					"description":               capability.Description,
-					"visibility":                capability.Visibility,
-					"status":                    capability.Status,
-					"required_credentials":      capability.RequiredCredentials,
-					"deprecated_at":             capability.DeprecatedAt,
-					"from_marketplace":          capability.WorkspaceID != agent.WorkspaceID,
-					"source_workspace_id":       capability.WorkspaceID,
-					"source_workspace_name":     capability.SourceWorkspaceName,
-					"latest_version_id":         capability.LatestVersionID,
-					"latest_version":            capability.LatestVersion,
-					"latest_version_created_at": capability.LatestVersionCreatedAt,
-					"pinned_version_id":         binding.CapabilityVersionID,
-					"pinned_version":            capability.Version,
-					"created_at":                capability.LatestVersionCreatedAt,
-					"updated_at":                capability.LatestVersionCreatedAt,
-				},
-			})
+			installedAny = append(installedAny, installedAgentCapabilityResponse(binding, capability, agent.WorkspaceID))
 		}
 		// Surface runtime-injected built-ins as installed, default-ON cards.
 		// These have no capability_version row; the enabled flag comes from
@@ -1437,7 +1406,8 @@ func enableAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 			})
 			return
 		}
-		if err := validateCapabilityCredentialBindings(r.Context(), runtimeStore, capabilityCredentialBindingValidationInput{
+		if err := validateBoundCapabilityCredentials(r.Context(), runtimeStore, capabilityCredentialBindingValidationInput{
+			PinningMode:     body.PinningMode,
 			WorkspaceID:     agent.WorkspaceID,
 			AgentVisibility: agentRecord.Visibility,
 			AgentConfig:     agentRecord.Config,
@@ -1620,7 +1590,8 @@ func upgradeAgentCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 			writeJSON(w, http.StatusNotFound, map[string]string{"error": "agent capability not found"})
 			return
 		}
-		if err := validateCapabilityCredentialBindings(r.Context(), runtimeStore, capabilityCredentialBindingValidationInput{
+		if err := validateBoundCapabilityCredentials(r.Context(), runtimeStore, capabilityCredentialBindingValidationInput{
+			PinningMode:     body.PinningMode,
 			WorkspaceID:     agent.WorkspaceID,
 			AgentVisibility: agent.Visibility,
 			AgentConfig:     agent.Config,

--- a/server/internal/dev/routes_agents.go
+++ b/server/internal/dev/routes_agents.go
@@ -364,7 +364,8 @@ func createAgent(runtimeStore RuntimeStore, agentDaemonSandbox AgentDaemonSandbo
 				writeJSON(w, http.StatusForbidden, map[string]string{"error": "marketplace capability is unavailable"})
 				return
 			}
-			if err := validateCapabilityCredentialBindings(r.Context(), runtimeStore, capabilityCredentialBindingValidationInput{
+			if err := validateBoundCapabilityCredentials(r.Context(), runtimeStore, capabilityCredentialBindingValidationInput{
+				PinningMode:     requested.PinningMode,
 				WorkspaceID:     workspaceID,
 				AgentVisibility: req.Visibility,
 				AgentConfig:     req.Config,
@@ -664,7 +665,8 @@ func syncAgentCapabilities(
 				"capability_id", cap.capabilityID, "name", name, "version_id", latestVersionID, "err", err)
 			continue
 		}
-		if err := validateCapabilityCredentialBindings(ctx, rs, capabilityCredentialBindingValidationInput{
+		if err := validateBoundCapabilityCredentials(ctx, rs, capabilityCredentialBindingValidationInput{
+			PinningMode:     mode,
 			WorkspaceID:     workspaceID,
 			AgentVisibility: agent.Visibility,
 			AgentConfig:     agent.Config,

--- a/server/internal/store/capabilities.go
+++ b/server/internal/store/capabilities.go
@@ -20,6 +20,7 @@ type RequiredCredential struct {
 }
 
 type EnabledCapabilityRead struct {
+	AgentVisibility   string         `json:"-"`
 	AgentCapabilityID string         `json:"agent_capability_id"`
 	AgentID           string         `json:"agent_id"`
 	Enabled           bool           `json:"enabled"`
@@ -1174,6 +1175,7 @@ func enabledCapabilityFromRow(row sqlc.GetEnabledCapabilitiesForAgentRow) (Enabl
 	}
 	return EnabledCapabilityRead{
 		AgentCapabilityID:         row.AgentCapabilityID,
+		AgentVisibility:           row.AgentVisibility,
 		AgentID:                   row.AgentID,
 		Enabled:                   row.Enabled,
 		Configuration:             configuration,

--- a/server/internal/store/capabilities.go
+++ b/server/internal/store/capabilities.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
-	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
 )
 
 type RequiredCredential struct {
@@ -20,10 +20,10 @@ type RequiredCredential struct {
 }
 
 type EnabledCapabilityRead struct {
-	AgentCapabilityID      string               `json:"agent_capability_id"`
-	AgentID                string               `json:"agent_id"`
-	Enabled                bool                 `json:"enabled"`
-	Configuration          map[string]any       `json:"configuration"`
+	AgentCapabilityID string         `json:"agent_capability_id"`
+	AgentID           string         `json:"agent_id"`
+	Enabled           bool           `json:"enabled"`
+	Configuration     map[string]any `json:"configuration"`
 	// PinningMode is 'latest' or 'pinned'. In 'latest' mode the daemon
 	// resolver ignores OssKey/SHA256/CanonicalSpec/Version on this struct
 	// and uses LatestOssKey/LatestSHA256/LatestCanonicalSpec/LatestVersion
@@ -51,14 +51,16 @@ type EnabledCapabilityRead struct {
 	// version (resolved at query time via the lateral subquery on
 	// capability_version). The daemon resolver reads these when
 	// PinningMode == "latest".
-	LatestOssKey        string `json:"latest_oss_key,omitempty"`
-	LatestSHA256        string `json:"latest_sha256,omitempty"`
-	LatestCanonicalSpec []byte `json:"latest_canonical_spec,omitempty"`
-	LatestSchemaVersion int16  `json:"latest_schema_version,omitempty"`
-	GitRepoURL          string `json:"git_repo_url,omitempty"`
-	GitRef              string `json:"git_ref,omitempty"`
-	Path                string `json:"path,omitempty"`
-	Content             []byte `json:"content,omitempty"`
+	LatestOssKey              string               `json:"latest_oss_key,omitempty"`
+	LatestSHA256              string               `json:"latest_sha256,omitempty"`
+	LatestCanonicalSpec       []byte               `json:"latest_canonical_spec,omitempty"`
+	LatestContent             []byte               `json:"-"`
+	LatestRequiredCredentials []RequiredCredential `json:"-"`
+	LatestSchemaVersion       int16                `json:"latest_schema_version,omitempty"`
+	GitRepoURL                string               `json:"git_repo_url,omitempty"`
+	GitRef                    string               `json:"git_ref,omitempty"`
+	Path                      string               `json:"path,omitempty"`
+	Content                   []byte               `json:"content,omitempty"`
 	// CanonicalSpec carries the scaffold-agnostic capability description
 	// (see server/internal/capability/canonical). Empty for legacy rows;
 	// the connector falls back to interpreting Content directly. Reflects
@@ -1171,40 +1173,42 @@ func enabledCapabilityFromRow(row sqlc.GetEnabledCapabilitiesForAgentRow) (Enabl
 		return EnabledCapabilityRead{}, fmt.Errorf("capability %s: decode tags: %w", row.CapabilityID, err)
 	}
 	return EnabledCapabilityRead{
-		AgentCapabilityID:      row.AgentCapabilityID,
-		AgentID:                row.AgentID,
-		Enabled:                row.Enabled,
-		Configuration:          configuration,
-		PinningMode:            row.PinningMode,
-		CapabilityID:           row.CapabilityID,
-		WorkspaceID:            row.WorkspaceID,
-		SourceWorkspaceName:    row.SourceWorkspaceName,
-		Type:                   row.Type,
-		Name:                   row.Name,
-		Description:            row.Description,
-		Visibility:             row.Visibility,
-		Status:                 row.Status,
-		DeprecatedAt:           pgOptionalTime(row.DeprecatedAt),
-		RequiredCredentials:    decodeRequiredCredentials(row.RequiredCredentials),
-		CapabilityVersionID:    row.CapabilityVersionID,
-		Version:                row.Version,
-		LatestVersionID:        row.LatestVersionID,
-		LatestVersion:          row.LatestVersion,
-		LatestVersionCreatedAt: pgOptionalTime(row.LatestVersionCreatedAt),
-		LatestOssKey:           row.LatestOssKey,
-		LatestSHA256:           row.LatestSha256,
-		LatestCanonicalSpec:    append([]byte(nil), row.LatestCanonicalSpec...),
-		LatestSchemaVersion:    row.LatestSchemaVersion,
-		GitRepoURL:             textValue(row.GitRepoUrl),
-		GitRef:                 textValue(row.GitRef),
-		Path:                   textValue(row.Path),
-		Content:                append([]byte(nil), row.Content...),
-		CanonicalSpec:          append([]byte(nil), row.CanonicalSpec...),
-		SchemaVersion:          row.SchemaVersion,
-		OssKey:                 row.OssKey,
-		SHA256:                 row.Sha256,
-		Tags:                   tags,
-		CapabilityCreatorID:    row.CapabilityCreatorID,
+		AgentCapabilityID:         row.AgentCapabilityID,
+		AgentID:                   row.AgentID,
+		Enabled:                   row.Enabled,
+		Configuration:             configuration,
+		PinningMode:               row.PinningMode,
+		CapabilityID:              row.CapabilityID,
+		WorkspaceID:               row.WorkspaceID,
+		SourceWorkspaceName:       row.SourceWorkspaceName,
+		Type:                      row.Type,
+		Name:                      row.Name,
+		Description:               row.Description,
+		Visibility:                row.Visibility,
+		Status:                    row.Status,
+		DeprecatedAt:              pgOptionalTime(row.DeprecatedAt),
+		RequiredCredentials:       decodeRequiredCredentials(row.RequiredCredentials),
+		CapabilityVersionID:       row.CapabilityVersionID,
+		Version:                   row.Version,
+		LatestVersionID:           row.LatestVersionID,
+		LatestVersion:             row.LatestVersion,
+		LatestVersionCreatedAt:    pgOptionalTime(row.LatestVersionCreatedAt),
+		LatestOssKey:              row.LatestOssKey,
+		LatestSHA256:              row.LatestSha256,
+		LatestCanonicalSpec:       append([]byte(nil), row.LatestCanonicalSpec...),
+		LatestContent:             append([]byte(nil), row.LatestContent...),
+		LatestRequiredCredentials: decodeRequiredCredentials(row.LatestRequiredCredentials),
+		LatestSchemaVersion:       row.LatestSchemaVersion,
+		GitRepoURL:                textValue(row.GitRepoUrl),
+		GitRef:                    textValue(row.GitRef),
+		Path:                      textValue(row.Path),
+		Content:                   append([]byte(nil), row.Content...),
+		CanonicalSpec:             append([]byte(nil), row.CanonicalSpec...),
+		SchemaVersion:             row.SchemaVersion,
+		OssKey:                    row.OssKey,
+		SHA256:                    row.Sha256,
+		Tags:                      tags,
+		CapabilityCreatorID:       row.CapabilityCreatorID,
 	}, nil
 }
 

--- a/server/internal/store/capability_latest_content_test.go
+++ b/server/internal/store/capability_latest_content_test.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestEnabledCapabilityLatestContent(t *testing.T) {
+	db := openTestDB(t)
+	ctx := t.Context()
+	st := New(db)
+	ids := DefaultDevFixtureIDs()
+	mustSeedDevFixture(t, ctx, st)
+	content := func(command string) map[string]any {
+		return map[string]any{"mcpServers": map[string]any{"versioned": map[string]any{"command": command}}}
+	}
+	capability, err := st.CreateCapability(ctx, CreateCapabilityInput{
+		WorkspaceID: ids.WorkspaceID, CreatorID: ids.UserID, Type: "mcp", Name: "latest-content",
+		InitialVersion: &CreateCapabilityVersionInput{Version: "1.0.0", CreatorID: ids.UserID, Content: content("v1"), RequiredCredentials: []RequiredCredential{{Kind: "github_pat", Required: true}}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	versions, err := st.ListCapabilityVersions(ctx, capability.ID)
+	if err != nil || len(versions) != 1 {
+		t.Fatalf("initial versions = %+v: %v", versions, err)
+	}
+	v2, err := st.CreateCapabilityVersion(ctx, CreateCapabilityVersionInput{
+		CapabilityID: capability.ID, CreatorID: ids.UserID, Version: "2.0.0", Content: content("v2"), RequiredCredentials: []RequiredCredential{{Kind: "slack_bot_token", Required: true}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := st.CreateAgent(ctx, CreateAgentInput{
+		WorkspaceID: ids.WorkspaceID, CreatedBy: ids.UserID, Name: "Latest Content", ConnectorType: "agent_daemon",
+		AgentConfig:         map[string]any{"agent_kind": "claude_code", "daemon_mode": "local"},
+		InitialCapabilities: []InitialAgentCapabilityInput{{CapabilityVersionID: versions[0].ID, PinningMode: PinningModeLatest}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := st.GetEnabledCapabilitiesForAgent(ctx, created.Agent.ID)
+	if err != nil || len(rows) != 1 {
+		t.Fatalf("enabled capabilities = %+v: %v", rows, err)
+	}
+	row := rows[0]
+	if row.CapabilityVersionID != versions[0].ID || row.LatestVersionID != v2.ID || row.PinningMode != PinningModeLatest {
+		t.Fatalf("unexpected version metadata: %+v", row)
+	}
+	for _, field := range []struct {
+		name        string
+		raw         []byte
+		credentials []RequiredCredential
+		command     string
+		kind        string
+	}{{"stored", row.Content, row.RequiredCredentials, "v1", "github_pat"}, {"latest", row.LatestContent, row.LatestRequiredCredentials, "v2", "slack_bot_token"}} {
+		var parsed struct {
+			MCPServers map[string]struct{ Command string }
+		}
+		if err := json.Unmarshal(field.raw, &parsed); err != nil || parsed.MCPServers["versioned"].Command != field.command {
+			t.Fatalf("%s content mismatch: %s (%v)", field.name, field.raw, err)
+		}
+		if len(field.credentials) != 1 || field.credentials[0].Kind != field.kind || !field.credentials[0].Required {
+			t.Fatalf("%s credentials mismatch: %+v", field.name, field.credentials)
+		}
+	}
+}

--- a/server/internal/store/capability_latest_content_test.go
+++ b/server/internal/store/capability_latest_content_test.go
@@ -47,6 +47,13 @@ func TestEnabledCapabilityLatestContent(t *testing.T) {
 	if row.CapabilityVersionID != versions[0].ID || row.LatestVersionID != v2.ID || row.PinningMode != PinningModeLatest {
 		t.Fatalf("unexpected version metadata: %+v", row)
 	}
+	if _, err := st.UpdateAgentVisibility(ctx, created.Agent.ID, "public", ids.UserID); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := st.GetEnabledCapabilitiesForAgent(ctx, created.Agent.ID)
+	if err != nil || len(updated) != 1 || updated[0].AgentVisibility != "public" {
+		t.Fatalf("Agent visibility was not read with its enabled capabilities: %+v (%v)", updated, err)
+	}
 	for _, field := range []struct {
 		name        string
 		raw         []byte


### PR DESCRIPTION
This draft makes MCP and System Prompt bindings follow their selected version and aligns runtime content, credential declarations, installed metadata and API validation.

Do not merge. Three independent blind reviews exposed unresolved boundaries: latest can change an OAuth connector while retaining a credential bound for the previous connector, and upgrade inherits configuration that the current validator treats as newly submitted. The selected version’s source provenance and inherited-configuration validation need a consistent design before this change is safe.

Scope remains version selection and its existing credential rules. No schema, credential-policy or runtime-process redesign is approved in this draft. The candidate is deferred while independent issues continue.

Validation: repository `make check`, regenerated OpenAPI/sqlc, production web build and focused isolated PostgreSQL checks passed. Independent review findings remain blocking; passing checks do not establish readiness to merge.
