### PR TITLE
fix(web): clarify Agent capability picker feedback

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1201,8 +1201,9 @@
         },
         "capabilities": {
           "title": "Capabilities",
-          "add": "+ Add",
-          "empty": "No capability enabled yet. Click \"+ Add\" to install one from the workspace.",
+          "add": "Add capability",
+          "pickerHint": "Choose a Skill or tool for this Agent. Enabling it takes effect on the next run; runtime availability is checked during execution.",
+          "empty": "No capability enabled yet. Choose “Add capability” to enable one from this workspace.",
           "loadError": "Failed to load capabilities."
         }
       },
@@ -1292,7 +1293,8 @@
           "upgradeShort": "New version v{{version}}"
         },
         "state": {
-          "ready": "Ready",
+          "ready": "Enabled in configuration",
+          "available": "Available to enable",
           "attention": "Update available",
           "blocked": "Not usable",
           "deprecated": "Deprecated"

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1201,8 +1201,9 @@
         },
         "capabilities": {
           "title": "能力",
-          "add": "+ 添加",
-          "empty": "还没有启用任何 capability。点击右上角「+ 添加」从工作区可装 capability 中挑一个。",
+          "add": "添加能力",
+          "pickerHint": "为此 Agent 选择 Skill 或工具。启用后在下次运行生效，实际可用性会在执行时检查。",
+          "empty": "尚未启用能力。点击“添加能力”从此工作区中选择。",
           "loadError": "加载 capability 失败。"
         }
       },
@@ -1292,7 +1293,8 @@
           "upgradeShort": "有新版本 v{{version}}"
         },
         "state": {
-          "ready": "可用",
+          "ready": "已在配置中启用",
+          "available": "可启用",
           "attention": "有更新",
           "blocked": "不可用",
           "deprecated": "已废弃"

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -502,14 +502,14 @@ function CapabilityCard({
   // flight, and a capability with a newer version is doing nothing at all —
   // it would have spun forever inside the rail.
   const needsAttention = deprecated || upgradable
-  const status: StatusKind = blocked ? "failed" : needsAttention ? "interrupted" : "completed"
+  const status: StatusKind = blocked ? "failed" : needsAttention ? "interrupted" : mode === "available" ? "queued" : "completed"
   const statusLabel = blocked
     ? t("agents.detail.capabilities.state.blocked")
     : deprecated
       ? t("agents.detail.capabilities.state.deprecated")
       : upgradable
         ? t("agents.detail.capabilities.state.attention")
-        : t("agents.detail.capabilities.state.ready")
+        : t(`agents.detail.capabilities.state.${mode === "available" ? "available" : "ready"}`)
 
   return (
     <CapabilityLine
@@ -999,6 +999,7 @@ function AddCapabilityDialog({
       <DialogContent className="max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-lg grid-cols-1 grid-rows-[auto_minmax(0,1fr)_auto]">
         <DialogHeader>
           <DialogTitle>{t("agents.detail.config.capabilities.add")}</DialogTitle>
+          <DialogDescription>{t("agents.detail.config.capabilities.pickerHint")}</DialogDescription>
         </DialogHeader>
         <div className="flex min-h-0 min-w-0 flex-col gap-3">
           <div className="relative shrink-0">
@@ -1007,15 +1008,15 @@ function AddCapabilityDialog({
               type="search"
               value={q}
               onChange={(e) => setQ(e.target.value)}
-              placeholder={t("agents.detail.config.capabilities.add")}
-              aria-label={t("agents.detail.config.capabilities.add")}
+              placeholder={t("capabilities.filters.search")}
+              aria-label={t("capabilities.filters.search")}
               className="pl-7"
               autoFocus
             />
           </div>
           <div className="min-h-0 max-h-80 overflow-y-auto">
             {filtered.length === 0 ? (
-              <EmptyState size="compact" title={t("agents.detail.capabilities.emptyAvailable")} />
+              <EmptyState size="compact" title={t(q.trim() ? "capabilities.emptyFiltered.title" : "agents.detail.capabilities.emptyAvailable")} />
             ) : (
               <ul className="m-0 list-none border-t border-line p-0">
                 {filtered.map((capability) => (


### PR DESCRIPTION
The Agent capability picker used “+ Add” as both its title and search label, and showed uninstalled capabilities as green Ready items. Give it an explicit title, capability search label and next-run explanation; use a neutral available-to-enable state and a correct no-match message. Enabled capability labels describe configuration rather than runtime health.

Validation: make check, web production build, and real-data browser checks for English/Chinese picker content, filtering, no-match feedback and entry into the existing enable confirmation. No capability mutations or compatibility checks changed.
