### PR TITLE
fix(web): retain failed conversation runs after refresh

### DIFF
--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -17,6 +17,7 @@ import { ApprovalBar } from "./ApprovalBar"
 import { ConversationInteractionCards } from "./ConversationInteractionCards"
 import { MessageMarkdown } from "./MessageMarkdown"
 import { WorkTrace, type TraceStep } from "./WorkTrace"
+import { RunFailureNotice } from "./RunFailureNotice"
 import { Button } from "../ui/button"
 import { EmptyState } from "../ui/empty-state"
 import { ErrorState, InlineError } from "../ui/error-state"
@@ -382,7 +383,7 @@ function ChatStream({
   // network error). Server now auto-starts agent_daemon runs, so a
   // /start that returns 200 `already running` is fine; only true
   // network/5xx errors land here.
-  const [chatToast, setChatToast] = useState<{ text: string; detail?: string } | null>(null)
+  const [chatToast, setChatToast] = useState<{ text: string; detail?: string; runID?: string } | null>(null)
   const stream = useAgentRunStream(conversationId, activeRunId, { enabled: !!activeRunId })
   const hasActiveStream = !!activeRunId && stream.status !== "error" && stream.status !== "done"
   // Our sentence and the server's string, kept apart. They used to be one
@@ -452,7 +453,13 @@ function ChatStream({
     }
     return m
   }, [runs])
-  const liveRunAnchored = !!activeRunId && runs.some((r) => r.id === activeRunId)
+  const visibleMessageIDs = new Set(messages.map((message) => message.id))
+  const hasVisibleAnchor = (run: ConversationTimelineRun) => visibleMessageIDs.has(run.trigger_message_id || run.output_message_id || "")
+  const unanchoredFailures = runs.filter((run) =>
+    (run.status === "failed" || run.status === "interrupted") &&
+    !hasVisibleAnchor(run),
+  )
+  const liveRunAnchored = !!activeRunId && runs.some((r) => r.id === activeRunId && hasVisibleAnchor(r))
 
   // Pending permission requests of this conversation, oldest first: they
   // take the composer's slot as the approval bar and open the run's trace.
@@ -501,12 +508,24 @@ function ChatStream({
       }
     />
   )
-  const traceFor = (run: ConversationTimelineRun) =>
-    run.id === activeRunId ? (
-      liveTrace(run)
-    ) : (
-      <RunTrace key={run.id} run={run} live={null} attention={runsAwaitingUser.has(run.id)} />
-    )
+  const traceFor = (run: ConversationTimelineRun) => (
+    <Fragment key={run.id}>
+      {run.id === activeRunId
+        ? liveTrace(run)
+        : <RunTrace run={run} live={null} attention={runsAwaitingUser.has(run.id)} />}
+      {(run.status === "failed" || run.status === "interrupted") && (
+        <RunFailureNotice
+          run={run}
+          workspaceID={convWorkspaceId}
+          canRetry={canWrite && !activeRunId}
+          onRunStarted={(runID) => {
+            startRun(runID)
+            void timelineQ.refetch()
+          }}
+        />
+      )}
+    </Fragment>
+  )
 
   // When the stream finishes, refetch the timeline so the persisted
   // assistant message replaces the in-memory deltaText, then drop the
@@ -525,7 +544,7 @@ function ChatStream({
         // activeRunId is cleared below, which resets the stream hook to idle.
         // Keep a durable, dismissible copy so a fast provider rejection does
         // not disappear before the user can read it and look like a stalled run.
-        setChatToast(streamErrorMessage)
+        setChatToast({ ...streamErrorMessage, runID: activeRunId })
       }
       setActiveRunId(null)
     }, 0)
@@ -582,10 +601,12 @@ function ChatStream({
                 <Fragment key={m.id}>
                   {(orphanRunsByOutput.get(m.id) ?? []).map(traceFor)}
                   {row}
+                  {(runsByTrigger.get(m.id) ?? []).map(traceFor)}
                 </Fragment>
               )
             })
           )}
