### PR TITLE
fix(web): remove excess space above runtime environments

### DIFF
--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -185,7 +185,7 @@ export function RuntimePage() {
           </TabsList>
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-10">
-        <TabsContent value="environments" className="mt-0 pt-4">
+        <TabsContent value="environments" className="mt-0">
           {workspaceID && <RuntimeLedger workspaceID={workspaceID} />}
         </TabsContent>
 


### PR DESCRIPTION
The Runtime Environments tab adds a blank band above an otherwise compact ledger header. Remove that redundant spacing so the list starts directly below the tabs.

Only the Environments tab spacing changes. Header/row dimensions, group controls, device actions, and the Instances tab retain their behavior.

Validation: `make check` and production build passed. Browser measurements confirm a 28px header and 36px data row with the extra 16px gap removed. Group and tab navigation passed. A fresh blind review of `ea135625d52110155b3ee049397d664ca1245226` found no blocking findings and independently checked geometry, group/tab behavior, device-dialog cancellation, and `make check`. Database smoke was skipped because local Docker must remain stopped.
