### PR TITLE
fix(web): unify authentication submission feedback

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -566,6 +566,10 @@ Three concrete rules:
 When a dialog uses a multi-column grid, give every column `min-w-0` —
 otherwise long children push the grid track wider instead of wrapping.
 
+Authentication submission failures use the shared `ErrorDialog`, preserving
+form input and restoring action focus on dismissal. Field validation stays
+inline; sign-in-required invitation guidance stays visible as a guided step.
+
 Pages with a detail rail may opt into wrapping header actions through
 `PageHeader.actionClassName` and an auto-height header. Other pages retain
 the default single-row header layout.

--- a/apps/web/src/components/ui/error-dialog.tsx
+++ b/apps/web/src/components/ui/error-dialog.tsx
@@ -1,0 +1,44 @@
+import { AlertTriangle } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "./button"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "./dialog"
+import { VerbatimBlock } from "./verbatim"
+
+export function ErrorDialog({ title, message, detail, onClose, onRestoreFocus }: {
+  title: string
+  message: string
+  detail?: string
+  onClose: () => void
+  onRestoreFocus: () => void
+}) {
+  const { t } = useTranslation("common")
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent
+        showCloseButton={false}
+        onCloseAutoFocus={(event) => { event.preventDefault(); onRestoreFocus() }}
+        className="w-[calc(100%-2rem)] max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-hidden"
+      >
+        <DialogHeader className="min-w-0 pr-4">
+          <DialogTitle className="flex items-start gap-2 break-all">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-status-failed" strokeWidth={1.5} aria-hidden="true" />
+            {title}
+          </DialogTitle>
+        </DialogHeader>
+        <DialogDescription className="break-all text-fg">{message}</DialogDescription>
+        {detail && (
+          <details className="min-w-0">
+            <summary className="cursor-pointer text-sm text-fg-muted focus-visible:outline-accent">
+              {t("errors.details")}
+            </summary>
+            <VerbatimBlock className="mt-3 max-h-52 w-full break-all">{detail}</VerbatimBlock>
+          </details>
+        )}
+        <DialogFooter>
+          <Button autoFocus onClick={onClose}>{t("actions.close")}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/components/ui/error-dialog.tsx
+++ b/apps/web/src/components/ui/error-dialog.tsx
@@ -1,23 +1,32 @@
 import { AlertTriangle } from "lucide-react"
+import type { RefObject } from "react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "./button"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "./dialog"
 import { VerbatimBlock } from "./verbatim"
 
-export function ErrorDialog({ title, message, detail, onClose, onRestoreFocus }: {
+export function ErrorDialog({ title, message, detail, onClose, onRestoreFocus, focusScopeRef }: {
   title: string
   message: string
   detail?: string
   onClose: () => void
   onRestoreFocus: () => void
+  focusScopeRef: RefObject<HTMLElement | null>
 }) {
   const { t } = useTranslation("common")
   return (
     <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
       <DialogContent
         showCloseButton={false}
-        onCloseAutoFocus={(event) => { event.preventDefault(); onRestoreFocus() }}
+        onCloseAutoFocus={(event) => {
+          event.preventDefault()
+          onRestoreFocus()
+          const scope = focusScopeRef.current
+          if (scope && !scope.contains(document.activeElement)) {
+            scope.querySelector<HTMLElement>('input:not(:disabled), button:not(:disabled), a[href]')?.focus()
+          }
+        }}
         className="w-[calc(100%-2rem)] max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-hidden"
       >
         <DialogHeader className="min-w-0 pr-4">

--- a/apps/web/src/components/ui/error-dialog.tsx
+++ b/apps/web/src/components/ui/error-dialog.tsx
@@ -41,7 +41,7 @@ export function ErrorDialog({ title, message, detail, onClose, onRestoreFocus, f
             <summary className="cursor-pointer text-sm text-fg-muted focus-visible:outline-accent">
               {t("errors.details")}
             </summary>
-            <VerbatimBlock className="mt-3 max-h-52 w-full break-all">{detail}</VerbatimBlock>
+            <VerbatimBlock tabIndex={0} aria-label={t("errors.details")} className="mt-3 max-h-52 w-full break-all focus-visible:outline-accent">{detail}</VerbatimBlock>
           </details>
         )}
         <DialogFooter>

--- a/apps/web/src/i18n/locales/en-US/common.json
+++ b/apps/web/src/i18n/locales/en-US/common.json
@@ -112,7 +112,8 @@
     "passwordPlaceholder": "Your password",
     "submitButton": "Sign in",
     "submitting": "Signing in...",
-    "invalidCredentials": "Invalid email or password",
+    "failedTitle": "Sign-in failed",
+    "invalidCredentials": "The email or password is incorrect. Check them and try again.",
     "genericError": "Something went wrong. Please try again.",
     "headline": "Your team's agent console.",
     "headlineSub": "Log in to your Parsar account",
@@ -137,6 +138,7 @@
     }
   },
   "setup": {
+    "failedTitle": "Account could not be created",
     "title": "Welcome to Parsar",
     "subtitle": "This install has no owner yet. Create the first account to get started — you will become the workspace owner.",
     "nameLabel": "Your name",
@@ -249,6 +251,8 @@
     "next": "Next"
   },
   "errors": {
+    "details": "Technical details",
+    "submitRetryHint": "Please try again. If the problem continues, contact your administrator.",
     "loadFailed": "Failed to load"
   }
 }

--- a/apps/web/src/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/i18n/locales/zh-CN/common.json
@@ -112,7 +112,8 @@
     "passwordPlaceholder": "请输入密码",
     "submitButton": "登录",
     "submitting": "登录中...",
-    "invalidCredentials": "邮箱或密码错误",
+    "failedTitle": "登录失败",
+    "invalidCredentials": "邮箱或密码不正确，请检查后重试。",
     "genericError": "发生错误,请稍后重试。",
     "headline": "团队的 Agent 控制台。",
     "headlineSub": "登录你的 Parsar 账号",
@@ -137,6 +138,7 @@
     }
   },
   "setup": {
+    "failedTitle": "账号创建失败",
     "title": "欢迎使用 Parsar",
     "subtitle": "本实例尚未创建拥有者。请注册第一位账号 — 你将成为工作区 Owner。",
     "nameLabel": "你的姓名",
@@ -249,6 +251,8 @@
     "next": "下一页"
   },
   "errors": {
+    "details": "技术详情",
+    "submitRetryHint": "请重试；如果问题持续，请联系管理员。",
     "loadFailed": "加载失败"
   }
 }

