### PR TITLE
fix(web): restore actionable capability failure feedback

### DIFF
--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -43,6 +43,7 @@ import type {
   ToolStep,
 } from "../../lib/api-types"
 import { isUserMessageSender } from "../../lib/message-sender"
+import { isRuntimeCapabilityError } from "../../lib/message-kind"
 import { useRelativeTime } from "../../lib/relative-time"
 import { credentialKindLabel } from "../../pages/admin/capability-ui"
 import { ToolCardSlot, SingleSlot, ListSlot } from "../plugin/SlotRenderer"
@@ -837,7 +838,7 @@ const MessageRow = memo(function MessageRow({
   }
   const senderName = senderType === "system" ? t("conversations.detail.systemSender") : agentName
   const byline = senderName ? `${senderName} · ${stamp}` : stamp
-  if (messageType === "runtime_error") {
+  if (isRuntimeCapabilityError(messageType, metadata)) {
     const runtimeError = runtimeErrorViewModel(metadata, content, conversationId, i18n.language, t)
     return (
       <div className="max-w-[85%]">

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -286,16 +286,16 @@
       "systemSender": "System"
     },
     "runtime_error": {
-      "badge": "Run failed",
+      "badge": "Capability unavailable",
       "fallbackCapability": "this capability",
       "capability_credential_missing": "Capability {{name}} failed to start: missing {{kind}} credential.",
       "capability_credential_decrypt_failed": "Capability {{name}} credential could not be decrypted. Please contact an administrator.",
       "capability_credential_kind_mismatch": "Capability {{name}} credential type does not match. Please set it again.",
-      "capability_version_unavailable": "Capability {{name}} has no usable upload yet. Re-upload it as a zip, pick a newer version, or switch the binding to 'latest'.",
+      "capability_version_unavailable": "Capability {{name}} has no usable upload. Import a working version, then enable it on this Agent.",
       "addCredential": "Add credential",
       "resetCredential": "Reset credential",
       "manageCapability": "Manage capability",
-      "retryHint": "After setting the credential, send your request again. Parsar will not retry automatically.",
+      "retryHint": "This capability was unavailable for this run, so any answer may be incomplete. Fix the capability or its credential, then send your request again. Parsar will not retry automatically.",
       "generic": "A runtime capability failed to start. Please retry later or contact an administrator."
     },
     "composer": {
@@ -353,7 +353,7 @@
     "trace": {
       "label": "Work trace",
       "running": "Running",
-      "completed": "Done",
+      "completed": "Execution finished",
       "failed": "Failed",
       "cancelled": "Cancelled",
       "interrupted": "Interrupted",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -286,16 +286,16 @@
       "systemSender": "系统"
     },
     "runtime_error": {
-      "badge": "运行失败",
+      "badge": "能力不可用",
       "fallbackCapability": "此能力",
       "capability_credential_missing": "能力 {{name}} 启动失败：缺少 {{kind}} 凭据。",
       "capability_credential_decrypt_failed": "能力 {{name}} 凭据解密失败，请联系管理员。",
       "capability_credential_kind_mismatch": "能力 {{name}} 凭据类型不匹配，请重新设置。",
-      "capability_version_unavailable": "能力 {{name}} 还没有可用的上传版本，请重新上传 zip、选择更新的版本，或将该能力切换为 latest 模式。",
+      "capability_version_unavailable": "能力 {{name}} 没有可用的上传版本。请导入可用版本，再在此 Agent 上启用。",
       "addCredential": "去添加凭据",
       "resetCredential": "去重新设置",
       "manageCapability": "去管理能力",
-      "retryHint": "设置好后请回到对话里重新发送请求，系统不会自动重试。",
+      "retryHint": "本次执行未能使用此能力，回答可能不完整。请修复能力或其凭据，再重新发送请求。系统不会自动重试。",
       "generic": "运行期能力启动失败，请稍后重试或联系管理员。"
     },
     "composer": {
@@ -353,7 +353,7 @@
     "trace": {
       "label": "执行轨迹",
       "running": "运行中",
-      "completed": "已完成",
+      "completed": "执行结束",
       "failed": "失败",
       "cancelled": "已取消",
       "interrupted": "已中断",

--- a/apps/web/src/lib/message-kind.ts
+++ b/apps/web/src/lib/message-kind.ts
@@ -1,0 +1,3 @@
+export function isRuntimeCapabilityError(kind?: string, metadata?: Record<string, unknown>): boolean {
+  return kind === "runtime_error" || (kind === "error" && metadata?.kind === "runtime_error")
+}

--- a/apps/web/src/lib/parsar-chat-runtime.ts
+++ b/apps/web/src/lib/parsar-chat-runtime.ts
@@ -24,6 +24,7 @@ import type {
 } from "./api-types"
 import { startAgentRun } from "./api-conversations"
 import { isUserMessageSender } from "./message-sender"
+import { isRuntimeCapabilityError } from "./message-kind"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -116,7 +117,7 @@ export function convertTimelineMessage(
     }
   }
 
-  if (msg.sender_type === "system" && msg.kind !== "runtime_error") {
+  if (msg.sender_type === "system" && !isRuntimeCapabilityError(msg.kind, msg.metadata)) {
     return {
       id: msg.id,
       role: "system",
@@ -167,7 +168,7 @@ export function convertTimelineMessage(
   // routes to RuntimeErrorCard. Safe because API strings never contain
   // null bytes. If this becomes fragile, switch to a Map<messageId, metadata>
   // side-channel.
-  if (msg.kind === "runtime_error") {
+  if (isRuntimeCapabilityError(msg.kind, msg.metadata)) {
     // Replace the plain text part with one that includes metadata marker
     const errorText = msg.content || ""
     const metaJson = JSON.stringify(msg.metadata ?? {})


### PR DESCRIPTION
Runtime capability failures are persisted as `kind=error` with `metadata.kind=runtime_error`, but both web renderers only recognized the legacy kind. Recognize both formats so affected capabilities and recovery links are shown instead of internal codes. The warning explains that an answer may be incomplete, and the trace says “Execution finished”.

Validation: `make check`, web production build, real historical failure in console and shared views, and English/Chinese browser cases for both error formats plus ordinary system, user, IM and Agent messages. Backend behavior and automatic retries are unchanged.
