### PR TITLE
fix(web): describe paired execution without assuming host location

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -578,7 +578,7 @@
       "codex": "Codex",
       "piagent": "Piagent",
       "sandbox": "Sandbox",
-      "local": "Local",
+      "local": "Paired machine",
       "online": "Online",
       "offline": "Offline",
       "degraded": "Degraded",
@@ -1383,7 +1383,7 @@
         "executionMode": "Execution mode",
         "agentEngine": "Agent engine",
         "codexMode": "Codex collaboration mode",
-        "device": "Local device",
+        "device": "Paired machine",
         "sandboxSize": "Sandbox size",
         "sandboxAutoRenew": "Auto-renew sandbox",
         "sandboxImage": "Sandbox image",
@@ -1408,7 +1408,7 @@
       "errors": {
         "modelRequired": "Pick a model first.",
         "modelUnavailable": "The current model is unavailable. Select an active model.",
-        "deviceRequired": "Select a local device.",
+        "deviceRequired": "Select a paired machine.",
         "workDirAbsolute": "Working directory must be an absolute path, or start with `~/`."
       },
       "sandboxSize": {
@@ -1489,7 +1489,7 @@
       "modelProtocolMismatch": "{{engine}} can't use this model's protocol",
       "selected": "Selected",
       "devicePicker": {
-        "hint": "Pick a connected local daemon. Cloud isolation does not need a device; Parsar lazy-starts a sandbox daemon on first run.",
+        "hint": "Choose the machine where this Agent will run. It can be your computer or a shared server. Cloud isolation does not require a paired machine.",
         "addDevice": "Connect device",
         "placeholder": "Pick a device…",
         "emptyTitle": "No agent daemons connected yet",
@@ -1497,7 +1497,7 @@
       },
       "workDir": {
         "placeholder": "/Users/me/code/my-app",
-        "hintLocal": "The directory the agent runs in on your local device — an absolute path, or one starting with `~/`. Leave blank to use a per-conversation scratch dir; created if it does not exist.",
+        "hintLocal": "The directory the agent runs in on the selected machine — an absolute path, or one starting with `~/`. Leave blank to use a per-conversation scratch dir; created if it does not exist.",
         "hintSandbox": "The directory the agent runs in inside the sandbox container (e.g. /workspace/my-app) — an absolute path, or one starting with `~/`. Leave blank to use a per-conversation scratch dir; created if it does not exist."
       }
     },
@@ -1528,8 +1528,8 @@
         "poolEmpty": "Sandbox pool is empty — cold start required after creation"
       },
       "localDevice": {
-        "title": "Local device",
-        "description": "Use a paired local device for local code."
+        "title": "Paired machine",
+        "description": "Run on a connected computer or server."
       },
       "external": {
         "title": "External Agent",
@@ -2230,7 +2230,7 @@
       }
     },
     "placement": {
-      "local_device": "Local device",
+      "local_device": "Paired machine",
       "cloud_sandbox": "Cloud sandbox",
       "external_agent": "External agent"
     },
@@ -2240,7 +2240,7 @@
       "pairingExpired": "Startup timed out",
       "loadError": "Failed to load runtimes",
       "emptyTitle": "No runtime connected yet",
-      "emptyDescription": "Pair a local device with the button above; a cloud sandbox starts on an Agent's first run; an External Agent is chosen when you create the Agent.",
+      "emptyDescription": "Connect a computer or server with the button above; a cloud sandbox starts on an Agent's first run; an External Agent is chosen when you create the Agent.",
       "preparing": "Preparing"
     },
     "tabs": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -578,7 +578,7 @@
       "codex": "Codex",
       "piagent": "Piagent",
       "sandbox": "沙盒",
-      "local": "本地",
+      "local": "已接入设备",
       "online": "在线",
       "offline": "离线",
       "degraded": "降级",
@@ -1383,7 +1383,7 @@
         "executionMode": "执行方式",
         "agentEngine": "Agent 引擎",
         "codexMode": "Codex 协作模式",
-        "device": "本地设备",
+        "device": "已接入设备",
         "sandboxSize": "沙盒规格",
         "sandboxAutoRenew": "沙盒自动续期",
         "sandboxImage": "沙盒镜像",
