### PR TITLE
fix(web): guide agent setup when no capabilities exist

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1429,8 +1429,8 @@
         "description": "Go to Models to onboard one. The fields you typed here will be carried over so you can come back.",
         "cta": "Configure Model"
       },
-      "noTagsAdmin": "This workspace has no reusable capability tags yet.",
-      "noTagsMember": "This workspace has no reusable capability tags yet.",
+      "noTagsAdmin": "No skills or MCP tools are available yet. These are optional: save the Agent now, then add capabilities on the Capabilities page and enable them in the Agent’s Config tab.",
+      "noTagsMember": "No skills or MCP tools are available yet. These are optional: save the Agent now, then ask a workspace administrator to add capabilities and enable them in the Agent’s Config tab.",
       "noCapabilityVersion": "No version",
       "deprecatedCapabilityBadge": "Deprecated",
       "deprecatedCapabilityTooltip": "This capability has been deprecated. Existing bindings keep working; once you uncheck it you cannot re-add it.",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1429,8 +1429,8 @@
         "description": "先去 Models 页接入一个模型；当前已填内容会带过去，配完后可以回到新建 Agent。",
         "cta": "去配置 Model"
       },
-      "noTagsAdmin": "当前工作区还没有可复用的能力标签。",
-      "noTagsMember": "当前工作区还没有可复用的能力标签。",
+      "noTagsAdmin": "当前还没有可用的 Skill 或 MCP 工具，能力配置是可选的。可以先保存 Agent，之后在「能力」页添加，再到 Agent 的「配置」中启用。",
+      "noTagsMember": "当前还没有可用的 Skill 或 MCP 工具，能力配置是可选的。可以先保存 Agent，之后请工作区管理员添加能力，再到 Agent 的「配置」中启用。",
       "noCapabilityVersion": "无可用版本",
       "deprecatedCapabilityBadge": "已下架",
       "deprecatedCapabilityTooltip": "该能力已下架,保留旧绑定可继续使用;取消勾选后无法再选回。",


### PR DESCRIPTION
The empty Agent capability picker called skills and MCP tools “tags” and gave first-time users no next step. Explain that capabilities are optional, that they can save the Agent now, and where to add and enable capabilities later. Member copy directs users to a workspace administrator for adding capabilities.

This changes only the existing English and Chinese empty-state text. Navigation, form state, permissions and import behavior are unchanged.

Validation: `make check`, production web build and copy self-review passed. The real creation dialog was checked with a synthetic empty catalog in English/dark and Chinese/light; Create Agent remains enabled without capability selection.
