### PR TITLE
fix(web): clarify workspace archive confirmation

### DIFF
--- a/apps/web/src/i18n/locales/en-US/common.json
+++ b/apps/web/src/i18n/locales/en-US/common.json
@@ -81,8 +81,8 @@
       "createTitle": "Create workspace",
       "renameTitle": "Rename workspace",
       "archiveTitle": "Archive workspace",
-      "archiveDescription": "Archive \"{{name}}\"? The workspace will disappear from the switcher; existing members and agents stay in the database but become unreachable through the workspace JOIN.",
-      "archiveMarketplaceDependents": "If capabilities published by this workspace are still used by Agents in other workspaces, archive will be blocked. Unpublish first and wait for those workspaces to remove the capabilities.",
+      "archiveDescription": "Archive \"{{name}}\"? The workspace will be hidden and no longer accessible. Member and Agent data will be kept.",
+      "archiveMarketplaceDependents": "If other workspaces still use capabilities published here, unpublish those capabilities and ask their owners to remove them before archiving.",
       "namePlaceholder": "e.g. Platform Team"
     },
     "join": {

--- a/apps/web/src/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/i18n/locales/zh-CN/common.json
@@ -81,8 +81,8 @@
       "createTitle": "新建工作区",
       "renameTitle": "重命名工作区",
       "archiveTitle": "归档工作区",
-      "archiveDescription": "确认归档「{{name}}」？归档后将从切换器中消失，原有成员和 Agent 保留在数据库中，但通过工作区维度的查询都不会再返回。",
-      "archiveMarketplaceDependents": "如果这个工作区发布的市场能力仍被其它工作区的 Agent 使用，归档会被阻止。请先取消发布并等待对方移除后再归档。",
+      "archiveDescription": "归档「{{name}}」后，工作区将被隐藏，无法继续访问。成员和 Agent 数据会保留。",
+      "archiveMarketplaceDependents": "若其他工作区仍在使用这里发布的能力，请先取消发布，并联系对方移除这些能力后再归档。",
       "namePlaceholder": "例如：平台团队"
     },
     "join": {


### PR DESCRIPTION
The workspace archive confirmation exposed database and JOIN terminology. Replace its existing English and Chinese copy with concise access, data-retention, and marketplace-dependency guidance.

Only four translation values change. Archive behavior, permissions, validation, and dialog controls are unchanged. Developer self-review, `make check`, the web production build, and browser rendering of both languages passed. Local PostgreSQL migration smoke was skipped because Docker remains stopped.
