### PR TITLE
fix(web): clarify cloud runtime status and error details

### DIFF
--- a/apps/web/src/components/runtime/RuntimeCredentialCard.tsx
+++ b/apps/web/src/components/runtime/RuntimeCredentialCard.tsx
@@ -24,7 +24,6 @@ import {
 import { Field } from "../ui/label"
 import { Input } from "../ui/input"
 import { InlineError } from "./InlineError"
-import { PropertyList, Property } from "../ui/property-list"
 import { Skeleton } from "../ui/skeleton"
 import { ApiError } from "../../lib/api-client"
 import {
@@ -32,7 +31,6 @@ import {
   useRuntimeStatus,
   useSaveRuntimeCredential,
 } from "../../lib/api-runtime"
-import { SectionHead } from "../ui/section"
 
 interface RuntimeCredentialCardProps {
   workspaceID: string | null
@@ -41,10 +39,6 @@ interface RuntimeCredentialCardProps {
   className?: string
 }
 
-/**
- * Workspace sandbox credential: a 12px/500 head with the actions on its
- * right, then a property row with the masked key.
- */
 export function RuntimeCredentialCard({ workspaceID, isAdmin, className }: RuntimeCredentialCardProps) {
   const { t } = useTranslation("admin")
   const statusQ = useRuntimeStatus(workspaceID)
@@ -70,39 +64,33 @@ export function RuntimeCredentialCard({ workspaceID, isAdmin, className }: Runti
 
   return (
     <section className={className} data-testid="runtime-credential-card">
-      {/* The shared head, not a second implementation of it: the panel above
-          this one on the same page already uses `SectionHead`. */}
-      <SectionHead
-        title={t("runtime.credential.title")}
-        action={
-          isAdmin && (
-            <div className="flex items-center gap-1">
-              {hasCredential ? (
-                <>
-                  <Button size="sm" variant="outline" onClick={() => setSaveOpen(true)} data-testid="runtime-credential-reset">
-                    {t("runtime.credential.actions.reset")}
-                  </Button>
-                  <Button size="sm" variant="ghost" onClick={() => setConfirmClear(true)} data-testid="runtime-credential-delete">
-                    {t("runtime.credential.actions.delete")}
-                  </Button>
-                </>
-              ) : (
-                <Button size="sm" variant="outline" onClick={() => setSaveOpen(true)} data-testid="runtime-credential-save">
-                  {t("runtime.credential.actions.save")}
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+        <div className="min-w-0">
+          <h3 className="text-base font-medium text-fg">{t("runtime.credential.title")}</h3>
+          <p className="mt-1 text-xs text-fg-muted">
+            {hasCredential ? t("runtime.credential.state.hasCredential") : t("runtime.credential.state.noCredential")}
+            {hasCredential && <span className="ml-2 break-all font-mono"> {masked ?? "•••"}</span>}
+          </p>
+        </div>
+        {isAdmin && (
+          <div className="flex flex-wrap items-center gap-1">
+            {hasCredential ? (
+              <>
+                <Button size="sm" variant="outline" onClick={() => setSaveOpen(true)} data-testid="runtime-credential-reset">
+                  {t("runtime.credential.actions.reset")}
                 </Button>
-              )}
+                <Button size="sm" variant="ghost" onClick={() => setConfirmClear(true)} data-testid="runtime-credential-delete">
+                  {t("runtime.credential.actions.delete")}
+                </Button>
+              </>
+            ) : (
+              <Button size="sm" variant="outline" onClick={() => setSaveOpen(true)} data-testid="runtime-credential-save">
+                {t("runtime.credential.actions.save")}
+              </Button>
+            )}
             </div>
-          )
-        }
-      />
-      <PropertyList>
-        <Property
-          label={hasCredential ? t("runtime.credential.state.hasCredential") : t("runtime.credential.state.noCredential")}
-          mono
-        >
-          {hasCredential ? masked ?? "•••" : "—"}
-        </Property>
-      </PropertyList>
+        )}
+      </div>
 
       <SaveDialog
         key={String(saveOpen)}

--- a/apps/web/src/components/runtime/RuntimeStatusBanner.tsx
+++ b/apps/web/src/components/runtime/RuntimeStatusBanner.tsx
@@ -15,8 +15,7 @@ interface RuntimeStatusBannerProps {
 }
 
 /**
- * Cloud runtime status as a 32px hairline row: a 14px status icon, the
- * status sentence in ink, and at most one action on the right.
+ * Cloud runtime status and its existing recovery action.
  */
 export function RuntimeStatusBanner({ workspaceID, action, className }: RuntimeStatusBannerProps) {
   const { t } = useTranslation("admin")
@@ -25,7 +24,7 @@ export function RuntimeStatusBanner({ workspaceID, action, className }: RuntimeS
   if (query.isLoading) {
     return (
       <div className={className} data-testid="runtime-status-banner-loading">
-        <div className="flex h-8 items-center border-b border-line">
+        <div className="flex h-8 items-center">
           <Skeleton className="h-3 w-56" />
         </div>
       </div>
@@ -113,12 +112,12 @@ function StatusRow({
 }) {
   return (
     <div
-      className={`flex h-8 items-center gap-2 border-b border-line text-sm text-fg ${className ?? ""}`}
+      className={`flex min-h-8 flex-wrap items-center gap-2 text-sm text-fg ${className ?? ""}`}
       role={role}
       data-testid={testId}
     >
       <StatusIcon status={status} />
-      <span className="min-w-0 flex-1 truncate">{title}</span>
+      <span className="min-w-0 flex-1 break-all">{title}</span>
       {action && <div className="flex shrink-0 items-center gap-2">{action}</div>}
     </div>
   )

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -2096,6 +2096,7 @@
       },
       "errors": {
         "loadFailed": "Failed to load runtime instances",
+        "details": "Technical details",
         "bulkKillPartial": "Some runtime instances could not be reclaimed",
         "bulkKillDismiss": "Dismiss"
       },
@@ -2164,6 +2165,7 @@
       "notRunAfter": "Subsequent checks were not run (prerequisite failed)."
     },
     "cloud": {
+      "setupTitle": "Cloud runtime",
       "instances": {
         "title": "Active Cloud Sandboxes",
         "emptyTitle": "No active Cloud Sandbox yet",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -2096,6 +2096,7 @@
       },
       "errors": {
         "loadFailed": "加载运行实例失败",
+        "details": "技术详情",
         "bulkKillPartial": "部分运行实例回收失败",
         "bulkKillDismiss": "关闭"
       },
@@ -2164,6 +2165,7 @@
       "notRunAfter": "后续检查未执行（前置依赖未通过）。"
     },
     "cloud": {
+      "setupTitle": "云端配置",
       "instances": {
         "title": "正在运行的云端沙盒",
         "emptyTitle": "还没有正在运行的云端沙盒",

--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { AlertTriangle, Loader2, Skull, Zap } from "lucide-react"
 
@@ -285,6 +285,11 @@ function CloudInstancesPanel({
   const { t } = useTranslation("admin")
   const fmtAgo = useRelativeTime()
   const checkLabelFor = useConnectivityCheckLabel()
+  const [settledError, setSettledError] = useState<{ workspaceID: string | null; error: unknown } | null>(null)
+  useEffect(() => {
+    if (!loading) setSettledError(error ? { workspaceID, error } : null)
+  }, [workspaceID, loading, error])
+  const displayedError = error || (loading && settledError?.workspaceID === workspaceID ? settledError.error : null)
   const [testingId, setTestingId] = useState<string | null>(null)
   const [testResult, setTestResult] = useState<{ bindingId: string; result: ConnectivityResult } | null>(null)
   const connTest = useSandboxConnectivityTest()
@@ -362,10 +367,10 @@ function CloudInstancesPanel({
         </div>
       )}
 
-      {loading ? (
+      {displayedError ? (
+        <RuntimeInstancesError error={displayedError} onRetry={onRefresh} />
+      ) : loading ? (
         <LedgerSkeleton />
-      ) : error ? (
-        <RuntimeInstancesError error={error} onRetry={onRefresh} />
       ) : bindings.length === 0 ? (
         <EmptyState
           title={t("runtime.cloud.instances.emptyTitle")}

--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -6,10 +6,9 @@ import { AdminLayout } from "../../components/layout/AdminLayout"
 import { PageHeader } from "../../components/layout/PageHeader"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ConnectivityResultPanel } from "../../components/runtime/ConnectivityResultPanel"
-import { RuntimeCredentialCard } from "../../components/runtime/RuntimeCredentialCard"
-import { RuntimeStatusBanner } from "../../components/runtime/RuntimeStatusBanner"
 import { PairDaemonDialog } from "../../components/admin/PairDaemonDialog"
 import { RuntimeLedger } from "./runtimes/RuntimeLedger"
+import { RuntimeCloudPanel, RuntimeInstancesError } from "./runtimes/RuntimeCloudPanel"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -23,13 +22,12 @@ import {
 import { ActionIconButton, RowActions } from "../../components/ui/action-button"
 import { Button } from "../../components/ui/button"
 import { EmptyState } from "../../components/ui/empty-state"
-import { ErrorState } from "../../components/ui/error-state"
 import type { StatusKind } from "../../components/ui/status-icon"
 import { Ledger, LedgerHeader, LedgerId, LedgerRow, SelectableStatus, col } from "../../components/ui/ledger"
 import { Select } from "../../components/ui/select"
 import { Skeleton } from "../../components/ui/skeleton"
 import { ApiError } from "../../lib/api-client"
-import { useRuntimeStatus, type ConnectivityResult, type RuntimeStatus } from "../../lib/api-runtime"
+import { useRuntimeStatus, type ConnectivityResult } from "../../lib/api-runtime"
 import {
   killSandboxRequestRaw,
   useSandboxConnectivityTest,
@@ -43,7 +41,6 @@ import { useNow } from "../../lib/use-now"
 import { useWorkspaceId } from "../../lib/workspace"
 import { SectionHead } from "../../components/ui/section"
 
-type CloudState = "loading" | "notConfigured" | "ready" | "error" | "unknown"
 type SortKey = "last_active" | "created_at" | "agent"
 
 
@@ -110,11 +107,6 @@ export function RuntimePage() {
 
   const role = workspacesQ.data?.workspaces.find((w) => w.id === workspaceID)?.role
   const isAdmin = role === "owner" || role === "admin"
-  const cloudState = resolveCloudState({
-    status: statusQuery.data,
-    statusLoading: statusQuery.isLoading,
-    statusError: Boolean(statusQuery.error),
-  })
 
   const bindings = useMemo(
     () => sortBindings(sandboxesQuery.data ?? [], sortKey),
@@ -190,29 +182,34 @@ export function RuntimePage() {
         </TabsContent>
 
         <TabsContent value="instances" className="mt-0">
-          <CloudSandboxPanel
+          <RuntimeCloudPanel
             workspaceID={workspaceID}
             status={statusQuery.data}
+            statusLoading={statusQuery.isLoading}
             statusError={Boolean(statusQuery.error)}
-            cloudState={cloudState}
             isAdmin={isAdmin}
-            bindings={activeBindings}
-            listLoading={sandboxesQuery.isLoading}
-            listError={sandboxesQuery.error}
-            sortKey={sortKey}
-            selected={selected}
-            bulkPending={bulkPending}
-            bulkErrors={bulkErrors}
-            onRefresh={() => {
-              void statusQuery.refetch()
-              void sandboxesQuery.refetch()
-            }}
-            onSortChange={setSortKey}
-            onToggleOne={toggleOne}
-            onToggleAll={toggleAll}
-            onClearBulkErrors={() => setBulkErrors([])}
-            onConfirmBulkKill={() => setConfirming(true)}
-          />
+          >
+            <CloudInstancesPanel
+              workspaceID={workspaceID}
+              isAdmin={isAdmin}
+              bindings={activeBindings}
+              loading={sandboxesQuery.isLoading}
+              error={sandboxesQuery.error}
+              sortKey={sortKey}
+              selected={selected}
+              bulkPending={bulkPending}
+              bulkErrors={bulkErrors}
+              onRefresh={() => {
+                void statusQuery.refetch()
+                void sandboxesQuery.refetch()
+              }}
+              onSortChange={setSortKey}
+              onToggleOne={toggleOne}
+              onToggleAll={toggleAll}
+              onClearBulkErrors={() => setBulkErrors([])}
+              onConfirmBulkKill={() => setConfirming(true)}
+            />
+          </RuntimeCloudPanel>
         </TabsContent>
         </div>
       </Tabs>
@@ -235,81 +232,6 @@ export function RuntimePage() {
     </AdminLayout>
   )
 }
-
-function CloudSandboxPanel({
-  workspaceID,
-  status,
-  statusError,
-  cloudState,
-  isAdmin,
-  bindings,
-  listLoading,
-  listError,
-  sortKey,
-  selected,
-  bulkPending,
-  bulkErrors,
-  onRefresh,
-  onSortChange,
-  onToggleOne,
-  onToggleAll,
-  onClearBulkErrors,
-  onConfirmBulkKill,
-}: {
-  workspaceID: string | null
-  status: RuntimeStatus | undefined
-  statusError: boolean
-  cloudState: CloudState
-  isAdmin: boolean
-  bindings: SandboxBinding[]
-  listLoading: boolean
-  listError: unknown
-  sortKey: SortKey
-  selected: Set<string>
-  bulkPending: boolean
-  bulkErrors: { sandboxID: string; status: number | string; message: string }[]
-  onRefresh: () => void
-  onSortChange: (next: SortKey) => void
-  onToggleOne: (bindingID: string) => void
-  onToggleAll: () => void
-  onClearBulkErrors: () => void
-  onConfirmBulkKill: () => void
-}) {
-  const showCredentialControl =
-    cloudState !== "loading" && cloudState !== "unknown" && status?.profile !== "managed"
-  const showInstances = !statusError && Boolean(workspaceID)
-
-  return (
-    <div className="pt-4">
-      <RuntimeStatusBanner workspaceID={workspaceID} />
-
-      {showCredentialControl && (
-        <RuntimeCredentialCard workspaceID={workspaceID} isAdmin={isAdmin} className="mt-4" />
-      )}
-
-      {showInstances ? (
-        <CloudInstancesPanel
-          workspaceID={workspaceID}
-          isAdmin={isAdmin}
-          bindings={bindings}
-          loading={listLoading}
-          error={listError}
-          sortKey={sortKey}
-          selected={selected}
-          bulkPending={bulkPending}
-          bulkErrors={bulkErrors}
-          onRefresh={onRefresh}
-          onSortChange={onSortChange}
-          onToggleOne={onToggleOne}
-          onToggleAll={onToggleAll}
-          onClearBulkErrors={onClearBulkErrors}
-          onConfirmBulkKill={onConfirmBulkKill}
-        />
-      ) : null}
-    </div>
-  )
-}
-
 
 function LedgerSkeleton({ rows = 3 }: { rows?: number }) {
   return (
@@ -443,11 +365,7 @@ function CloudInstancesPanel({
       {loading ? (
         <LedgerSkeleton />
       ) : error ? (
-        <ErrorState
-          title={t("runtime.list.errors.loadFailed")}
-          detail={error instanceof Error ? error.message : String(error)}
-          onRetry={onRefresh}
-        />
+        <RuntimeInstancesError error={error} onRetry={onRefresh} />
       ) : bindings.length === 0 ? (
         <EmptyState
           title={t("runtime.cloud.instances.emptyTitle")}
@@ -607,20 +525,3 @@ function ConfirmBulkKillDialog({
     </AlertDialog>
   )
 }
-
-function resolveCloudState({
-  status,
-  statusLoading,
-  statusError,
-}: {
-  status: RuntimeStatus | undefined
-  statusLoading: boolean
-  statusError: boolean
-}): CloudState {
-  if (statusLoading && !status) return "loading"
-  if (statusError || !status) return "unknown"
-  if (status.profile === "managed") return status.available ? "ready" : "error"
-  if (!status.has_credential) return "notConfigured"
-  return status.available ? "ready" : "error"
-}
-

--- a/apps/web/src/pages/admin/runtimes/RuntimeCloudPanel.tsx
+++ b/apps/web/src/pages/admin/runtimes/RuntimeCloudPanel.tsx
@@ -1,0 +1,78 @@
+import type { ReactNode } from "react"
+import { useTranslation } from "react-i18next"
+import { RuntimeCredentialCard } from "../../../components/runtime/RuntimeCredentialCard"
+import { RuntimeStatusBanner } from "../../../components/runtime/RuntimeStatusBanner"
+import { ErrorState } from "../../../components/ui/error-state"
+import { SectionHead } from "../../../components/ui/section"
+import { VerbatimBlock } from "../../../components/ui/verbatim"
+import type { RuntimeStatus } from "../../../lib/api-runtime"
+
+type CloudState = "loading" | "notConfigured" | "ready" | "error" | "unknown"
+
+export function RuntimeCloudPanel({
+  workspaceID,
+  status,
+  statusLoading,
+  statusError,
+  isAdmin,
+  children,
+}: {
+  workspaceID: string | null
+  status: RuntimeStatus | undefined
+  statusLoading: boolean
+  statusError: boolean
+  isAdmin: boolean
+  children: ReactNode
+}) {
+  const { t } = useTranslation("admin")
+  const cloudState = resolveCloudState({ status, statusLoading, statusError })
+  const showCredentialControl =
+    cloudState !== "loading" && cloudState !== "unknown" && status?.profile !== "managed"
+  const showInstances = !statusError && Boolean(workspaceID)
+
+  return (
+    <div className="pt-4">
+      <section className="max-w-2xl border-b border-line pb-4">
+        <SectionHead title={t("runtime.cloud.setupTitle")} />
+        <RuntimeStatusBanner workspaceID={workspaceID} />
+        {showCredentialControl && (
+          <RuntimeCredentialCard workspaceID={workspaceID} isAdmin={isAdmin} className="mt-4" />
+        )}
+      </section>
+      {showInstances ? children : null}
+    </div>
+  )
+}
+
+export function RuntimeInstancesError({ error, onRetry }: { error: unknown; onRetry: () => void }) {
+  const { t } = useTranslation("admin")
+  return (
+    <div role="alert">
+      <ErrorState title={t("runtime.list.errors.loadFailed")} onRetry={onRetry} className="pb-2" />
+      <details className="ml-6 max-w-2xl pb-4">
+        <summary className="cursor-pointer text-xs text-fg-muted hover:text-fg focus-visible:outline-accent">
+          {t("runtime.list.errors.details")}
+        </summary>
+        <VerbatimBlock className="mt-2 max-h-40 w-fit max-w-full break-all">
+          {error instanceof Error ? error.message : String(error)}
+        </VerbatimBlock>
+      </details>
+    </div>
+  )
+}
+
+function resolveCloudState({
+  status,
+  statusLoading,
+  statusError,
+}: {
+  status: RuntimeStatus | undefined
+  statusLoading: boolean
+  statusError: boolean
+}): CloudState {
+  if (statusLoading && !status) return "loading"
+  if (statusError || !status) return "unknown"
+  if (status.profile === "managed") return status.available ? "ready" : "error"
+  if (!status.has_credential) return "notConfigured"
+  return status.available ? "ready" : "error"
+}


### PR DESCRIPTION
Runtime Instances scattered cloud readiness, credential setup, and load failures across the page. Group setup status with its credential controls, keep actions near the relevant state, and show exact load errors in an accessible technical-details disclosure that stays open during refreshes.

This change is limited to Instances presentation and the related component extraction. Existing credential permissions, managed/OSS behavior, sandbox queries and lifecycle actions are preserved.

Validation: `make check`, web build, independent blind review, and real QA browser checks passed. Local scenario checks covered missing/saved credentials, member access, managed ready/error and backend failure, English/Chinese, light/dark, narrow layouts, keyboard disclosure, retry, and non-submitted action dialogs. Docker remained stopped; local PostgreSQL checks were skipped by the gate. Cloud provisioning was not exercised.
