### PR TITLE
fix(agents): check cloud availability before configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -591,6 +591,11 @@ Pages with a detail rail may opt into wrapping header actions through
 `PageHeader.actionClassName` and an auto-height header. Other pages retain
 the default single-row header layout.
 
+The Agent form checks workspace runtime status before creating or switching to
+cloud execution. Unknown or unavailable status blocks advancing and submitting;
+ordinary edits to an existing cloud Agent and local execution stay independent.
+Cloud setup opens Runtime's Instances tab separately so form input is retained.
+
 Use `EmptyState` with `size="compact"` for detail tabs, subsections, and
 compact result panels. Keep their alignment and spacing in that shared
 component; page-level empty states retain the default size.

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1399,6 +1399,11 @@
         "label": "Instructions",
         "hint": "Describe what this Agent should do, how it should respond, and when it should ask for clarification."
       },
+      "cloudPreflight": {
+        "hint": "Cloud execution must be configured before continuing. Open cloud settings in a new tab, then return here and check again. Your Agent settings stay in this form.",
+        "configure": "Open cloud settings",
+        "retry": "Check again"
+      },
       "defaults": {
         "workspaceName": "My Workspace",
         "name": "{{workspace}}'s agent",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1399,6 +1399,11 @@
         "label": "行为指令",
         "hint": "说明这个 Agent 应该做什么、如何回答，以及什么时候需要向用户确认。"
       },
