### PR TITLE
fix(web): display legacy Agent runtime bindings

### DIFF
--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -143,7 +143,7 @@ export interface Agent {
   enabled_at?: string
   /**
    * Explicit runtime binding. When set, the admin list renders "{kind} ·
-   * {name}". Empty → "unbound" warning (dispatch is blocked).
+   * {name}". Local daemon Agents may use legacy config.device_id when empty.
    *
    * `runtime_kind` mirrors `runtimes.type`; distinct from the legacy
    * top-level `runtime` field above (pre-v5 placement metadata).

--- a/apps/web/src/lib/use-agent-runtime-binding.ts
+++ b/apps/web/src/lib/use-agent-runtime-binding.ts
@@ -1,0 +1,25 @@
+import { agentExecutionPlacement } from "./agent-runtime"
+import type { Agent } from "./api-types"
+import { useWorkspaceRuntimes } from "./api-runtimes"
+
+export function useAgentRuntimeBinding(agent: Agent) {
+  const explicitID = agent.runtime_id?.trim() ?? ""
+  const legacyID = agent.connector_type === "agent_daemon"
+    && agentExecutionPlacement(agent) === "local"
+    && typeof agent.config?.device_id === "string"
+    ? agent.config.device_id.trim()
+    : ""
+  const id = explicitID || legacyID
+  const { data: runtimes } = useWorkspaceRuntimes(
+    !explicitID && legacyID ? agent.workspace_id : "",
+    undefined,
+    { staleTime: 5_000 },
+  )
+  const legacy = runtimes?.find((runtime) => runtime.id === legacyID && runtime.type === "agent_daemon")
+
+  return {
+    id,
+    name: (explicitID ? agent.runtime_name : legacy?.name)?.trim() || id,
+    liveness: explicitID ? agent.runtime_liveness : legacy?.liveness,
+  }
+}

--- a/apps/web/src/pages/admin/agents/AgentConfigSummary.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigSummary.tsx
@@ -11,6 +11,7 @@ import {
   agentWorkdirOf,
 } from "../../../lib/agent-view-model"
 import type { AgentDetail } from "../../../lib/api-types"
+import { useAgentRuntimeBinding } from "../../../lib/use-agent-runtime-binding"
 import { DetailSection } from "./DetailSection"
 
 /* Config reads in the rail now, so it takes the shared property grid: no
@@ -31,7 +32,7 @@ export function AgentConfigSummary({
   const executionMode = agentExecutionModeOf(agent)
   const agentEngine = agentEngineOf(agent)
   const workdir = agentWorkdirOf(agent)
-  const binding = agent.runtime_name || agent.runtime_id
+  const binding = useAgentRuntimeBinding(agent).name
 
   return (
     <>

--- a/apps/web/src/pages/admin/agents/AgentRuntimeCell.tsx
+++ b/apps/web/src/pages/admin/agents/AgentRuntimeCell.tsx
@@ -3,12 +3,13 @@ import { useTranslation } from "react-i18next"
 import { cn } from "../../../lib/utils"
 import { agentExecutionPlacement } from "../../../lib/agent-runtime"
 import type { Agent } from "../../../lib/api-types"
+import { useAgentRuntimeBinding } from "../../../lib/use-agent-runtime-binding"
 
 type LivenessTone = "online" | "offline" | "pending"
 
-function runtimeLivenessTone(agent: Agent): LivenessTone | null {
-  if (!agent.runtime_id) return null
-  const liveness = (agent.runtime_liveness ?? "").toLowerCase()
+function runtimeLivenessTone(value?: string): LivenessTone | null {
+  const liveness = (value ?? "").toLowerCase()
+  if (!liveness) return null
   if (liveness === "online" || liveness === "live") return "online"
   if (liveness === "pending_pairing" || liveness === "pending") return "pending"
   return "offline"
@@ -29,7 +30,7 @@ function RuntimeLine({
   title,
   className,
 }: {
-  tone: LivenessTone
+  tone: LivenessTone | null
   kind?: string
   name: string
   mono?: boolean
@@ -38,7 +39,7 @@ function RuntimeLine({
 }) {
   return (
     <span className={cn("flex min-w-0 items-center gap-1.5 text-sm text-fg", className)} title={title}>
-      <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", DOT[tone])} aria-hidden="true" />
+      {tone && <span className={cn("h-1.5 w-1.5 shrink-0 rounded-full", DOT[tone])} aria-hidden="true" />}
       {kind && <span className="shrink-0 text-xs text-fg-muted">{kind} ·</span>}
       <span className={cn("min-w-0 truncate", mono && "font-mono text-xs")}>{name}</span>
     </span>
@@ -48,6 +49,7 @@ function RuntimeLine({
 export function AgentRuntimeCell({ agent, className }: { agent: Agent; className?: string }) {
   const { t } = useTranslation("admin")
   const placement = agentExecutionPlacement(agent)
+  const binding = useAgentRuntimeBinding(agent)
 
   if (placement === "sandbox") {
     const fullId = (agent.sandbox_external_id ?? "").trim()
@@ -64,11 +66,8 @@ export function AgentRuntimeCell({ agent, className }: { agent: Agent; className
     return <RuntimeLine className={className} tone="offline" kind="Sandbox" name={t("agents.runtimeCell.pending")} />
   }
 
-  const name = (agent.runtime_name ?? "").trim()
-  const runtimeID = (agent.runtime_id ?? "").trim()
-  if (placement === "local" && runtimeID && name) {
-    const tone = runtimeLivenessTone(agent) ?? "offline"
-    return <RuntimeLine className={className} tone={tone} kind="Local" name={name} title={[name, agent.runtime_liveness].filter(Boolean).join(" · ")} />
+  if (placement === "local" && binding.id) {
+    return <RuntimeLine className={className} tone={runtimeLivenessTone(binding.liveness)} kind="Local" name={binding.name} title={[binding.name, binding.liveness].filter(Boolean).join(" · ")} />
   }
 
   return <RuntimeLine className={className} tone="pending" name={t("agents.runtimeCell.unbound")} />


### PR DESCRIPTION
Agents configured with legacy config.device_id can run successfully while their list and Config views report no runtime binding. Share the binding display lookup: prefer the explicit runtime, resolve legacy local devices in the current workspace, and retain the ID when a name is unavailable. Missing health data no longer implies an offline runtime.

Validation: make check, web production build, actual remote Agent data in the list and Config views, and browser cases for explicit precedence, legacy devices, missing names, unbound Agents, sandboxes and external connectors. Execution dispatch and backend configuration are unchanged.
