### PR TITLE
fix(web): share column alignment across ledger headings and rows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -570,6 +570,13 @@ Pages with a detail rail may opt into wrapping header actions through
 `PageHeader.actionClassName` and an auto-height header. Other pages retain
 the default single-row header layout.
 
+Structured `Ledger` columns own both header and cell alignment: numbers align
+right; text, identifiers, and dates align left. Keep widths and alignment in
+the shared column model, not separate page-specific header rules. Direct cell
+components must forward `className` to their grid item. Fixed icon/action
+tracks, legacy string templates, and rows spanning multiple columns retain
+their existing layout.
+
 ## Typography contract
 
 The type scale has 7 defined steps. Arbitrary pixel sizes (`text-[Npx]`) are

--- a/apps/web/src/components/ui/ledger.tsx
+++ b/apps/web/src/components/ui/ledger.tsx
@@ -143,10 +143,18 @@ function useColumns() {
   return React.useContext(LedgerContext)
 }
 
+function flattenCells(children: React.ReactNode): React.ReactNode[] {
+  return React.Children.toArray(React.Children.map(children, (child) => (
+    React.isValidElement<{ children?: React.ReactNode }>(child) && child.type === React.Fragment
+      ? flattenCells(child.props.children)
+      : child
+  )))
+}
+
 function alignCells(children: React.ReactNode, columns?: LedgerColumn[]) {
   if (!columns) return children
-  const cells = React.Children.toArray(children)
-  // Spanning editors and composed rows retain their own layout.
+  const cells = flattenCells(children)
+  // Spanning editors retain their own layout.
   if (cells.length !== columns.length) return children
   return cells.map((cell, index) => {
     const kind = columns[index].kind

--- a/apps/web/src/components/ui/ledger.tsx
+++ b/apps/web/src/components/ui/ledger.tsx
@@ -114,7 +114,7 @@ export function adaptLegacyTemplate(template: string): string {
     .join(" ")
 }
 
-const LedgerContext = React.createContext<{ template: string; trailingActions: boolean }>({ template: "minmax(0,1fr)", trailingActions: false })
+const LedgerContext = React.createContext<{ template: string; trailingActions: boolean; columns?: LedgerColumn[] }>({ template: "minmax(0,1fr)", trailingActions: false })
 
 export function Ledger({
   columns,
@@ -126,6 +126,7 @@ export function Ledger({
     () => ({
       template: typeof columns === "string" ? adaptLegacyTemplate(columns) : ledgerTemplate(columns),
       trailingActions: typeof columns !== "string" && columns[columns.length - 1]?.kind === "actions",
+      columns: typeof columns === "string" ? undefined : columns,
     }),
     [columns],
   )
@@ -142,6 +143,24 @@ function useColumns() {
   return React.useContext(LedgerContext)
 }
 
+function alignCells(children: React.ReactNode, columns?: LedgerColumn[]) {
+  if (!columns) return children
+  const cells = React.Children.toArray(children)
+  // Spanning editors and composed rows retain their own layout.
+  if (cells.length !== columns.length) return children
+  return cells.map((cell, index) => {
+    const kind = columns[index].kind
+    if (
+      !React.isValidElement<{ className?: string }>(cell) ||
+      cell.type === React.Fragment ||
+      ["icon", "check", "tile", "actions", "fixed"].includes(kind)
+    ) return cell
+    return React.cloneElement(cell, {
+      className: cn(cell.props.className, kind === "num" ? "text-right" : "text-left"),
+    })
+  })
+}
+
 /* Rows and the header share one gutter: 24px each side, the topbar's
    padding, so the first and last columns of every ledger sit on the same
    two edges page after page. A trailing (zero-width) actions track still
@@ -151,7 +170,7 @@ function gutterClass(trailingActions: boolean) {
 }
 
 export function LedgerHeader({ children, className }: { children: React.ReactNode; className?: string }) {
-  const { template, trailingActions } = useColumns()
+  const { template, trailingActions, columns } = useColumns()
   return (
     <div
       aria-hidden="true"
@@ -162,7 +181,7 @@ export function LedgerHeader({ children, className }: { children: React.ReactNod
         className,
       )}
     >
-      {children}
+      {alignCells(children, columns)}
     </div>
   )
 }
@@ -265,7 +284,7 @@ export const LedgerRow = React.forwardRef<
   HTMLLIElement,
   React.LiHTMLAttributes<HTMLLIElement> & { selected?: boolean }
 >(({ selected, className, children, ...props }, ref) => {
-  const { template, trailingActions } = useColumns()
+  const { template, trailingActions, columns } = useColumns()
   return (
     <li
       ref={ref}
@@ -281,7 +300,7 @@ export const LedgerRow = React.forwardRef<
       )}
       {...props}
     >
-      {children}
+      {alignCells(children, columns)}
     </li>
   )
 })

--- a/apps/web/src/pages/admin/ScheduledTasksPage.tsx
+++ b/apps/web/src/pages/admin/ScheduledTasksPage.tsx
@@ -65,7 +65,7 @@ type FreqType = "hourly" | "daily" | "weekly" | "monthly" | "weekday" | "custom"
 const SCHED_PAGE_SIZE = 20
 
 /** status icon · name · schedule · cron · agent · next run · last run · actions */
-const LEDGER_COLUMNS = [col.icon(), col.title(), col.text(160, 1), col.id(104), col.text(140, 1), col.num(120), col.num(120), col.actions(4)]
+const LEDGER_COLUMNS = [col.icon(), col.title(), col.text(160, 1), col.id(104), col.text(140, 1), col.age(120, 0.5), col.age(120, 0.5), col.actions(4)]
 
 const FALLBACK_TZS = [
   "UTC",

--- a/apps/web/src/pages/admin/agents/AgentRuntimeCell.tsx
+++ b/apps/web/src/pages/admin/agents/AgentRuntimeCell.tsx
@@ -27,15 +27,17 @@ function RuntimeLine({
   name,
   mono,
   title,
+  className,
 }: {
   tone: LivenessTone
   kind?: string
   name: string
   mono?: boolean
   title?: string
+  className?: string
 }) {
   return (
-    <span className="flex min-w-0 items-center gap-1.5 text-sm text-fg" title={title}>
+    <span className={cn("flex min-w-0 items-center gap-1.5 text-sm text-fg", className)} title={title}>
       <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", DOT[tone])} aria-hidden="true" />
       {kind && <span className="shrink-0 text-xs text-fg-muted">{kind} ·</span>}
       <span className={cn("min-w-0 truncate", mono && "font-mono text-xs")}>{name}</span>
@@ -43,7 +45,7 @@ function RuntimeLine({
   )
 }
 
-export function AgentRuntimeCell({ agent }: { agent: Agent }) {
+export function AgentRuntimeCell({ agent, className }: { agent: Agent; className?: string }) {
   const { t } = useTranslation("admin")
   const placement = agentExecutionPlacement(agent)
 
@@ -57,17 +59,17 @@ export function AgentRuntimeCell({ agent }: { agent: Agent }) {
           : status === "spawning" || status === "renewing"
             ? "pending"
             : "offline"
-      return <RuntimeLine tone={tone} kind="Sandbox" name={fullId} mono title={[fullId, status].filter(Boolean).join(" · ")} />
+      return <RuntimeLine className={className} tone={tone} kind="Sandbox" name={fullId} mono title={[fullId, status].filter(Boolean).join(" · ")} />
     }
-    return <RuntimeLine tone="offline" kind="Sandbox" name={t("agents.runtimeCell.pending")} />
+    return <RuntimeLine className={className} tone="offline" kind="Sandbox" name={t("agents.runtimeCell.pending")} />
   }
 
   const name = (agent.runtime_name ?? "").trim()
   const runtimeID = (agent.runtime_id ?? "").trim()
   if (placement === "local" && runtimeID && name) {
     const tone = runtimeLivenessTone(agent) ?? "offline"
-    return <RuntimeLine tone={tone} kind="Local" name={name} title={[name, agent.runtime_liveness].filter(Boolean).join(" · ")} />
+    return <RuntimeLine className={className} tone={tone} kind="Local" name={name} title={[name, agent.runtime_liveness].filter(Boolean).join(" · ")} />
   }
 
-  return <RuntimeLine tone="pending" name={t("agents.runtimeCell.unbound")} />
+  return <RuntimeLine className={className} tone="pending" name={t("agents.runtimeCell.unbound")} />
 }


### PR DESCRIPTION
Structured ledgers currently leave heading and data alignment to each page, so column semantics can diverge. Let the shared column descriptors apply the same alignment to both: text, identifiers, and dates start-aligned; numeric values end-aligned. Preserve existing track dimensions, fixed controls, legacy string templates, and spanning editors.

Document the shared contract, classify scheduled timestamps as dates without changing their widths, and allow the Agent runtime cell to receive the shared alignment. No data, filter, sorting, or runtime behavior changes.

Validation: `make check` and production build passed. Actual browser checks covered capabilities, usage, runs, runtime, models, members, agents and conversations, including keyboard opening, nested menus, group collapse, and rename cancellation. A fresh independent blind review of `d01013ecd606028fe04bba8a87753d95ae3286ad` found no actionable findings and passed independent component/browser checks. Local Docker remains stopped; database smoke was skipped. Page-specific column overflow remains separately tracked.
