### PR TITLE
fix(web): show imported capability names in success feedback

### DIFF
--- a/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
@@ -32,6 +32,7 @@ import { InlineNotice } from "./notices"
 import type {
   CanonicalSpec,
   ImportCommitRequest,
+  ImportCommitResponse,
   ImportInlineSecretInput,
   SourceFormat,
 } from "./types"
@@ -42,7 +43,7 @@ interface Props {
   onOpenChange: (open: boolean) => void
   /** Optional callback after a successful import — the page can navigate to
    *  the new capability detail view, etc. */
-  onCreated?: (capabilityID: string) => void
+  onCreated?: (capability: ImportCommitResponse["capability"]) => void
 }
 
 type AddCapabilityKind = "mcp" | "skill"
@@ -161,7 +162,7 @@ export function ImportCapabilityDialog({ workspaceID, open, onOpenChange, onCrea
     commitMut.mutate(payload, {
       onSuccess: (res) => {
         onOpenChange(false)
-        onCreated?.(res.capability.id)
+        onCreated?.(res.capability)
       },
     })
   }

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -485,8 +485,8 @@ export function CapabilitiesPage() {
         workspaceID={wid}
         open={importOpen}
         onOpenChange={setImportOpen}
-        onCreated={(capabilityID) => {
-          toast.show(t("capabilities.toast.created", { name: capabilityID }))
+        onCreated={(capability) => {
+          toast.show(t("capabilities.toast.created", { name: capability.name }))
         }}
       />
       {addVersionCapability && (


### PR DESCRIPTION
Capability imports showed an internal UUID in the success toast. Pass the returned capability to the existing callback so both Skill and MCP imports show its name, while keeping the existing next-step guidance and import flow.

Validation: `make check`, production web build, and browser checks for Skill and MCP success feedback, dialog dismissal, and list refresh. The MCP fixture returns a different name from the draft to verify the response is used.
