### PR TITLE
docs: scale independent review to change impact

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,8 @@ commits to `main` are forbidden.**
   back into it.
 - After implementing and verifying, push the feature branch and open a PR
   against `main`. **Merging into `main` requires PR review** — local
-  fast-forward or local merge to bypass review is not allowed.
+  fast-forward or local merge to bypass review is not allowed. Self-review
+  qualifies for low-impact changes under the review policy below.
 - Run `make check` (and any relevant E2E target) before requesting review.
 - Place worktrees under `.worktrees/<feature-name>/` so they don't litter
   the repo root.
@@ -55,15 +56,22 @@ Fix one issue per PR. State the expected behavior, acceptance criteria, and
 explicit scope exclusions before implementation. Keep unrelated refactors,
 features, formatting, and dependency updates in separate PRs.
 
+Small, low-impact changes may use developer self-review and relevant
+verification without a subagent. Examples include isolated copy, spacing,
+documentation, and local corrections to an already-reviewed change.
+
+Substantial changes, shared interaction behavior, security-sensitive changes,
+and changes whose impact is uncertain require an independent blind review.
 After implementation and required checks, ask one fresh subagent to review
-the entire diff. Give it the requirements, acceptance criteria, project rules,
-and scope boundaries. Do not share the developer's conversation, implementation
+the entire diff. Give it requirements, acceptance criteria, project rules,
+and scope boundaries, without the developer's conversation, implementation
 summary, suspected defects, or previous review findings.
 
-Address blocking findings within the same scope, rerun the relevant checks,
-and repeat the blind review with a fresh subagent after each revision. Merge
-only after checks pass and the review has no unresolved blocking findings.
-Record verification and the PR outcome in the linked issue.
+Address blocking findings within the same scope and rerun the relevant checks.
+Revisions with material behavior changes need a fresh blind reviewer; small
+local corrections may be self-reviewed. Required checks still apply to every
+PR. Merge only after checks pass and all blocking findings are resolved.
+Record the review method, verification, and PR outcome in the linked issue.
 
 If review and fixes keep cycling, stop patching and reassess the design. If
 the design still does not converge, document the unresolved problem and defer


### PR DESCRIPTION
Allow developer self-review for small, low-impact changes and local corrections to reviewed work. Keep fresh blind review for substantial, security-sensitive, shared-interaction or uncertain changes, and retain the PR workflow, required checks and resolution of blocking findings.

Validation: self-reviewed as requested; `make check` passed. No runtime or product behavior changes.
