### PR TITLE
fix(web): clarify persistent execution failure feedback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -590,6 +590,11 @@ of the available width. Labels wrap and values retain their existing overflow
 behavior. Do not size individual groups from their longest label or add
 page-specific label widths; groups in the same context must align.
 
+Persistent execution failures use `ErrorState` with `appearance="panel"` to
+separate recovery guidance from expandable technical detail. Keep raw reasons
+in one place; historical conversation messages disable live announcements.
+Loading errors and field validation retain their existing presentation.
+
 ## Typography contract
 
 The type scale has 7 defined steps. Arbitrary pixel sizes (`text-[Npx]`) are

--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -3,7 +3,6 @@ import { useQueryClient } from "@tanstack/react-query"
 import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
-  AlertTriangle,
   ArrowUp,
   ArrowUpRight,
   Loader2,
@@ -54,7 +53,6 @@ const THREAD_STYLE = { ["--thread-max-width" as string]: "48rem" }
 /** title · conversation id · age (actions replace the age on hover) */
 
 import type { SandboxSendGuard } from "../../lib/sandbox-send-guard"
-import { VerbatimBlock } from "../ui/verbatim"
 
 /* ============================================================== */
 /*  The conversation thread, mounted by the console and by /c/<id> */
@@ -603,15 +601,7 @@ function ChatStream({
             omitPermission
           />
           {stream.status === "error" && (
-            <div className="flex flex-col gap-1">
-              <p className="m-0 flex items-start gap-1.5 text-sm text-fg">
-                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-failed" strokeWidth={1.5} aria-hidden="true" />
-                <span>{streamErrorMessage?.text}</span>
-              </p>
-              {streamErrorMessage?.detail && (
-                <VerbatimBlock className="ml-5 max-h-32">{streamErrorMessage.detail}</VerbatimBlock>
-              )}
-            </div>
+            <ErrorState appearance="panel" title={streamErrorMessage?.text} detail={streamErrorMessage?.detail} />
           )}
           {/*
             Queued runs render one "queued" line per run, distinct from the
@@ -785,21 +775,12 @@ function RunTrace({
   )
 }
 
-/**
- * Inline error line above the chat composer: a failed-red triangle, the
- * message in ink, one ghost dismiss button. Ad-hoc on purpose — it is
- * rendered in one place today.
- */
 function ChatErrorToast({ message, onDismiss }: { message: { text: string; detail?: string }; onDismiss: () => void }) {
   const { t: tc } = useTranslation("common")
   return (
-    <div className="mb-2 flex items-start gap-1.5 text-sm text-fg">
-      <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-failed" strokeWidth={1.5} aria-hidden="true" />
-      <span className="min-w-0 flex-1 break-words">
-        {message.text}
-        {message.detail && <VerbatimBlock className="mt-1 max-h-24">{message.detail}</VerbatimBlock>}
-      </span>
-      <Button variant="ghost" size="icon" className="-my-1.5 h-6 w-6" onClick={onDismiss} aria-label={tc("actions.close")}>
+    <div className="relative mb-2">
+      <ErrorState appearance="panel" className="pr-10" title={message.text} detail={message.detail} />
+      <Button variant="ghost" size="icon" className="absolute right-2 top-2 h-6 w-6" onClick={onDismiss} aria-label={tc("actions.close")}>
         <X strokeWidth={1.5} aria-hidden="true" />
       </Button>
     </div>
@@ -859,21 +840,17 @@ const MessageRow = memo(function MessageRow({
     return (
       <div className="max-w-[85%]">
         <div className="mb-1 text-xs text-fg-muted">{byline}</div>
-        <div className="flex items-start gap-1.5 text-base text-fg">
-          <AlertTriangle className="mt-1 h-3.5 w-3.5 shrink-0 text-status-failed" strokeWidth={1.5} aria-hidden="true" />
-          <div className="min-w-0">
-            {/* No "Run failed" heading over it: the red triangle says failure
-                and the sentence beneath says it again in words — three
-                statements of one fact in four lines. */}
-            <p className="m-0 break-words font-medium">{runtimeError.message}</p>
-            {runtimeError.href && runtimeError.action && (
-              <Button asChild variant="outline" size="sm" className="mt-2">
-                <a href={runtimeError.href}>{runtimeError.action}</a>
-              </Button>
-            )}
-            <p className="m-0 mt-2 text-xs text-fg-muted">{t("conversations.runtime_error.retryHint")}</p>
-          </div>
-        </div>
+        <ErrorState
+          appearance="panel"
+          announce={false}
+          title={runtimeError.message}
+          hint={t("conversations.runtime_error.retryHint")}
+          action={runtimeError.href && runtimeError.action ? (
+            <Button asChild variant="outline" size="sm">
+              <a href={runtimeError.href}>{runtimeError.action}</a>
+            </Button>
+          ) : undefined}
+        />
       </div>
     )
   }

--- a/apps/web/src/components/ui/error-state.tsx
+++ b/apps/web/src/components/ui/error-state.tsx
@@ -34,7 +34,7 @@ export function ErrorState({
 }: ErrorStateProps) {
   const { t } = useTranslation("common")
   const resolvedTitle = title ?? t("errors.loadFailed", { defaultValue: "Failed to load" })
-  const detailBlock = detail && <VerbatimBlock className="max-h-40 w-fit max-w-[min(52rem,100%)]">{detail}</VerbatimBlock>
+  const detailBlock = detail && <VerbatimBlock tabIndex={appearance === "panel" ? 0 : undefined} aria-label={appearance === "panel" ? t("errors.details") : undefined} className="max-h-40 w-fit max-w-[min(52rem,100%)] focus-visible:outline-accent">{detail}</VerbatimBlock>
   return (
     <div
       role={appearance === "panel" && announce ? "alert" : undefined}

--- a/apps/web/src/components/ui/error-state.tsx
+++ b/apps/web/src/components/ui/error-state.tsx
@@ -17,17 +17,10 @@ interface ErrorStateProps {
   onRetry?: () => void
   action?: ReactNode
   className?: string
+  appearance?: "inline" | "panel"
+  announce?: boolean
 }
 
-/**
- * Flat error state: a failed-status icon, an ink title, the message and
- * hint in muted, one retry button. No red box; colour lives in the icon.
- *
- * `description` and `detail` are two different voices and are not
- * interchangeable: the first is a sentence we wrote, the second is a string the
- * server produced. Only the second gets the recessed block, which is how the
- * reader tells at a glance which half was meant for them.
- */
 export function ErrorState({
   title,
   description,
@@ -36,20 +29,28 @@ export function ErrorState({
   onRetry,
   action,
   className,
+  appearance = "inline",
+  announce = true,
 }: ErrorStateProps) {
   const { t } = useTranslation("common")
   const resolvedTitle = title ?? t("errors.loadFailed", { defaultValue: "Failed to load" })
+  const detailBlock = detail && <VerbatimBlock className="max-h-40 w-fit max-w-[min(52rem,100%)]">{detail}</VerbatimBlock>
   return (
-    <div className={cn("flex flex-col items-start gap-3 py-4 text-sm", className)}>
+    <div
+      role={appearance === "panel" && announce ? "alert" : undefined}
+      className={cn("flex flex-col items-start gap-3 py-4 text-sm", appearance === "panel" && "rounded-md border border-line bg-surface p-3", className)}
+    >
       <div className="flex w-full items-start gap-2">
         <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-failed" strokeWidth={1.5} aria-hidden="true" />
         <div className="min-w-0 flex-1 space-y-1">
-          <p className="font-medium text-fg">{resolvedTitle}</p>
+          <p className="break-all font-medium text-fg">{resolvedTitle}</p>
           {description && <p className="break-words text-xs text-fg">{description}</p>}
-          {/* Shrink to the string, then wrap at the reading measure: a short
-              server message should not stretch into a grey bar the width of
-              the page. */}
-          {detail && <VerbatimBlock className="max-h-40 w-fit max-w-[min(52rem,100%)]">{detail}</VerbatimBlock>}
+          {appearance === "panel" && detail ? (
+            <details className="min-w-0">
+              <summary className="cursor-pointer py-1 text-xs text-fg-muted focus-visible:outline-accent">{t("errors.details")}</summary>
+              {detailBlock}
+            </details>
+          ) : detailBlock}
           {hint && <p className="text-xs text-fg-muted">{hint}</p>}
         </div>
       </div>

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -427,6 +427,8 @@
       "description": "@Agent in IM groups or Web conversations and runs will appear here."
     },
     "detail": {
+      "errorTitle": "This run needs attention",
+      "actionError": "The action could not be completed",
       "duration": "Duration",
       "conversation": "Conversation",
       "tabs": {

--- a/apps/web/src/i18n/locales/en-US/common.json
+++ b/apps/web/src/i18n/locales/en-US/common.json
@@ -249,6 +249,7 @@
     "next": "Next"
   },
   "errors": {
-    "loadFailed": "Failed to load"
+    "loadFailed": "Failed to load",
+    "details": "Technical details"
   }
 }

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -427,6 +427,8 @@
       "description": "在 IM 群或 Web 对话里 @Agent，运行记录会出现在这里。"
     },
     "detail": {
+      "errorTitle": "本次运行需要处理",
+      "actionError": "操作未完成",
       "duration": "耗时",
       "conversation": "对话",
       "tabs": {

--- a/apps/web/src/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/i18n/locales/zh-CN/common.json
@@ -249,6 +249,7 @@
     "next": "下一页"
   },
   "errors": {
-    "loadFailed": "加载失败"
+    "loadFailed": "加载失败",
+    "details": "技术详情"
   }
 }

--- a/apps/web/src/pages/admin/RunsPage.tsx
+++ b/apps/web/src/pages/admin/RunsPage.tsx
@@ -548,10 +548,13 @@ function RunDetailRail({
       </h2>
 
       {(errorSummary || cancelError) && (
-        <p className="mb-3 flex items-start gap-1.5 break-words text-sm text-fg">
-          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-failed" strokeWidth={1.5} aria-hidden="true" />
-          <span>{cancelError ?? errorSummary}</span>
-        </p>
+        <ErrorState
+          appearance="panel"
+          className="mb-3"
+          title={t(cancelError ? "runs.detail.actionError" : "runs.detail.errorTitle")}
+          description={cancelError ? undefined : diagnosis.action}
+          detail={cancelError ?? errorSummary ?? undefined}
+        />
       )}
 
       <PropertyList>
@@ -609,13 +612,17 @@ function RunDetailRail({
               {diagnosis.title !== t(`runStatus.${run.status}`) && (
                 <Property label={t("runs.detail.diagnostics.fields.result")}>{diagnosis.title}</Property>
               )}
-              <Property label={t("runs.detail.diagnostics.fields.reason")} className="h-auto min-h-7 whitespace-normal py-1 [overflow-wrap:anywhere]">
-                {diagnosis.reason}
-              </Property>
+              {(cancelError || diagnosis.reason !== errorSummary) && (
+                <Property label={t("runs.detail.diagnostics.fields.reason")} className="h-auto min-h-7 whitespace-normal py-1 [overflow-wrap:anywhere]">
+                  {diagnosis.reason}
+                </Property>
+              )}
               <Property label={t("runs.detail.diagnostics.fields.source")}>{enumLabel(translateDetail, diagnosis.source)}</Property>
-              <Property label={t("runs.detail.diagnostics.fields.nextAction")} className="h-auto min-h-7 whitespace-normal py-1">
-                {diagnosis.action}
-              </Property>
+              {(!errorSummary || cancelError) && (
+                <Property label={t("runs.detail.diagnostics.fields.nextAction")} className="h-auto min-h-7 whitespace-normal py-1">
+                  {diagnosis.action}
+                </Property>
+              )}
               <Property label={t("runs.detail.diagnostics.fields.latestEvent")}>{diagnosis.latest}</Property>
             </PropertyList>
           </RailSection>


### PR DESCRIPTION
Run failures displayed an ungrouped raw reason above their metadata and repeated it in Diagnostics. Group persistent run and active-conversation failures in the shared rounded error panel, with recovery guidance and keyboard-accessible technical details. Keep the original reasons, recovery links, run actions and conversation behavior.

Validation: `make check` and web production build passed. Real QA data and local failure fixtures covered narrow/expanded run views, retry rejection, historical credential errors, streaming failure and dismissal, both locales/themes, and keyboard scrolling. Independent blind review completed; its focus finding was corrected and rechecked under the agreed small-change review policy. Local Docker remained stopped; Docker-dependent integration checks were skipped.
