### PR TITLE
fix(web): add field names to device credential and version selectors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -608,6 +608,8 @@ DOM change events. Keep option values, labels and disabled rules in the caller,
 and popup styling, keyboard navigation and focus behavior in the shared control.
 Keep its Radix dismissal and focus dependencies compatible with `Dialog` so
 nested menus share one layer stack.
+Associate each control with its field label through `htmlFor`/`id` or an
+accessible-name attribute; include the item context for repeated selectors.
 
 Persistent execution failures use `ErrorState` with `appearance="panel"` to
 separate recovery guidance from expandable technical detail. Keep raw reasons

--- a/apps/web/src/components/admin/CredentialBindingSelect.tsx
+++ b/apps/web/src/components/admin/CredentialBindingSelect.tsx
@@ -2,6 +2,7 @@ import { Select, SelectOption } from "../ui/select"
 import type { Secret } from "../../lib/api-types"
 
 interface CredentialBindingSelectProps {
+  label: string
   value: string
   secrets: Secret[]
   allowPersonal: boolean
@@ -16,6 +17,7 @@ interface CredentialBindingSelectProps {
 
 /** Shared source selector used by Agent creation and Capability enabling. */
 export function CredentialBindingSelect({
+  label,
   value,
   secrets,
   allowPersonal,
@@ -29,6 +31,7 @@ export function CredentialBindingSelect({
 }: CredentialBindingSelectProps) {
   return (
     <Select
+      aria-label={label}
       value={value}
       onValueChange={(nextValue) => onChange(nextValue)}
       onClick={(event) => event.stopPropagation()}

--- a/apps/web/src/components/admin/CredentialCheckPanel.tsx
+++ b/apps/web/src/components/admin/CredentialCheckPanel.tsx
@@ -317,6 +317,7 @@ export function CredentialCheckPanel({
                     <div className="mt-1.5 space-y-1.5">
                       {kindSecrets.length > 0 && (
                         <CredentialBindingSelect
+                          label={displayName}
                           value={"existing_secret_id" in choice ? choice.existing_secret_id : "__new__"}
                           secrets={kindSecrets}
                           allowPersonal={false}

--- a/apps/web/src/components/admin/DevicePicker.tsx
+++ b/apps/web/src/components/admin/DevicePicker.tsx
@@ -134,6 +134,7 @@ export function DevicePicker({ workspaceID, value, onChange, agentKind, preserve
   return (
     <div className="flex gap-2">
       <Select
+        aria-label={t("agents.form.fields.device")}
         value={value}
         disabled={disabled}
         onValueChange={(nextValue) => onChange(nextValue)}

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -1354,6 +1354,7 @@ export function CreateAgentDialog({
                           <div className="mt-1.5 flex flex-col gap-2">
                             {sharedSecrets.length > 0 && (
                               <Select
+                                aria-label={t("credentialCheck.modelBindingShared")}
                                 value={"existing_secret_id" in modelBindingChoice ? modelBindingChoice.existing_secret_id : "__new__"}
                                 onValueChange={(nextValue) => {
                                   if (nextValue === "__new__") {
@@ -1558,6 +1559,7 @@ export function CreateAgentDialog({
                                       {!cap.deprecated && !checked && !cap.latestVersion && <span className="shrink-0"><Badge variant="warning" dot>{t("agents.form.noCapabilityVersion")}</Badge></span>}
                                       {!cap.deprecated && checked && cap.id && (
                                         <CapabilityVersionPicker
+                                          label={`${cap.name} · ${t("agents.detail.capabilities.enableDialog.version")}`}
                                           capabilityID={cap.id}
                                           fromMarketplace={sec === "marketplace"}
                                           workspaceID={workspaceID}
@@ -1764,6 +1766,7 @@ function DependencyCard({ title, description, href, cta }: { title: string; desc
  * the dropdown never collapses to empty mid-edit.
  */
 function CapabilityVersionPicker({
+  label,
   capabilityID,
   fromMarketplace,
   workspaceID,
@@ -1772,6 +1775,7 @@ function CapabilityVersionPicker({
   choice,
   onChange,
 }: {
+  label: string
   capabilityID: string
   fromMarketplace: boolean
   workspaceID: string | null
@@ -1803,6 +1807,7 @@ function CapabilityVersionPicker({
 
   return (
     <Select
+      aria-label={label}
       value={selectValue}
       onValueChange={handleChange}
       onClick={(event) => event.stopPropagation()}

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -299,7 +299,7 @@ function MutationError({ error }: { error: unknown }) {
 function VersionSelect({ versions, value, onChange }: { versions: CapabilityVersion[]; value: string; onChange: (value: string) => void }) {
   const { t } = useTranslation("admin")
   return (
-    <Select value={value} onValueChange={(nextValue) => onChange(nextValue)}>
+    <Select aria-label={t("agents.detail.capabilities.enableDialog.version")} value={value} onValueChange={(nextValue) => onChange(nextValue)}>
       {versions.map((version, index) => (
         <SelectOption key={version.id} value={version.id}>v{version.version}{index === 0 ? ` · ${t("agents.detail.capabilities.switchDialog.latest")}` : ""}</SelectOption>
       ))}
@@ -335,6 +335,7 @@ function EnableCredentialBindingList({
         return (
           <Field key={rc.kind} label={credentialKindLabel(rc.kind, i18n.language, rc.kind)}>
             <CredentialBindingSelect
+              label={credentialKindLabel(rc.kind, i18n.language, rc.kind)}
               value={selectedSecretID}
               secrets={kindSecrets}
               allowPersonal={!publicAgent}


### PR DESCRIPTION
Several device, credential and version selectors had no associated field name, so assistive technology could only announce the selected value. They now reuse the existing field labels, with the capability or credential-kind name where selections repeat. Descriptive titles are retained.

This is limited to accessible names, required label props and the contributor convention. Option values, callbacks, permissions and layout are unchanged.

Validation: `make check` and web build passed. Audited all 26 shared Select callers for a field-name attribute or associated ID. Browser checks verified English/Chinese device labels and a contextual capability-version name while retaining selection. This small semantic correction was self-reviewed under the contributor policy.
