### PR TITLE
fix(web): keep workspace capability fields readable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -577,6 +577,10 @@ components must forward `className` to their grid item. Fixed icon/action
 tracks, legacy string templates, and rows spanning multiple columns retain
 their existing layout.
 
+When a list needs a compact presentation beside a detail rail, use container
+queries against the list width. Keep the same data and row actions, with
+explicit field labels when column headings are hidden.
+
 ## Typography contract
 
 The type scale has 7 defined steps. Arbitrary pixel sizes (`text-[Npx]`) are

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -616,10 +616,14 @@
     "table": {
       "name": "Capability",
       "latestVersion": "Latest version",
-      "enabledAgents": "Enabled Agents",
+      "enabledAgents": "Agents",
       "credentials": "Credential requirement",
       "updated": "Updated",
-      "installs": "Installs"
+      "installs": "Installs",
+      "version": "Version",
+      "credentialsShort": "Credentials",
+      "noCredentials": "None",
+      "ownSource": "This workspace"
     },
     "credentials": {
       "none": "No credential required"

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -616,10 +616,14 @@
     "table": {
       "name": "能力名",
       "latestVersion": "最新版本",
-      "enabledAgents": "已启用 Agent 数",
+      "enabledAgents": "Agent 数",
       "credentials": "凭据需求",
       "updated": "更新于",
-      "installs": "安装数"
+      "installs": "安装数",
+      "version": "版本",
+      "credentialsShort": "凭据",
+      "noCredentials": "无需凭据",
+      "ownSource": "本工作区"
     },
     "credentials": {
       "none": "无需凭据"

--- a/apps/web/src/pages/admin/capabilities/CapabilityRow.tsx
+++ b/apps/web/src/pages/admin/capabilities/CapabilityRow.tsx
@@ -1,0 +1,75 @@
+import type { KeyboardEvent, ReactNode } from "react"
+import { useTranslation } from "react-i18next"
+import { Badge } from "../../../components/ui/badge"
+import { LedgerNum, LedgerRow } from "../../../components/ui/ledger"
+import type { Capability } from "../../../lib/api-types"
+import { CapabilityTypeBadge } from "./CapabilityTypeBadge"
+
+export function CapabilityRow({
+  capability,
+  version,
+  source,
+  availabilityLabel,
+  enabledCount,
+  credentials,
+  age,
+  selected,
+  onOpen,
+  actions,
+}: {
+  capability: Capability
+  version?: string
+  source: string
+  availabilityLabel: string
+  enabledCount: number
+  credentials: string
+  age: string
+  selected: boolean
+  onOpen: () => void
+  actions: ReactNode
+}) {
+  const { t } = useTranslation("admin")
+  const onKeyDown = (e: KeyboardEvent<HTMLLIElement>) => {
+    if (e.target !== e.currentTarget) return
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault()
+      onOpen()
+    }
+  }
+  return (
+    <LedgerRow selected={selected} onClick={onOpen} onKeyDown={onKeyDown} className="h-auto min-h-12 py-2">
+      <div className="min-w-0 @max-xl/capability-list:col-span-full">
+        <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span className="min-w-0 max-w-full break-words font-medium">{capability.name}</span>
+          <CapabilityTypeBadge type={capability.type} />
+          {availabilityLabel && <Badge variant="neutral" className="shrink-0" dot>{availabilityLabel}</Badge>}
+        </span>
+        {capability.description && (
+          <span className="block truncate text-xs text-fg-muted" title={capability.description}>{capability.description}</span>
+        )}
+        <dl className="mt-2 hidden grid-cols-2 gap-x-4 gap-y-1 text-xs @max-xl/capability-list:grid">
+          {[
+            [t("capabilities.table.version"), version ?? "—"],
+            [t("capabilities.marketplaceDetail.source.title"), source],
+            [t("capabilities.table.enabledAgents"), String(enabledCount)],
+            [t("capabilities.table.credentialsShort"), credentials],
+            [t("capabilities.table.updated"), age],
+          ].map(([label, value]) => (
+            <div key={label} className="grid min-w-0 grid-cols-[4rem_minmax(0,1fr)] gap-x-2">
+              <dt className="text-fg-muted">{label}</dt>
+              <dd className="break-words">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+      <span className="break-all font-mono text-xs @max-xl/capability-list:hidden">{version ?? "—"}</span>
+      <span className="break-words text-xs text-fg-muted @max-xl/capability-list:hidden">{source}</span>
+      <LedgerNum className="@max-xl/capability-list:hidden">{enabledCount}</LedgerNum>
+      <span className="break-words text-xs text-fg-muted @max-xl/capability-list:hidden">{credentials}</span>
+      <span className="break-words text-right text-xs text-fg-muted @max-xl/capability-list:hidden">{age}</span>
+      <span className="@max-xl/capability-list:col-start-[-1] @max-xl/capability-list:row-start-1" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+        {actions}
+      </span>
+    </LedgerRow>
+  )
+}

--- a/apps/web/src/pages/admin/capabilities/CapabilityRow.tsx
+++ b/apps/web/src/pages/admin/capabilities/CapabilityRow.tsx
@@ -39,7 +39,7 @@ export function CapabilityRow({
   return (
     <LedgerRow selected={selected} onClick={onOpen} onKeyDown={onKeyDown} className="h-auto min-h-12 py-2">
       <div className="min-w-0 @max-xl/capability-list:col-span-full">
-        <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <span className="flex flex-wrap items-center gap-x-2 gap-y-1 @max-xl/capability-list:min-h-7 @max-xl/capability-list:pr-20">
           <span className="min-w-0 max-w-full break-words font-medium">{capability.name}</span>
           <CapabilityTypeBadge type={capability.type} />
           {availabilityLabel && <Badge variant="neutral" className="shrink-0" dot>{availabilityLabel}</Badge>}
@@ -47,7 +47,7 @@ export function CapabilityRow({
         {capability.description && (
           <span className="block truncate text-xs text-fg-muted" title={capability.description}>{capability.description}</span>
         )}
-        <dl className="mt-2 hidden grid-cols-2 gap-x-4 gap-y-1 text-xs @max-xl/capability-list:grid">
+        <dl className="mt-2 hidden grid-cols-2 gap-x-4 gap-y-1 text-xs @max-xl/capability-list:grid @max-sm/capability-list:grid-cols-1">
           {[
             [t("capabilities.table.version"), version ?? "—"],
             [t("capabilities.marketplaceDetail.source.title"), source],
@@ -67,7 +67,7 @@ export function CapabilityRow({
       <LedgerNum className="@max-xl/capability-list:hidden">{enabledCount}</LedgerNum>
       <span className="break-words text-xs text-fg-muted @max-xl/capability-list:hidden">{credentials}</span>
       <span className="break-words text-right text-xs text-fg-muted @max-xl/capability-list:hidden">{age}</span>
-      <span className="@max-xl/capability-list:col-start-[-1] @max-xl/capability-list:row-start-1" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+      <span className="@max-xl/capability-list:absolute @max-xl/capability-list:right-0 @max-xl/capability-list:top-2 @max-xl/capability-list:h-7 @max-xl/capability-list:w-0" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
         {actions}
       </span>
     </LedgerRow>

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -81,6 +81,7 @@ import { useWorkspaceId } from "../../../lib/workspace"
 import { useRelativeTime } from "../../../lib/relative-time"
 import { requiredCredentialsLabel } from "../../../lib/credential-kind-ui"
 import { CapabilityTypeBadge } from "./CapabilityTypeBadge"
+import { CapabilityRow } from "./CapabilityRow"
 import { InlineNotice } from "./notices"
 import { useCapabilityEnabledAgents } from "./use-capability-enabled-agents"
 import { MarketplaceCapabilityRail } from "./MarketplaceCapabilityRail"
@@ -110,7 +111,7 @@ const TYPE_FILTERS: { value: CapabilityTypeFilter; label: string }[] = [
 ]
 
 /** name (+type, +description) · version · source · enabled agents · credentials · updated · actions */
-const LEDGER_COLUMNS = [col.title(280), col.id(96, 0.4), col.meta(104), col.num(96), col.meta(120), col.age(80), col.actions(2)]
+const LEDGER_COLUMNS = [col.title(0), col.id(48, 0.4), col.meta(0), col.num(48), col.meta(0), col.age(0), col.actions(2)]
 
 export function CapabilitiesPage() {
   const { t, i18n } = useTranslation("admin")
@@ -298,15 +299,12 @@ export function CapabilitiesPage() {
         key={`${fromMarketplace ? "market" : "own"}-${cap.id}`}
         capability={cap}
         version={version}
-        // Own capabilities show nothing rather than an em dash: the value is
-        // not missing, it is redundant with the group header — and a dash in
-        // this ledger means "unknown".
-        source={fromMarketplace ? marketplaceSourceName(marketCap) : ""}
+        source={fromMarketplace ? marketplaceSourceName(marketCap) : t("capabilities.table.ownSource")}
         availabilityLabel={fromMarketplace && cap.visibility === "workspace"
           ? t("capabilities.unpublished.badge")
           : cap.deprecated_at ? t("capabilities.deprecated.badgeSource") : ""}
         enabledCount={enabledCount}
-        credentials={requiredCredentialsLabel(cap.required_credentials, i18n.language, t("capabilities.credentials.none"))}
+        credentials={requiredCredentialsLabel(cap.required_credentials, i18n.language, t("capabilities.table.noCredentials"))}
         age={fmtAgo(cap.updated_at ?? cap.created_at)}
         selected={cap.id === entityId}
         onOpen={() => openCapability(cap, fromMarketplace)}
@@ -359,13 +357,13 @@ export function CapabilitiesPage() {
     />
   ) : (
     <>
-      <Ledger columns={LEDGER_COLUMNS} role="listbox" aria-label={pageTitle}>
-        <LedgerHeader>
+      <Ledger columns={LEDGER_COLUMNS} className="@container/capability-list" role="listbox" aria-label={pageTitle}>
+        <LedgerHeader className="h-auto min-h-7 py-1 @max-xl/capability-list:hidden [&>*]:break-words [&>*]:whitespace-normal">
           <span>{t("capabilities.table.name")}</span>
-          <span>{t("capabilities.table.latestVersion")}</span>
+          <span>{t("capabilities.table.version")}</span>
           <span>{t("capabilities.marketplaceDetail.source.title")}</span>
           <span className="text-right">{t("capabilities.table.enabledAgents")}</span>
-          <span>{t("capabilities.table.credentials")}</span>
+          <span>{t("capabilities.table.credentialsShort")}</span>
           <span className="text-right">{t("capabilities.table.updated")}</span>
           <span />
         </LedgerHeader>
@@ -570,66 +568,6 @@ export function CapabilitiesPage() {
       )}
     </AdminLayout>
   )
-}
-
-/* ------------------------------------------------------------------ */
-/*  List row                                                            */
-/* ------------------------------------------------------------------ */
-
-function CapabilityRow({
-  capability,
-  version,
-  source,
-  availabilityLabel,
-  enabledCount,
-  credentials,
-  age,
-  selected,
-  onOpen,
-  actions,
-}: {
-  capability: Capability
-  version?: string
-  source: string
-  availabilityLabel: string
-  enabledCount: number
-  credentials: string
-  age: string
-  selected: boolean
-  onOpen: () => void
-  actions: ReactNode
-}) {
-  const onKeyDown = (e: KeyboardEvent<HTMLLIElement>) => {
-    if (e.target !== e.currentTarget) return
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault()
-      onOpen()
-    }
-  }
-  return (
-    <LedgerRow selected={selected} onClick={onOpen} onKeyDown={onKeyDown}>
-      <span className="flex min-w-0 items-center gap-2">
-        <span className="min-w-0 truncate font-medium" title={capability.name}>{capability.name}</span>
-        <CapabilityTypeBadge type={capability.type} />
-        {availabilityLabel && <Badge variant="neutral" className="shrink-0" dot>{availabilityLabel}</Badge>}
-        {capability.description && (
-          <span className="min-w-0 flex-1 truncate text-xs text-fg-muted">· {capability.description}</span>
-        )}
-      </span>
-      <span className={cnMono(!!version)}>{version ?? "—"}</span>
-      <span className="truncate text-xs text-fg-muted">{source}</span>
-      <LedgerNum>{enabledCount}</LedgerNum>
-      <span className="truncate text-xs text-fg-muted">{credentials}</span>
-      <span className="truncate text-right text-xs text-fg-muted">{age}</span>
-      <span onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
-        {actions}
-      </span>
-    </LedgerRow>
-  )
-}
-
-function cnMono(present: boolean) {
-  return present ? "truncate font-mono text-xs text-fg" : "truncate font-mono text-xs text-fg-muted"
 }
 
 function LedgerSkeleton() {


### PR DESCRIPTION
Workspace capability rows lose their source context and become difficult to read beside an open detail rail. Show an explicit local source, keep wide rows on the shared column layout, and present labelled fields at narrow list widths with accessible row actions.

Validation: `make check` and the web build passed. Real-browser checks covered wide and compact lists down to 317px, complete field values, search/filter, row menus and keyboard navigation. Fresh independent blind review found no actionable issues. Docker remained stopped; the database integration check was skipped.

Scope is Workspace capability list presentation. Nested detail ledgers, APIs, installation, version handling and permissions are unchanged.
