### PR TITLE
fix(web): retain capabilities when cloning agents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,9 @@ description and keep ownership on the side listed here.
 
 ### Agent CLI adapter contract
 
+- Agent cloning copies enabled capability bindings, version choices, and configuration.
+  Credential requirements come from each selected version; shared credentials remain
+  independent per capability, and personal or unavailable credentials require a new choice.
 - Agent creation and editing store behavior instructions in `system_prompt`.
   Preserve saved text when opening the form; clearing it sends an empty string.
 - OpenCode model selectors use `provider/model`. Its Anthropic SDK base URL

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1494,6 +1494,13 @@
         "placeholder": "/Users/me/code/my-app",
         "hintLocal": "The directory the agent runs in on your local device — an absolute path, or one starting with `~/`. Leave blank to use a per-conversation scratch dir; created if it does not exist.",
         "hintSandbox": "The directory the agent runs in inside the sandbox container (e.g. /workspace/my-app) — an absolute path, or one starting with `~/`. Leave blank to use a per-conversation scratch dir; created if it does not exist."
+      },
+      "clone": {
+        "loading": "Loading the source Agent’s capabilities…",
+        "loadFailed": "The source capabilities could not be loaded.",
+        "credentials": "Capabilities and their settings are copied. Select credentials for this new Agent; existing credential bindings are not copied.",
+        "unavailable": "These source capabilities are no longer available for creation. Remove them from this copy to continue.",
+        "remove": "Remove from copy"
       }
     },
     "pendingCapability": {

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1501,7 +1501,9 @@
         "credentials": "Capabilities and settings are copied, including available shared credentials. Personal or unavailable credentials need a new selection.",
         "unavailable": "These source capabilities are no longer available for creation. Remove them from this copy to continue.",
         "remove": "Remove from copy",
-        "manageCredentials": "Add or authorize credentials (opens a new tab)"
+        "manageCredentials": "Add or authorize credentials (opens a new tab)",
+        "refreshCredentials": "Refresh credentials",
+        "credentialsFailed": "Credentials could not be loaded."
       }
     },
     "pendingCapability": {

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1498,9 +1498,10 @@
       "clone": {
         "loading": "Loading the source Agent’s capabilities…",
         "loadFailed": "The source capabilities could not be loaded.",
-        "credentials": "Capabilities and their settings are copied. Select credentials for this new Agent; existing credential bindings are not copied.",
+        "credentials": "Capabilities and settings are copied, including available shared credentials. Personal or unavailable credentials need a new selection.",
         "unavailable": "These source capabilities are no longer available for creation. Remove them from this copy to continue.",
-        "remove": "Remove from copy"
+        "remove": "Remove from copy",
+        "manageCredentials": "Add or authorize credentials (opens a new tab)"
       }
     },
     "pendingCapability": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1494,6 +1494,13 @@
         "placeholder": "/Users/me/code/my-app",
         "hintLocal": "Agent 在你这台本地设备上运行时的目录，填绝对路径或以 ~/ 开头的路径。留空则每个会话各用一个临时目录；路径不存在时自动创建。",
         "hintSandbox": "Agent 在沙盒容器内运行时的目录（如 /workspace/my-app），填绝对路径或以 ~/ 开头的路径。留空则每个会话各用一个临时目录；路径不存在时自动创建。"
+      },
+      "clone": {
+        "loading": "正在读取源 Agent 的能力…",
+        "loadFailed": "无法读取源 Agent 的能力。",
+        "credentials": "已复制能力及其设置。请为新 Agent 选择凭证，原有凭证绑定不会复制。",
+        "unavailable": "以下源能力已无法用于创建 Agent，请从本次克隆中移除后继续。",
+        "remove": "从克隆中移除"
       }
     },
     "pendingCapability": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1501,7 +1501,9 @@
         "credentials": "已复制能力、设置及可用的共享凭证。个人或已失效的凭证需要重新选择。",
         "unavailable": "以下源能力已无法用于创建 Agent，请从本次克隆中移除后继续。",
         "remove": "从克隆中移除",
