### PR TITLE
Preserve the selected Run tab when expanding details

### DIFF
--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -423,6 +423,7 @@ function RunDetailRail({
     setShownId(id)
     setConfirmCancel(false)
     setCancelError(null)
+    setActiveTab("steps")
   }
 
   const runData = runQ.data

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -417,6 +417,7 @@ function RunDetailRail({
   const requeueRun = useRequeueRun(wsId)
   const [confirmCancel, setConfirmCancel] = useState(false)
   const [cancelError, setCancelError] = useState<string | null>(null)
+  const [activeTab, setActiveTab] = useState("steps")
 
   if (shownId !== id) {
     setShownId(id)
@@ -588,7 +589,7 @@ function RunDetailRail({
         )}
       </PropertyList>
 
-      <Tabs defaultValue="steps" className="mt-4">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="mt-4">
         <TabsList className="flex w-full">
           <TabsTrigger value="overview" className="flex-1">{t("runs.detail.tabs.overview")}</TabsTrigger>
           <TabsTrigger value="steps" className="flex-1">{t("runs.detail.tabs.steps")}</TabsTrigger>


### PR DESCRIPTION
Opening a Run in the expanded panel could replace the selected diagnostic tab with Steps. Keep the selected tab when expanding or collapsing the same Run; selecting another Run or opening a fresh detail starts on Steps.

This changes only Run-detail tab state. Scrolling, layout, runtime actions, and API behavior are outside this PR.

Validation: `make check`, production web build, actual-browser expand/collapse and Run-switch checks, and an independent blind review with no blocking findings.
