### PR TITLE
fix(web): expose scheduled task run history

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -2484,6 +2484,16 @@
       "agentRequired": "Select an executing agent",
       "promptRequired": "Prompt is required",
       "cronInvalid": "cron must have 5 fields (min hour dom mon dow)"
+    },
+    "history": {
+      "title": "Run history",
+      "description": "{{name}} · Up to 50 recent runs",
+      "open": "View run history for {{name}}",
+      "empty": "No runs yet",
+      "emptyDescription": "Run this task or wait for its next scheduled time.",
+      "loadError": "Could not load run history",
+      "openRun": "View run",
+      "openConversation": "View conversation"
     }
   },
   "shared": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -2484,6 +2484,16 @@
       "agentRequired": "请选择执行 Agent",
       "promptRequired": "请填写 Prompt",
       "cronInvalid": "cron 表达式需为 5 段（分 时 日 月 周）"
+    },
+    "history": {
+      "title": "执行历史",
+      "description": "{{name}} · 最近 50 次执行",
+      "open": "查看「{{name}}」的执行历史",
+      "empty": "暂无执行记录",
+      "emptyDescription": "执行此任务，或等待下一次计划时间。",
+      "loadError": "无法加载执行历史",
+      "openRun": "查看执行详情",
+      "openConversation": "查看会话"
     }
   },
   "shared": {

--- a/apps/web/src/lib/api-scheduled-tasks.ts
+++ b/apps/web/src/lib/api-scheduled-tasks.ts
@@ -128,6 +128,7 @@ export function useScheduledTaskRuns(taskID: string | null) {
     enabled: Boolean(taskID),
     retry: noUnreachableRetry,
     staleTime: 10_000,
+    refetchInterval: 5_000,
   })
 }
 

--- a/apps/web/src/lib/scheduled-task-format.ts
+++ b/apps/web/src/lib/scheduled-task-format.ts
@@ -1,0 +1,33 @@
+import type { StatusKind } from "../components/ui/status-icon"
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0")
+}
+
+/** The last run's outcome as the ledger's status icon; a task that never ran is "queued". */
+export function scheduledTaskStatusIcon(status: string): StatusKind {
+  switch (status) {
+    case "running":
+      return "running"
+    case "completed":
+      return "completed"
+    case "failed":
+      return "failed"
+    case "cancelled":
+    case "skipped_overlap":
+      return "cancelled"
+    case "interrupted":
+    case "auto_disabled":
+      return "interrupted"
+    default:
+      return "queued"
+  }
+}
+
+export function formatScheduledTaskTime(iso: string | null): string {
+  if (!iso) return "—"
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+}
+

--- a/apps/web/src/pages/admin/ScheduledTasksPage.tsx
+++ b/apps/web/src/pages/admin/ScheduledTasksPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import type { TFunction } from "i18next"
 import { AlertTriangle, CalendarClock, Loader2, Pencil, Play, Plus, Power, Trash2 } from "lucide-react"
@@ -44,11 +44,14 @@ import { OffsetPagination } from "../../components/ui/offset-pagination"
 import { Property, PropertyList } from "../../components/ui/property-list"
 import { Select, SelectOption } from "../../components/ui/select"
 import { Skeleton } from "../../components/ui/skeleton"
-import { StatusIcon, type StatusKind } from "../../components/ui/status-icon"
+import { StatusIcon } from "../../components/ui/status-icon"
 import { Textarea } from "../../components/ui/textarea"
 import { ApiError } from "../../lib/api-client"
 import { useAgents } from "../../lib/api-agents"
 import { useMyWorkspaces } from "../../lib/api-workspaces"
+import { useNavigateAdmin } from "../../lib/admin-router"
+import { scheduledTaskStatusIcon, formatScheduledTaskTime } from "../../lib/scheduled-task-format"
+import { ScheduledTaskHistoryDialog } from "./scheduled/ScheduledTaskHistoryDialog"
 import { useWorkspaceId } from "../../lib/workspace"
 import type { Agent } from "../../lib/api-types"
 import {
@@ -173,33 +176,6 @@ function describeCron(cron: string, t: TFunction<"admin">, weekdays: string[]): 
   return ""
 }
 
