### PR TITLE
fix(web): unify compact empty states across details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -570,6 +570,10 @@ Pages with a detail rail may opt into wrapping header actions through
 `PageHeader.actionClassName` and an auto-height header. Other pages retain
 the default single-row header layout.
 
+Use `EmptyState` with `size="compact"` for detail tabs, subsections, and
+compact result panels. Keep their alignment and spacing in that shared
+component; page-level empty states retain the default size.
+
 Structured `Ledger` columns own both header and cell alignment: numbers align
 right; text, identifiers, and dates align left. Keep widths and alignment in
 the shared column model, not separate page-specific header rules. Direct cell

--- a/apps/web/src/components/admin/ResourceAuditTimeline.tsx
+++ b/apps/web/src/components/admin/ResourceAuditTimeline.tsx
@@ -118,7 +118,7 @@ export function ResourceAuditTimeline({
         description={t("audit.resourceTimeline.empty.description", {
           defaultValue: "This resource has not produced any audit records.",
         })}
-        className="py-8"
+        size="compact"
       />
     )
   }

--- a/apps/web/src/components/admin/SandboxPanel.tsx
+++ b/apps/web/src/components/admin/SandboxPanel.tsx
@@ -170,7 +170,7 @@ export function SandboxPanel({
           <EmptyState
             icon={Box}
             title={t("agents.detail.sandbox.empty.title")}
-            className="py-8"
+            size="compact"
             action={
               <Button size="sm" variant="outline" disabled={acquireMut.isPending} onClick={triggerAcquire}>
                 {acquireMut.isPending && <Loader2 className="animate-spin" />}

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -8,22 +8,24 @@ interface EmptyStateProps {
   description?: string
   action?: ReactNode
   className?: string
+  size?: "default" | "compact"
 }
 
 /**
  * Flat empty state: a muted icon, an ink title, optional one-line
  * description and one action. No dashed box, no card.
  */
-export function EmptyState({ icon: Icon, title, description, action, className }: EmptyStateProps) {
+export function EmptyState({ icon: Icon, title, description, action, className, size = "default" }: EmptyStateProps) {
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center gap-3 px-6 py-16 text-center",
+        "flex min-w-0 flex-col items-center justify-center gap-3 text-center",
+        size === "compact" ? "px-4 py-8" : "px-6 py-16",
         className
       )}
     >
       {Icon && <Icon className="h-5 w-5 text-fg-muted" strokeWidth={1.5} aria-hidden="true" />}
-      <div className="space-y-1">
+      <div className="min-w-0 max-w-full space-y-1 [overflow-wrap:anywhere]">
         <p className="text-sm font-medium text-fg">{title}</p>
         {description && (
           <p className="max-w-sm text-sm text-fg-muted">{description}</p>

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -527,8 +527,10 @@
           "days": "{{count}}d ago"
         }
       },
+      "artifactsEmpty": "No artifacts yet",
       "steps": {
-        "empty": "No persisted events yet. New runs will show token generation, tools, approvals, and completion here.",
+        "emptyTitle": "No steps yet",
+        "empty": "New runs will show token generation, tools, approvals, and completion here.",
         "viewRaw": "View raw events",
         "hideRaw": "Hide raw events",
         "generated": "Generated {{count}} characters",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -527,8 +527,10 @@
           "days": "约 {{count}} 天前"
         }
       },
+      "artifactsEmpty": "暂无产物",
       "steps": {
-        "empty": "这条 run 还没有持久化事件。新运行会在这里显示 token、工具、审批和完成状态。",
+        "emptyTitle": "暂无执行步骤",
+        "empty": "新运行的生成内容、工具调用、审批与完成事件会显示在这里。",
         "viewRaw": "查看原始事件",
         "hideRaw": "收起原始事件",
         "generated": "生成了 {{count}} 个字符",

--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -27,6 +27,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "../../components/ui/dialog"
+import { EmptyState } from "../../components/ui/empty-state"
 import { Input } from "../../components/ui/input"
 import { InitialTile, Ledger, LedgerId, LedgerRow, col } from "../../components/ui/ledger"
 import { Skeleton } from "../../components/ui/skeleton"
@@ -492,9 +493,7 @@ function ConversationList(p: ListProps) {
           ))}
         </div>
       ) : p.conversations.length === 0 ? (
-        <p className="m-0 px-4 py-6 text-center text-sm text-fg-muted">
-          {t("conversations.sidebar.emptyForAgent")}
-        </p>
+        <EmptyState size="compact" title={t("conversations.sidebar.emptyForAgent")} />
       ) : (
         <Ledger columns={LIST_COLUMNS} role="listbox" aria-label={listLabel}>
           <ul className="m-0 list-none p-0">

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -405,7 +405,6 @@ function RunDetailRail({
   onClosed: () => void
 }) {
   const { t } = useTranslation("admin")
-  const { t: tc } = useTranslation("common")
   const { navigate } = useAdminView()
 
   // The rail is not remounted between runs (that would replay its
@@ -667,7 +666,7 @@ function RunDetailRail({
               ))}
             </ul>
           ) : (
-            <p className="py-6 text-center text-sm text-fg-muted">{tc("states.emptyTitle")}</p>
+            <EmptyState size="compact" title={t("runs.detail.artifactsEmpty")} />
           )}
         </TabsContent>
 
