### PR TITLE
fix(web): unify single-select menus across forms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -590,6 +590,13 @@ of the available width. Labels wrap and values retain their existing overflow
 behavior. Do not size individual groups from their longest label or add
 page-specific label widths; groups in the same context must align.
 
+Single-choice form controls use the shared Radix-backed `Select` and
+`SelectOption` components. Pass values through `onValueChange`; do not fabricate
+DOM change events. Keep option values, labels and disabled rules in the caller,
+and popup styling, keyboard navigation and focus behavior in the shared control.
+Keep its Radix dismissal and focus dependencies compatible with `Dialog` so
+nested menus share one layer stack.
+
 ## Typography contract
 
 The type scale has 7 defined steps. Arbitrary pixel sizes (`text-[Npx]`) are

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-collapsible": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.18",
     "@radix-ui/react-dropdown-menu": "^2.1.19",
+    "@radix-ui/react-select": "^2.3.2",
     "@radix-ui/react-slot": "^1.3.0",
     "@radix-ui/react-tabs": "^1.1.16",
     "@radix-ui/react-tooltip": "^1.2.11",

--- a/apps/web/src/components/admin/CredentialBindingSelect.tsx
+++ b/apps/web/src/components/admin/CredentialBindingSelect.tsx
@@ -1,4 +1,4 @@
-import { Select } from "../ui/select"
+import { Select, SelectOption } from "../ui/select"
 import type { Secret } from "../../lib/api-types"
 
 interface CredentialBindingSelectProps {
@@ -30,18 +30,18 @@ export function CredentialBindingSelect({
   return (
     <Select
       value={value}
-      onChange={(event) => onChange(event.target.value)}
+      onValueChange={(nextValue) => onChange(nextValue)}
       onClick={(event) => event.stopPropagation()}
       className={className}
     >
-      {allowPersonal && <option value="">{personalLabel}</option>}
-      {!allowPersonal && !value && <option value="">{personalPlaceholder ?? personalLabel}</option>}
+      {allowPersonal && <SelectOption value="">{personalLabel}</SelectOption>}
+      {!allowPersonal && !value && <SelectOption value="">{personalPlaceholder ?? personalLabel}</SelectOption>}
       {secrets.map((secret) => (
-        <option key={secret.id} value={secret.id}>
+        <SelectOption key={secret.id} value={secret.id}>
           {sharedLabel}: {secret.name}
-        </option>
+        </SelectOption>
       ))}
-      {allowCreateNew && <option value="__new__">{createNewLabel ?? sharedLabel}</option>}
+      {allowCreateNew && <SelectOption value="__new__">{createNewLabel ?? sharedLabel}</SelectOption>}
     </Select>
   )
 }

--- a/apps/web/src/components/admin/DevicePicker.tsx
+++ b/apps/web/src/components/admin/DevicePicker.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next"
 import { Plus } from "lucide-react"
 
 import { Button } from "../ui/button"
-import { Select } from "../ui/select"
+import { Select, SelectOption } from "../ui/select"
 import { Skeleton } from "../ui/skeleton"
 import { InlineError } from "../runtime/InlineError"
 import {
@@ -136,17 +136,17 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
       <Select
         value={value}
         disabled={disabled}
-        onChange={(e) => onChange(e.target.value)}
+        onValueChange={(nextValue) => onChange(nextValue)}
         data-testid="agent-daemon-device-picker"
         wrapperClassName="min-w-0 flex-1"
       >
-        <option value="">
+        <SelectOption value="">
           {t("agents.form.devicePicker.placeholder", { defaultValue: "Pick a device…" })}
-        </option>
+        </SelectOption>
         {selectableDevices.map((r) => (
-          <option key={r.id} value={r.id}>
+          <SelectOption key={r.id} value={r.id}>
             {formatDeviceLabel(r)}
-          </option>
+          </SelectOption>
         ))}
       </Select>
       {onAddDevice && (

--- a/apps/web/src/components/admin/ScopeRequiredState.tsx
+++ b/apps/web/src/components/admin/ScopeRequiredState.tsx
@@ -11,7 +11,7 @@ import { setWorkspaceId } from "../../lib/workspace"
 import { workspaceOwnerName } from "../../lib/workspace-defaults"
 import { Button } from "../ui/button"
 import { EmptyState } from "../ui/empty-state"
-import { Select } from "../ui/select"
+import { Select, SelectOption } from "../ui/select"
 import { WorkspaceFormDialog } from "../layout/WorkspaceCrudDialogs"
 
 interface ScopeRequiredStateProps {
@@ -53,17 +53,17 @@ export function ScopeRequiredState({ resourceName }: ScopeRequiredStateProps) {
         aria-label={pickLabel}
         defaultValue=""
         wrapperClassName="w-60"
-        onChange={(event) => {
-          if (event.target.value) setWorkspaceId(event.target.value)
+        onValueChange={(nextValue) => {
+          if (nextValue) setWorkspaceId(nextValue)
         }}
       >
-        <option value="" disabled>
+        <SelectOption value="" disabled>
           {pickLabel}
-        </option>
+        </SelectOption>
         {workspaces.map((workspace) => (
-          <option key={workspace.id} value={workspace.id}>
+          <SelectOption key={workspace.id} value={workspace.id}>
             {workspace.name}
-          </option>
+          </SelectOption>
         ))}
       </Select>
     )

--- a/apps/web/src/components/admin/channel-connectors/PlatformSelector.tsx
+++ b/apps/web/src/components/admin/channel-connectors/PlatformSelector.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next"
 
 import { Field } from "../../ui/label"
-import { Select } from "../../ui/select"
+import { Select, SelectOption } from "../../ui/select"
 
 export type ConnectorPlatform = "feishu" | "slack" | "discord" | "teams"
 
@@ -31,14 +31,14 @@ export function PlatformSelector({
       <Select
         id={id}
         value={value}
-        onChange={(e) => onChange(e.target.value as ConnectorPlatform)}
+        onValueChange={(nextValue) => onChange(nextValue as ConnectorPlatform)}
         disabled={disabled}
         data-testid={testId ?? "channel-connector-platform-select"}
       >
         {options.map((opt) => (
-          <option key={opt} value={opt}>
+          <SelectOption key={opt} value={opt}>
             {t(`connections.connector.platformSelect.options.${opt}`)}
-          </option>
+          </SelectOption>
         ))}
       </Select>
     </Field>

--- a/apps/web/src/components/admin/channel-connectors/slackFields.tsx
+++ b/apps/web/src/components/admin/channel-connectors/slackFields.tsx
@@ -11,7 +11,7 @@ import { useCreateSecret } from "../../../lib/api-secrets"
 import type { CreateSecretRequest } from "../../../lib/api-types"
 import { Button } from "../../ui/button"
 import { Input } from "../../ui/input"
-import { Select } from "../../ui/select"
+import { Select, SelectOption } from "../../ui/select"
 import { InlineError } from "../../runtime/InlineError"
 import { EnabledField, Field, FormFooter, FormSection, SecretInput } from "./shared"
 import { randomHex } from "../../../lib/random"
@@ -213,13 +213,13 @@ function SlackConnectorFieldsInner({
         <Select
           id="slack-event-mode"
           value={draft.event_mode}
-          onChange={(e) => setDraft({ ...draft, event_mode: e.target.value === "events" ? "events" : "socket" })}
+          onValueChange={(nextValue) => setDraft({ ...draft, event_mode: nextValue === "events" ? "events" : "socket" })}
           disabled={locked}
         >
           {(["socket", "events"] as const).map((mode) => (
-            <option key={mode} value={mode}>
+            <SelectOption key={mode} value={mode}>
               {t(`connections.connector.slack.fields.eventMode.options.${mode}`)}
-            </option>
+            </SelectOption>
           ))}
         </Select>
       </Field>
@@ -287,7 +287,7 @@ function configKey(config: SlackConnectorInput): string {
     config.app_token_ref,
     config.signing_secret_ref,
     config.event_mode,
-  ].join(" ")
+  ].join("\u0000")
 }
 
 function applyChange(

--- a/apps/web/src/components/layout/WorkspaceCrudDialogs.tsx
+++ b/apps/web/src/components/layout/WorkspaceCrudDialogs.tsx
@@ -22,7 +22,7 @@ import {
 import { InlineError } from "../ui/error-state"
 import { Input } from "../ui/input"
 import { Field } from "../ui/label"
-import { Select } from "../ui/select"
+import { Select, SelectOption } from "../ui/select"
 import { Textarea } from "../ui/textarea"
 
 type FormMode = "create" | "rename"
@@ -113,12 +113,12 @@ export function WorkspaceFormDialog({
             <Select
               id="ws-visibility"
               value={visibility}
-              onChange={(e) => setVisibility(e.target.value as WorkspaceVisibility)}
+              onValueChange={(nextValue) => setVisibility(nextValue as WorkspaceVisibility)}
             >
               {(["private", "public"] as const).map((v) => (
-                <option key={v} value={v}>
+                <SelectOption key={v} value={v}>
                   {t(`workspaceCrud.visibility.${v}`)}
-                </option>
+                </SelectOption>
               ))}
             </Select>
           </Field>

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -19,7 +19,10 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
     <SelectPrimitive.Root
       value={value === undefined ? undefined : itemValue(value)}
       defaultValue={defaultValue === undefined ? undefined : itemValue(defaultValue)}
-      onValueChange={(next) => onValueChange?.(next.slice(6))}
+      onValueChange={(next) => {
+        // The native form bridge emits an unencoded empty value while options load.
+        if (next.startsWith("value:")) onValueChange?.(next.slice(6))
+      }}
       disabled={disabled}
     >
       <span className={cn("relative inline-flex min-w-0 w-full", wrapperClassName)}>

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,33 +1,71 @@
+import * as SelectPrimitive from "@radix-ui/react-select"
 import * as React from "react"
-import { ChevronDown } from "lucide-react"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
 import { cn } from "../../lib/utils"
+import { menuContentClass, menuItemClass } from "./menu"
 
-/**
- * The one native select, styled like Input: 28px, paper, strong hairline,
- * control shadow, 6px radius, indigo focus, a 14px muted chevron.
- */
-export const Select = React.forwardRef<
-  HTMLSelectElement,
-  React.SelectHTMLAttributes<HTMLSelectElement> & { wrapperClassName?: string }
->(({ className, wrapperClassName, children, ...props }, ref) => {
-  return (
-    <span className={cn("relative inline-flex w-full", wrapperClassName)}>
-      <select
-        ref={ref}
-        className={cn(
-          "app-shadow-control h-7 w-full appearance-none rounded-md border border-line-strong bg-surface pl-2 pr-7 text-sm text-fg transition-[border-color,box-shadow] duration-150 ease-settle focus-visible:border-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent disabled:cursor-not-allowed disabled:bg-surface-muted disabled:opacity-60",
-          className,
-        )}
-        {...props}
-      >
-        {children}
-      </select>
-      <ChevronDown
-        className="pointer-events-none absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-fg-muted"
-        strokeWidth={1.5}
-        aria-hidden="true"
-      />
-    </span>
-  )
-})
+type SelectProps = Omit<React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>, "value" | "defaultValue" | "onChange"> & {
+  value?: string | number
+  defaultValue?: string | number
+  onValueChange?: (value: string) => void
+  wrapperClassName?: string
+}
+
+// Prefix every value so an empty application value remains a selectable item.
+const itemValue = (value: string | number) => `value:${value}`
+
+export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
+  ({ value, defaultValue, onValueChange, disabled, className, wrapperClassName, children, ...props }, ref) => (
+    <SelectPrimitive.Root
+      value={value === undefined ? undefined : itemValue(value)}
+      defaultValue={defaultValue === undefined ? undefined : itemValue(defaultValue)}
+      onValueChange={(next) => onValueChange?.(next.slice(6))}
+      disabled={disabled}
+    >
+      <span className={cn("relative inline-flex min-w-0 w-full", wrapperClassName)}>
+        <SelectPrimitive.Trigger
+          ref={ref}
+          className={cn(
+            "app-shadow-control flex h-7 w-full min-w-0 items-center justify-between gap-2 rounded-md border border-line-strong bg-surface px-2 text-left text-sm text-fg transition-[border-color,box-shadow] duration-150 ease-settle focus-visible:border-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent disabled:cursor-not-allowed disabled:bg-surface-muted disabled:opacity-60",
+            className,
+          )}
+          {...props}
+        >
+          <span className="min-w-0 truncate"><SelectPrimitive.Value /></span>
+          <SelectPrimitive.Icon asChild>
+            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-fg-muted" strokeWidth={1.5} aria-hidden="true" />
+          </SelectPrimitive.Icon>
+        </SelectPrimitive.Trigger>
+      </span>
+      <SelectPrimitive.Portal>
+        <SelectPrimitive.Content
+          position="popper"
+          sideOffset={4}
+          collisionPadding={8}
+          className={cn(menuContentClass, "w-[var(--radix-select-trigger-width)] max-w-[var(--radix-select-content-available-width)] max-h-[min(18rem,var(--radix-select-content-available-height))]")}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <SelectPrimitive.ScrollUpButton className="flex justify-center py-1 text-fg-muted">
+            <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+          </SelectPrimitive.ScrollUpButton>
+          <SelectPrimitive.Viewport>{children}</SelectPrimitive.Viewport>
+          <SelectPrimitive.ScrollDownButton className="flex justify-center py-1 text-fg-muted">
+            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+          </SelectPrimitive.ScrollDownButton>
+        </SelectPrimitive.Content>
+      </SelectPrimitive.Portal>
+    </SelectPrimitive.Root>
+  ),
+)
 Select.displayName = "Select"
+
+export function SelectOption({ value, children, disabled }: { value: string | number; children: React.ReactNode; disabled?: boolean }) {
+  return (
+    <SelectPrimitive.Item value={itemValue(value)} disabled={disabled} className={cn(menuItemClass, "relative items-start pl-7 [overflow-wrap:anywhere] data-[disabled]:pointer-events-none data-[disabled]:opacity-50")}>
+      <SelectPrimitive.ItemIndicator className="absolute left-2 top-2">
+        <Check className="h-3.5 w-3.5" strokeWidth={1.5} aria-hidden="true" />
+      </SelectPrimitive.ItemIndicator>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+}

--- a/apps/web/src/pages/admin/BulkImportModelsDialog.tsx
+++ b/apps/web/src/pages/admin/BulkImportModelsDialog.tsx
@@ -15,7 +15,7 @@ import {
 import { ErrorState } from "../../components/ui/error-state"
 import { Field } from "../../components/ui/label"
 import { Input } from "../../components/ui/input"
-import { Select } from "../../components/ui/select"
+import { Select, SelectOption } from "../../components/ui/select"
 import { StatusIcon } from "../../components/ui/status-icon"
 import { ApiError } from "../../lib/api-client"
 import type { Model, ModelCredentialMode, Secret } from "../../lib/api-types"
@@ -269,19 +269,19 @@ export function BulkImportModelsDialog({
                   <Select
                     id="bulk-model-secret"
                     value={existingSecretID}
-                    onChange={(event) => {
-                      setExistingSecretID(event.target.value)
-                      if (event.target.value !== "") setApiKey("")
+                    onValueChange={(nextValue) => {
+                      setExistingSecretID(nextValue)
+                      if (nextValue !== "") setApiKey("")
                       resetDiscovery()
                     }}
                   >
-                    <option value="">
+                    <SelectOption value="">
                       {t("models.createModel.credentialMode.inlineSecret.reuseNone")}
-                    </option>
+                    </SelectOption>
                     {activeSecrets.map((secret) => (
-                      <option key={secret.id} value={secret.id}>
+                      <SelectOption key={secret.id} value={secret.id}>
                         {secret.name} ({secret.masked})
-                      </option>
+                      </SelectOption>
                     ))}
                   </Select>
                 </Field>

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -1,4 +1,4 @@
-import { Fragment, forwardRef, useEffect, useId, useMemo, useRef, useState, type ChangeEvent, type KeyboardEvent, type ReactNode } from "react"
+import { Fragment, forwardRef, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 import { useQueryClient } from "@tanstack/react-query"
 import { AlertTriangle, ArrowUpRight, Check, ChevronDown, Eye, EyeOff, Search } from "lucide-react"
@@ -16,7 +16,7 @@ import {
 } from "../../components/ui/dialog"
 import { Input } from "../../components/ui/input"
 import { Label } from "../../components/ui/label"
-import { Select } from "../../components/ui/select"
+import { Select, SelectOption } from "../../components/ui/select"
 import { AgentInstructionsField } from "./agents/AgentInstructionsField"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
@@ -1107,17 +1107,17 @@ export function CreateAgentDialog({
                     <Field label={t("agents.form.fields.agentEngine")} required>
                       <Select
                         value={agentEngine}
-                        onChange={(e) => {
-                          const next = e.target.value
+                        onValueChange={(nextValue) => {
+                          const next = nextValue
                           if (next === "claude_code" || next === "codex" || next === "pi") setAgentEngine(next)
                         }}
                         disabled={pending}
                         aria-label={t("agents.form.fields.agentEngine")}
                       >
-                        <option value="claude_code">{t("agents.engine.claudeCode.title")}</option>
-                        <option value="codex">{t("agents.engine.codex.title")}</option>
-                        <option value="pi">{t("agents.engine.pi.title")}</option>
-                        <option value="opencode" disabled>{t("agents.engine.opencode.title")}</option>
+                        <SelectOption value="claude_code">{t("agents.engine.claudeCode.title")}</SelectOption>
+                        <SelectOption value="codex">{t("agents.engine.codex.title")}</SelectOption>
+                        <SelectOption value="pi">{t("agents.engine.pi.title")}</SelectOption>
+                        <SelectOption value="opencode" disabled>{t("agents.engine.opencode.title")}</SelectOption>
                       </Select>
                     </Field>
                   )}
@@ -1128,12 +1128,12 @@ export function CreateAgentDialog({
                     >
                       <Select
                         value={codexMode}
-                        onChange={(e) => setCodexMode(e.target.value === "plan" ? "plan" : "default")}
+                        onValueChange={(nextValue) => setCodexMode(nextValue === "plan" ? "plan" : "default")}
                         disabled={pending}
                         aria-label={t("agents.form.fields.codexMode")}
                       >
-                        <option value="default">{t("agents.form.codexMode.default")}</option>
-                        <option value="plan">{t("agents.form.codexMode.plan")}</option>
+                        <SelectOption value="default">{t("agents.form.codexMode.default")}</SelectOption>
+                        <SelectOption value="plan">{t("agents.form.codexMode.plan")}</SelectOption>
                       </Select>
                     </Field>
                   )}
@@ -1145,12 +1145,12 @@ export function CreateAgentDialog({
                       >
                         <Select
                           value={sandboxSize}
-                          onChange={(e) => setSandboxSize(e.target.value === "xl" ? "xl" : "standard")}
+                          onValueChange={(nextValue) => setSandboxSize(nextValue === "xl" ? "xl" : "standard")}
                           disabled={pending}
                           aria-label={t("agents.form.fields.sandboxSize")}
                         >
-                          <option value="standard">{t("agents.form.sandboxSize.standard")}</option>
-                          <option value="xl">{t("agents.form.sandboxSize.xl")}</option>
+                          <SelectOption value="standard">{t("agents.form.sandboxSize.standard")}</SelectOption>
+                          <SelectOption value="xl">{t("agents.form.sandboxSize.xl")}</SelectOption>
                         </Select>
                       </Field>
                       <Field
@@ -1355,25 +1355,24 @@ export function CreateAgentDialog({
                             {sharedSecrets.length > 0 && (
                               <Select
                                 value={"existing_secret_id" in modelBindingChoice ? modelBindingChoice.existing_secret_id : "__new__"}
-                                onChange={(e) => {
-                                  e.stopPropagation()
-                                  if (e.target.value === "__new__") {
+                                onValueChange={(nextValue) => {
+                                  if (nextValue === "__new__") {
                                     setModelNewSecretExpanded(true)
                                     if (!("new_secret" in modelBindingChoice)) {
                                       setModelNewSecretDisplayName("")
                                       setModelNewSecretPlaintext("")
                                     }
                                   } else {
-                                    setModelBindingChoice({ source: "shared", existing_secret_id: e.target.value })
+                                    setModelBindingChoice({ source: "shared", existing_secret_id: nextValue })
                                     setModelNewSecretExpanded(false)
                                   }
                                 }}
                                 onClick={(e) => e.stopPropagation()}
                               >
                                 {sharedSecrets.map((s) => (
-                                  <option key={s.id} value={s.id}>{s.name}</option>
+                                  <SelectOption key={s.id} value={s.id}>{s.name}</SelectOption>
                                 ))}
-                                <option value="__new__">{t("credentialCheck.createNewShared")}</option>
+                                <SelectOption value="__new__">{t("credentialCheck.createNewShared")}</SelectOption>
                               </Select>
                             )}
                             {sharedSecrets.length === 0 && !modelNewSecretExpanded && !("new_secret" in modelBindingChoice) && (
@@ -1791,10 +1790,7 @@ function CapabilityVersionPicker({
     ? "__latest__"
     : choice?.versionID ?? "__latest__"
 
-  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    event.stopPropagation()
-    event.preventDefault()
-    const value = event.target.value
+  const handleChange = (value: string) => {
     if (value === "__latest__") {
       onChange({ pinningMode: "latest", versionID: latestVersionID, pinnedVersion: undefined })
       return
@@ -1808,7 +1804,7 @@ function CapabilityVersionPicker({
   return (
     <Select
       value={selectValue}
-      onChange={handleChange}
+      onValueChange={handleChange}
       onClick={(event) => event.stopPropagation()}
       // Marketplace bindings see the same picker but the cue (label
       // suffix) reminds the user that breaking changes can land
@@ -1818,9 +1814,9 @@ function CapabilityVersionPicker({
       className="w-auto font-mono text-xs"
       title={fromMarketplace ? t("agents.form.versionPicker.marketplaceHint") : t("agents.form.versionPicker.localHint")}
     >
-      <option value="__latest__">
+      <SelectOption value="__latest__">
         {t("agents.form.versionPicker.latest")}{latestVersion ? ` (v${latestVersion})` : ""}
-      </option>
+      </SelectOption>
       {versions.length === 0 && choice?.pinningMode === "pinned" && choice.versionID && (
         // Versions list still loading — keep the current pin visible
         // so the dropdown doesn't appear to forget the user's choice
@@ -1830,12 +1826,12 @@ function CapabilityVersionPicker({
         // fall back to latestVersion here, which would mis-label the
         // pinned option with whatever the capability's newest version
         // happens to be.
-        <option value={choice.versionID}>v{choice.pinnedVersion || "?"}</option>
+        <SelectOption value={choice.versionID}>v{choice.pinnedVersion || "?"}</SelectOption>
       )}
       {versions.map((version) => (
-        <option key={version.id} value={version.id}>
+        <SelectOption key={version.id} value={version.id}>
           v{version.version}
-        </option>
+        </SelectOption>
       ))}
     </Select>
   )

--- a/apps/web/src/pages/admin/MembersPage.tsx
+++ b/apps/web/src/pages/admin/MembersPage.tsx
@@ -51,7 +51,7 @@ import {
   LedgerRow,
   col,
 } from "../../components/ui/ledger"
-import { Select } from "../../components/ui/select"
+import { Select, SelectOption } from "../../components/ui/select"
 import { Skeleton } from "../../components/ui/skeleton"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
@@ -635,9 +635,9 @@ function InviteLinkForm({
         </Field>
         <Field label={t("members.invite.roleLabel")} htmlFor="invite-role">
           {canChooseRole ? (
-            <Select id="invite-role" value={role} onChange={(e) => setRole(e.target.value as MemberRole)} disabled={pending}>
+            <Select id="invite-role" value={role} onValueChange={(nextValue) => setRole(nextValue as MemberRole)} disabled={pending}>
               {ROLES.map((r) => (
-                <option key={r} value={r}>{t(`members.role.${r}`)}</option>
+                <SelectOption key={r} value={r}>{t(`members.role.${r}`)}</SelectOption>
               ))}
             </Select>
           ) : (
@@ -723,9 +723,9 @@ function AddExistingForm({
           <UserSearchCombobox excludeWorkspace={wsId} selected={selected} onChange={setSelected} disabled={pending} />
         </Field>
         <Field label={t("members.add.field.role")} htmlFor="add-role">
-          <Select id="add-role" value={role} onChange={(e) => setRole(e.target.value as MemberRole)} disabled={pending}>
+          <Select id="add-role" value={role} onValueChange={(nextValue) => setRole(nextValue as MemberRole)} disabled={pending}>
             {ROLES.map((r) => (
-              <option key={r} value={r}>{t(`members.role.${r}`)}</option>
+              <SelectOption key={r} value={r}>{t(`members.role.${r}`)}</SelectOption>
             ))}
           </Select>
         </Field>

--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -31,7 +31,7 @@ import { ErrorState } from "../../components/ui/error-state"
 import { Field } from "../../components/ui/label"
 import { Input } from "../../components/ui/input"
 import { PropertyList, Property } from "../../components/ui/property-list"
-import { Select } from "../../components/ui/select"
+import { Select, SelectOption } from "../../components/ui/select"
 import { CredentialKindCombobox } from "./capabilities/CredentialKindCombobox"
 import { ModelKeyCombobox } from "./ModelKeyCombobox"
 import { ProviderTypeCombobox } from "./ProviderTypeCombobox"
@@ -616,10 +616,10 @@ export function CreateModelDialog({
                 <Select
                   id="model-auth-scheme"
                   value={authScheme}
-                  onChange={(e) => setAuthScheme(e.target.value as "api-key" | "bearer")}
+                  onValueChange={(nextValue) => setAuthScheme(nextValue as "api-key" | "bearer")}
                 >
-                  <option value="api-key">x-api-key</option>
-                  <option value="bearer">Authorization: Bearer</option>
+                  <SelectOption value="api-key">x-api-key</SelectOption>
+                  <SelectOption value="bearer">Authorization: Bearer</SelectOption>
                 </Select>
               </Field>
             )}
@@ -649,28 +649,28 @@ export function CreateModelDialog({
                     <Select
                       id="model-existing-secret"
                       value={existingSecretID}
-                      onChange={(e) => {
-                        setExistingSecretID(e.target.value)
-                        if (e.target.value !== "") setApiKey("")
+                      onValueChange={(nextValue) => {
+                        setExistingSecretID(nextValue)
+                        if (nextValue !== "") setApiKey("")
                       }}
                     >
-                      <option value="">
+                      <SelectOption value="">
                         {t("models.createModel.credentialMode.inlineSecret.reuseNone")}
-                      </option>
+                      </SelectOption>
                       {sourceSecretMissing && (
                         // Phantom option for a duplicate whose source Secret
                         // is not visible to the caller. Marked disabled so
                         // submit can't proceed via this path — the user has
                         // to either pick another visible Secret or paste a
                         // fresh key in the field above.
-                        <option value={existingSecretID} disabled>
+                        <SelectOption value={existingSecretID} disabled>
                           {`${existingSecretID.slice(0, 8)}… (${t("models.copy.secretInaccessible")})`}
-                        </option>
+                        </SelectOption>
                       )}
                       {activeSecrets.map((s) => (
-                        <option key={s.id} value={s.id}>
+                        <SelectOption key={s.id} value={s.id}>
                           {s.name} ({s.masked})
-                        </option>
+                        </SelectOption>
                       ))}
                     </Select>
                     {sourceSecretMissing && (
@@ -909,16 +909,16 @@ export function EditModelDialog({
                   id="edit-model-secret"
                   aria-label={t("models.editModel.credentialBinding.boundSecret")}
                   value={secretID}
-                  onChange={(e) => setSecretID(e.target.value)}
+                  onValueChange={(nextValue) => setSecretID(nextValue)}
                   disabled={newAPIKey.trim() !== ""}
                 >
-                  <option value="">
+                  <SelectOption value="">
                     {t("models.editModel.credentialBinding.boundSecretNone")}
-                  </option>
+                  </SelectOption>
                   {activeSecrets.map((s) => (
-                    <option key={s.id} value={s.id}>
+                    <SelectOption key={s.id} value={s.id}>
                       {s.name} ({s.masked})
-                    </option>
+                    </SelectOption>
                   ))}
                 </Select>
                 <TextField

--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -24,7 +24,7 @@ import { Button } from "../../components/ui/button"
 import { EmptyState } from "../../components/ui/empty-state"
 import type { StatusKind } from "../../components/ui/status-icon"
 import { Ledger, LedgerHeader, LedgerId, LedgerRow, SelectableStatus, col } from "../../components/ui/ledger"
-import { Select } from "../../components/ui/select"
+import { Select, SelectOption } from "../../components/ui/select"
 import { Skeleton } from "../../components/ui/skeleton"
 import { ApiError } from "../../lib/api-client"
 import { useRuntimeStatus, type ConnectivityResult } from "../../lib/api-runtime"
@@ -319,15 +319,15 @@ function CloudInstancesPanel({
           <div className="flex items-center gap-2">
             <Select
               value={sortKey}
-              onChange={(e) => onSortChange(e.target.value as SortKey)}
+              onValueChange={(nextValue) => onSortChange(nextValue as SortKey)}
               aria-label={t("runtime.list.sort.label")}
               wrapperClassName="w-[180px]"
               className="h-6 text-xs"
               data-testid="runtime-sort"
             >
-              <option value="last_active">{t("runtime.list.sort.lastActive")}</option>
-              <option value="created_at">{t("runtime.list.sort.createdAt")}</option>
-              <option value="agent">{t("runtime.list.sort.agent")}</option>
+              <SelectOption value="last_active">{t("runtime.list.sort.lastActive")}</SelectOption>
+              <SelectOption value="created_at">{t("runtime.list.sort.createdAt")}</SelectOption>
+              <SelectOption value="agent">{t("runtime.list.sort.agent")}</SelectOption>
             </Select>
             <Button
               size="sm"

--- a/apps/web/src/pages/admin/ScheduledTasksPage.tsx
+++ b/apps/web/src/pages/admin/ScheduledTasksPage.tsx
@@ -42,7 +42,7 @@ import {
 } from "../../components/ui/ledger"
 import { OffsetPagination } from "../../components/ui/offset-pagination"
 import { Property, PropertyList } from "../../components/ui/property-list"
-import { Select } from "../../components/ui/select"
+import { Select, SelectOption } from "../../components/ui/select"
 import { Skeleton } from "../../components/ui/skeleton"
 import { StatusIcon, type StatusKind } from "../../components/ui/status-icon"
 import { Textarea } from "../../components/ui/textarea"
@@ -612,10 +612,10 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
             {task ? (
               <Input id="sched-agent" value={agentName.get(task.agent_id) ?? task.agent_id} disabled readOnly />
             ) : (
-              <Select id="sched-agent" value={agentID} onChange={(e) => setAgentID(e.target.value)} disabled={pending} data-testid="scheduled-agent">
-                {agents.length === 0 && <option value="">—</option>}
+              <Select id="sched-agent" value={agentID} onValueChange={(nextValue) => setAgentID(nextValue)} disabled={pending} data-testid="scheduled-agent">
+                {agents.length === 0 && <SelectOption value="">—</SelectOption>}
                 {agents.map((a) => (
-                  <option key={a.id} value={a.id}>{a.name}</option>
+                  <SelectOption key={a.id} value={a.id}>{a.name}</SelectOption>
                 ))}
               </Select>
             )}
@@ -635,13 +635,13 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
 
           <div className="grid grid-cols-2 gap-3">
             <Field label={t("scheduledTasks.dialog.frequency")} htmlFor="sched-freq">
-              <Select id="sched-freq" value={freq} onChange={(e) => setFreq(e.target.value as FreqType)} disabled={pending} data-testid="scheduled-freq">
-                <option value="daily">{t("scheduledTasks.freq.daily")}</option>
-                <option value="weekday">{t("scheduledTasks.freq.weekday")}</option>
-                <option value="weekly">{t("scheduledTasks.freq.weekly")}</option>
-                <option value="monthly">{t("scheduledTasks.freq.monthly")}</option>
-                <option value="hourly">{t("scheduledTasks.freq.hourly")}</option>
-                <option value="custom">{t("scheduledTasks.freq.custom")}</option>
+              <Select id="sched-freq" value={freq} onValueChange={(nextValue) => setFreq(nextValue as FreqType)} disabled={pending} data-testid="scheduled-freq">
+                <SelectOption value="daily">{t("scheduledTasks.freq.daily")}</SelectOption>
+                <SelectOption value="weekday">{t("scheduledTasks.freq.weekday")}</SelectOption>
+                <SelectOption value="weekly">{t("scheduledTasks.freq.weekly")}</SelectOption>
+                <SelectOption value="monthly">{t("scheduledTasks.freq.monthly")}</SelectOption>
+                <SelectOption value="hourly">{t("scheduledTasks.freq.hourly")}</SelectOption>
+                <SelectOption value="custom">{t("scheduledTasks.freq.custom")}</SelectOption>
               </Select>
             </Field>
 
@@ -684,9 +684,9 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
 
             {freq === "weekly" && (
               <Field label={t("scheduledTasks.dialog.dayOfWeek")} htmlFor="sched-dow">
-                <Select id="sched-dow" value={dow} onChange={(e) => setDow(Number(e.target.value))} disabled={pending}>
+                <Select id="sched-dow" value={dow} onValueChange={(nextValue) => setDow(Number(nextValue))} disabled={pending}>
                   {weekdays.map((d, idx) => (
-                    <option key={idx} value={idx}>{d}</option>
+                    <SelectOption key={idx} value={idx}>{d}</SelectOption>
                   ))}
                 </Select>
               </Field>
@@ -694,18 +694,18 @@ function ScheduledTaskDialog({ open, task, agents, agentName, weekdays, pending,
 
             {freq === "monthly" && (
               <Field label={t("scheduledTasks.dialog.dayOfMonth")} htmlFor="sched-dom">
-                <Select id="sched-dom" value={dom} onChange={(e) => setDom(Number(e.target.value))} disabled={pending}>
+                <Select id="sched-dom" value={dom} onValueChange={(nextValue) => setDom(Number(nextValue))} disabled={pending}>
                   {Array.from({ length: 28 }, (_, i) => i + 1).map((d) => (
-                    <option key={d} value={d}>{d}</option>
+                    <SelectOption key={d} value={d}>{d}</SelectOption>
                   ))}
                 </Select>
               </Field>
             )}
 
             <Field label={t("scheduledTasks.dialog.timezone")} htmlFor="sched-tz" className={freq === "weekly" || freq === "monthly" ? undefined : "col-span-2"}>
-              <Select id="sched-tz" value={tz} onChange={(e) => setTz(e.target.value)} disabled={pending} data-testid="scheduled-tz">
+              <Select id="sched-tz" value={tz} onValueChange={(nextValue) => setTz(nextValue)} disabled={pending} data-testid="scheduled-tz">
                 {tzOptions.map((z) => (
-                  <option key={z} value={z}>{z}</option>
+                  <SelectOption key={z} value={z}>{z}</SelectOption>
                 ))}
               </Select>
             </Field>

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -9,7 +9,7 @@ import { EmptyState } from "../../../components/ui/empty-state"
 import { ErrorState } from "../../../components/ui/error-state"
 import { Input } from "../../../components/ui/input"
 import { Field } from "../../../components/ui/label"
-import { Select } from "../../../components/ui/select"
+import { Select, SelectOption } from "../../../components/ui/select"
 import { Skeleton } from "../../../components/ui/skeleton"
 import { StatusIcon, type StatusKind } from "../../../components/ui/status-icon"
 import {
@@ -299,9 +299,9 @@ function MutationError({ error }: { error: unknown }) {
 function VersionSelect({ versions, value, onChange }: { versions: CapabilityVersion[]; value: string; onChange: (value: string) => void }) {
   const { t } = useTranslation("admin")
   return (
-    <Select value={value} onChange={(event) => onChange(event.target.value)}>
+    <Select value={value} onValueChange={(nextValue) => onChange(nextValue)}>
       {versions.map((version, index) => (
-        <option key={version.id} value={version.id}>v{version.version}{index === 0 ? ` · ${t("agents.detail.capabilities.switchDialog.latest")}` : ""}</option>
+        <SelectOption key={version.id} value={version.id}>v{version.version}{index === 0 ? ` · ${t("agents.detail.capabilities.switchDialog.latest")}` : ""}</SelectOption>
       ))}
     </Select>
   )

--- a/apps/web/src/pages/admin/credentials/CredentialDialogs.tsx
+++ b/apps/web/src/pages/admin/credentials/CredentialDialogs.tsx
@@ -24,7 +24,7 @@ import {
 import { ErrorState } from "../../../components/ui/error-state"
 import { Input } from "../../../components/ui/input"
 import { Field } from "../../../components/ui/label"
-import { Select } from "../../../components/ui/select"
+import { Select, SelectOption } from "../../../components/ui/select"
 import { Skeleton } from "../../../components/ui/skeleton"
 import {
   ApiError,
@@ -117,21 +117,21 @@ export function CredentialDialog({
               <Select
                 id="credential-kind"
                 value={kind}
-                onChange={(event) => setKind(event.target.value)}
+                onValueChange={(nextValue) => setKind(nextValue)}
                 disabled={kindLocked}
               >
                 {/* A locked kind may not be in the live options list
                     (legacy data, admin-added kind, in-flight prefill);
                     render it explicitly so the field shows a label. */}
                 {kindLocked && !kindOptions.options.includes(kind) && (
-                  <option value={kind}>
+                  <SelectOption value={kind}>
                     {credentialKindLabel(kind, i18n.language, kind, kindOptions.kinds)}
-                  </option>
+                  </SelectOption>
                 )}
                 {kindOptions.options.map((option) => (
-                  <option key={option} value={option}>
+                  <SelectOption key={option} value={option}>
                     {credentialKindLabel(option, i18n.language, option, kindOptions.kinds)}
-                  </option>
+                  </SelectOption>
                 ))}
               </Select>
             </Field>

--- a/apps/web/src/pages/admin/credentials/OrgSecretsTab.tsx
+++ b/apps/web/src/pages/admin/credentials/OrgSecretsTab.tsx
@@ -23,7 +23,7 @@ import {
   LedgerRow,
   col,
 } from "../../../components/ui/ledger"
-import { Select } from "../../../components/ui/select"
+import { Select, SelectOption } from "../../../components/ui/select"
 import { Skeleton } from "../../../components/ui/skeleton"
 import { ApiError } from "../../../lib/api-client"
 import {
@@ -300,15 +300,15 @@ function CreateDialog({ onClose, onSubmit, pending, error }: CreateDialogProps) 
               <Select
                 id="secret-purpose"
                 value={purpose}
-                onChange={(event) => {
-                  const next = event.target.value as "runtime" | "custom_api"
+                onValueChange={(nextValue) => {
+                  const next = nextValue as "runtime" | "custom_api"
                   setPurpose(next)
                   if (next === "runtime") setProvider("e2b")
                   else setProvider("")
                 }}
               >
-                <option value="runtime">{t("secrets.create.purpose.runtime")}</option>
-                <option value="custom_api">{t("secrets.create.purpose.custom")}</option>
+                <SelectOption value="runtime">{t("secrets.create.purpose.runtime")}</SelectOption>
+                <SelectOption value="custom_api">{t("secrets.create.purpose.custom")}</SelectOption>
               </Select>
             </Field>
             <Field label={t("secrets.create.field.name")} htmlFor="secret-name">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.19
         version: 2.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-select':
+        specifier: ^2.3.2
+        version: 2.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.2.17)(react@19.2.7)
@@ -570,6 +573,9 @@ packages:
     resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@radix-ui/number@1.1.2':
+    resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
 
   '@radix-ui/number@1.1.3':
     resolution: {integrity: sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==}
@@ -1255,6 +1261,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-select@2.3.2':
+    resolution: {integrity: sha512-brXD6C/V0fVK0DDbscLVw6LsXrjQ+ay8jdOBaN+tLb4vsHsAMm6Gt6eT77wHX1Eq8GPtD5rJ+RxFtfDozsb4+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.3.7':
     resolution: {integrity: sha512-WFGImkmbzcfxeIwq/+4HvRN0pizBwbwQUED4I13ezQsDdfl38ZntN6TmR8XaSzPBqoCToe8rF75j6NPNDSzhbg==}
     peerDependencies:
@@ -1512,6 +1531,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.4':
     resolution: {integrity: sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.2':
+    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -3613,6 +3641,8 @@ snapshots:
     dependencies:
       playwright: 1.61.1
 
+  '@radix-ui/number@1.1.2': {}
+
   '@radix-ui/number@1.1.3': {}
 
   '@radix-ui/primitive@1.1.4': {}
@@ -4344,6 +4374,36 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-select@2.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-select@2.3.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/number': 1.1.3
@@ -4627,6 +4687,12 @@ snapshots:
       '@types/react': 19.2.17
 
   '@radix-ui/react-use-layout-effect@1.1.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-previous@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
     optionalDependencies:

--- a/tests/e2e/scheduled-tasks.spec.ts
+++ b/tests/e2e/scheduled-tasks.spec.ts
@@ -20,9 +20,11 @@ test("create a scheduled task with an agent, run it now, see it in the list", as
   await page.getByTestId("scheduled-name").fill(name)
   // Standalone page picks the executing agent in the dialog; default is the
   // first active agent, select it explicitly to exercise the dropdown.
-  await page.getByTestId("scheduled-agent").selectOption({ index: 0 })
+  await page.getByTestId("scheduled-agent").click()
+  await page.getByRole("listbox").getByRole("option").first().click()
   await page.getByTestId("scheduled-prompt").fill("e2e smoke prompt")
-  await page.getByTestId("scheduled-freq").selectOption("custom")
+  await page.getByTestId("scheduled-freq").click()
+  await page.getByRole("option", { name: "Custom", exact: true }).click()
   await page.getByTestId("scheduled-cron").fill("0 9 * * *")
   await page.getByTestId("scheduled-save").click()
 


### PR DESCRIPTION
Existing single-choice fields now open a menu styled with Parsar’s shared menu tokens. The shared control provides selected markers, bounded scrolling, keyboard navigation and focus return, including inside dialogs. All existing callers retain their option values, disabled rules and selection effects. Empty application values remain selectable, and a newly selected value is retained while its option list refreshes.

The change is limited to the shared control, mechanical caller adaptations, its Radix dependency, the existing scheduled-task smoke test, and the contributor convention. No API, scheduling or permission behavior changes.

Validation:
- `make check` and web build passed.
- Five existing Agent instruction creation/editing E2E cases passed.
- Browser checks covered scheduled frequency/day/timezone, Agent engine and capability version selection, empty/numeric/dynamic options, disabled choices, narrow menus, both themes/locales, and nested dialog focus.
- Independent review completed; its two findings were corrected and the local corrections verified. Pre-existing missing accessible names are tracked separately.

The opt-in scheduled create/run-now test was adapted to popup interaction; this branch’s browser checks exercised its fields without saving to the shared environment.