@@ -1408,7 +1408,7 @@
       "errors": {
         "modelRequired": "请选择一个模型",
         "modelUnavailable": "当前模型已不可用，请重新选择一个可用模型。",
-        "deviceRequired": "请选择一台本地设备。",
+        "deviceRequired": "请选择一台已接入设备。",
         "workDirAbsolute": "工作目录必须是绝对路径，或以 ~/ 开头。"
       },
       "sandboxSize": {
@@ -1489,7 +1489,7 @@
       "modelProtocolMismatch": "{{engine}} 无法使用该模型的协议",
       "selected": "已选择",
       "devicePicker": {
-        "hint": "选择一台已连接的本地 daemon。云端隔离不需要选择设备，会在首次运行时自动拉起 sandbox daemon。",
+        "hint": "选择 Agent 实际运行的设备，可以是个人电脑或共享服务器。云端隔离无需选择已接入设备。",
         "addDevice": "接入新设备",
         "placeholder": "选择设备…",
         "emptyTitle": "尚未接入任何 agent daemon",
@@ -1497,7 +1497,7 @@
       },
       "workDir": {
         "placeholder": "/Users/me/code/my-app",
-        "hintLocal": "Agent 在你这台本地设备上运行时的目录，填绝对路径或以 ~/ 开头的路径。留空则每个会话各用一个临时目录；路径不存在时自动创建。",
+        "hintLocal": "Agent 在所选设备上运行时的目录，填绝对路径或以 ~/ 开头的路径。留空则每个会话各用一个临时目录；路径不存在时自动创建。",
         "hintSandbox": "Agent 在沙盒容器内运行时的目录（如 /workspace/my-app），填绝对路径或以 ~/ 开头的路径。留空则每个会话各用一个临时目录；路径不存在时自动创建。"
       }
     },
@@ -1528,8 +1528,8 @@
         "poolEmpty": "沙盒池已空，创建后需要等待冷启动"
       },
       "localDevice": {
-        "title": "本地设备",
-        "description": "使用已配对的本地设备,贴近本机代码。"
+        "title": "已接入设备",
+        "description": "在已接入的电脑或服务器上运行。"
       },
       "external": {
         "title": "外部 Agent",
@@ -2230,7 +2230,7 @@
       }
     },
     "placement": {
-      "local_device": "本地设备",
+      "local_device": "已接入设备",
       "cloud_sandbox": "云端沙盒",
       "external_agent": "外部 Agent"
     },
@@ -2240,7 +2240,7 @@
       "pairingExpired": "启动超时",
       "loadError": "无法加载运行环境列表",
       "emptyTitle": "尚未接入任何运行环境",
-      "emptyDescription": "本地设备用右上角的按钮生成接入命令；云端沙盒在 Agent 首次运行时自动拉起；外部 Agent 在创建 Agent 时选择。",
+      "emptyDescription": "电脑或服务器可通过右上角的按钮生成接入命令；云端沙盒在 Agent 首次运行时自动拉起；外部 Agent 在创建 Agent 时选择。",
       "preparing": "准备中"
     },
     "tabs": {

--- a/apps/web/src/pages/admin/agents/AgentRuntimeCell.tsx
+++ b/apps/web/src/pages/admin/agents/AgentRuntimeCell.tsx
@@ -67,7 +67,7 @@ export function AgentRuntimeCell({ agent, className }: { agent: Agent; className
   }
 
   if (placement === "local" && binding.id) {
-    return <RuntimeLine className={className} tone={runtimeLivenessTone(binding.liveness)} kind="Local" name={binding.name} title={[binding.name, binding.liveness].filter(Boolean).join(" · ")} />
+    return <RuntimeLine className={className} tone={runtimeLivenessTone(binding.liveness)} name={binding.name} title={[binding.name, binding.liveness].filter(Boolean).join(" · ")} />
   }
 
   return <RuntimeLine className={className} tone="pending" name={t("agents.runtimeCell.unbound")} />


### PR DESCRIPTION
Paired runtimes may live on a user computer or a deployment server. Agent setup, working-directory guidance, details, Run labels and Runtime grouping now say “Paired machine” and refer to the selected machine instead of claiming execution is on the viewer’s local computer. Agent rows show the actual runtime name without the misleading Local prefix.

Only display copy changes; runtime identifiers, placement values, routing and liveness remain unchanged.

Validation: `make check`, web production build, self-review, and browser checks of Agent list/details/edit and Runtime grouping with the existing remote runtime data. Tracks UX-004.
