### PR TITLE
fix(web): preserve workspace context when membership loading fails

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
+import { RefreshCw } from "lucide-react"
 import { AdminRouter } from "./pages/admin/AdminRouter"
 import { LoginPage } from "./pages/LoginPage"
 import { OnboardingPage } from "./pages/OnboardingPage"
@@ -11,6 +12,7 @@ import { AuthProvider, useAuth } from "./lib/auth-context"
 import { ThemeProvider } from "./lib/theme-provider"
 import { ToastProvider } from "./components/ui/toast"
 import { ErrorState } from "./components/ui/error-state"
+import { Button } from "./components/ui/button"
 import { useMyWorkspaces } from "./lib/api-workspaces"
 import { SingleSlot } from "./components/plugin/SlotRenderer"
 import { usePluginClients } from "./lib/use-plugins"
@@ -27,6 +29,7 @@ function LoadingScreen({ message }: { message: string }) {
 function AuthedRoot() {
   const { t } = useTranslation("common")
   const wsQuery = useMyWorkspaces()
+  const retrying = wsQuery.fetchStatus !== "idle"
   const wsId = useWorkspaceId()
   usePluginClients(wsId)
 
@@ -38,7 +41,12 @@ function AuthedRoot() {
       <main className="grid min-h-screen place-items-center bg-surface p-6">
         <ErrorState
           title={t("workspaceSwitcher.loadFailed")}
-          onRetry={() => void wsQuery.refetch()}
+          action={
+            <Button size="sm" variant="outline" disabled={retrying} onClick={() => void wsQuery.refetch()}>
+              <RefreshCw className={retrying ? "animate-spin" : undefined} strokeWidth={1.5} aria-hidden="true" />
+              {retrying ? t("states.loading") : t("actions.retry")}
+            </Button>
+          }
         />
       </main>
     )

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,6 +10,7 @@ import { SharedConversationPage } from "./pages/SharedConversationPage"
 import { AuthProvider, useAuth } from "./lib/auth-context"
 import { ThemeProvider } from "./lib/theme-provider"
 import { ToastProvider } from "./components/ui/toast"
+import { ErrorState } from "./components/ui/error-state"
 import { useMyWorkspaces } from "./lib/api-workspaces"
 import { SingleSlot } from "./components/plugin/SlotRenderer"
 import { usePluginClients } from "./lib/use-plugins"
@@ -30,7 +31,17 @@ function AuthedRoot() {
   usePluginClients(wsId)
 
   if (wsQuery.isLoading) {
-    return <LoadingScreen message={t("login.loading")} />
+    return <LoadingScreen message={t("states.loading")} />
+  }
+  if (wsQuery.isError && !wsQuery.data?.workspaces.length) {
+    return (
+      <main className="grid min-h-screen place-items-center bg-surface p-6">
+        <ErrorState
+          title={t("workspaceSwitcher.loadFailed")}
+          onRetry={() => void wsQuery.refetch()}
+        />
+      </main>
+    )
   }
   if ((wsQuery.data?.workspaces.length ?? 0) === 0) {
     return <OnboardingPage />

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -30,7 +30,7 @@ function AuthedRoot() {
   const wsId = useWorkspaceId()
   usePluginClients(wsId)
 
-  if (wsQuery.isLoading) {
+  if (wsQuery.isPending) {
     return <LoadingScreen message={t("states.loading")} />
   }
   if (wsQuery.isError && !wsQuery.data?.workspaces.length) {
@@ -43,7 +43,7 @@ function AuthedRoot() {
       </main>
     )
   }
-  if ((wsQuery.data?.workspaces.length ?? 0) === 0) {
+  if (wsQuery.data?.workspaces.length === 0) {
     return <OnboardingPage />
   }
   // workspace.main slot: when a plugin registers here, it takes over

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -147,7 +147,7 @@ export function WorkspaceSwitcher() {
                   {t(workspaces.length > 0 ? "workspaceSwitcher.refreshFailed" : "workspaceSwitcher.loadFailed")}
                 </InlineNotice>
                 <DropdownMenu.Item
-                  disabled={workspacesQuery.isFetching}
+                  disabled={workspacesQuery.fetchStatus !== "idle"}
                   onSelect={(event) => {
                     event.preventDefault()
                     void workspacesQuery.refetch()
@@ -155,7 +155,7 @@ export function WorkspaceSwitcher() {
                   className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-fg outline-none data-[highlighted]:bg-surface-muted data-[disabled]:opacity-50"
                 >
                   <RefreshCw className="h-3.5 w-3.5" strokeWidth={1.5} aria-hidden="true" />
-                  {workspacesQuery.isFetching ? t("states.loading") : t("actions.retry")}
+                  {workspacesQuery.fetchStatus !== "idle" ? t("states.loading") : t("actions.retry")}
                 </DropdownMenu.Item>
               </>
             )}

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -5,12 +5,14 @@ import {
   Globe,
   Layers,
   Plus,
+  RefreshCw,
   Send,
   X,
 } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { BrandMark } from "../ui/brand-mark"
+import { InlineNotice } from "../ui/error-state"
 import { WorkspaceMenuItem } from "./WorkspaceMenuItem"
 import {
   setWorkspaceId,
@@ -64,10 +66,10 @@ export function WorkspaceSwitcher() {
   // Self-heal: stale wsId from localStorage (archived ws or old dev seed)
   // would leave currentWorkspace undefined; auto-pick the first one.
   useEffect(() => {
-    if (workspacesQuery.isLoading || workspacesQuery.isFetching || workspaces.length === 0) return
+    if (workspacesQuery.isLoading || workspacesQuery.isFetching || workspacesQuery.isError || workspaces.length === 0) return
     if (wsId && workspaces.some((w) => w.id === wsId)) return
     setWorkspaceId(workspaces[0].id)
-  }, [wsId, workspaces, workspacesQuery.isLoading, workspacesQuery.isFetching])
+  }, [wsId, workspaces, workspacesQuery.isLoading, workspacesQuery.isFetching, workspacesQuery.isError])
 
   // Dialog state lives here so Radix Dropdown's focus trap doesn't fight
   // the dialog's focus trap.
@@ -96,7 +98,7 @@ export function WorkspaceSwitcher() {
     ? currentWorkspace.name
     : wsId
       ? `WS · ${shortId(wsId)}`
-      : t("workspaceSwitcher.demoWorkspace")
+      : t("workspaceSwitcher.workspaceLabel")
 
   return (
     <>
@@ -139,7 +141,26 @@ export function WorkspaceSwitcher() {
               {t("workspaceSwitcher.workspaceLabel")}
             </DropdownMenu.Label>
 
-            {workspaces.length === 0 && (
+            {workspacesQuery.isError && (
+              <>
+                <InlineNotice tone="error" className="px-2 py-2">
+                  {t(workspaces.length > 0 ? "workspaceSwitcher.refreshFailed" : "workspaceSwitcher.loadFailed")}
+                </InlineNotice>
+                <DropdownMenu.Item
+                  disabled={workspacesQuery.isFetching}
+                  onSelect={(event) => {
+                    event.preventDefault()
+                    void workspacesQuery.refetch()
+                  }}
+                  className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-fg outline-none data-[highlighted]:bg-surface-muted data-[disabled]:opacity-50"
+                >
+                  <RefreshCw className="h-3.5 w-3.5" strokeWidth={1.5} aria-hidden="true" />
+                  {workspacesQuery.isFetching ? t("states.loading") : t("actions.retry")}
+                </DropdownMenu.Item>
+              </>
+            )}
+
+            {!workspacesQuery.isError && workspaces.length === 0 && (
               <div className="px-2 py-2 text-sm text-fg-faint">
                 {workspacesQuery.isLoading
                   ? t("states.loading")

--- a/apps/web/src/i18n/locales/en-US/common.json
+++ b/apps/web/src/i18n/locales/en-US/common.json
@@ -41,6 +41,8 @@
     "demoWorkspace": "Demo Workspace",
     "workspaceLabel": "Workspace",
     "noWorkspaces": "No workspaces available",
+    "loadFailed": "Workspaces could not be loaded. Try again.",
+    "refreshFailed": "Workspaces could not be refreshed. Showing the last loaded list.",
     "discoverLabel": "Other workspaces",
     "memberCount": "{{count}} members",
     "requestJoinAction": "Request to join",

--- a/apps/web/src/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/i18n/locales/zh-CN/common.json
@@ -40,6 +40,8 @@
     "triggerAriaLabel": "切换工作区",
     "demoWorkspace": "演示工作区",
     "workspaceLabel": "工作区",
+    "loadFailed": "工作区加载失败，请重试。",
+    "refreshFailed": "工作区刷新失败，当前显示上次加载的列表。",
     "noWorkspaces": "暂无可用工作区",
     "discoverLabel": "其他工作区",
     "memberCount": "{{count}} 人",

--- a/apps/web/src/lib/api-workspaces.ts
+++ b/apps/web/src/lib/api-workspaces.ts
@@ -1,9 +1,7 @@
 /**
  * Workspace picker data + CRUD for the admin header switcher.
  *
- * `useMyWorkspaces` falls back to a single "Demo Workspace" *placeholder*
- * when `/api/v1/me/workspaces` is unreachable so the header switcher still
- * renders something.
+ * Failed requests preserve cached workspace data and expose the query error.
  */
 import {
   useMutation,
@@ -35,18 +33,6 @@ const KEY_DISCOVERABLE_WORKSPACES_PAGE = (
 const KEY_PENDING_JOIN_REQUESTS = (wsId: string) =>
   ["admin", "pendingJoinRequests", wsId] as const
 
-const MOCK_WORKSPACES: UserWorkspace[] = [
-  {
-    id: "mock-ws-1",
-    name: "Demo Workspace",
-    slug: "demo",
-    visibility: "private",
-    role: "owner",
-    created_at: new Date(Date.now() - 86_400_000 * 30).toISOString(),
-    updated_at: new Date(Date.now() - 86_400_000 * 30).toISOString(),
-  },
-]
-
 async function listMyWorkspacesRequest(): Promise<ListMyWorkspacesResponse> {
   return apiRequest<ListMyWorkspacesResponse>("/api/v1/me/workspaces", {
     method: "GET",
@@ -56,18 +42,7 @@ async function listMyWorkspacesRequest(): Promise<ListMyWorkspacesResponse> {
 export function useMyWorkspaces() {
   return useQuery({
     queryKey: KEY_MY_WORKSPACES,
-    queryFn: async () => {
-      try {
-        return await listMyWorkspacesRequest()
-      } catch {
-        // Switcher must always render something — fall back to mock so the
-        // popover doesn't show a permanent "empty" state when API is down.
-        return {
-          user_id: "mock-user",
-          workspaces: MOCK_WORKSPACES,
-        } satisfies ListMyWorkspacesResponse
-      }
-    },
+    queryFn: listMyWorkspacesRequest,
     retry: noUnreachableRetry,
     staleTime: 60_000,
     // Membership can be granted from another account while this tab is open.


### PR DESCRIPTION
Workspace-list failures currently appear as a successful Demo Workspace response and can replace the requested workspace in the URL. Preserve real memberships and the requested link, show an explicit load failure with retry feedback, and enter onboarding only after a successful empty response.

Scope is limited to workspace-query failure and recovery UI. Authentication, membership roles, and workspace APIs are unchanged.

Validation: `make check` and production build passed. Browser checks cover cold failure, cached-data failure, offline retry, busy feedback, recovery preserving the requested page, and successful empty-list onboarding. A fresh independent blind review of `0320da01ccd264e49add192f1e5d1037a48acf68` found no introduced blocking findings. Database smoke was skipped because local Docker must remain stopped.
