### PR TITLE
fix(web): keep audit search hints readable

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1804,7 +1804,7 @@
       "model": "Model"
     },
     "search": {
-      "placeholder": "Search by event / actor / target ID"
+      "placeholder": "Search events, actors or IDs…"
     },
     "table": {
       "time": "Time",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1804,7 +1804,7 @@
       "model": "模型"
     },
     "search": {
-      "placeholder": "按事件 / actor / target ID 搜索"
+      "placeholder": "搜索事件、操作人或目标 ID…"
     },
     "table": {
       "time": "时间",


### PR DESCRIPTION
The Audit search hint is clipped by the shortcut area. Shorten the English and Chinese hints so the existing search targets remain readable in the unchanged field.

Only two translation values change. Search semantics, filters, field dimensions, and keyboard behavior are preserved.

Validation: `make check` and production build passed. Actual browser checks covered both languages, Command-K, event search, and filter/reset behavior. A fresh independent blind review of `87fd48e871d7c153450de977e9e9be6aaa9d1144` found no blockers and independently exercised search/filters in a 1200 × 757 viewport. Local Docker remains stopped; database smoke was skipped.
