### PR TITLE
fix(web): refresh scheduled task run status

### DIFF
--- a/apps/web/src/lib/api-scheduled-tasks.ts
+++ b/apps/web/src/lib/api-scheduled-tasks.ts
@@ -114,6 +114,7 @@ export function useScheduledTasksByWorkspace(
     enabled: Boolean(workspaceID),
     retry: noUnreachableRetry,
     staleTime: 15_000,
+    refetchInterval: 5_000,
     // Keep pagination placeholders within one workspace so task rows never cross boundaries.
     placeholderData: (prev, previousQuery) =>
       previousQuery?.queryKey[2] === (workspaceID ?? "_none") ? prev : undefined,


### PR DESCRIPTION
Scheduled tasks could stay marked as running after their run completed. Refresh the visible task list every five seconds so both manually started and scheduled runs update without reloading the page.

Scope: only the existing workspace list query refresh policy changes. Pagination, workspace isolation, scheduling, dispatch, mutations and the unused run-history query remain unchanged. React Query keeps its default background-tab behavior.

Validation: `make check`, web production build, and browser transitions from not run to running to succeeded without navigation or reload. A read-only API fixture changed server state independently of the client cache. Local migration smoke was skipped because Docker remains stopped; no database changes are included. Self-reviewed as a low-impact one-line query change.
