### PR TITLE
fix(web): preserve console links across sign-in

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -577,6 +577,9 @@ otherwise long children push the grid track wider instead of wrapping.
 Authentication submission failures use the shared `ErrorDialog`, preserving
 form input and restoring action focus on dismissal. Field validation stays
 inline; sign-in-required invitation guidance stays visible as a guided step.
+The authenticated root owns post-login return navigation for password and SSO
+sign-in. Preserve allowed in-app paths, query parameters and fragments through
+the existing session return intent; login forms must not race that navigation.
 
 Pages with a detail rail may opt into wrapping header actions through
 `PageHeader.actionClassName` and an auto-height header. Other pages retain

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -72,9 +72,9 @@ function Root() {
   useEffect(() => {
     if (isLoading || !isAuthenticated) return
     if (joinWsId !== null) return
-    const pending = popPendingJoinIntent()
-    if (pending) {
-      window.location.replace(pending)
+    const destination = popPendingJoinIntent() ?? (window.location.pathname === "/login" ? "/" : null)
+    if (destination) {
+      window.location.replace(destination)
     }
   }, [isLoading, isAuthenticated, joinWsId])
 
@@ -88,9 +88,8 @@ function Root() {
     return <LoadingScreen message={t("login.loading")} />
   }
   if (!isAuthenticated) {
-    // Sign-in can leave by SSO redirect as well as by the form, and only the
-    // form comes back to the same address on its own.
-    if (sharedConversationId !== null) stashReturnTo()
+    // Preserve the destination before either password or SSO sign-in.
+    stashReturnTo()
     return <LoginPage />
   }
   // A shared conversation needs a signed-in workspace member and nothing else,

--- a/apps/web/src/lib/api-auth.ts
+++ b/apps/web/src/lib/api-auth.ts
@@ -112,6 +112,8 @@ export function useLoginWithPassword() {
       // Cookie is set by the 200 response; refresh me-query so AuthProvider
       // flips isAuthenticated -> true and the router mounts AuthedRoot.
       await qc.invalidateQueries({ queryKey: ["me"] })
+      // Retry session bootstrap if the new cookie could not be confirmed.
+      if (!qc.getQueryData(["me"])) window.location.reload()
     },
   })
 }

--- a/apps/web/src/lib/join-intent.ts
+++ b/apps/web/src/lib/join-intent.ts
@@ -14,11 +14,12 @@ const RETURNABLE = ["/join-workspace", "/c/", "/invite/"]
 
 function isReturnable(path: string): boolean {
   if (!path.startsWith("/") || path.startsWith("//")) return false
+  if (path.startsWith("/?") || path.startsWith("/#")) return true
   return RETURNABLE.some((prefix) => path.startsWith(prefix))
 }
 
 /** Remember the current address before handing off to sign-in. */
-export function stashReturnTo(path = window.location.pathname + window.location.search): void {
+export function stashReturnTo(path = window.location.pathname + window.location.search + window.location.hash): void {
   try {
     if (isReturnable(path)) sessionStorage.setItem(JOIN_INTENT_KEY, path)
   } catch {

--- a/apps/web/src/pages/InviteAcceptPage.tsx
+++ b/apps/web/src/pages/InviteAcceptPage.tsx
@@ -9,7 +9,7 @@ import { Field } from "../components/ui/label"
 import { useInviteInfo, useAcceptInvite } from "../lib/api-invitations"
 import { ApiError } from "../lib/api-client"
 import { useAuth } from "../lib/auth-context"
-import { stashReturnTo } from "../lib/join-intent"
+import { popPendingJoinIntent, stashReturnTo } from "../lib/join-intent"
 import { validateNewPassword } from "../lib/password-policy"
 import { setWorkspaceId } from "../lib/workspace"
 
@@ -78,6 +78,7 @@ export function InviteAcceptPage({ token }: { token: string }) {
     }
     try {
       const res = await acceptMut.mutateAsync({ token, password: isCurrentInvitee ? "" : password })
+      popPendingJoinIntent()
       setWorkspaceId(res.workspace_id)
       window.location.assign("/")
     } catch (err) {

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -12,7 +12,6 @@ import { Field } from "../components/ui/label"
 import { ApiError } from "../lib/api-client"
 import { useAuthProviders, useLoginWithPassword } from "../lib/api-auth"
 import { useBootstrapStatus } from "../lib/api-bootstrap"
-import { popPendingJoinIntent } from "../lib/join-intent"
 import { SetupPage } from "./SetupPage"
 
 /**
@@ -71,11 +70,6 @@ function SignInView() {
     if (invalid || submitting) return
     try {
       await loginM.mutateAsync({ email: email.trim(), password })
-      // Cookie set on 200; a full navigation so AuthProvider re-reads /me with
-      // the fresh cookie. Someone who followed a shared link signed in *at*
-      // that link and must land back on it; everyone else goes to the console,
-      // because reloading /login would leave the whole session on that path.
-      window.location.assign(popPendingJoinIntent() ?? afterLoginPath())
     } catch {
       /* mutation state carries the error */
     }
@@ -180,12 +174,6 @@ function SignInView() {
       )}
     </EntryPage>
   )
-}
-
-/** The address to resume at when no return-to was stashed. */
-function afterLoginPath(): string {
-  const here = window.location.pathname
-  return here === "/login" || here === "/" ? "/" : here + window.location.search
 }
 
 /**


### PR DESCRIPTION
Signing in from an Agent configuration or other console link dropped its query parameters and returned to the Agents list. Preserve allowed in-app paths, workspace/entity/tab parameters and fragments through password sign-in and SSO callbacks. Post-login navigation is owned by the authenticated root; a failed identity refresh retains the existing reload recovery. Completing invitation registration clears abandoned login intent so the newly joined workspace remains selected.

Validation: `make check` and the web build passed. Browser checks with synthetic authentication and read-only data covered password/SSO return, direct login, invalid-password retry, shared conversation and invitation paths, one-time identity-query failure, and switching from an old console link to invitation registration. Stored-path checks covered external-address rejection and one-time consumption. Two independent blind reviews were completed; their findings were corrected, with the final localized invitation cleanup self-reviewed and replayed in the browser. Local PostgreSQL migration smoke was skipped with Docker stopped.
