### PR TITLE
fix(web): contain hidden Select form controls

### DIFF
--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -16,16 +16,16 @@ const itemValue = (value: string | number) => `value:${value}`
 
 export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
   ({ value, defaultValue, onValueChange, disabled, className, wrapperClassName, children, ...props }, ref) => (
-    <SelectPrimitive.Root
-      value={value === undefined ? undefined : itemValue(value)}
-      defaultValue={defaultValue === undefined ? undefined : itemValue(defaultValue)}
-      onValueChange={(next) => {
-        // The native form bridge emits an unencoded empty value while options load.
-        if (next.startsWith("value:")) onValueChange?.(next.slice(6))
-      }}
-      disabled={disabled}
-    >
-      <span className={cn("relative inline-flex min-w-0 w-full", wrapperClassName)}>
+    <span className={cn("relative inline-flex min-w-0 w-full", wrapperClassName)}>
+      <SelectPrimitive.Root
+        value={value === undefined ? undefined : itemValue(value)}
+        defaultValue={defaultValue === undefined ? undefined : itemValue(defaultValue)}
+        onValueChange={(next) => {
+          // The native form bridge emits an unencoded empty value while options load.
+          if (next.startsWith("value:")) onValueChange?.(next.slice(6))
+        }}
+        disabled={disabled}
+      >
         <SelectPrimitive.Trigger
           ref={ref}
           className={cn(
@@ -39,25 +39,25 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
             <ChevronDown className="h-3.5 w-3.5 shrink-0 text-fg-muted" strokeWidth={1.5} aria-hidden="true" />
           </SelectPrimitive.Icon>
         </SelectPrimitive.Trigger>
-      </span>
-      <SelectPrimitive.Portal>
-        <SelectPrimitive.Content
-          position="popper"
-          sideOffset={4}
-          collisionPadding={8}
-          className={cn(menuContentClass, "w-[var(--radix-select-trigger-width)] max-w-[var(--radix-select-content-available-width)] max-h-[min(18rem,var(--radix-select-content-available-height))]")}
-          onClick={(event) => event.stopPropagation()}
-        >
-          <SelectPrimitive.ScrollUpButton className="flex justify-center py-1 text-fg-muted">
-            <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
-          </SelectPrimitive.ScrollUpButton>
-          <SelectPrimitive.Viewport>{children}</SelectPrimitive.Viewport>
-          <SelectPrimitive.ScrollDownButton className="flex justify-center py-1 text-fg-muted">
-            <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
-          </SelectPrimitive.ScrollDownButton>
-        </SelectPrimitive.Content>
-      </SelectPrimitive.Portal>
-    </SelectPrimitive.Root>
+        <SelectPrimitive.Portal>
+          <SelectPrimitive.Content
+            position="popper"
+            sideOffset={4}
+            collisionPadding={8}
+            className={cn(menuContentClass, "w-[var(--radix-select-trigger-width)] max-w-[var(--radix-select-content-available-width)] max-h-[min(18rem,var(--radix-select-content-available-height))]")}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <SelectPrimitive.ScrollUpButton className="flex justify-center py-1 text-fg-muted">
+              <ChevronUp className="h-3.5 w-3.5" aria-hidden="true" />
+            </SelectPrimitive.ScrollUpButton>
+            <SelectPrimitive.Viewport>{children}</SelectPrimitive.Viewport>
+            <SelectPrimitive.ScrollDownButton className="flex justify-center py-1 text-fg-muted">
+              <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+            </SelectPrimitive.ScrollDownButton>
+          </SelectPrimitive.Content>
+        </SelectPrimitive.Portal>
+      </SelectPrimitive.Root>
+    </span>
   ),
 )
 Select.displayName = "Select"


### PR DESCRIPTION
Selecting capabilities in an Agent form and focusing Create could scroll the dialog title out of view. Keep the Select native form control inside the positioned trigger wrapper so it cannot enlarge the dialog scroll area.

Validation: `make check` and web build passed. Browser comparison reproduced the original title clipping and verified the corrected geometry, controlled empty/prefixed values, numeric keyboard selection, uncontrolled selection, disabled options, and selection inside a dialog. Local PostgreSQL migration smoke was skipped because Docker is stopped.

Scope: one shared component; no page, API, dependency, or selection behavior changes. Independent blind review completed with no blocking findings.
