### PR TITLE
fix(web): wrap conversation identifiers in run details

### DIFF
--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -557,7 +557,7 @@ function RunDetailRail({
 
       <PropertyList>
         <Property label={t("runs.detail.connector")}>{connectorLabel(run.connector_type)}</Property>
-        <Property label={t("runs.detail.conversation")} mono>
+        <Property label={t("runs.detail.conversation")} mono className="h-auto min-h-7 whitespace-normal py-1 [overflow-wrap:anywhere]">
           {run.conversation_id ?? "—"}
         </Property>
         <Property label={t("runs.detail.created")} mono>{fmtDateTime(run.created_at)}</Property>


### PR DESCRIPTION
Long Conversation UUIDs in Run details are clipped by the side panel. Allow this field to wrap within the available width while preserving the complete value and native tooltip.

Only the Conversation field layout changes; run actions, tabs, and other metadata retain their behavior.

Validation: `make check`, production build, and real-browser checks at 320, 384, and 640px panel widths plus expanded view. A fresh independent blind review of `bc4594de3e3022d55adb995ed47121a20dd33329` found no blocking findings and independently verified those layouts. Database smoke was skipped because local Docker must remain stopped.
