### PR TITLE
fix(web): render assistant reply Markdown in conversation views

### DIFF
--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -15,6 +15,7 @@ import {
 import { PageHeader } from "../layout/PageHeader"
 import { ApprovalBar } from "./ApprovalBar"
 import { ConversationInteractionCards } from "./ConversationInteractionCards"
+import { MessageMarkdown } from "./MessageMarkdown"
 import { WorkTrace, type TraceStep } from "./WorkTrace"
 import { Button } from "../ui/button"
 import { EmptyState } from "../ui/empty-state"
@@ -876,7 +877,9 @@ const MessageRow = memo(function MessageRow({
       <ToolCardSlot
         presentation={presentation}
         content={content}
-        fallback={<p className="m-0 whitespace-pre-wrap break-words text-base text-fg">{content}</p>}
+        fallback={senderType === "agent"
+          ? <MessageMarkdown content={content} />
+          : <p className="m-0 whitespace-pre-wrap break-words text-base text-fg">{content}</p>}
       />
       {failedRun && onOpenRun && (
         <Button variant="link" size="sm" className="mt-1 px-0" onClick={() => onOpenRun(failedRun.id)}>

--- a/apps/web/src/components/conversation/MessageMarkdown.tsx
+++ b/apps/web/src/components/conversation/MessageMarkdown.tsx
@@ -1,0 +1,11 @@
+import ReactMarkdown from "react-markdown"
+
+export function MessageMarkdown({ content }: { content: string }) {
+  return (
+    <div className="prose prose-sm min-w-0 max-w-none text-fg [overflow-wrap:anywhere] prose-p:my-1.5 prose-pre:my-3 prose-pre:whitespace-pre-wrap prose-pre:break-all prose-pre:rounded-md prose-pre:bg-surface-muted prose-pre:text-fg prose-code:text-fg prose-code:before:content-none prose-code:after:content-none prose-a:text-fg prose-a:underline prose-a:underline-offset-4 prose-blockquote:text-fg prose-blockquote:border-line prose-headings:text-fg prose-strong:text-fg prose-strong:font-medium">
+      <ReactMarkdown components={{ h1: ({ children }) => <h2>{children}</h2> }}>
+        {content}
+      </ReactMarkdown>
+    </div>
+  )
+}

--- a/apps/web/src/components/conversation/ParsarThread.tsx
+++ b/apps/web/src/components/conversation/ParsarThread.tsx
@@ -266,7 +266,7 @@ const AssistantTextPart: FC = () => {
   }
 
   return (
-    <div className="prose prose-sm max-w-none text-fg prose-p:my-1.5 prose-pre:my-3 prose-pre:rounded-md prose-pre:bg-surface-muted prose-pre:text-fg prose-code:text-fg prose-code:before:content-none prose-code:after:content-none prose-a:text-fg prose-a:underline prose-a:underline-offset-4 prose-headings:text-fg prose-strong:text-fg prose-strong:font-medium">
+    <div className="prose prose-sm max-w-none text-fg prose-p:my-1.5 prose-pre:my-3 prose-pre:rounded-md prose-pre:bg-surface-muted prose-pre:text-fg prose-code:text-fg prose-code:before:content-none prose-code:after:content-none prose-a:text-fg prose-a:underline prose-a:underline-offset-4 prose-blockquote:text-fg prose-blockquote:border-line prose-headings:text-fg prose-strong:text-fg prose-strong:font-medium">
       <MarkdownTextPrimitive />
     </div>
   )


### PR DESCRIPTION
Assistant replies in console and shared conversations now render Markdown paragraphs, emphasis, headings, lists, links, quotes, and code instead of displaying the raw formatting characters. The same fallback handles persisted replies and incoming text; user, external, and system text, tool presentations, and runtime-error handling keep their existing behavior. Quote text and borders use theme colors in both chat renderers.

Validation: `make check` and production web build pass. Browser checks used the original reported conversation in console and shared views, plus incomplete/complete Markdown fixtures. Long code wrapped within 320 px, script and raw image HTML stayed inert, and JavaScript URLs were removed while HTTPS links remained. One independent blind review found dark-mode quote contrast; the small theme correction was self-reviewed and browser-verified in both chat renderers. No dependencies or API/runtime behavior changed.
