### PR TITLE
fix(web): route conversation recovery actions to their console pages

### DIFF
--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -44,6 +44,7 @@ import type {
 } from "../../lib/api-types"
 import { isUserMessageSender } from "../../lib/message-sender"
 import { isRuntimeCapabilityError } from "../../lib/message-kind"
+import { conversationRecoveryLinks } from "../../lib/conversation-recovery-links"
 import { useRelativeTime } from "../../lib/relative-time"
 import { credentialKindLabel } from "../../pages/admin/capability-ui"
 import { ToolCardSlot, SingleSlot, ListSlot } from "../plugin/SlotRenderer"
@@ -563,7 +564,7 @@ function ChatStream({
                   outputRuns={runsByOutputMessage.get(m.id)}
                   stamp={fmtAgo(m.created_at)}
                   agentName={agent?.name || (m.sender_id === convInfoQ.data?.primary_agent_id ? agentName : "")}
-                  conversationId={conversationId}
+                  workspaceID={convWorkspaceId}
                   onOpenRun={openRun}
                 />
               )
@@ -591,7 +592,7 @@ function ChatStream({
               content={stream.deltaText}
               stamp={t("conversations.stream.caretHint")}
               agentName={agentName}
-              conversationId={conversationId}
+              workspaceID={convWorkspaceId}
             />
           )}
           <ConversationInteractionCards
@@ -807,7 +808,7 @@ const MessageRow = memo(function MessageRow({
   outputRuns,
   stamp,
   agentName,
-  conversationId,
+  workspaceID,
   onOpenRun,
 }: {
   senderType: string
@@ -817,7 +818,7 @@ const MessageRow = memo(function MessageRow({
   outputRuns?: ConversationTimelineRun[]
   stamp: string
   agentName: string
-  conversationId: string
+  workspaceID: string | null
   onOpenRun?: (runID: string) => void
 }) {
   const { i18n, t } = useTranslation("admin")
@@ -839,7 +840,7 @@ const MessageRow = memo(function MessageRow({
   const senderName = senderType === "system" ? t("conversations.detail.systemSender") : agentName
   const byline = senderName ? `${senderName} · ${stamp}` : stamp
   if (isRuntimeCapabilityError(messageType, metadata)) {
-    const runtimeError = runtimeErrorViewModel(metadata, content, conversationId, i18n.language, t)
+    const runtimeError = runtimeErrorViewModel(metadata, content, workspaceID, i18n.language, t)
     return (
       <div className="max-w-[85%]">
         <div className="mb-1 text-xs text-fg-muted">{byline}</div>
@@ -895,7 +896,7 @@ const MessageRow = memo(function MessageRow({
 function runtimeErrorViewModel(
   metadata: Record<string, unknown> | undefined,
   fallback: string,
-  conversationId: string,
+  workspaceID: string | null,
   language: string,
   t: ReturnType<typeof useTranslation<"admin">>["t"],
 ) {
@@ -910,13 +911,8 @@ function runtimeErrorViewModel(
     language,
     t("capabilities.credentials.none"),
   )
-  const current = `${window.location.pathname}${window.location.search || `?admin=conversations&id=${conversationId}`}`
-  const href = credentialKind
-    ? `?profile=credentials&kind=${encodeURIComponent(credentialKind)}&returnTo=${encodeURIComponent(current)}`
-    : ""
-  const manageCapabilityHref = capabilityID
-    ? `?admin=capabilities&id=${encodeURIComponent(capabilityID)}`
-    : "?admin=capabilities"
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`
+  const { credential: href, capability: manageCapabilityHref } = conversationRecoveryLinks(workspaceID, capabilityID, credentialKind, current)
 
   switch (subKind) {
     case "capability_credential_missing":

--- a/apps/web/src/components/conversation/ParsarThread.tsx
+++ b/apps/web/src/components/conversation/ParsarThread.tsx
@@ -30,6 +30,7 @@ import { ParsarToolCallCard } from "./ParsarToolCallCard"
 import { Button } from "../ui/button"
 import { ErrorState } from "../ui/error-state"
 import { credentialKindLabel } from "../../lib/credential-kind-ui"
+import { conversationRecoveryLinks } from "../../lib/conversation-recovery-links"
 import { cn } from "../../lib/utils"
 
 // ---------------------------------------------------------------------------
@@ -303,13 +304,14 @@ function RuntimeErrorCard({ text, metadata }: { text: string; metadata: Record<s
   let message = text || t("conversations.runtime_error.generic")
   let action = ""
   let href = ""
-  const current = `${window.location.pathname}${window.location.search}`
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`
+  const links = conversationRecoveryLinks(stringMeta(metadata, "workspace_id"), capabilityID, credentialKind, current)
 
   switch (subKind) {
     case "capability_credential_missing":
       message = t("conversations.runtime_error.capability_credential_missing", { name: capabilityName, kind: kindLabel })
       action = t("conversations.runtime_error.addCredential")
-      href = credentialKind ? `?profile=credentials&kind=${encodeURIComponent(credentialKind)}&returnTo=${encodeURIComponent(current)}` : ""
+      href = links.credential
       break
     case "capability_credential_decrypt_failed":
       message = t("conversations.runtime_error.capability_credential_decrypt_failed", { name: capabilityName })
@@ -317,12 +319,12 @@ function RuntimeErrorCard({ text, metadata }: { text: string; metadata: Record<s
     case "capability_credential_kind_mismatch":
       message = t("conversations.runtime_error.capability_credential_kind_mismatch", { name: capabilityName })
       action = t("conversations.runtime_error.resetCredential")
-      href = credentialKind ? `?profile=credentials&kind=${encodeURIComponent(credentialKind)}&returnTo=${encodeURIComponent(current)}` : ""
+      href = links.credential
       break
     case "capability_version_unavailable":
       message = t("conversations.runtime_error.capability_version_unavailable", { name: capabilityName })
       action = t("conversations.runtime_error.manageCapability")
-      href = capabilityID ? `?admin=capabilities&id=${encodeURIComponent(capabilityID)}` : "?admin=capabilities"
+      href = links.capability
       break
   }
 

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -777,6 +777,7 @@ export interface CreateConversationRequest {
  */
 export interface ConversationTimelineMessage {
   id: string
+  workspace_id?: string
   conversation_id: string
   sender_type: string
   sender_id?: string

--- a/apps/web/src/lib/conversation-recovery-links.ts
+++ b/apps/web/src/lib/conversation-recovery-links.ts
@@ -1,0 +1,18 @@
+export function conversationRecoveryLinks(
+  workspaceID: string | null | undefined,
+  capabilityID: string,
+  credentialKind: string,
+  returnTo: string,
+) {
+  const capability = new URLSearchParams({ admin: "capabilities" })
+  const credential = new URLSearchParams({ profile: "credentials", kind: credentialKind, returnTo })
+  if (workspaceID) {
+    capability.set("ws", workspaceID)
+    credential.set("ws", workspaceID)
+  }
+  if (capabilityID) capability.set("id", capabilityID)
+  return {
+    capability: `/?${capability}`,
+    credential: credentialKind ? `/?${credential}` : "",
+  }
+}

--- a/apps/web/src/lib/parsar-chat-runtime.ts
+++ b/apps/web/src/lib/parsar-chat-runtime.ts
@@ -171,7 +171,7 @@ export function convertTimelineMessage(
   if (isRuntimeCapabilityError(msg.kind, msg.metadata)) {
     // Replace the plain text part with one that includes metadata marker
     const errorText = msg.content || ""
-    const metaJson = JSON.stringify(msg.metadata ?? {})
+    const metaJson = JSON.stringify({ ...msg.metadata, workspace_id: msg.workspace_id })
     const enrichedParts: typeof parts = [
       {
         type: "text" as const,


### PR DESCRIPTION
Capability and credential recovery links from shared `/c/:id` chats currently append console parameters to the chat URL, leaving the user on the same page. Build root console links with the conversation workspace, and preserve the complete return location when opening personal credentials. Both message renderers use the same link helper.

Validation: `make check`, production web build, and browser checks for capability details, the preselected credential dialog, and return navigation including query and fragment. No credential or capability mutations were made during navigation checks.
