### PR TITLE
fix(web): align shared property groups consistently

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -581,6 +581,11 @@ When a list needs a compact presentation beside a detail rail, use container
 queries against the list width. Keep the same data and row actions, with
 explicit field labels when column headings are hidden.
 
+Property groups use the shared `PropertyList` label track: 8rem capped at 40%
+of the available width. Labels wrap and values retain their existing overflow
+behavior. Do not size individual groups from their longest label or add
+page-specific label widths; groups in the same context must align.
+
 ## Typography contract
 
 The type scale has 7 defined steps. Arbitrary pixel sizes (`text-[Npx]`) are

--- a/apps/web/src/components/ui/property-list.tsx
+++ b/apps/web/src/components/ui/property-list.tsx
@@ -1,26 +1,10 @@
 import type { ReactNode } from "react"
 import { cn } from "../../lib/utils"
 
-/**
- * Label / value grid used in detail rails and overview panes: a muted 12px
- * label column, 13px ink values, 28px rows. Values are never muted; pass
- * `mono` for identifiers, paths and timestamps.
- *
- * The label column is sized by its own longest label rather than by a number
- * someone picked: 84px was wide enough for Chinese and too narrow for
- * "Working directory", which wrapped inside a fixed 28px row and pushed its
- * value out of line with it. `max-content` grows to the labels actually
- * present — narrower in Chinese, wider in English — while the 5.25rem floor
- * keeps sections of a rail lined up with each other and a 12rem cap on the
- * label keeps a long one from eating the value column. (`fit-content()` is the
- * obvious tool here and cannot be used: it is not a legal max inside
- * `minmax()`, so the whole declaration is dropped and the grid silently
- * collapses to one column.) Label and value both truncate and both carry their
- * full text in a tooltip.
- */
+// Shared tracks align independent property groups without letting labels crowd values.
 export function PropertyList({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <dl className={cn("m-0 grid grid-cols-[minmax(5.25rem,max-content)_minmax(0,1fr)] gap-x-3", className)}>
+    <dl className={cn("m-0 grid grid-cols-[min(8rem,40%)_minmax(0,1fr)] gap-x-3", className)}>
       {children}
     </dl>
   )
@@ -43,12 +27,7 @@ export function Property({
   return (
     <>
       <dt
-        // A block, not a flex row: `text-overflow` only applies to block
-        // containers, so a flex `dt` clips without ever drawing the ellipsis.
-        // `leading-7` centres the one line in the 28px row instead. The cap is
-        // what keeps `max-content` honest — a label long enough to eat the
-        // value column truncates and keeps its `title`.
-        className="h-7 max-w-48 truncate leading-7 text-xs text-fg-muted"
+        className="min-h-7 min-w-0 py-1 text-xs leading-5 text-fg-muted [overflow-wrap:anywhere]"
         title={typeof label === "string" ? label : undefined}
       >
         {label}


### PR DESCRIPTION
Property groups sized their labels independently, so values in Run diagnostics/runtime and Agent configuration started in different columns. Use one shared bounded label track and wrap long labels across all PropertyList callers. Keep existing value formatting, overflow overrides, tooltips, and controls.

Validation: `make check`, web build, and independent blind review passed. Browser checks covered Run/Agent/capability groups, settings, model editing, resolved approvals, English/Chinese, light/dark, 320px rails and expanded dialogs. No API or data behavior changed. Docker remained stopped; local database checks were skipped by the gate.