@@ -716,7 +715,7 @@ function RunSteps({ events, loading }: { events: AgentRunEvent[]; loading: boole
     )
   }
   if (steps.length === 0) {
-    return <p className="pt-2 text-sm text-fg-muted">{t("runs.detail.steps.empty")}</p>
+    return <EmptyState size="compact" title={t("runs.detail.steps.emptyTitle")} description={t("runs.detail.steps.empty")} />
   }
 
   return (

--- a/apps/web/src/pages/admin/SettingsPage.tsx
+++ b/apps/web/src/pages/admin/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { PageHeader } from "../../components/layout/PageHeader"
 import { ActionIconButton, RowActions } from "../../components/ui/action-button"
 import { Badge } from "../../components/ui/badge"
 import { Ledger, LedgerHeader, LedgerId, LedgerRow, col } from "../../components/ui/ledger"
+import { EmptyState } from "../../components/ui/empty-state"
 import { Property, PropertyList } from "../../components/ui/property-list"
 import { Skeleton } from "../../components/ui/skeleton"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
@@ -80,7 +81,7 @@ export function SettingsPage() {
                   {t("settings.authentication.error")}
                 </p>
               ) : providers.length === 0 ? (
-                <p className="text-sm text-fg-muted">{tc("states.emptyTitle")}</p>
+                <EmptyState size="compact" title={tc("states.emptyTitle")} />
               ) : (
                 <Ledger
                   columns={PROVIDER_COLUMNS}

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -922,7 +922,7 @@ function ConfigCapabilitiesSection({
       }
     >
       {enabledCaps.length === 0 ? (
-        <EmptyState title={t("agents.detail.config.capabilities.empty")} className="py-8" />
+        <EmptyState size="compact" title={t("agents.detail.config.capabilities.empty")} />
       ) : (
         <ul className="m-0 list-none border-t border-line p-0">
           {enabledCaps.map((item) =>
@@ -1014,9 +1014,7 @@ function AddCapabilityDialog({
           </div>
           <div className="min-h-0 max-h-80 overflow-y-auto">
             {filtered.length === 0 ? (
-              <p className="py-6 text-center text-sm text-fg-muted">
-                {t("agents.detail.capabilities.emptyAvailable")}
-              </p>
+              <EmptyState size="compact" title={t("agents.detail.capabilities.emptyAvailable")} />
             ) : (
               <ul className="m-0 list-none border-t border-line p-0">
                 {filtered.map((capability) => (

--- a/apps/web/src/pages/admin/agents/AgentDynamicsTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentDynamicsTab.tsx
@@ -8,6 +8,7 @@ import {
   LedgerRow,
   col,
 } from "../../../components/ui/ledger"
+import { EmptyState } from "../../../components/ui/empty-state"
 import { PropertyList, Property } from "../../../components/ui/property-list"
 import { Skeleton } from "../../../components/ui/skeleton"
 import { StatusIcon } from "../../../components/ui/status-icon"
@@ -84,7 +85,7 @@ function RunsLedger({ runs, loading, emptyLabel }: { runs: AgentRunSummary[]; lo
     )
   }
   if (runs.length === 0) {
-    return <p className="text-sm text-fg-muted">{emptyLabel}</p>
+    return <EmptyState size="compact" title={emptyLabel} />
   }
 
   return (
@@ -130,7 +131,7 @@ function MetricsList({ metrics, loading }: { metrics?: AgentMetrics; loading: bo
     )
   }
   if (!metrics || metrics.completed_count + metrics.failed_count === 0) {
-    return <p className="text-sm text-fg-muted">{t("agents.detail.dynamics.metrics.empty")}</p>
+    return <EmptyState size="compact" title={t("agents.detail.dynamics.metrics.empty")} />
   }
   return (
     <PropertyList>

--- a/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityRail.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityRail.tsx
@@ -116,7 +116,7 @@ export function MarketplaceCapabilityRail({ id, open, onClose, onClosed }: {
           {agentsQ.isLoading ? (
             <Skeleton className="mt-2 h-3 w-full" />
           ) : agents.length === 0 ? (
-            <p className="pt-1 text-sm text-fg-muted">{t("capabilities.marketplaceDetail.enabledAgents.empty")}</p>
+            <EmptyState size="compact" title={t("capabilities.marketplaceDetail.enabledAgents.empty")} />
           ) : (
             <Ledger columns={AGENT_COLUMNS} className="-mx-4" role="listbox" aria-label={t("capabilities.marketplaceDetail.enabledAgents.title", { count: agentCount })}>
               <ul className="m-0 list-none p-0">

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -956,7 +956,7 @@ export function CapabilityRail({ id, open, onClose, onClosed }: {
         {versionsQ.isLoading ? (
           <div className="space-y-2 pt-2">{Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-3 w-full max-w-lg" />)}</div>
         ) : versions.length === 0 ? (
-          <EmptyState icon={PackageCheck} title={t("capabilities.versions.empty.title")} description={t("capabilities.versions.empty.description")} className="py-8" />
+          <EmptyState icon={PackageCheck} title={t("capabilities.versions.empty.title")} description={t("capabilities.versions.empty.description")} size="compact" />
         ) : (
           <Ledger columns={VERSION_COLUMNS} className="-mx-4" role="listbox" aria-label={t("capabilities.versions.title")}>
             <LedgerHeader className="static">
@@ -983,7 +983,7 @@ export function CapabilityRail({ id, open, onClose, onClosed }: {
         {installationSummary.isLoading ? (
           <Skeleton className="mt-2 h-3 w-full max-w-lg" />
         ) : enabledCount === 0 ? (
-          <p className="pt-1 text-sm text-fg-muted">{t("capabilities.detail.enabledAgents.empty")}</p>
+          <EmptyState size="compact" title={t("capabilities.detail.enabledAgents.empty")} />
         ) : (
           <Ledger columns={AGENT_COLUMNS} className="-mx-4" role="listbox" aria-label={t("capabilities.detail.enabledAgents.title", { count: enabledCount })}>
             <ul className="m-0 list-none p-0">


### PR DESCRIPTION
Detail panels used different padding, alignment, and typography for the same empty-result state. Add a compact variant to the shared empty-state component and use it in Run tabs and equivalent Agent, capability, conversation, and settings areas. Page-level empty states keep their existing layout; queries, conditions, actions, and populated results are unchanged.

Validation: `make check`, web production build, and a fresh independent review passed. Browser checks covered English/Chinese, light/dark themes, narrow rails, expanded dialogs, and switching back to populated results. Local Docker remained stopped; database-dependent checks were skipped by the existing gate.