-/** The last run's outcome as the ledger's status icon; a task that never ran is "queued". */
-function lastStatusIcon(status: string): StatusKind {
-  switch (status) {
-    case "running":
-      return "running"
-    case "completed":
-      return "completed"
-    case "failed":
-      return "failed"
-    case "cancelled":
-    case "skipped_overlap":
-      return "cancelled"
-    case "interrupted":
-    case "auto_disabled":
-      return "interrupted"
-    default:
-      return "queued"
-  }
-}
-
-function fmtWhen(iso: string | null): string {
-  if (!iso) return "—"
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return iso
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
-}
-
 /* ------------------------------------------------------------------ */
 /*  Page                                                               */
 /* ------------------------------------------------------------------ */
@@ -208,6 +184,9 @@ export function ScheduledTasksPage() {
   const { t } = useTranslation("admin")
   const { t: tc } = useTranslation("common")
   const workspaceID = useWorkspaceId()
+  const navigate = useNavigateAdmin()
+  const [historyTask, setHistoryTask] = useState<ScheduledTask | null>(null)
+  const historyTrigger = useRef<HTMLButtonElement | null>(null)
   const workspacesQ = useMyWorkspaces()
   const [offset, setOffset] = useState(0)
   const tasksQ = useScheduledTasksByWorkspace(workspaceID, { offset, limit: SCHED_PAGE_SIZE })
@@ -228,6 +207,7 @@ export function ScheduledTasksPage() {
   if (offsetKey !== (workspaceID ?? "")) {
     setOffsetKey(workspaceID ?? "")
     setOffset(0)
+    setHistoryTask(null)
   }
 
   const weekdays = (t("scheduledTasks.weekdays", { returnObjects: true }) as unknown as string[]) ?? []
@@ -366,9 +346,18 @@ export function ScheduledTasksPage() {
                     data-testid="scheduled-row"
                     data-task-name={task.name}
                   >
-                    <StatusIcon status={lastStatusIcon(task.last_status)} title={t(`scheduledTasks.status.${statusKey}` as never)} />
+                    <StatusIcon status={scheduledTaskStatusIcon(task.last_status)} title={t(`scheduledTasks.status.${statusKey}` as never)} />
                     <span className="flex min-w-0 items-center gap-1.5">
-                      <span className="truncate font-medium" title={task.prompt}>{task.name}</span>
+                      <button
+                        className="min-w-0 truncate rounded-sm text-left font-medium underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                        title={task.prompt}
+                        aria-label={t("scheduledTasks.history.open", { name: task.name })}
+                        aria-haspopup="dialog"
+                        onClick={(event) => {
+                          historyTrigger.current = event.currentTarget
+                          setHistoryTask(task)
+                        }}
+                      >{task.name}</button>
                       {!task.enabled && (
                         <Badge variant="neutral" dot className="shrink-0">{t("scheduledTasks.disabled")}</Badge>
                       )}
@@ -384,8 +373,14 @@ export function ScheduledTasksPage() {
                       <InitialTile name={agent} />
                       <span className="truncate">{agent}</span>
                     </span>
-                    <LedgerNum muted={!task.next_run_at}>{fmtWhen(task.next_run_at)}</LedgerNum>
-                    <LedgerNum muted={!task.last_run_at}>{fmtWhen(task.last_run_at)}</LedgerNum>
+                    <LedgerNum muted={!task.next_run_at}>{formatScheduledTaskTime(task.next_run_at)}</LedgerNum>
+                    <LedgerNum muted={!task.last_run_at}>
+                      {task.last_run_id ? (
+                        <Button variant="link" className="h-auto p-0 font-mono font-normal" title={t("scheduledTasks.history.openRun")} onClick={() => navigate("runs", { id: task.last_run_id })}>
+                          {formatScheduledTaskTime(task.last_run_at)}
+                        </Button>
+                      ) : formatScheduledTaskTime(task.last_run_at)}
+                    </LedgerNum>
                     {canManageTasks ? (
                     <RowActions>
                       <ActionIconButton
@@ -434,6 +429,19 @@ export function ScheduledTasksPage() {
           />
         )}
       </div>
+
+      {historyTask && (
+        <ScheduledTaskHistoryDialog
+          task={historyTask}
+          onClose={() => setHistoryTask(null)}
+          onCloseAutoFocus={(event) => {
+            if (historyTrigger.current?.isConnected) {
+              event.preventDefault()
+              historyTrigger.current.focus()
+            }
+          }}
+        />
+      )}
 
       {dialogOpen && canManageTasks && (
         <ScheduledTaskDialog

--- a/apps/web/src/pages/admin/scheduled/ScheduledTaskHistoryDialog.tsx
+++ b/apps/web/src/pages/admin/scheduled/ScheduledTaskHistoryDialog.tsx
@@ -1,0 +1,62 @@
+import { History } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { Button } from "../../../components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../../../components/ui/dialog"
+import { EmptyState } from "../../../components/ui/empty-state"
+import { ErrorState } from "../../../components/ui/error-state"
+import { Skeleton } from "../../../components/ui/skeleton"
+import { StatusIcon } from "../../../components/ui/status-icon"
+import { useNavigateAdmin } from "../../../lib/admin-router"
+import { useScheduledTaskRuns, type ScheduledTask } from "../../../lib/api-scheduled-tasks"
+import { formatScheduledTaskTime, scheduledTaskStatusIcon } from "../../../lib/scheduled-task-format"
+
+export function ScheduledTaskHistoryDialog({ task, onClose, onCloseAutoFocus }: {
+  task: ScheduledTask
+  onClose: () => void
+  onCloseAutoFocus: (event: Event) => void
+}) {
+  const { t } = useTranslation("admin")
+  const navigate = useNavigateAdmin()
+  const runsQ = useScheduledTaskRuns(task.id)
+  const runs = runsQ.data ?? []
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent className="max-h-[calc(100vh-2rem)] w-[calc(100%-2rem)] max-w-lg overflow-x-hidden overflow-y-auto" onCloseAutoFocus={onCloseAutoFocus}>
+        <DialogHeader>
+          <DialogTitle>{t("scheduledTasks.history.title")}</DialogTitle>
+          <DialogDescription className="break-words">{t("scheduledTasks.history.description", { name: task.name })}</DialogDescription>
+        </DialogHeader>
+        {runsQ.isLoading ? (
+          <div className="space-y-3" aria-busy="true">
+            {Array.from({ length: 3 }, (_, index) => <Skeleton key={index} className="h-14 w-full" />)}
+          </div>
+        ) : runsQ.error ? (
+          <ErrorState title={t("scheduledTasks.history.loadError")} detail={runsQ.error instanceof Error ? runsQ.error.message : undefined} onRetry={() => void runsQ.refetch()} />
+        ) : runs.length === 0 ? (
+          <EmptyState icon={History} size="compact" title={t("scheduledTasks.history.empty")} description={t("scheduledTasks.history.emptyDescription")} />
+        ) : (
+          <ul className="m-0 list-none divide-y divide-line p-0">
+            {runs.map((run) => (
+              <li key={run.id} className="flex min-w-0 flex-wrap items-center justify-between gap-x-4 gap-y-2 py-3 first:pt-0 last:pb-0">
+                <div className="min-w-0 space-y-1">
+                  <span className="flex items-center gap-1.5 font-medium">
+                    <StatusIcon status={scheduledTaskStatusIcon(run.status)} />
+                    {t(`scheduledTasks.status.${run.status}` as never, { defaultValue: run.status })}
+                  </span>
+                  <time dateTime={run.created_at} className="font-mono text-xs text-fg-muted">{formatScheduledTaskTime(run.created_at)}</time>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button variant="outline" size="sm" onClick={() => navigate("runs", { id: run.id })}>{t("scheduledTasks.history.openRun")}</Button>
+                  {run.conversation_id && (
+                    <Button variant="outline" size="sm" onClick={() => navigate("conversations", { id: run.conversation_id })}>{t("scheduledTasks.history.openConversation")}</Button>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
Scheduled tasks now expose recent execution history from the task name, with links to each run and its result conversation. The latest-run timestamp also opens that run directly. Previously users had to find the result manually in Runs or Conversations.

The history uses the existing endpoint (up to 50 recent runs), refreshes while open, and handles loading, empty, and error states. Status and time presentation is shared with the task list. Scope is limited to scheduled-task web presentation and the existing read query; scheduling, execution, API contracts, and permissions are unchanged.

Validation: `make check` and production web build pass. Browser verification covered real remote history and run/conversation destinations, synthetic empty/error recovery and 50-row history, English/Chinese, light/dark themes, 360 × 640 layout without horizontal overflow, and focus returning to the task name. Self-reviewed as a limited read-only UI change. Local Docker remained stopped; the repository's Postgres migration smoke test was skipped for that reason.
