### PR TITLE
fix(web): keep agent lists readable beside the detail rail

### DIFF
--- a/apps/web/src/pages/admin/agents/AgentsListTable.tsx
+++ b/apps/web/src/pages/admin/agents/AgentsListTable.tsx
@@ -21,7 +21,7 @@ import { AgentRuntimeCell } from "./AgentRuntimeCell"
 import { AgentStatusIcon } from "./AgentStatusBadge"
 
 /** status icon · agent (+ description) · engine · runtime · connector · model · last enabled · actions */
-export const AGENTS_LEDGER_COLUMNS = [col.icon(), col.title(180), col.meta(88), col.text(120, 1), col.meta(80), col.id(120, 0.8), col.age(72), col.actions(2)]
+export const AGENTS_LEDGER_COLUMNS = [col.icon(), col.title(0), col.meta(0), col.text(0, 1), col.meta(0), col.id(0, 0.8), col.age(0), col.actions(2)]
 
 export function AgentsListTable({
   agents,
@@ -76,8 +76,8 @@ export function AgentsListTable({
   }
 
   return (
-    <Ledger columns={AGENTS_LEDGER_COLUMNS} role="listbox" aria-label={t("agents.page.title")}>
-      <LedgerHeader>
+    <Ledger columns={AGENTS_LEDGER_COLUMNS} className="@container/agent-list" role="listbox" aria-label={t("agents.page.title")}>
+      <LedgerHeader className="@max-3xl/agent-list:hidden">
         <span />
         <span>{t("agents.table.agent")}</span>
         <span>{t("agents.table.engine")}</span>
@@ -90,6 +90,13 @@ export function AgentsListTable({
       <ul className="m-0 list-none p-0">
         {filtered.map((agent) => {
           const model = defaultModelOf(agent, models, unavailable)
+          const fields = [
+            { label: t("agents.table.engine"), value: t(agentEngineLabel(agentEngineOf(agent))) },
+            { label: t("agents.table.runtime"), value: <AgentRuntimeCell agent={agent} /> },
+            { label: t("agents.table.connector"), value: agentConnectorLabel(agent.connector_type), className: "text-xs text-fg-muted" },
+            { label: t("agents.table.model"), value: <span className={cn("font-mono text-xs", model === "—" && "text-fg-muted")}>{model}</span> },
+            { label: t("agents.table.updated"), value: agent.enabled_at ? formatRelativeTime(agent.enabled_at) : "—", className: "text-xs text-fg-muted" },
+          ]
           const onKeyDown = (event: KeyboardEvent<HTMLLIElement>) => {
             if (event.target !== event.currentTarget) return
             if (event.key === "Enter" || event.key === " ") {
@@ -98,31 +105,38 @@ export function AgentsListTable({
             }
           }
           return (
-            <LedgerRow key={agent.id} selected={agent.id === selectedID} onClick={() => onOpenAgent(agent)} onKeyDown={onKeyDown}>
-              <AgentStatusIcon status={agent.status} />
-              <span className="flex min-w-0 items-center gap-1.5">
-                <InitialTile name={agent.name} />
-                <span className="shrink-0 truncate font-medium">{agent.name}</span>
-                {agent.description && (
-                  <span className="min-w-0 truncate text-xs text-fg-muted">· {agent.description}</span>
-                )}
+            <LedgerRow key={agent.id} selected={agent.id === selectedID} onClick={() => onOpenAgent(agent)} onKeyDown={onKeyDown} className="@max-3xl/agent-list:h-auto @max-3xl/agent-list:py-2">
+              <span className="@max-3xl/agent-list:hidden"><AgentStatusIcon status={agent.status} /></span>
+              <div className="min-w-0 @max-3xl/agent-list:col-span-full">
+                <div className="flex min-w-0 items-center gap-1.5 @max-3xl/agent-list:min-h-7 @max-3xl/agent-list:items-start @max-3xl/agent-list:pr-20">
+                  <span className="mt-0.5 hidden @max-3xl/agent-list:block"><AgentStatusIcon status={agent.status} /></span>
+                  <InitialTile name={agent.name} />
+                  <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden @max-3xl/agent-list:flex-col @max-3xl/agent-list:items-start @max-3xl/agent-list:gap-1">
+                    <span className="min-w-0 max-w-full shrink-0 truncate font-medium @max-3xl/agent-list:whitespace-normal @max-3xl/agent-list:break-words" title={agent.name}>{agent.name}</span>
+                    {agent.description && <span className="min-w-0 max-w-full truncate text-xs text-fg-muted" title={agent.description}>{agent.description}</span>}
+                  </div>
+                </div>
+                <dl className="mt-2 hidden grid-cols-2 gap-x-4 gap-y-1 text-xs @max-3xl/agent-list:grid @max-sm/agent-list:grid-cols-1">
+                  {fields.map(({ label, value }) => (
+                    <div key={label} className="grid min-w-0 grid-cols-[4rem_minmax(0,1fr)] gap-x-2">
+                      <dt className="text-fg-muted">{label}</dt>
+                      <dd className="min-w-0 break-words">{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+              {fields.map(({ label, value, className }) => <span key={label} className={cn("truncate @max-3xl/agent-list:hidden", className)}>{value}</span>)}
+              <span className="@max-3xl/agent-list:absolute @max-3xl/agent-list:right-0 @max-3xl/agent-list:top-2 @max-3xl/agent-list:h-7 @max-3xl/agent-list:w-0" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+                <AgentRowActions
+                  agent={agent}
+                  chatPending={chatPendingID === agent.id}
+                  deletePending={deletePending}
+                  onChat={() => onChat(agent)}
+                  onEdit={() => onEdit(agent)}
+                  onClone={() => onClone(agent)}
+                  onDelete={() => onDelete(agent)}
+                />
               </span>
-              <span className="truncate">{t(agentEngineLabel(agentEngineOf(agent)))}</span>
-              <AgentRuntimeCell agent={agent} />
-              <span className="truncate text-xs text-fg-muted">{agentConnectorLabel(agent.connector_type)}</span>
-              <span className={cn("truncate font-mono text-xs", model === "—" ? "text-fg-muted" : "text-fg")}>{model}</span>
-              <span className="truncate text-right text-xs text-fg-muted">
-                {agent.enabled_at ? formatRelativeTime(agent.enabled_at) : "—"}
-              </span>
-              <AgentRowActions
-                agent={agent}
-                chatPending={chatPendingID === agent.id}
-                deletePending={deletePending}
-                onChat={() => onChat(agent)}
-                onEdit={() => onEdit(agent)}
-                onClone={() => onClone(agent)}
-                onDelete={() => onDelete(agent)}
-              />
             </LedgerRow>
           )
         })}


### PR DESCRIPTION
Opening an Agent detail rail previously left a fixed-width list that overflowed horizontally and crowded long names into the next column. The Agent list now follows the existing capability-list pattern: narrow containers show complete names and labeled metadata, while wider containers retain the aligned table columns. Both presentations use the same field values and actions.

Only `AgentsListTable.tsx` changes. Search, filtering, selected rows, keyboard opening and action callbacks are preserved. Long names/descriptions retain their full text in the title attribute.

Validation: `make check` and web build passed. Browser checks covered 338–968px list widths, a 203-character name, English/dark and Chinese/light layouts, search, Enter to open details, the Edit menu and Chat callback. This localized presentation change was self-reviewed under the small-change policy.
