### PR TITLE
fix(web): preserve custom credential kinds in failure messages

### DIFF
--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -910,7 +910,7 @@ function runtimeErrorViewModel(
   const kindLabel = credentialKindLabel(
     credentialKind,
     language,
-    t("capabilities.credentials.none"),
+    credentialKind || t("myCredentials.kind.unknown"),
   )
   const current = `${window.location.pathname}${window.location.search}${window.location.hash}`
   const { credential: href, capability: manageCapabilityHref } = conversationRecoveryLinks(workspaceID, capabilityID, credentialKind, current)

--- a/apps/web/src/components/conversation/ParsarThread.tsx
+++ b/apps/web/src/components/conversation/ParsarThread.tsx
@@ -299,7 +299,7 @@ function RuntimeErrorCard({ text, metadata }: { text: string; metadata: Record<s
   const capabilityName = stringMeta(metadata, "capability_name") || t("conversations.runtime_error.fallbackCapability")
   const credentialKind = stringMeta(metadata, "credential_kind")
   const capabilityID = stringMeta(metadata, "capability_id")
-  const kindLabel = credentialKindLabel(credentialKind, i18n.language, t("capabilities.credentials.none"))
+  const kindLabel = credentialKindLabel(credentialKind, i18n.language, credentialKind || t("myCredentials.kind.unknown"))
 
   let message = text || t("conversations.runtime_error.generic")
   let action = ""


### PR DESCRIPTION
Capability errors currently describe an unrecognized custom credential kind as “No credential required”. Preserve the provided kind code as the label fallback in both conversation renderers; use “Unknown type” only when the code is absent. Built-in localization and credential actions remain unchanged.

Validation: developer self-review, `make check`, production web build, and browser verification of the original missing-credential conversation and credential entry route.