+      "cloudPreflight": {
+        "hint": "继续前需要先配置云执行环境。请在新标签页完成配置，再回到这里重新检查；当前 Agent 表单会保留。",
+        "configure": "打开云执行设置",
+        "retry": "重新检查"
+      },
       "defaults": {
         "workspaceName": "当前 Workspace",
         "name": "{{workspace}} 的 Agent",

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -18,6 +18,7 @@ import { Input } from "../../components/ui/input"
 import { Label } from "../../components/ui/label"
 import { Select, SelectOption } from "../../components/ui/select"
 import { AgentInstructionsField } from "./agents/AgentInstructionsField"
+import { AgentCloudPreflight } from "./agents/AgentCloudPreflight"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
 import { cn } from "../../lib/utils"
@@ -730,6 +731,11 @@ export function CreateAgentDialog({
     setModelBindingChoice({ source: "shared", existing_secret_id: sharedSecrets[0].id })
   }, [mode, requiresModel, selectedModel, modelBindingChoice, modelNewSecretExpanded, sharedSecrets])
   const daemonExecutionEditable = connector === "agent_daemon"
+  const needsCloudPreflight = daemonExecutionEditable && executionMode === "sandbox"
+    && (mode === "create" || executionModeFromAgent(agent) !== "sandbox")
+  const cloudReady = !needsCloudPreflight || (!runtimeStatus.isError
+    && runtimeStatus.data?.available === true
+    && (runtimeStatus.data.profile === "managed" || runtimeStatus.data.has_credential))
   const showExecutionChoices = mode === "create" || daemonExecutionEditable
   const showDevicePicker = connector === "agent_daemon" && executionMode === "local_device" && Boolean(workspaceID)
   const errMsg = extractErrorMessage(error)
@@ -795,6 +801,7 @@ export function CreateAgentDialog({
 
   async function submit() {
     setSubmitAttempted(true)
+    if (!cloudReady) return
     if (!hasRequiredModel) {
       modelFieldRef.current?.scrollIntoView({ behavior: "smooth", block: "center" })
       return
@@ -988,6 +995,7 @@ export function CreateAgentDialog({
     name.trim() !== "" &&
     hasConnector &&
     hasRequiredModel &&
+    cloudReady &&
     (connector !== "agent_daemon" || executionMode !== "local_device" || deviceID !== "") &&
     workDirValid &&
     (mode !== "create" || !allCapabilitiesQ.isLoading) &&
@@ -997,6 +1005,7 @@ export function CreateAgentDialog({
     name.trim() !== "" &&
     hasConnector &&
     hasRequiredModel &&
+    cloudReady &&
     (connector !== "agent_daemon" || executionMode !== "local_device" || deviceID !== "") &&
     workDirValid
   const totalSteps = 2
@@ -1049,6 +1058,10 @@ export function CreateAgentDialog({
           stepOfLabel={t("agents.form.wizard.stepOf", { current: step, total: totalSteps })}
           completeLabel={t("agents.form.wizard.complete", { percent: progressPercent })}
         />
+
+        {needsCloudPreflight && !cloudReady && workspaceID && (
+          <AgentCloudPreflight workspaceID={workspaceID} checking={runtimeStatus.isFetching} failed={runtimeStatus.isError} onRetry={() => void runtimeStatus.refetch()} />
+        )}
 
         <form
           className="flex min-h-0 flex-1 flex-col gap-5 overflow-y-auto overflow-x-hidden pr-1"

--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -39,6 +39,7 @@ import { useMyWorkspaces } from "../../lib/api-workspaces"
 import { useRelativeTime } from "../../lib/relative-time"
 import { useNow } from "../../lib/use-now"
 import { useWorkspaceId } from "../../lib/workspace"
+import { useAppRoute, useNavigateAdmin } from "../../lib/admin-router"
 import { SectionHead } from "../../components/ui/section"
 
 type SortKey = "last_active" | "created_at" | "agent"
@@ -92,8 +93,9 @@ export function RuntimePage() {
   const sandboxesQuery = useWorkspaceSandboxes(workspaceID)
   const workspacesQ = useMyWorkspaces()
 
-  type RuntimeTab = "environments" | "instances"
-  const [tab, setTab] = useState<RuntimeTab>("environments")
+  const route = useAppRoute()
+  const navigate = useNavigateAdmin()
+  const tab = route.tab === "instances" ? "instances" : "environments"
   const [pairOpen, setPairOpen] = useState(false)
   const [selected, setSelected] = useState<Set<string>>(new Set())
   const [sortKey, setSortKey] = useState<SortKey>("last_active")
@@ -157,7 +159,7 @@ export function RuntimePage() {
       {/* Two objects, two shapes: a runtime is a registered place an agent can
           run, an instance is a live sandbox that will be reclaimed. Tabs are
           for different shapes; the placements within a runtime are groups. */}
-      <Tabs value={tab} onValueChange={(v) => setTab(v as RuntimeTab)} className="flex min-h-0 flex-1 flex-col">
+      <Tabs value={tab} onValueChange={(v) => navigate("runtime", { tab: v })} className="flex min-h-0 flex-1 flex-col">
         <PageHeader
           className="static mx-0 mb-0"
           title={t("runtime.page.title")}

--- a/apps/web/src/pages/admin/agents/AgentCloudPreflight.tsx
+++ b/apps/web/src/pages/admin/agents/AgentCloudPreflight.tsx
@@ -1,0 +1,36 @@
+import { ArrowUpRight, RefreshCw } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { RuntimeStatusBanner } from "../../../components/runtime/RuntimeStatusBanner"
+import { Button } from "../../../components/ui/button"
+
+export function AgentCloudPreflight({ workspaceID, checking, failed, onRetry }: {
+  workspaceID: string
+  checking: boolean
+  failed: boolean
+  onRetry: () => void
+}) {
+  const { t } = useTranslation("admin")
+  const setupURL = `/?${new URLSearchParams({ ws: workspaceID, admin: "runtime", tab: "instances" })}`
+
+  return (
+    <section className="shrink-0 rounded-md border border-line bg-surface p-3">
+      <RuntimeStatusBanner workspaceID={workspaceID} />
+      <p className="mt-2 text-xs text-fg-muted">{t("agents.form.cloudPreflight.hint")}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Button asChild variant="outline" size="sm">
+          <a href={setupURL} target="_blank" rel="noreferrer">
+            {t("agents.form.cloudPreflight.configure")}
+            <ArrowUpRight strokeWidth={1.5} aria-hidden="true" />
+          </a>
+        </Button>
+        {!failed && (
+          <Button variant="outline" size="sm" disabled={checking} onClick={onRetry}>
+            <RefreshCw strokeWidth={1.5} aria-hidden="true" />
+            {t("agents.form.cloudPreflight.retry")}
+          </Button>
+        )}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
Creating an Agent with cloud execution, or switching a local Agent to cloud execution, now checks workspace cloud availability before advancing and submitting. Missing setup or failed checks offer a cloud settings link and retry while preserving the form. Runtime links can open the Instances tab directly.

Local execution and ordinary edits to existing cloud Agents keep their current behavior. No provisioning or credential policy changes.

Validation: `make check`, web production build, browser checks for missing/unavailable/error/recovered and managed states, setup navigation, final-submit gating, and local/existing-cloud edit paths. Runtime statuses and the create response were synthetic; no live cloud provision was attempted without credentials. Independent blind review found no actionable issues.

Tracks UX-022 in the September QA table.