-        "manageCredentials": "添加或授权凭证（在新标签页打开）"
+        "manageCredentials": "添加或授权凭证（在新标签页打开）",
+        "refreshCredentials": "刷新凭证",
+        "credentialsFailed": "无法加载凭证。"
       }
     },
     "pendingCapability": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1498,9 +1498,10 @@
       "clone": {
         "loading": "正在读取源 Agent 的能力…",
         "loadFailed": "无法读取源 Agent 的能力。",
-        "credentials": "已复制能力及其设置。请为新 Agent 选择凭证，原有凭证绑定不会复制。",
+        "credentials": "已复制能力、设置及可用的共享凭证。个人或已失效的凭证需要重新选择。",
         "unavailable": "以下源能力已无法用于创建 Agent，请从本次克隆中移除后继续。",
-        "remove": "从克隆中移除"
+        "remove": "从克隆中移除",
+        "manageCredentials": "添加或授权凭证（在新标签页打开）"
       }
     },
     "pendingCapability": {

--- a/apps/web/src/lib/agent-clone.ts
+++ b/apps/web/src/lib/agent-clone.ts
@@ -1,0 +1,12 @@
+import type { AgentCapability } from "./api-types"
+
+export function withoutCredentialBindings(config: Record<string, unknown>): Record<string, unknown> {
+  const copy = { ...config }
+  delete copy.credential_bindings
+  delete copy.model_credential_binding
+  return copy
+}
+
+export function cloneableAgentCapabilities(bindings: AgentCapability[]): AgentCapability[] {
+  return bindings.filter((binding) => binding.enabled && !binding.built_in)
+}

--- a/apps/web/src/lib/credential-bindings.ts
+++ b/apps/web/src/lib/credential-bindings.ts
@@ -1,4 +1,4 @@
-import type { Secret, UserCredential } from "./api-types"
+import type { CapabilityVersion, Secret, UserCredential } from "./api-types"
 
 export type PerKindBindingChoice =
   | { source: "personal" }
@@ -44,4 +44,11 @@ export function credentialBinding(config: Record<string, unknown> | undefined, k
 
 export function hasCredentialKind(credentials: UserCredential[], kind: string) {
   return credentials.some((credential) => credential.kind === kind)
+}
+
+export function catalogIDFromVersion(version: CapabilityVersion | undefined) {
+  const payload = version?.source_payload
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return ""
+  const catalogID = (payload as Record<string, unknown>).catalog_id
+  return typeof catalogID === "string" ? catalogID.trim() : ""
 }

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -20,6 +20,9 @@ import { Select, SelectOption } from "../../components/ui/select"
 import { AgentInstructionsField } from "./agents/AgentInstructionsField"
 import { AgentCloneNotice } from "./agents/AgentCloneNotice"
 import { useAgentCloneCapabilities } from "./agents/useAgentCloneCapabilities"
+import { useAgentCloneCredentials } from "./agents/useAgentCloneCredentials"
+import { AgentCloneCredentials } from "./agents/AgentCloneCredentials"
+import { sharedSecretsForKind } from "../../lib/credential-bindings"
 import { withoutCredentialBindings } from "../../lib/agent-clone"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
@@ -535,15 +538,18 @@ export function CreateAgentDialog({
       setVisibility("public")
       setDeviceID(cloneSource ? deviceIDFromAgent(cloneSource) : "")
       setWorkDir(cloneSource ? workDirFromAgent(cloneSource) || defaultWorkDir(initialExecutionMode) : defaultWorkDir(initialExecutionMode))
-      // Clones explicitly drop the source agent's credential bindings: the
-      // copy is a fresh agent and the user re-picks. Without these resets a
-      // previous clone's bindings would leak across dialog opens.
+      // Capability credentials are resolved separately for each cloned binding.
       setCredentialBindings({})
       setInitialCredentialBindings(undefined)
-      // Create is locked to public, so personal binding is disabled — start on
-      // shared. Left as a pending pick here (secrets may still be loading); the
-      // resolver effect below upgrades it to the first existing secret if any.
-      setModelBindingChoice({ source: "shared" })
+      // Public clones retain a shared model binding or wait for an explicit
+      // choice; only fresh creation uses the automatic default below.
+      const sourceModelBinding = agentConfig(cloneSource).model_credential_binding as { source?: string; secret_id?: string } | undefined
+      setModelBindingChoice(sourceModelBinding?.source === "shared" && sourceModelBinding.secret_id
+        ? { source: "shared", existing_secret_id: sourceModelBinding.secret_id }
+        : { source: "shared" })
+      setModelNewSecretExpanded(false)
+      setModelNewSecretDisplayName("")
+      setModelNewSecretPlaintext("")
       setInlineNewSecrets([])
     } else if (agent) {
       setName(agent.name)
@@ -605,8 +611,11 @@ export function CreateAgentDialog({
   const clone = useAgentCloneCapabilities(open, cloneSourceID,
     existingBindingsQ.isFetching || existingBindingsQ.isError ? undefined : existingBindingsQ.data?.installed,
     setSelectedCapabilityIDs, setCapabilityVersionChoices)
+  const cloneCredentials = useAgentCloneCredentials(cloneSourceID, workspaceID, agentConfig(agent),
+    clone.bindings, allCapabilitiesPool, selectedCapabilityIDs, capabilityVersionChoices, sharedSecrets)
   const cloneLoadFailed = Boolean(cloneSourceID) && (
-    (!clone.ready && existingBindingsQ.isError) || (!allCapabilitiesQ.data && allCapabilitiesQ.isError)
+    (!clone.ready && existingBindingsQ.isError) || (!allCapabilitiesQ.data && allCapabilitiesQ.isError) ||
+    cloneCredentials.failed || (cloneCredentials.needsCredentials && secretsQ.isError)
   )
   const unavailableCloneCapabilities = clone.bindings.filter((binding) =>
     selectedCapabilityIDs.includes(binding.capability_id) && (
@@ -732,13 +741,22 @@ export function CreateAgentDialog({
   // on the credential_ref UI so no-credential models stay untouched; with zero
   // secrets it stays pending and the inline new-secret form takes over.
   useEffect(() => {
-    if (mode !== "create") return
+    if (mode !== "create" || cloneSourceID) return
     if (!requiresModel || selectedModel?.credential_mode !== "credential_ref") return
     if (modelBindingChoice.source !== "shared") return
     if ("existing_secret_id" in modelBindingChoice || "new_secret" in modelBindingChoice) return
     if (modelNewSecretExpanded || sharedSecrets.length === 0) return
     setModelBindingChoice({ source: "shared", existing_secret_id: sharedSecrets[0].id })
-  }, [mode, requiresModel, selectedModel, modelBindingChoice, modelNewSecretExpanded, sharedSecrets])
+  }, [mode, cloneSourceID, requiresModel, selectedModel, modelBindingChoice, modelNewSecretExpanded, sharedSecrets])
+  const modelSharedSecrets = cloneSourceID
+    ? sharedSecretsForKind(sharedSecrets, selectedModel?.credential_kind_code || "model_api_key")
+    : sharedSecrets
+  const cloneModelCredentialValid = !cloneSourceID || !requiresModel || selectedModel?.credential_mode !== "credential_ref" || (
+    modelBindingChoice.source === "shared" && (
+      ("existing_secret_id" in modelBindingChoice && modelSharedSecrets.some((secret) => secret.id === modelBindingChoice.existing_secret_id)) ||
+      ("new_secret" in modelBindingChoice && !!modelBindingChoice.new_secret.plaintext.trim())
+    )
+  )
   const daemonExecutionEditable = connector === "agent_daemon"
   const showExecutionChoices = mode === "create" || daemonExecutionEditable
   const showDevicePicker = connector === "agent_daemon" && executionMode === "local_device" && Boolean(workspaceID)
@@ -817,7 +835,7 @@ export function CreateAgentDialog({
       // the user a clearer error tied to the input instead of a stream error.
       return
     }
-    if (mode === "create" && (allCapabilitiesQ.isLoading || !clone.ready || cloneLoadFailed || unavailableCloneCapabilities.length > 0)) return
+    if (mode === "create" && (allCapabilitiesQ.isLoading || !clone.ready || !cloneCredentials.valid || !cloneModelCredentialValid || cloneLoadFailed || unavailableCloneCapabilities.length > 0)) return
     const selectedCapabilities = mode === "create"
       ? allCapabilitiesPool.filter((cap) => selectedCapabilityIDs.includes(cap.id) && cap.latest_version_id)
       : []
@@ -835,7 +853,7 @@ export function CreateAgentDialog({
         ? (choice?.versionID || (cap.latest_version_id as string))
         : (cap.latest_version_id as string)
       return { capability_version_id: versionID, pinning_mode: pinningMode,
-        ...(source ? { configuration: withoutCredentialBindings(source.configuration) } : {}) }
+        ...(cloneSourceID ? { configuration: cloneCredentials.rows.find((row) => row.capabilityID === cap.id)?.configuration } : {}) }
     })
     const profile = {
       ...(requiresModel ? { model_id: selectedModelID } : {}),
@@ -1003,14 +1021,15 @@ export function CreateAgentDialog({
     (connector !== "agent_daemon" || executionMode !== "local_device" || deviceID !== "") &&
     workDirValid &&
     (mode !== "create" || (!allCapabilitiesQ.isLoading && clone.ready && !cloneLoadFailed && unavailableCloneCapabilities.length === 0)) &&
-    (aggregatedRequiredKinds.length === 0 || allCredentialsSatisfied)
+    cloneModelCredentialValid &&
+    (cloneSourceID ? cloneCredentials.valid : aggregatedRequiredKinds.length === 0 || allCredentialsSatisfied)
 
   const step1Valid =
     name.trim() !== "" &&
     hasConnector &&
     hasRequiredModel &&
     (connector !== "agent_daemon" || executionMode !== "local_device" || deviceID !== "") &&
-    workDirValid
+    workDirValid && cloneModelCredentialValid
   const totalSteps = 2
   const progressPercent = Math.round((step / totalSteps) * 100)
 
@@ -1350,8 +1369,8 @@ export function CreateAgentDialog({
                         onChange={() => {
                           // Default selection on flip-in: existing secret if any, else
                           // mark shared "pending" so the radio selects + form renders.
-                          if (sharedSecrets[0]) {
-                            setModelBindingChoice({ source: "shared", existing_secret_id: sharedSecrets[0].id })
+                          if (modelSharedSecrets[0]) {
+                            setModelBindingChoice({ source: "shared", existing_secret_id: modelSharedSecrets[0].id })
                           } else {
                             setModelBindingChoice({ source: "shared" })
                             setModelNewSecretExpanded(true)
@@ -1364,12 +1383,13 @@ export function CreateAgentDialog({
                         <span className="block">{t("credentialCheck.modelBindingShared")}</span>
                         {modelBindingChoice.source === "shared" && (
                           <div className="mt-1.5 flex flex-col gap-2">
-                            {sharedSecrets.length > 0 && (
+                            {modelSharedSecrets.length > 0 && (
                               <Select
                                 aria-label={t("credentialCheck.modelBindingShared")}
-                                value={"existing_secret_id" in modelBindingChoice ? modelBindingChoice.existing_secret_id : "__new__"}
+                                value={"existing_secret_id" in modelBindingChoice ? (modelSharedSecrets.some((secret) => secret.id === modelBindingChoice.existing_secret_id) ? modelBindingChoice.existing_secret_id : "") : "new_secret" in modelBindingChoice || modelNewSecretExpanded || !cloneSourceID ? "__new__" : ""}
                                 onValueChange={(nextValue) => {
                                   if (nextValue === "__new__") {
+                                    if (cloneSourceID) setModelBindingChoice({ source: "shared" })
                                     setModelNewSecretExpanded(true)
                                     if (!("new_secret" in modelBindingChoice)) {
                                       setModelNewSecretDisplayName("")
@@ -1382,13 +1402,14 @@ export function CreateAgentDialog({
                                 }}
                                 onClick={(e) => e.stopPropagation()}
                               >
-                                {sharedSecrets.map((s) => (
+                                {cloneSourceID && <SelectOption value="">{t("credentialCheck.sharedPlaceholder")}</SelectOption>}
+                                {modelSharedSecrets.map((s) => (
                                   <SelectOption key={s.id} value={s.id}>{s.name}</SelectOption>
                                 ))}
                                 <SelectOption value="__new__">{t("credentialCheck.createNewShared")}</SelectOption>
                               </Select>
                             )}
-                            {sharedSecrets.length === 0 && !modelNewSecretExpanded && !("new_secret" in modelBindingChoice) && (
+                            {modelSharedSecrets.length === 0 && !modelNewSecretExpanded && !("new_secret" in modelBindingChoice) && (
                               <Button
                                 type="button"
                                 variant="outline"
@@ -1473,8 +1494,8 @@ export function CreateAgentDialog({
                                       // fall the binding back to an existing one (if any) or to personal,
                                       // so we don't leave the shared radio "selected with nothing inside".
                                       if (!("new_secret" in modelBindingChoice)) {
-                                        if (sharedSecrets[0]) {
-                                          setModelBindingChoice({ source: "shared", existing_secret_id: sharedSecrets[0].id })
+                                        if (modelSharedSecrets[0]) {
+                                          setModelBindingChoice({ source: "shared", existing_secret_id: modelSharedSecrets[0].id })
                                         } else if (visibility !== "public") {
                                           setModelBindingChoice({ source: "personal" })
                                         }
@@ -1518,10 +1539,10 @@ export function CreateAgentDialog({
           {step === 2 && (
             <>
               {cloneSourceID && <AgentCloneNotice
-                ready={clone.ready && !allCapabilitiesQ.isLoading}
+                ready={clone.ready && cloneCredentials.ready && !allCapabilitiesQ.isLoading}
                 failed={cloneLoadFailed}
                 unavailable={unavailableCloneCapabilities}
-                onRetry={() => { void existingBindingsQ.refetch(); void allCapabilitiesQ.refetch() }}
+                onRetry={() => { void existingBindingsQ.refetch(); void allCapabilitiesQ.refetch(); void secretsQ.refetch(); cloneCredentials.retry() }}
                 onRemove={(id) => setSelectedCapabilityIDs((current) => current.filter((selected) => selected !== id))}
               />}
               <section className="flex flex-col gap-3">
@@ -1602,7 +1623,7 @@ export function CreateAgentDialog({
                 )}
               </section>
 
-              {aggregatedRequiredKinds.length > 0 && (
+              {cloneSourceID ? <AgentCloneCredentials credentials={cloneCredentials} workspaceID={workspaceID} /> : aggregatedRequiredKinds.length > 0 && (
                 <section className="flex flex-col gap-3">
                   <h3 className="text-sm font-medium text-fg">{t("agents.form.sections.credentials")}</h3>
                   <CredentialCheckPanel

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -22,6 +22,7 @@ import { AgentCloneNotice } from "./agents/AgentCloneNotice"
 import { useAgentCloneCapabilities } from "./agents/useAgentCloneCapabilities"
 import { useAgentCloneCredentials } from "./agents/useAgentCloneCredentials"
 import { AgentCloneCredentials } from "./agents/AgentCloneCredentials"
+import { AgentCloneCredentialRefresh } from "./agents/AgentCloneCredentialRefresh"
 import { sharedSecretsForKind } from "../../lib/credential-bindings"
 import { withoutCredentialBindings } from "../../lib/agent-clone"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
@@ -847,9 +848,8 @@ export function CreateAgentDialog({
     // a fallback for the daemon).
     const initialCapabilities = selectedCapabilities.map((cap) => {
       const choice = capabilityVersionChoices[cap.id]
-      const source = clone.bindings.find((binding) => binding.capability_id === cap.id)
       const pinningMode: "latest" | "pinned" = choice?.pinningMode ?? "latest"
-      const versionID = pinningMode === "pinned" || source
+      const versionID = pinningMode === "pinned" || cloneSourceID
         ? (choice?.versionID || (cap.latest_version_id as string))
         : (cap.latest_version_id as string)
       return { capability_version_id: versionID, pinning_mode: pinningMode,
@@ -1343,6 +1343,8 @@ export function CreateAgentDialog({
               )}
               {requiresModel && selectedModel && selectedModel.credential_mode === "credential_ref" && (
                 <Field label={t("credentialCheck.modelBindingTitle")}>
+                  {cloneSourceID && <AgentCloneCredentialRefresh failed={secretsQ.isError} fetching={secretsQ.isFetching}
+                    onRefresh={() => { void secretsQ.refetch() }} />}
                   <div className="flex flex-col gap-1" role="radiogroup">
                     <label className={cn("flex items-start gap-2 py-1", visibility === "public" ? "cursor-not-allowed opacity-50" : "cursor-pointer")}>
                       <input
@@ -1493,7 +1495,9 @@ export function CreateAgentDialog({
                                       // If the user cancels and no existing secret has been chosen yet,
                                       // fall the binding back to an existing one (if any) or to personal,
                                       // so we don't leave the shared radio "selected with nothing inside".
-                                      if (!("new_secret" in modelBindingChoice)) {
+                                      if (cloneSourceID) {
+                                        setModelBindingChoice({ source: "shared" })
+                                      } else if (!("new_secret" in modelBindingChoice)) {
                                         if (modelSharedSecrets[0]) {
                                           setModelBindingChoice({ source: "shared", existing_secret_id: modelSharedSecrets[0].id })
                                         } else if (visibility !== "public") {
@@ -1623,7 +1627,8 @@ export function CreateAgentDialog({
                 )}
               </section>
 
-              {cloneSourceID ? <AgentCloneCredentials credentials={cloneCredentials} workspaceID={workspaceID} /> : aggregatedRequiredKinds.length > 0 && (
+              {cloneSourceID ? <AgentCloneCredentials credentials={cloneCredentials} workspaceID={workspaceID}
+                failed={secretsQ.isError} fetching={secretsQ.isFetching} onRefresh={() => { void secretsQ.refetch() }} /> : aggregatedRequiredKinds.length > 0 && (
                 <section className="flex flex-col gap-3">
                   <h3 className="text-sm font-medium text-fg">{t("agents.form.sections.credentials")}</h3>
                   <CredentialCheckPanel

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -18,6 +18,9 @@ import { Input } from "../../components/ui/input"
 import { Label } from "../../components/ui/label"
 import { Select, SelectOption } from "../../components/ui/select"
 import { AgentInstructionsField } from "./agents/AgentInstructionsField"
+import { AgentCloneNotice } from "./agents/AgentCloneNotice"
+import { useAgentCloneCapabilities } from "./agents/useAgentCloneCapabilities"
+import { withoutCredentialBindings } from "../../lib/agent-clone"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
 import { cn } from "../../lib/utils"
@@ -327,10 +330,8 @@ export function CreateAgentDialog({
 
   const capabilitiesQ = useCapabilitiesQuery(workspaceID, capabilitySearch)
   const allCapabilitiesQ = useCapabilitiesQuery(workspaceID, "")
-  // In edit mode, fetch existing per-agent bindings so we can
-  // hydrate the version dropdowns with the current pinning_mode +
-  // capability_version_id. In create mode the response is empty.
-  const existingBindingsQ = useAgentCapabilitiesQuery(workspaceID, mode === "edit" ? agent?.id ?? null : null)
+  const cloneSourceID = mode === "create" && open ? agent?.id ?? null : null
+  const existingBindingsQ = useAgentCapabilitiesQuery(workspaceID, mode === "edit" ? agent?.id ?? null : cloneSourceID)
   const enableBindingMut = useEnableAgentCapabilityMutation(workspaceID, agent?.id ?? null)
   const secretsQ = useSecrets(workspaceID)
   const sharedSecrets: Secret[] = useMemo(
@@ -527,8 +528,6 @@ export function CreateAgentDialog({
       setHighlightedModelID(null)
       setSystemPrompt(params.get("agent_prompt") ?? (cloneSource ? promptFromAgent(cloneSource, defaultSystemPrompt) : defaultSystemPrompt))
       setCapabilities(cloneSource ? capabilitiesFromAgent(cloneSource) : [])
-      // Capability IDs aren't prefilled on clone: mapping installed names back
-      // to IDs needs an extra round-trip, so users re-pick from the marketplace.
       setSelectedCapabilityIDs([])
       setCapabilityVersionChoices({})
       setCapabilitySearch("")
@@ -602,6 +601,17 @@ export function CreateAgentDialog({
     setStep(1)
     setCapabilityTypeFilter("all")
   }, [open, mode, agent, agent?.id, defaultAgentDescription, defaultAgentName, defaultSystemPrompt, firstModelID])
+
+  const clone = useAgentCloneCapabilities(open, cloneSourceID,
+    existingBindingsQ.isFetching || existingBindingsQ.isError ? undefined : existingBindingsQ.data?.installed,
+    setSelectedCapabilityIDs, setCapabilityVersionChoices)
+  const cloneLoadFailed = Boolean(cloneSourceID) && (
+    (!clone.ready && existingBindingsQ.isError) || (!allCapabilitiesQ.data && allCapabilitiesQ.isError)
+  )
+  const unavailableCloneCapabilities = clone.bindings.filter((binding) =>
+    selectedCapabilityIDs.includes(binding.capability_id) && (
+      !binding.capability_version_id || !allCapabilitiesPool.some((cap) => cap.id === binding.capability_id && cap.latest_version_id)
+    ))
 
   function selectExecutionMode(nextMode: ExecutionMode) {
     setExecutionMode(nextMode)
@@ -807,7 +817,7 @@ export function CreateAgentDialog({
       // the user a clearer error tied to the input instead of a stream error.
       return
     }
-    if (mode === "create" && allCapabilitiesQ.isLoading) return
+    if (mode === "create" && (allCapabilitiesQ.isLoading || !clone.ready || cloneLoadFailed || unavailableCloneCapabilities.length > 0)) return
     const selectedCapabilities = mode === "create"
       ? allCapabilitiesPool.filter((cap) => selectedCapabilityIDs.includes(cap.id) && cap.latest_version_id)
       : []
@@ -819,11 +829,13 @@ export function CreateAgentDialog({
     // a fallback for the daemon).
     const initialCapabilities = selectedCapabilities.map((cap) => {
       const choice = capabilityVersionChoices[cap.id]
+      const source = clone.bindings.find((binding) => binding.capability_id === cap.id)
       const pinningMode: "latest" | "pinned" = choice?.pinningMode ?? "latest"
-      const versionID = pinningMode === "pinned"
+      const versionID = pinningMode === "pinned" || source
         ? (choice?.versionID || (cap.latest_version_id as string))
         : (cap.latest_version_id as string)
-      return { capability_version_id: versionID, pinning_mode: pinningMode }
+      return { capability_version_id: versionID, pinning_mode: pinningMode,
+        ...(source ? { configuration: withoutCredentialBindings(source.configuration) } : {}) }
     })
     const profile = {
       ...(requiresModel ? { model_id: selectedModelID } : {}),
@@ -831,7 +843,7 @@ export function CreateAgentDialog({
       skills: capabilityNames,
     }
     const mergedConfig: Record<string, unknown> = {
-      ...configBaseForSubmit(agent, connector),
+      ...(cloneSourceID ? withoutCredentialBindings(configBaseForSubmit(agent, connector)) : configBaseForSubmit(agent, connector)),
       profile,
       ...(connector === "agent_daemon" ? {
         agent_kind: agentEngine,
@@ -990,7 +1002,7 @@ export function CreateAgentDialog({
     hasRequiredModel &&
     (connector !== "agent_daemon" || executionMode !== "local_device" || deviceID !== "") &&
     workDirValid &&
-    (mode !== "create" || !allCapabilitiesQ.isLoading) &&
+    (mode !== "create" || (!allCapabilitiesQ.isLoading && clone.ready && !cloneLoadFailed && unavailableCloneCapabilities.length === 0)) &&
     (aggregatedRequiredKinds.length === 0 || allCredentialsSatisfied)
 
   const step1Valid =
@@ -1505,6 +1517,13 @@ export function CreateAgentDialog({
 
           {step === 2 && (
             <>
+              {cloneSourceID && <AgentCloneNotice
+                ready={clone.ready && !allCapabilitiesQ.isLoading}
+                failed={cloneLoadFailed}
+                unavailable={unavailableCloneCapabilities}
+                onRetry={() => { void existingBindingsQ.refetch(); void allCapabilitiesQ.refetch() }}
+                onRemove={(id) => setSelectedCapabilityIDs((current) => current.filter((selected) => selected !== id))}
+              />}
               <section className="flex flex-col gap-3">
                 <Input value={capabilitySearch} onChange={(e) => setCapabilitySearch(e.target.value)} placeholder={t("agents.form.placeholders.capabilitySearch")} />
                 {capabilityOptions.length === 0 ? (
@@ -1538,7 +1557,7 @@ export function CreateAgentDialog({
                               const checked = mode === "create" ? selectedCapabilityIDs.includes(cap.id) : capabilities.includes(cap.name)
                               const lockedNoVersion = mode === "create" && !cap.latestVersionID
                               const lockedDeprecatedAndUnchecked = cap.deprecated && !checked
-                              const disabled = lockedNoVersion || lockedDeprecatedAndUnchecked
+                              const disabled = lockedNoVersion || lockedDeprecatedAndUnchecked || !clone.ready
                               const ghostTitle = cap.deprecated ? t("agents.form.deprecatedCapabilityTooltip") : undefined
                               return (
                                 <label key={`${sec}:${cap.id || cap.name}`} title={ghostTitle} data-row-index={index} className={cn("flex w-full min-w-0 items-start gap-2 border-b border-line py-2 text-left", disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer hover:app-hover")}>

--- a/apps/web/src/pages/admin/agents/AgentCloneCredentialRefresh.tsx
+++ b/apps/web/src/pages/admin/agents/AgentCloneCredentialRefresh.tsx
@@ -1,0 +1,18 @@
+import { useTranslation } from "react-i18next"
+import { Button } from "../../../components/ui/button"
+import { ErrorState } from "../../../components/ui/error-state"
+
+export function AgentCloneCredentialRefresh({ failed, fetching, onRefresh }: {
+  failed: boolean
+  fetching: boolean
+  onRefresh: () => void
+}) {
+  const { t } = useTranslation("admin")
+  const { t: tc } = useTranslation("common")
+  const action = <Button type="button" variant="outline" size="sm" disabled={fetching} onClick={onRefresh}>
+    {fetching ? tc("states.loading") : t("agents.form.clone.refreshCredentials")}
+  </Button>
+  return failed
+    ? <ErrorState appearance="panel" title={t("agents.form.clone.credentialsFailed")} action={action} />
+    : <div>{action}</div>
+}

--- a/apps/web/src/pages/admin/agents/AgentCloneCredentials.tsx
+++ b/apps/web/src/pages/admin/agents/AgentCloneCredentials.tsx
@@ -1,0 +1,34 @@
+import { useTranslation } from "react-i18next"
+import { CredentialBindingSelect } from "../../../components/admin/CredentialBindingSelect"
+import { Field } from "../../../components/ui/label"
+import { credentialKindLabel } from "../../../lib/credential-kind-ui"
+import type { useAgentCloneCredentials } from "./useAgentCloneCredentials"
+
+export function AgentCloneCredentials({ credentials, workspaceID }: {
+  credentials: ReturnType<typeof useAgentCloneCredentials>
+  workspaceID: string | null
+}) {
+  const { t, i18n } = useTranslation("admin")
+  if (!credentials.needsCredentials) return null
+  return <section className="flex flex-col gap-3">
+    <h3 className="text-sm font-medium text-fg">{t("agents.form.sections.credentials")}</h3>
+    {credentials.rows.filter((row) => row.fields.length > 0).map((row) => (
+      <div key={row.capabilityID} className="space-y-3 rounded-md border border-line p-3">
+        <h4 className="break-words text-sm font-medium">{row.name}</h4>
+        {row.fields.map((field) => (
+          <Field key={field.kind} label={credentialKindLabel(field.kind, i18n.language, field.kind)}>
+            <CredentialBindingSelect
+              label={`${row.name} · ${credentialKindLabel(field.kind, i18n.language, field.kind)}`}
+              value={field.value} secrets={field.available} allowPersonal={false}
+              personalLabel={t("credentialCheck.sharedPlaceholder")}
+              sharedLabel={t("credentialCheck.sourceShared")}
+              onChange={(value) => credentials.choose(row.capabilityID, field.kind, value)}
+            />
+          </Field>
+        ))}
+      </div>
+    ))}
+    <a href={`/?ws=${encodeURIComponent(workspaceID ?? "")}&admin=credentials`} target="_blank" rel="noopener noreferrer"
+      className="text-sm text-fg underline underline-offset-4">{t("agents.form.clone.manageCredentials")}</a>
+  </section>
+}

--- a/apps/web/src/pages/admin/agents/AgentCloneCredentials.tsx
+++ b/apps/web/src/pages/admin/agents/AgentCloneCredentials.tsx
@@ -3,10 +3,14 @@ import { CredentialBindingSelect } from "../../../components/admin/CredentialBin
 import { Field } from "../../../components/ui/label"
 import { credentialKindLabel } from "../../../lib/credential-kind-ui"
 import type { useAgentCloneCredentials } from "./useAgentCloneCredentials"
+import { AgentCloneCredentialRefresh } from "./AgentCloneCredentialRefresh"
 
-export function AgentCloneCredentials({ credentials, workspaceID }: {
+export function AgentCloneCredentials({ credentials, workspaceID, failed, fetching, onRefresh }: {
   credentials: ReturnType<typeof useAgentCloneCredentials>
   workspaceID: string | null
+  failed: boolean
+  fetching: boolean
+  onRefresh: () => void
 }) {
   const { t, i18n } = useTranslation("admin")
   if (!credentials.needsCredentials) return null
@@ -30,5 +34,6 @@ export function AgentCloneCredentials({ credentials, workspaceID }: {
     ))}
     <a href={`/?ws=${encodeURIComponent(workspaceID ?? "")}&admin=credentials`} target="_blank" rel="noopener noreferrer"
       className="text-sm text-fg underline underline-offset-4">{t("agents.form.clone.manageCredentials")}</a>
+    <AgentCloneCredentialRefresh failed={failed} fetching={fetching} onRefresh={onRefresh} />
   </section>
 }

--- a/apps/web/src/pages/admin/agents/AgentCloneNotice.tsx
+++ b/apps/web/src/pages/admin/agents/AgentCloneNotice.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from "react-i18next"
+import { Button } from "../../../components/ui/button"
+import { ErrorState, InlineNotice } from "../../../components/ui/error-state"
+import type { AgentCapability } from "../../../lib/api-types"
+
+export function AgentCloneNotice({ ready, failed, unavailable, onRetry, onRemove }: {
+  ready: boolean
+  failed: boolean
+  unavailable: AgentCapability[]
+  onRetry: () => void
+  onRemove: (id: string) => void
+}) {
+  const { t } = useTranslation("admin")
+  const { t: tc } = useTranslation("common")
+  if (failed) return <ErrorState appearance="panel" title={t("agents.form.clone.loadFailed")}
+    action={<Button type="button" size="sm" variant="outline" onClick={onRetry}>{tc("actions.retry")}</Button>} />
+  if (!ready) return <p role="status" className="text-sm text-fg-muted">{t("agents.form.clone.loading")}</p>
+  return (
+    <div className="space-y-3 rounded-md border border-line p-3">
+      <InlineNotice>{t("agents.form.clone.credentials")}</InlineNotice>
+      {unavailable.length > 0 && <>
+        <p className="text-sm text-fg">{t("agents.form.clone.unavailable")}</p>
+        {unavailable.map((binding) => (
+          <div key={binding.capability_id} className="flex items-center gap-2">
+            <span className="min-w-0 flex-1 break-words text-sm">{binding.capability?.name ?? binding.name ?? binding.capability_id}</span>
+            <Button type="button" size="sm" variant="outline" onClick={() => onRemove(binding.capability_id)}>{t("agents.form.clone.remove")}</Button>
+          </div>
+        ))}
+      </>}
+    </div>
+  )
+}

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -43,7 +43,7 @@ import { useSecrets } from "../../../lib/api-secrets"
 import { agentCapabilityFollowsLatest, agentCapabilityVersion } from "../../../lib/agent-capability-version"
 import { agentExecutionPlacement } from "../../../lib/agent-runtime"
 import { agentEngineLabel, agentEngineOf, agentEngineSupportsCapability, agentEnginesSupportingCapability } from "../../../lib/agent-view-model"
-import { credentialBinding, hasCredentialKind, sharedSecretsForKind } from "../../../lib/credential-bindings"
+import { catalogIDFromVersion, credentialBinding, hasCredentialKind, sharedSecretsForKind } from "../../../lib/credential-bindings"
 import type { Agent, AgentCapability, AgentDetail, Capability, CapabilityVersion, Secret, UserCredential } from "../../../lib/api-types"
 import { CredentialBindingSelect } from "../../../components/admin/CredentialBindingSelect"
 import { CapabilityTypeBadge } from "../CapabilitiesPage"
@@ -118,13 +118,6 @@ function hasUsableCredential(agent: Agent, binding: AgentCapability | undefined,
   const sharedID = boundSharedSecretID(agent, binding, kind)
   if (sharedID && sharedSecretsForKind(sharedSecrets, kind, catalogID).some((secret) => secret.id === sharedID)) return true
   return agent.visibility !== "public" && hasCredentialKind(credentials, kind)
-}
-
-function catalogIDFromVersion(version: CapabilityVersion | undefined) {
-  const payload = version?.source_payload
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return ""
-  const catalogID = (payload as Record<string, unknown>).catalog_id
-  return typeof catalogID === "string" ? catalogID.trim() : ""
 }
 
 function useCapabilityVersions(

--- a/apps/web/src/pages/admin/agents/useAgentCloneCapabilities.ts
+++ b/apps/web/src/pages/admin/agents/useAgentCloneCapabilities.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react"
+import { cloneableAgentCapabilities } from "../../../lib/agent-clone"
+import type { AgentCapability } from "../../../lib/api-types"
+
+type VersionChoice = { pinningMode: "latest" | "pinned"; versionID: string; pinnedVersion?: string }
+
+export function useAgentCloneCapabilities(
+  open: boolean,
+  sourceID: string | null,
+  bindings: AgentCapability[] | undefined,
+  setSelectedIDs: Dispatch<SetStateAction<string[]>>,
+  setVersionChoices: Dispatch<SetStateAction<Record<string, VersionChoice>>>,
+) {
+  const [snapshot, setSnapshot] = useState<{ sourceID: string; bindings: AgentCapability[] } | null>(null)
+  useEffect(() => {
+    if (!open || !sourceID) {
+      setSnapshot(null)
+      return
+    }
+    if (snapshot?.sourceID === sourceID || !bindings) return
+    const selected = cloneableAgentCapabilities(bindings)
+    setSelectedIDs(selected.map((binding) => binding.capability_id))
+    setVersionChoices(Object.fromEntries(selected.map((binding) => [binding.capability_id, {
+      pinningMode: binding.pinning_mode === "latest" ? "latest" : "pinned",
+      versionID: binding.capability_version_id,
+      pinnedVersion: binding.version ?? binding.capability?.pinned_version,
+    }])))
+    setSnapshot({ sourceID, bindings: selected })
+  }, [open, sourceID, bindings, snapshot, setSelectedIDs, setVersionChoices])
+  return {
+    ready: !sourceID || snapshot?.sourceID === sourceID,
+    bindings: snapshot?.sourceID === sourceID ? snapshot.bindings : [],
+  }
+}

--- a/apps/web/src/pages/admin/agents/useAgentCloneCredentials.ts
+++ b/apps/web/src/pages/admin/agents/useAgentCloneCredentials.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react"
+import { useQueries } from "@tanstack/react-query"
+import { KEY_CAPABILITY_VERSIONS, listCapabilityVersions } from "../../../lib/api-capabilities"
+import { noUnreachableRetry } from "../../../lib/api-client"
+import type { AgentCapability, Capability, Secret } from "../../../lib/api-types"
+import { catalogIDFromVersion, credentialBinding, sharedSecretsForKind } from "../../../lib/credential-bindings"
+import { withoutCredentialBindings } from "../../../lib/agent-clone"
+
+export function useAgentCloneCredentials(
+  sourceID: string | null,
+  workspaceID: string | null,
+  sourceConfig: Record<string, unknown>,
+  bindings: AgentCapability[],
+  capabilities: Capability[],
+  selectedIDs: string[],
+  versions: Record<string, { versionID: string }>,
+  secrets: Secret[],
+) {
+  const [choices, setChoices] = useState<Record<string, Record<string, string>>>({})
+  useEffect(() => setChoices({}), [sourceID])
+  const selected = sourceID ? capabilities.filter((cap) => selectedIDs.includes(cap.id)) : []
+  const queries = useQueries({ queries: selected.map((cap) => ({
+    queryKey: KEY_CAPABILITY_VERSIONS(workspaceID ?? "_none", cap.id),
+    queryFn: () => listCapabilityVersions(workspaceID as string, cap.id),
+    enabled: !!workspaceID,
+    retry: noUnreachableRetry,
+    staleTime: 30_000,
+  })) })
+  const rows = selected.map((cap, index) => {
+    const query = queries[index]
+    const versionID = versions[cap.id]?.versionID || cap.latest_version_id
+    const version = query.data?.versions.find((item) => item.id === versionID)
+    const source = bindings.find((binding) => binding.capability_id === cap.id)
+    const fields = (version?.required_credentials ?? []).filter((rc) => rc.required).map((rc) => {
+      const available = sharedSecretsForKind(secrets, rc.kind, catalogIDFromVersion(version))
+      // A per-capability personal binding overrides an Agent-wide shared one.
+      const original = credentialBinding(source?.configuration, rc.kind) ?? credentialBinding(sourceConfig, rc.kind)
+      const requested = choices[cap.id]?.[rc.kind] ?? original?.secretID ?? ""
+      const value = available.some((secret) => secret.id === requested) ? requested : ""
+      return { ...rc, available, value }
+    })
+    const configuration = withoutCredentialBindings(source?.configuration ?? {})
+    if (fields.length) configuration.credential_bindings = Object.fromEntries(fields
+      .filter((field) => field.value)
+      .map((field) => [field.kind, { source: "shared", secret_id: field.value }]))
+    return { capabilityID: cap.id, name: cap.name, versionID, fields, configuration,
+      ready: !!version,
+      failed: query.isError || (query.isSuccess && !version),
+    }
+  })
+  return {
+    rows,
+    ready: rows.every((row) => row.ready),
+    failed: rows.some((row) => row.failed),
+    valid: rows.every((row) => row.ready && row.fields.every((field) => field.value)),
+    needsCredentials: rows.some((row) => row.fields.length > 0),
+    retry: () => { for (const query of queries) void query.refetch() },
+    choose: (capabilityID: string, kind: string, secretID: string) => setChoices((prev) => ({
+      ...prev, [capabilityID]: { ...prev[capabilityID], [kind]: secretID },
+    })),
+  }
+}


### PR DESCRIPTION
Cloning an Agent copied its engine and model but lost its installed capabilities. The clone form now loads the source bindings, preserves enabled capabilities and version choices, and copies their configuration.

Shared credentials are checked and kept independently for each capability using its selected version. Personal or unavailable credentials require a replacement from the existing Credentials page. Model credentials keep a valid source selection or require an explicit choice. Fresh creation, editing, runtime resolution, and credential APIs are unchanged.

Validation: `make check` and web build passed. Browser fixtures verified captured clone payloads, independent MCP OAuth bindings, pinned versus latest credential requirements, personal/shared model credentials, new model secret entry, and version loading failure/retry. Local PostgreSQL migration smoke was skipped because Docker is stopped. Fresh independent blind review is pending.

Draft: deferred after review iterations. A catalog refresh can display latest v2 while submitting the cloned v1 binding. Version selection, displayed labels, credential validation and submission need one consistent rule before this PR can merge.
