### PR TITLE
fix(web): align agent actions with workspace permissions

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -995,6 +995,8 @@
       "title": "Agents"
     },
     "actions": {
+      "chatReadOnly": "Read-only access. Ask a workspace administrator for Member access to start conversations.",
+      "chatFailed": "Could not start the conversation. Please try again.",
       "create": "New Agent",
       "chat": "Chat",
       "edit": "Edit",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -995,6 +995,8 @@
       "title": "Agent"
     },
     "actions": {
+      "chatReadOnly": "当前为只读权限。请联系工作区管理员，获得成员权限后即可发起对话。",
+      "chatFailed": "无法开始对话，请重试。",
       "create": "新建 Agent",
       "chat": "聊一下",
       "edit": "编辑",

--- a/apps/web/src/lib/agent-actions.ts
+++ b/apps/web/src/lib/agent-actions.ts
@@ -1,0 +1,39 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { useToast } from "../components/ui/toast"
+import { useAdminView } from "./admin-router"
+import { ApiError } from "./api-client"
+import { createAgentConversation } from "./api-conversations"
+import type { Agent, UserWorkspace } from "./api-types"
+
+export function agentActionPermissions(role?: UserWorkspace["role"]) {
+  const canManage = role === "owner" || role === "admin"
+  return { canManage, canChat: canManage || role === "member" }
+}
+
+export function useAgentChat(workspaceID: string | null, canChat: boolean) {
+  const { t, i18n } = useTranslation("admin")
+  const { navigate } = useAdminView()
+  const toast = useToast()
+  const [pendingID, setPendingID] = useState<string | null>(null)
+
+  async function startChat(agent: Agent) {
+    if (!workspaceID || !canChat || pendingID || agent.status !== "active") return
+    setPendingID(agent.id)
+    try {
+      const conversation = await createAgentConversation(workspaceID, agent, i18n.language)
+      navigate("conversations", { id: conversation.id, focus: "compose" })
+    } catch (error) {
+      const forbidden = error instanceof ApiError && error.envelope.status === 403
+      toast.show(t(forbidden ? "agents.actions.chatReadOnly" : "agents.actions.chatFailed"), {
+        tone: "error",
+        detail: !forbidden && error instanceof Error ? error.message : undefined,
+      })
+    } finally {
+      setPendingID(null)
+    }
+  }
+
+  return { startChat, pendingID }
+}

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../components/ui/tabs"
 import { useAdminView, useAppRoute } from "../../lib/admin-router"
 import { ApiError } from "../../lib/api-client"
+import { agentActionPermissions, useAgentChat } from "../../lib/agent-actions"
 import { createAgentConversation } from "../../lib/api-conversations"
 import {
   useCreateAgent,
@@ -98,7 +99,6 @@ export function AgentsPage() {
   const [cloneAgent, setCloneAgent] = useState<Agent | null>(null)
   const [deleteTarget, setDeleteTarget] = useState<Agent | null>(null)
   const toast = useToast()
-  const [chatPendingID, setChatPendingID] = useState<string | null>(null)
   const fmtAgo = useRelativeTime()
 
   const query = useAgents(wid)
@@ -137,6 +137,8 @@ export function AgentsPage() {
   const currentWorkspace = workspacesQ.data?.workspaces.find((w) => w.id === wid)
   const workspaceRole = currentWorkspace?.role
   const workspaceName = currentWorkspace?.name
+  const { canManage, canChat } = agentActionPermissions(workspaceRole)
+  const { startChat: startChatWith, pendingID: chatPendingID } = useAgentChat(wid, canChat)
   const pendingCapability = usePendingCapability(wid)
 
   const err = query.error
@@ -155,19 +157,6 @@ export function AgentsPage() {
       onClosed={() => setRailID(null)}
     />
   ) : null
-
-  async function startChatWith(a: Agent) {
-    if (!wid || chatPendingID) return
-    setChatPendingID(a.id)
-    try {
-      const conversation = await createAgentConversation(wid, a, i18n.language)
-      navigate("conversations", { id: conversation.id, focus: "compose" })
-    } catch {
-      navigate("agents", { id: a.id })
-    } finally {
-      setChatPendingID(null)
-    }
-  }
 
   return (
     <AdminLayout activeMenu="agents" fullBleed>
@@ -210,10 +199,10 @@ export function AgentsPage() {
                   ))}
                 </FilterGroup>
               </FilterMenu>
-              <Button onClick={() => setCreateOpen(true)}>
+              {canManage && <Button onClick={() => setCreateOpen(true)}>
                 <Plus strokeWidth={1.5} aria-hidden="true" />
                 {t("agents.actions.create")}
-              </Button>
+              </Button>}
             </>
           }
         />
@@ -258,6 +247,7 @@ export function AgentsPage() {
         ) : (
           <AgentsListTable
             agents={agents}
+            workspaceRole={workspaceRole}
             models={models}
             keyword={keyword}
             connectorFilter={connectorFilter}
@@ -279,7 +269,7 @@ export function AgentsPage() {
       </RailLayout>
 
       <CreateAgentDialog
-        open={createOpen}
+        open={createOpen && canManage}
         mode="create"
         workspaceID={wid}
         workspaceName={workspaceName}
@@ -313,7 +303,7 @@ export function AgentsPage() {
       />
 
       <CreateAgentDialog
-        open={editAgent !== null}
+        open={editAgent !== null && canManage}
         mode="edit"
         workspaceID={wid}
         workspaceName={workspaceName}
@@ -346,7 +336,7 @@ export function AgentsPage() {
       />
 
       <CreateAgentDialog
-        open={cloneAgent !== null}
+        open={cloneAgent !== null && canManage}
         mode="create"
         workspaceID={wid}
         workspaceName={workspaceName}
@@ -372,7 +362,7 @@ export function AgentsPage() {
       />
 
       <DeleteAgentDialog
-        agent={deleteTarget}
+        agent={canManage ? deleteTarget : null}
         pending={deleteMut.isPending}
         error={deleteMut.error}
         onCancel={() => {

--- a/apps/web/src/pages/admin/agents/AgentDetailActions.tsx
+++ b/apps/web/src/pages/admin/agents/AgentDetailActions.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { Button } from "../../../components/ui/button"
 import { useDeleteAgent, useUpdateAgent, useUpdateAgentProfile } from "../../../lib/api-agents"
-import { createAgentConversation } from "../../../lib/api-conversations"
+import { agentActionPermissions, useAgentChat } from "../../../lib/agent-actions"
 import type { Agent, Model, UserWorkspace } from "../../../lib/api-types"
 import { useAdminView } from "../../../lib/admin-router"
 import { CreateAgentDialog } from "../CreateAgentDialog"
@@ -26,24 +26,21 @@ export function AgentDetailActions({
   models: Model[]
   onToast: ShowToast
 }) {
-  const { t, i18n } = useTranslation("admin")
+  const { t } = useTranslation("admin")
   const { navigate } = useAdminView()
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
-  const [chatPending, setChatPending] = useState(false)
+  const { canManage, canChat } = agentActionPermissions(workspaceRole)
+  const { startChat, pendingID } = useAgentChat(workspaceID, canChat)
+  const chatPending = pendingID !== null
   const updateMut = useUpdateAgent(workspaceID)
   const updateProfileMut = useUpdateAgentProfile(workspaceID)
   const deleteMut = useDeleteAgent(workspaceID)
 
-  async function startChat() {
-    if (!workspaceID || chatPending) return
-    setChatPending(true)
-    try {
-      const conversation = await createAgentConversation(workspaceID, agent, i18n.language)
-      navigate("conversations", { id: conversation.id, focus: "compose" })
-    } finally {
-      setChatPending(false)
-    }
+  if (!canChat) {
+    return workspaceRole === "viewer"
+      ? <p className="text-sm text-fg-muted">{t("agents.actions.chatReadOnly")}</p>
+      : null
   }
 
   return (
@@ -51,7 +48,7 @@ export function AgentDetailActions({
       <Button
         variant="outline"
         disabled={agent.status !== "active" || chatPending}
-        onClick={() => void startChat()}
+        onClick={() => void startChat(agent)}
       >
         {chatPending ? (
           <Loader2 className="animate-spin" strokeWidth={1.5} aria-hidden="true" />
@@ -60,6 +57,7 @@ export function AgentDetailActions({
         )}
         {t("agents.actions.chat")}
       </Button>
+      {canManage && <>
       <Button
         variant="outline"
         disabled={deleteMut.isPending}
@@ -128,6 +126,7 @@ export function AgentDetailActions({
           })
         }}
       />
+      </>}
     </>
   )
 }

--- a/apps/web/src/pages/admin/agents/AgentRowActions.tsx
+++ b/apps/web/src/pages/admin/agents/AgentRowActions.tsx
@@ -8,6 +8,7 @@ import type { Agent } from "../../../lib/api-types"
 
 export function AgentRowActions({
   agent,
+  canManage,
   chatPending,
   deletePending,
   onChat,
@@ -16,6 +17,7 @@ export function AgentRowActions({
   onDelete,
 }: {
   agent: Agent
+  canManage: boolean
   chatPending: boolean
   deletePending: boolean
   onChat: () => void
@@ -35,7 +37,7 @@ export function AgentRowActions({
         disabled={!enabled}
         onClick={onChat}
       />
-      <DropdownMenu.Root>
+      {canManage && <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild>
           <Button
             variant="ghost"
@@ -61,7 +63,7 @@ export function AgentRowActions({
             <MenuItem icon={Trash2} label={t("agents.actions.delete")} disabled={deletePending} onSelect={onDelete} />
           </DropdownMenu.Content>
         </DropdownMenu.Portal>
-      </DropdownMenu.Root>
+      </DropdownMenu.Root>}
     </RowActions>
   )
 }

--- a/apps/web/src/pages/admin/agents/AgentsListTable.tsx
+++ b/apps/web/src/pages/admin/agents/AgentsListTable.tsx
@@ -14,7 +14,8 @@ import {
   agentEngineOf,
   defaultModelOf,
 } from "../../../lib/agent-view-model"
-import type { Agent, Model } from "../../../lib/api-types"
+import { agentActionPermissions } from "../../../lib/agent-actions"
+import type { Agent, Model, UserWorkspace } from "../../../lib/api-types"
 import { cn } from "../../../lib/utils"
 import { AgentRowActions } from "./AgentRowActions"
 import { AgentRuntimeCell } from "./AgentRuntimeCell"
@@ -25,6 +26,7 @@ export const AGENTS_LEDGER_COLUMNS = [col.icon(), col.title(0), col.meta(0), col
 
 export function AgentsListTable({
   agents,
+  workspaceRole,
   models,
   keyword,
   connectorFilter,
@@ -40,6 +42,7 @@ export function AgentsListTable({
   onDelete,
 }: {
   agents: Agent[]
+  workspaceRole?: UserWorkspace["role"]
   models: Model[]
   keyword: string
   connectorFilter: string
@@ -55,6 +58,8 @@ export function AgentsListTable({
   onDelete: (agent: Agent) => void
 }) {
   const { t } = useTranslation("admin")
+  const { canManage, canChat } = agentActionPermissions(workspaceRole)
+  const columns = [...AGENTS_LEDGER_COLUMNS.slice(0, -1), ...(canChat ? [col.actions(canManage ? 2 : 1)] : [])]
   const unavailable = t("agents.modelUnavailable")
   const filtered = searchAgents(agents, keyword, models, t).filter(
     (agent) => !connectorFilter || agentConnectorKey(agent.connector_type) === connectorFilter,
@@ -76,7 +81,7 @@ export function AgentsListTable({
   }
 
   return (
-    <Ledger columns={AGENTS_LEDGER_COLUMNS} className="@container/agent-list" role="listbox" aria-label={t("agents.page.title")}>
+    <Ledger columns={columns} className="@container/agent-list" role="listbox" aria-label={t("agents.page.title")}>
       <LedgerHeader className="@max-3xl/agent-list:hidden">
         <span />
         <span>{t("agents.table.agent")}</span>
@@ -85,7 +90,7 @@ export function AgentsListTable({
         <span>{t("agents.table.connector")}</span>
         <span>{t("agents.table.model")}</span>
         <span className="text-right">{t("agents.table.updated")}</span>
-        <span />
+        {canChat && <span />}
       </LedgerHeader>
       <ul className="m-0 list-none p-0">
         {filtered.map((agent) => {
@@ -108,7 +113,7 @@ export function AgentsListTable({
             <LedgerRow key={agent.id} selected={agent.id === selectedID} onClick={() => onOpenAgent(agent)} onKeyDown={onKeyDown} className="@max-3xl/agent-list:h-auto @max-3xl/agent-list:py-2">
               <span className="@max-3xl/agent-list:hidden"><AgentStatusIcon status={agent.status} /></span>
               <div className="min-w-0 @max-3xl/agent-list:col-span-full">
-                <div className="flex min-w-0 items-center gap-1.5 @max-3xl/agent-list:min-h-7 @max-3xl/agent-list:items-start @max-3xl/agent-list:pr-20">
+                <div className={cn("flex min-w-0 items-center gap-1.5 @max-3xl/agent-list:min-h-7 @max-3xl/agent-list:items-start", canChat && (canManage ? "@max-3xl/agent-list:pr-20" : "@max-3xl/agent-list:pr-12"))}>
                   <span className="mt-0.5 hidden @max-3xl/agent-list:block"><AgentStatusIcon status={agent.status} /></span>
                   <InitialTile name={agent.name} />
                   <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden @max-3xl/agent-list:flex-col @max-3xl/agent-list:items-start @max-3xl/agent-list:gap-1">
@@ -126,9 +131,10 @@ export function AgentsListTable({
                 </dl>
               </div>
               {fields.map(({ label, value, className }) => <span key={label} className={cn("truncate @max-3xl/agent-list:hidden", className)}>{value}</span>)}
-              <span className="@max-3xl/agent-list:absolute @max-3xl/agent-list:right-0 @max-3xl/agent-list:top-2 @max-3xl/agent-list:h-7 @max-3xl/agent-list:w-0" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
+              {canChat && <span className="@max-3xl/agent-list:absolute @max-3xl/agent-list:right-0 @max-3xl/agent-list:top-2 @max-3xl/agent-list:h-7 @max-3xl/agent-list:w-0" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>
                 <AgentRowActions
                   agent={agent}
+                  canManage={canManage}
                   chatPending={chatPendingID === agent.id}
                   deletePending={deletePending}
                   onChat={() => onChat(agent)}
@@ -136,7 +142,7 @@ export function AgentsListTable({
                   onClone={() => onClone(agent)}
                   onDelete={() => onDelete(agent)}
                 />
-              </span>
+              </span>}
             </LedgerRow>
           )
         })}


### PR DESCRIPTION
Agent lists and detail panels offered management actions to workspace members and viewers even though the API rejects them; chat failures could be silent. Match those entry points to the existing server rules: owners/admins manage Agents, members can chat, and viewers receive a read-only explanation. Chat failures now show recoverable feedback in both locations.

The scope is Agent action UI and shared chat feedback. Backend RBAC, capability bindings, exposure rules and Agent lifecycle are unchanged. Management dialogs are unavailable without the required role, and read-only rows do not reserve action space.

Validation: `make check` and production web build passed. Browser role fixtures verified Viewer, Member and Admin entry points, management dialog access, 403/503 feedback, recovery and successful conversation navigation. An independent blind review found a pending-state regression when changing Agents; a one-line correction was self-reviewed and verified with a delayed request, including recovery after it completed.
