### PR TITLE
fix(web): distinguish system messages from agent replies

### DIFF
--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -834,7 +834,8 @@ const MessageRow = memo(function MessageRow({
       </div>
     )
   }
-  const byline = agentName ? `${agentName} · ${stamp}` : stamp
+  const senderName = senderType === "system" ? t("conversations.detail.systemSender") : agentName
+  const byline = senderName ? `${senderName} · ${stamp}` : stamp
   if (messageType === "runtime_error") {
     const runtimeError = runtimeErrorViewModel(metadata, content, conversationId, i18n.language, t)
     return (

--- a/apps/web/src/components/conversation/ParsarThread.tsx
+++ b/apps/web/src/components/conversation/ParsarThread.tsx
@@ -105,7 +105,7 @@ export function ParsarThread({
 const ThreadMessage: FC = () => {
   const role = useAuiState((s) => s.message.role)
   if (role === "user") return <UserMessage />
-  return <AssistantMessage />
+  return <AssistantMessage system={role === "system"} />
 }
 
 // ---------------------------------------------------------------------------
@@ -147,9 +147,11 @@ const UserMessage: FC = () => {
 // NOTE: "View run →" link for failed runs is not yet ported.
 // ---------------------------------------------------------------------------
 
-const AssistantMessage: FC = () => {
+const AssistantMessage: FC<{ system?: boolean }> = ({ system }) => {
+  const { t } = useTranslation("admin")
   return (
     <MessagePrimitive.Root className="relative">
+      {system && <div className="mb-1 text-xs text-fg-muted">{t("conversations.detail.systemSender")}</div>}
       <div className="text-base text-fg">
         <MessagePrimitive.GroupedParts
           groupBy={groupPartByType({

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -282,7 +282,8 @@
       "unnamed": "Untitled conversation",
       "emptyTimeline": "No messages yet",
       "viewRunLink": "View run details",
-      "externalUser": "IM user"
+      "externalUser": "IM user",
+      "systemSender": "System"
     },
     "runtime_error": {
       "badge": "Run failed",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -282,7 +282,8 @@
       "unnamed": "未命名对话",
       "emptyTimeline": "暂无消息",
       "viewRunLink": "查看运行详情",
-      "externalUser": "IM 用户"
+      "externalUser": "IM 用户",
+      "systemSender": "系统"
     },
     "runtime_error": {
       "badge": "运行失败",

--- a/apps/web/src/lib/parsar-chat-runtime.ts
+++ b/apps/web/src/lib/parsar-chat-runtime.ts
@@ -116,6 +116,15 @@ export function convertTimelineMessage(
     }
   }
 
+  if (msg.sender_type === "system" && msg.kind !== "runtime_error") {
+    return {
+      id: msg.id,
+      role: "system",
+      content: [{ type: "text", text: msg.content }],
+      createdAt: new Date(msg.created_at),
+    }
+  }
+
   // --- Assistant message ---
   const parts: Array<
     | { readonly type: "text"; readonly text: string }


### PR DESCRIPTION
Scheduled prompts were attributed to the Agent in conversation history. Label persisted system messages as “System” in both conversation renderers, preserving their role in the assistant-ui timeline adapter.

Existing user/IM alignment, Agent replies, message content, runtime-error cards, and execution behavior are preserved. No API or storage changes.

Validation: developer self-review, `make check`, and the web production build passed. Browser checks covered the real scheduled conversation in light/dark themes and the assistant-ui renderer with system, user, external, Agent, and runtime-error messages. Local PostgreSQL migration smoke was skipped with Docker stopped.
