### PR TITLE
fix(web): explain invalid agent working directories before submit

### DIFF
--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -1209,12 +1209,14 @@ export function CreateAgentDialog({
                 <Field
                   label={t("agents.form.fields.workDir")}
                   hint={t(executionMode === "sandbox" ? "agents.form.workDir.hintSandbox" : "agents.form.workDir.hintLocal")}
-                  error={submitAttempted && workDir.trim() !== "" && !isUsableWorkDir(workDir.trim()) ? t("agents.form.errors.workDirAbsolute") : undefined}
+                  error={!workDirValid ? t("agents.form.errors.workDirAbsolute") : undefined}
                 >
                   <Input
                     value={workDir}
                     onChange={(e) => setWorkDir(e.target.value)}
                     placeholder={t("agents.form.workDir.placeholder")}
+                    aria-label={t("agents.form.fields.workDir")}
+                    aria-invalid={!workDirValid}
                     disabled={pending}
                     spellCheck={false}
                     autoCapitalize="off"


### PR DESCRIPTION
An invalid relative working directory disabled Next before the user could submit, so its submit-only error never appeared. Show the existing inline path error immediately and expose the field's accessible name and invalid state.

The change is limited to field feedback in the shared create/edit dialog. Path validation, button gating, submitted configuration and capability selection are unchanged.

Validation: `make check`, production web build and diff review passed. Browser checks covered relative, absolute, `~/` and empty paths, error recovery, and navigation to the next step in the edit flow. This small localized change was self-reviewed.