+          {unanchoredFailures.map(traceFor)}
           {activeRunId && !liveRunAnchored && liveTrace(null)}
           {hasActiveStream && stream.deltaText && (
             <MessageRow
@@ -632,7 +653,9 @@ function ChatStream({
 
       <ComposerFooter>
         <ListSlot slotId="conversation.input.dock" context={{ conversationId }} />
-        {chatToast && <ChatErrorToast message={chatToast} onDismiss={() => setChatToast(null)} />}
+        {chatToast && !runs.some((run) => run.id === chatToast.runID && (run.status === "failed" || run.status === "interrupted")) && (
+          <ChatErrorToast message={chatToast} onDismiss={() => setChatToast(null)} />
+        )}
         {pendingPermissions.length > 0 && convWorkspaceId ? (
           // The approval takes the composer's slot: one control for the
           // decision, none for typing until the agent may continue.

--- a/apps/web/src/components/conversation/RunFailureNotice.tsx
+++ b/apps/web/src/components/conversation/RunFailureNotice.tsx
@@ -1,0 +1,62 @@
+import { useRef } from "react"
+import { useTranslation } from "react-i18next"
+import { useRetryRun } from "../../lib/api-agents"
+import type { ConversationTimelineRun } from "../../lib/api-types"
+import { Button } from "../ui/button"
+import { ErrorDialog } from "../ui/error-dialog"
+import { ErrorState } from "../ui/error-state"
+
+export function RunFailureNotice({
+  run,
+  workspaceID,
+  canRetry,
+  onRunStarted,
+}: {
+  run: ConversationTimelineRun
+  workspaceID: string | null
+  canRetry: boolean
+  onRunStarted: (runID: string) => void
+}) {
+  const { t } = useTranslation("admin")
+  const retry = useRetryRun(workspaceID)
+  const scopeRef = useRef<HTMLDivElement>(null)
+  const retryRef = useRef<HTMLButtonElement>(null)
+  return (
+    <div ref={scopeRef}>
+      <ErrorState
+        appearance="panel"
+        announce={false}
+        title={t("conversations.runFailure.title")}
+        action={workspaceID ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <Button asChild variant="outline" size="sm">
+              <a href={`/?${new URLSearchParams({ ws: workspaceID, admin: "runs", id: run.id })}`}>
+                {t("conversations.detail.viewRunLink")}
+              </a>
+            </Button>
+            {canRetry && !run.agent_deleted && <Button
+              ref={retryRef}
+              variant="outline"
+              size="sm"
+              disabled={retry.isPending}
+              onClick={() => retry.mutate(
+                { runID: run.id, reason: "user_clicked_retry" },
+                { onSuccess: (result) => onRunStarted(result.run_id) },
+              )}
+            >
+              {t("runs.actions.retry")}
+            </Button>}
+          </div>
+        ) : undefined}
+      />
+      {retry.error && <ErrorDialog
+        title={t("conversations.runFailure.retryErrorTitle")}
+        message={t("conversations.runFailure.retryError")}
+        detail={retry.error.message}
+        onClose={() => retry.reset()}
+        onRestoreFocus={() => retryRef.current?.focus()}
+        focusScopeRef={scopeRef}
+      />}
+    </div>
+  )
+}

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -285,6 +285,11 @@
       "externalUser": "IM user",
       "systemSender": "System"
     },
+    "runFailure": {
+      "title": "The Agent could not finish this request.",
+      "retryErrorTitle": "Could not retry",
+      "retryError": "The request could not be retried. Please try again."
+    },
     "runtime_error": {
       "badge": "Capability unavailable",
       "fallbackCapability": "this capability",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -285,6 +285,11 @@
       "externalUser": "IM 用户",
       "systemSender": "系统"
     },
+    "runFailure": {
+      "title": "Agent 未能完成这次请求。",
+      "retryErrorTitle": "重新执行失败",
+      "retryError": "重新执行失败，请再试一次。"
+    },
     "runtime_error": {
       "badge": "能力不可用",
       "fallbackCapability": "此能力",


### PR DESCRIPTION
A failed conversation run with no tool steps or answer disappears from the thread after refresh. Keep a failure notice on its triggering turn, including system and Agent triggers, with a link to persisted run diagnostics and an explicit retry action for permitted users. Retry uses the existing API, preserves the original run and follows the returned run; request failures use the existing error dialog.

Validation: `make check`, production web build, browser comparisons against the baseline, user/system/Agent triggers, retry success and failure, viewer/deleted-Agent restrictions, and the original OpenCode failure history with navigation to its persisted error event. No backend, authorization, dispatch or stream transport changes.

Independent blind reviews were completed. Findings about non-user triggers, diagnostic access, missing visible anchors and per-run deletion eligibility were addressed; the final local display-condition corrections were self-reviewed and verified in the browser.
