### PR TITLE
fix(web): distinguish empty capability search results

### DIFF
--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -1511,7 +1511,7 @@ export function CreateAgentDialog({
                 <Input value={capabilitySearch} onChange={(e) => setCapabilitySearch(e.target.value)} placeholder={t("agents.form.placeholders.capabilitySearch")} />
                 {capabilityOptions.length === 0 ? (
                   <p className="py-2 text-sm text-fg-muted">
-                    {admin ? t("agents.form.noTagsAdmin") : t("agents.form.noTagsMember")}
+                    {capabilitySearch.trim() ? tc("states.noResults") : admin ? t("agents.form.noTagsAdmin") : t("agents.form.noTagsMember")}
                   </p>
                 ) : (
                   <>


### PR DESCRIPTION
Searching for a capability with no matches incorrectly said the workspace had no capabilities. Use the existing no-results message when a search term is present, preserving the unfiltered empty-catalog guidance.

Only the empty-state text condition changes. Capability queries, selection and submission are unchanged.

Validation: `make check`, production web build and self-review passed. Browser verification against the existing six-capability workspace confirmed no-results feedback and catalog recovery after clearing the search.
