### PR TITLE
fix(web): restore keyboard focus after workspace dialogs

### DIFF
--- a/apps/web/src/components/layout/DiscoverWorkspacesDialog.tsx
+++ b/apps/web/src/components/layout/DiscoverWorkspacesDialog.tsx
@@ -25,6 +25,7 @@ import { Skeleton } from "../ui/skeleton"
 
 interface DiscoverWorkspacesDialogProps {
   open: boolean
+  onCloseAutoFocus?: (event: Event) => void
   onOpenChange: (open: boolean) => void
   /** Parent opens JoinRequestDialog (reason input); nesting two
    *  Radix dialogs would fight over focus trap. */
@@ -38,6 +39,7 @@ const LEDGER_COLUMNS = [col.title(), col.num(64), col.actions(1)]
 
 export function DiscoverWorkspacesDialog({
   open,
+  onCloseAutoFocus,
   onOpenChange,
   onSelectToJoin,
 }: DiscoverWorkspacesDialogProps) {
@@ -79,6 +81,7 @@ export function DiscoverWorkspacesDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
+        onCloseAutoFocus={onCloseAutoFocus}
         aria-describedby={undefined}
         className="flex max-h-[80vh] max-w-[640px] flex-col"
       >

--- a/apps/web/src/components/layout/WorkspaceCrudDialogs.tsx
+++ b/apps/web/src/components/layout/WorkspaceCrudDialogs.tsx
@@ -29,6 +29,7 @@ type FormMode = "create" | "rename"
 
 interface WorkspaceFormDialogProps {
   open: boolean
+  onCloseAutoFocus?: (event: Event) => void
   onOpenChange: (open: boolean) => void
   mode: FormMode
   initialName?: string
@@ -53,6 +54,7 @@ function extractErrorMessage(err: unknown): string | null {
 
 export function WorkspaceFormDialog({
   open,
+  onCloseAutoFocus,
   onOpenChange,
   mode,
   initialName = "",
@@ -86,7 +88,7 @@ export function WorkspaceFormDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent aria-describedby={undefined}>
+      <DialogContent aria-describedby={undefined} onCloseAutoFocus={onCloseAutoFocus}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
@@ -140,6 +142,7 @@ export function WorkspaceFormDialog({
 
 interface ConfirmArchiveDialogProps {
   open: boolean
+  onCloseAutoFocus?: (event: Event) => void
   onOpenChange: (open: boolean) => void
   title: string
   description: string
@@ -150,6 +153,7 @@ interface ConfirmArchiveDialogProps {
 
 export function ConfirmArchiveDialog({
   open,
+  onCloseAutoFocus,
   onOpenChange,
   title,
   description,
@@ -161,7 +165,7 @@ export function ConfirmArchiveDialog({
   const errMsg = extractErrorMessage(error)
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
-      <AlertDialogContent>
+      <AlertDialogContent onCloseAutoFocus={onCloseAutoFocus}>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>
           <AlertDialogDescription>{description}</AlertDialogDescription>
@@ -185,6 +189,7 @@ export function ConfirmArchiveDialog({
 
 interface JoinRequestDialogProps {
   open: boolean
+  onCloseAutoFocus?: (event: Event) => void
   onOpenChange: (open: boolean) => void
   workspaceName: string
   pending: boolean
@@ -194,6 +199,7 @@ interface JoinRequestDialogProps {
 
 export function JoinRequestDialog({
   open,
+  onCloseAutoFocus,
   onOpenChange,
   workspaceName,
   pending,
@@ -214,7 +220,7 @@ export function JoinRequestDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent aria-describedby={undefined}>
+      <DialogContent aria-describedby={undefined} onCloseAutoFocus={onCloseAutoFocus}>
         <DialogHeader>
           <DialogTitle>
             {t("workspaceCrud.join.title", { name: workspaceName })}

--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -37,6 +37,7 @@ import {
   WorkspaceFormDialog,
 } from "./WorkspaceCrudDialogs"
 import { DiscoverWorkspacesDialog } from "./DiscoverWorkspacesDialog"
+import { useWorkspaceDialogFocus } from "./useWorkspaceDialogFocus"
 
 function shortId(id: string | null | undefined): string {
   if (!id) return ""
@@ -79,6 +80,9 @@ export function WorkspaceSwitcher() {
   const [joinTarget, setJoinTarget] = useState<DiscoverableWorkspace | null>(
     null
   )
+  const dialogFocus = useWorkspaceDialogFocus(
+    createWsOpen || !!renameWs || !!archiveWs || !!joinTarget || discoverDialogOpen
+  )
   // Toast rendered next to the trigger (not page-top) since the switcher
   // is inside a dropdown. Auto-dismiss after 3s.
   const [joinToast, setJoinToast] = useState<string | null>(null)
@@ -109,6 +113,7 @@ export function WorkspaceSwitcher() {
       >
         <DropdownMenu.Trigger asChild>
           <button
+            ref={dialogFocus.triggerRef}
             type="button"
             aria-label={t("workspaceSwitcher.triggerAriaLabel")}
             title={triggerLabel}
@@ -132,6 +137,8 @@ export function WorkspaceSwitcher() {
 
         <DropdownMenu.Portal>
           <DropdownMenu.Content
+            ref={dialogFocus.menuRef}
+            onFocusCapture={dialogFocus.rememberFocus}
             align="start"
             sideOffset={6}
             className="app-shadow-floating z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] w-96 max-w-[calc(100vw-1rem)] overflow-x-hidden overflow-y-auto rounded-lg border border-line bg-surface p-1 text-sm text-fg-muted animate-pop-in data-[state=closed]:animate-pop-out"
@@ -281,6 +288,7 @@ export function WorkspaceSwitcher() {
 
       <WorkspaceFormDialog
         open={createWsOpen}
+        onCloseAutoFocus={dialogFocus.restoreFocus}
         onOpenChange={(open) => {
           if (!open) createWorkspaceMut.reset()
           setCreateWsOpen(open)
@@ -303,6 +311,7 @@ export function WorkspaceSwitcher() {
 
       <WorkspaceFormDialog
         open={renameWs !== null}
+        onCloseAutoFocus={dialogFocus.restoreFocus}
         onOpenChange={(open) => {
           if (!open) {
             updateWorkspaceMut.reset()
@@ -337,6 +346,7 @@ export function WorkspaceSwitcher() {
 
       <ConfirmArchiveDialog
         open={archiveWs !== null}
+        onCloseAutoFocus={dialogFocus.restoreFocus}
         onOpenChange={(open) => {
           if (!open) {
             archiveWorkspaceMut.reset()
@@ -365,6 +375,7 @@ export function WorkspaceSwitcher() {
 
       <JoinRequestDialog
         open={joinTarget !== null}
+        onCloseAutoFocus={dialogFocus.restoreFocus}
         onOpenChange={(open) => {
           if (!open) {
             requestJoinMut.reset()
@@ -393,6 +404,7 @@ export function WorkspaceSwitcher() {
 
       <DiscoverWorkspacesDialog
         open={discoverDialogOpen}
+        onCloseAutoFocus={dialogFocus.restoreFocus}
         onOpenChange={setDiscoverDialogOpen}
         onSelectToJoin={(ws) => {
           setDiscoverDialogOpen(false)

--- a/apps/web/src/components/layout/useWorkspaceDialogFocus.ts
+++ b/apps/web/src/components/layout/useWorkspaceDialogFocus.ts
@@ -1,0 +1,22 @@
+import { useRef, type FocusEvent } from "react"
+
+export function useWorkspaceDialogFocus(dialogOpen: boolean) {
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const originRef = useRef<HTMLElement | null>(null)
+
+  function rememberFocus(event: FocusEvent<HTMLDivElement>) {
+    originRef.current = event.target
+  }
+
+  function restoreFocus(event: Event) {
+    event.preventDefault()
+    // A closing discovery dialog may be handing focus to a join dialog.
+    if (dialogOpen) return
+    const origin = originRef.current
+    if (origin?.isConnected) origin.focus()
+    else (menuRef.current ?? triggerRef.current)?.focus()
+  }
+
+  return { triggerRef, menuRef, rememberFocus, restoreFocus }
+}


### PR DESCRIPTION
Closing a dialog opened from the workspace switcher left the menu open with focus on the page body. Return focus to the originating menu item, with a fallback to the menu or switcher if that item disappears. Discovery-to-join transitions retain focus in the new dialog.

The change is scoped to the switcher's dialog workflow; global dialog behavior, permission checks and workspace mutations are unchanged. `make check` and the web build pass. Browser verification covers actual create cancellation and synthetic rename, archive, discovery-to-join, and removed-origin recovery.