--- a/apps/web/src/pages/InviteAcceptPage.tsx
+++ b/apps/web/src/pages/InviteAcceptPage.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type FormEvent } from "react"
+import { useEffect, useRef, useState, type FormEvent } from "react"
 import { useTranslation } from "react-i18next"
 import { Button } from "../components/ui/button"
 import { EntryFooter, EntryPage, EntryPanel } from "../components/ui/entry-panel"
@@ -30,6 +30,10 @@ export function InviteAcceptPage({ token }: { token: string }) {
     password === "" || passwordPolicyError === null
       ? null
       : t(`passwordPolicy.errors.${passwordPolicyError}`)
+
+  useEffect(() => {
+    if (signInRequired) signInRef.current?.focus()
+  }, [signInRequired])
 
   if (infoQ.isLoading || authLoading) {
     return (
@@ -88,7 +92,7 @@ export function InviteAcceptPage({ token }: { token: string }) {
     <EntryPage>
       <EntryPanel
         title={t("invite.title", { name: workspace_name })}
-        description={signInRequired ? t("invite.signInRequired") : isCurrentInvitee
+        description={signInRequired ? <span role="status">{t("invite.signInRequired")}</span> : isCurrentInvitee
           ? t("invite.existingDescription", { email, role })
           : t("invite.description", { role })}
       >

--- a/apps/web/src/pages/InviteAcceptPage.tsx
+++ b/apps/web/src/pages/InviteAcceptPage.tsx
@@ -1,7 +1,8 @@
-import { useState, type FormEvent } from "react"
+import { useRef, useState, type FormEvent } from "react"
 import { useTranslation } from "react-i18next"
 import { Button } from "../components/ui/button"
 import { EntryFooter, EntryPage, EntryPanel } from "../components/ui/entry-panel"
+import { ErrorDialog } from "../components/ui/error-dialog"
 import { InlineError } from "../components/ui/error-state"
 import { Input } from "../components/ui/input"
 import { Field } from "../components/ui/label"
@@ -20,6 +21,9 @@ export function InviteAcceptPage({ token }: { token: string }) {
   const [password, setPassword] = useState("")
   const [confirm, setConfirm] = useState("")
   const [errMsg, setErrMsg] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<{ action: "signIn" | "accept"; message: string } | null>(null)
+  const submitRef = useRef<HTMLButtonElement>(null)
+  const signInRef = useRef<HTMLButtonElement>(null)
   const [signInRequired, setSignInRequired] = useState(false)
   const passwordPolicyError = validateNewPassword(password)
   const passwordPolicyErrorMsg =
@@ -52,7 +56,7 @@ export function InviteAcceptPage({ token }: { token: string }) {
       if (user) await logout()
       else window.location.assign("/login")
     } catch (err) {
-      setErrMsg(err instanceof Error ? err.message : t("invite.acceptFailed"))
+      setSubmitError({ action: "signIn", message: err instanceof Error ? err.message : t("login.genericError") })
     }
   }
 
@@ -74,10 +78,9 @@ export function InviteAcceptPage({ token }: { token: string }) {
     } catch (err) {
       if (err instanceof ApiError && err.envelope.code === "invitation_sign_in_required") {
         setSignInRequired(true)
-        setErrMsg(t("invite.signInRequired"))
         return
       }
-      setErrMsg(err instanceof Error ? err.message : t("invite.acceptFailed"))
+      setSubmitError({ action: "accept", message: err instanceof Error ? err.message : t("invite.acceptFailed") })
     }
   }
 
@@ -85,7 +88,7 @@ export function InviteAcceptPage({ token }: { token: string }) {
     <EntryPage>
       <EntryPanel
         title={t("invite.title", { name: workspace_name })}
-        description={signInRequired ? undefined : isCurrentInvitee
+        description={signInRequired ? t("invite.signInRequired") : isCurrentInvitee
           ? t("invite.existingDescription", { email, role })
           : t("invite.description", { role })}
       >
@@ -135,20 +138,29 @@ export function InviteAcceptPage({ token }: { token: string }) {
 
           <EntryFooter message={errMsg && <InlineError>{errMsg}</InlineError>}>
             {signInRequired ? (
-              <Button type="button" onClick={() => void signIn()}>{t("invite.signIn")}</Button>
+              <Button ref={signInRef} type="button" onClick={() => void signIn()}>{t("invite.signIn")}</Button>
             ) : (
-              <Button type="submit" disabled={acceptMut.isPending || (!isCurrentInvitee && passwordPolicyError !== null)}>
+              <Button ref={submitRef} type="submit" disabled={acceptMut.isPending || (!isCurrentInvitee && passwordPolicyError !== null)}>
                 {acceptMut.isPending ? t("invite.submitting") : t(isCurrentInvitee ? "invite.accept" : "invite.submit")}
               </Button>
             )}
           </EntryFooter>
           {!isCurrentInvitee && !signInRequired && (
-            <Button type="button" variant="ghost" className="self-start" onClick={() => void signIn()} disabled={acceptMut.isPending}>
+            <Button ref={signInRef} type="button" variant="ghost" className="self-start" onClick={() => void signIn()} disabled={acceptMut.isPending}>
               {t("invite.signIn")}
             </Button>
           )}
         </form>
       </EntryPanel>
+      {submitError && (
+        <ErrorDialog
+          title={t(submitError.action === "signIn" ? "login.failedTitle" : "invite.acceptFailed")}
+          message={t("errors.submitRetryHint")}
+          detail={submitError.message}
+          onClose={() => setSubmitError(null)}
+          onRestoreFocus={() => (submitError.action === "signIn" ? signInRef : submitRef).current?.focus()}
+        />
+      )}
     </EntryPage>
   )
 }

--- a/apps/web/src/pages/InviteAcceptPage.tsx
+++ b/apps/web/src/pages/InviteAcceptPage.tsx
@@ -24,6 +24,7 @@ export function InviteAcceptPage({ token }: { token: string }) {
   const [submitError, setSubmitError] = useState<{ action: "signIn" | "accept"; message: string } | null>(null)
   const submitRef = useRef<HTMLButtonElement>(null)
   const signInRef = useRef<HTMLButtonElement>(null)
+  const formRef = useRef<HTMLFormElement>(null)
   const [signInRequired, setSignInRequired] = useState(false)
   const passwordPolicyError = validateNewPassword(password)
   const passwordPolicyErrorMsg =
@@ -96,7 +97,7 @@ export function InviteAcceptPage({ token }: { token: string }) {
           ? t("invite.existingDescription", { email, role })
           : t("invite.description", { role })}
       >
-        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <form ref={formRef} onSubmit={handleSubmit} className="flex flex-col gap-3">
           <Field label={t("login.emailLabel")} htmlFor="invite-email">
             <Input id="invite-email" type="email" value={email} readOnly disabled />
           </Field>
@@ -163,6 +164,7 @@ export function InviteAcceptPage({ token }: { token: string }) {
           detail={submitError.message}
           onClose={() => setSubmitError(null)}
           onRestoreFocus={() => (submitError.action === "signIn" ? signInRef : submitRef).current?.focus()}
+          focusScopeRef={formRef}
         />
       )}
     </EntryPage>

--- a/apps/web/src/pages/InviteAcceptPage.tsx
+++ b/apps/web/src/pages/InviteAcceptPage.tsx
@@ -85,6 +85,10 @@ export function InviteAcceptPage({ token }: { token: string }) {
         setSignInRequired(true)
         return
       }
+      if (err instanceof ApiError && err.envelope.status === 400) {
+        setErrMsg(err.message)
+        return
+      }
       setSubmitError({ action: "accept", message: err instanceof Error ? err.message : t("invite.acceptFailed") })
     }
   }

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,10 +1,11 @@
-import { useState, type FormEvent } from "react"
+import { useRef, useState, type FormEvent } from "react"
 import { useTranslation } from "react-i18next"
 
 import { BrandMark } from "../components/ui/brand-mark"
 import { cn } from "../lib/utils"
 import { Button } from "../components/ui/button"
 import { EntryPage } from "../components/ui/entry-panel"
+import { ErrorDialog } from "../components/ui/error-dialog"
 import { InlineError } from "../components/ui/error-state"
 import { Input } from "../components/ui/input"
 import { Field } from "../components/ui/label"
@@ -52,6 +53,7 @@ function SignInView() {
 
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
+  const submitRef = useRef<HTMLButtonElement>(null)
 
   const submitting = loginM.isPending
   const invalid = email.trim() === "" || password === ""
@@ -60,15 +62,8 @@ function SignInView() {
       (p) => p.enabled && p.id !== "password" && Boolean(p.login_url),
     ) ?? []
 
-  const errorMsg = (() => {
-    const err = loginM.error
-    if (!err) return ""
-    if (err instanceof ApiError) {
-      if (err.envelope.code === "invalid_credentials") return t("login.invalidCredentials")
-      return err.envelope.message || t("login.genericError")
-    }
-    return t("login.genericError")
-  })()
+  const invalidCredentials = loginM.error instanceof ApiError &&
+    (loginM.error.envelope.code === "invalid_credentials" || loginM.error.envelope.status === 401)
 
   async function onSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault()
@@ -129,10 +124,8 @@ function SignInView() {
                 />
               </Field>
 
-              {errorMsg && <InlineError>{errorMsg}</InlineError>}
-
               <div className="mt-1 flex flex-col gap-2">
-                <Button type="submit" size="xl" className="w-full" disabled={invalid || submitting}>
+                <Button ref={submitRef} type="submit" size="xl" className="w-full" disabled={invalid || submitting}>
                   {submitting ? t("login.submitting") : t("login.submitButton")}
                 </Button>
                 <Button
@@ -174,6 +167,15 @@ function SignInView() {
           <InviteEntry onBack={() => setMode("signIn")} />
         )}
       </div>
+      {loginM.error && (
+        <ErrorDialog
+          title={t("login.failedTitle")}
+          message={t(invalidCredentials ? "login.invalidCredentials" : "login.genericError")}
+          detail={invalidCredentials ? undefined : loginM.error.message}
+          onClose={() => loginM.reset()}
+          onRestoreFocus={() => submitRef.current?.focus()}
+        />
+      )}
     </EntryPage>
   )
 }

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -54,6 +54,7 @@ function SignInView() {
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
   const submitRef = useRef<HTMLButtonElement>(null)
+  const formScopeRef = useRef<HTMLDivElement>(null)
 
   const submitting = loginM.isPending
   const invalid = email.trim() === "" || password === ""
@@ -82,7 +83,7 @@ function SignInView() {
 
   return (
     <EntryPage>
-      <div className="w-full max-w-[400px]">
+      <div ref={formScopeRef} className="w-full max-w-[400px]">
         <header className="mb-8 flex flex-col items-center text-center">
           <BrandMark size={44} />
           <h1 className="font-display mt-6 text-3xl leading-tight text-fg" translate="no">
@@ -174,6 +175,7 @@ function SignInView() {
           detail={invalidCredentials ? undefined : loginM.error.message}
           onClose={() => loginM.reset()}
           onRestoreFocus={() => submitRef.current?.focus()}
+          focusScopeRef={formScopeRef}
         />
       )}
     </EntryPage>

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -64,7 +64,7 @@ export function SetupPage() {
       : register.error instanceof Error
         ? register.error.message
         : ""
-  const fieldError = register.error instanceof ApiError && register.error.envelope.code === "bootstrap_invalid_input"
+  const fieldError = register.error instanceof ApiError && register.error.envelope.status === 400
 
   const passwordPolicyError = validateNewPassword(password)
   const passwordPolicyErrorMsg =

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -34,6 +34,7 @@ export function SetupPage() {
   const [workspaceEdited, setWorkspaceEdited] = useState(false)
   const [password, setPassword] = useState("")
   const submitRef = useRef<HTMLButtonElement>(null)
+  const formRef = useRef<HTMLFormElement>(null)
 
   function suggestedWorkspaceName(nextName: string, nextEmail: string): string {
     const owner = workspaceOwnerName({ name: nextName, email: nextEmail })
@@ -63,6 +64,7 @@ export function SetupPage() {
       : register.error instanceof Error
         ? register.error.message
         : ""
+  const fieldError = register.error instanceof ApiError && register.error.envelope.code === "bootstrap_invalid_input"
 
   const passwordPolicyError = validateNewPassword(password)
   const passwordPolicyErrorMsg =
@@ -93,7 +95,7 @@ export function SetupPage() {
   return (
     <EntryPage>
       <EntryPanel title={t("setup.title")} description={t("setup.subtitle")}>
-        <form className="flex flex-col gap-3" onSubmit={onSubmit} noValidate>
+        <form ref={formRef} className="flex flex-col gap-3" onSubmit={onSubmit} noValidate>
           <Field label={t("setup.nameLabel")} htmlFor="setup-name">
             <Input
               id="setup-name"
@@ -150,20 +152,21 @@ export function SetupPage() {
             />
           </Field>
 
-          <EntryFooter>
+          <EntryFooter message={fieldError && <InlineError>{errorMsg}</InlineError>}>
             <Button ref={submitRef} type="submit" disabled={invalid || submitting}>
               {submitting ? t("setup.submitting") : t("setup.submitButton")}
             </Button>
           </EntryFooter>
         </form>
       </EntryPanel>
-      {errorMsg && (
+      {errorMsg && !fieldError && (
         <ErrorDialog
           title={t("setup.failedTitle")}
           message={t("errors.submitRetryHint")}
           detail={errorMsg}
           onClose={() => register.reset()}
           onRestoreFocus={() => submitRef.current?.focus()}
+          focusScopeRef={formRef}
         />
       )}
     </EntryPage>

--- a/apps/web/src/pages/SetupPage.tsx
+++ b/apps/web/src/pages/SetupPage.tsx
@@ -1,8 +1,9 @@
-import { useState, type FormEvent } from "react"
+import { useRef, useState, type FormEvent } from "react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "../components/ui/button"
 import { EntryFooter, EntryPage, EntryPanel } from "../components/ui/entry-panel"
+import { ErrorDialog } from "../components/ui/error-dialog"
 import { InlineError } from "../components/ui/error-state"
 import { Input } from "../components/ui/input"
 import { Field } from "../components/ui/label"
@@ -21,8 +22,7 @@ import { workspaceOwnerName } from "../lib/workspace-defaults"
  * AuthedRoot.
  *
  * Password policy is validated server-side by password.Validate. The client
- * mirrors the same simple checks so users get immediate feedback before the
- * server's bootstrap_weak_password envelope is surfaced inline.
+ * mirrors those checks to provide immediate field feedback.
  */
 export function SetupPage() {
   const { t } = useTranslation("common")
@@ -33,6 +33,7 @@ export function SetupPage() {
   const [workspace, setWorkspace] = useState(() => t("workspaceDefaults.generic"))
   const [workspaceEdited, setWorkspaceEdited] = useState(false)
   const [password, setPassword] = useState("")
+  const submitRef = useRef<HTMLButtonElement>(null)
 
   function suggestedWorkspaceName(nextName: string, nextEmail: string): string {
     const owner = workspaceOwnerName({ name: nextName, email: nextEmail })
@@ -149,13 +150,22 @@ export function SetupPage() {
             />
           </Field>
 
-          <EntryFooter message={errorMsg && <InlineError>{errorMsg}</InlineError>}>
-            <Button type="submit" disabled={invalid || submitting}>
+          <EntryFooter>
+            <Button ref={submitRef} type="submit" disabled={invalid || submitting}>
               {submitting ? t("setup.submitting") : t("setup.submitButton")}
             </Button>
           </EntryFooter>
         </form>
       </EntryPanel>
+      {errorMsg && (
+        <ErrorDialog
+          title={t("setup.failedTitle")}
+          message={t("errors.submitRetryHint")}
+          detail={errorMsg}
+          onClose={() => register.reset()}
+          onRestoreFocus={() => submitRef.current?.focus()}
+        />
+      )}
     </EntryPage>
   )
 }


### PR DESCRIPTION
Failed authentication submissions now use a shared error dialog with clear localized guidance, retained form input and focus restoration. Password sign-in, first-owner setup and invitation actions share the pattern; server field-validation errors remain visible in the form, and existing-account invitations retain their sign-in step.

Validation: `make check` and web production build passed. Browser fixtures covered incorrect credentials, service failures, setup/invite validation, existing-account sign-in, successful navigation, long technical details, dismissal and resubmission, both locales/themes, and editing or switching forms during a pending request. Independent blind review completed; the final field-validation classification correction was self-reviewed and rechecked under the agreed small-change policy. No real accounts were modified. Local Docker remained stopped; Docker-dependent integration checks were skipped.
