### PR TITLE
fix: preserve streams while active runs await their first event

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,6 +189,9 @@ description and keep ownership on the side listed here.
 - `internal/agentdaemon/proto` is the only shared wire contract between the
   server and daemon. The daemon must not import `server/internal/...`, and the
   server must not import daemon-internal adapter packages.
+- The conversation SSE first-event timer observes run state; it is not an
+  execution deadline. Keep waiting while the stored run is queued or running.
+  Dispatch retains ownership of execution timeouts and terminal state.
 - Any state needed to recover a conversation after a server restart, daemon
   reconnect, or child-process exit must be stored durably by the server.
   In-memory maps may cache waiters or sockets only; they must not be the

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -3691,8 +3691,10 @@ paths:
   /api/v1/conversations/{conversationID}/runs/{runID}/stream:
     get:
       description: Server-Sent Events stream that forwards the connector's PromptEvents
-        (deltas, tool calls, permission requests, final message) for the run. Content-Type
-        is text/event-stream; each event's data field is a JSON-encoded PromptEvent.
+        (deltas, tool calls, permission requests, final message) for the run. Queued
+        and running tasks may wait for their first event without failing the stream.
+        Content-Type is text/event-stream; each event's data field is a JSON-encoded
+        PromptEvent.
       operationId: streamDevConversationAgentRun
       parameters:
       - description: Conversation UUID

--- a/server/internal/dev/run_stream.go
+++ b/server/internal/dev/run_stream.go
@@ -40,7 +40,7 @@ const dispatchRunTimeout = 30 * time.Minute
 // streamFirstEventTimeout protects /stream from hanging when no producer
 // ever publishes (e.g. /start failed or runID is stale). After this window
 // with zero events, refreshes run status: terminal → synthesize an error;
-// still queued → emit timeout error.
+// queued or running → keep waiting for the producer.
 //
 // var (not const) so tests can shrink it; production never reassigns.
 var streamFirstEventTimeout = 30 * time.Second
@@ -208,7 +208,7 @@ func startConversationAgentRun(runtimeStore RuntimeStore, cfg *routerConfig) htt
 // browser.
 //
 //	@Summary		Stream agent run events (SSE)
-//	@Description	Server-Sent Events stream that forwards the connector's PromptEvents (deltas, tool calls, permission requests, final message) for the run. Content-Type is text/event-stream; each event's data field is a JSON-encoded PromptEvent.
+//	@Description	Server-Sent Events stream that forwards the connector's PromptEvents (deltas, tool calls, permission requests, final message) for the run. Queued and running tasks may wait for their first event without failing the stream. Content-Type is text/event-stream; each event's data field is a JSON-encoded PromptEvent.
 //	@Tags			agent-runs
 //	@ID				streamDevConversationAgentRun
 //	@Produce		text/event-stream
@@ -289,10 +289,10 @@ func streamConversationAgentRun(runtimeStore RuntimeStore, cfg *routerConfig) ht
 			case <-r.Context().Done():
 				return
 			case <-firstEventTimer.C:
-				// A queued run can legitimately sit unbounded while
-				// an older sibling finishes. Re-arm the timer and
-				// keep waiting silently in that case.
-				if run, err := runtimeStore.GetAgentRun(r.Context(), runID); err == nil && run.Status == "queued" {
+				// Queued runs wait for siblings; running engines may
+				// take time to produce their first event. Neither is
+				// an execution failure while the stored run is active.
+				if run, err := runtimeStore.GetAgentRun(r.Context(), runID); err == nil && (run.Status == "queued" || run.Status == "running") {
 					firstEventTimer.Reset(streamFirstEventTimeout)
 					continue
 				}

--- a/server/internal/dev/run_stream_wait_test.go
+++ b/server/internal/dev/run_stream_wait_test.go
@@ -1,0 +1,85 @@
+package dev
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/runstream"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+type firstEventWaitStore struct {
+	stubRuntimeStore
+	status string
+	reads  int
+	onWait func()
+}
+
+func (s *firstEventWaitStore) GetAgentRun(ctx context.Context, runID string) (store.AgentRunDetailRead, error) {
+	s.reads++
+	// The initial read and two observation intervals precede the outcome.
+	if s.reads == 4 {
+		s.onWait()
+	}
+	run, err := s.stubRuntimeStore.GetAgentRun(ctx, runID)
+	run.Status = s.status
+	return run, err
+}
+
+func TestConversationStreamWaitsForActiveRunOutcome(t *testing.T) {
+	original := streamFirstEventTimeout
+	streamFirstEventTimeout = 5 * time.Millisecond
+	t.Cleanup(func() { streamFirstEventTimeout = original })
+
+	for _, active := range []string{"queued", "running"} {
+		for _, outcome := range []string{"event", "failed", "completed", "cancelled", "disconnect"} {
+			t.Run(active+"/"+outcome, func(t *testing.T) {
+				broker := runstream.NewBroker(runstream.DefaultBufferSize)
+				s := &firstEventWaitStore{status: active}
+				path := "/api/v1/conversations/" + testConversationID + "/runs/" + testRunID + "/stream"
+				req := newConversationMessageRequest(http.MethodGet, path, "", store.DefaultDevFixtureIDs().UserID)
+				ctx, cancel := context.WithTimeout(req.Context(), time.Second)
+				defer cancel()
+				s.onWait = func() {
+					switch outcome {
+					case "event":
+						broker.Publish(testRunID, connector.PromptEvent{Type: connector.EventDone, Final: &connector.PromptOutput{Content: "delayed reply"}})
+						broker.Finish(testRunID)
+					case "disconnect":
+						cancel()
+					default:
+						s.status = outcome
+					}
+				}
+				r := chi.NewRouter()
+				r.Get("/api/v1/conversations/{conversationID}/runs/{runID}/stream", streamConversationAgentRun(s, &routerConfig{runBroker: broker}))
+				response := serveConversationMessageRequest(r, req.WithContext(ctx))
+				if response.Code != http.StatusOK || s.reads < 4 {
+					t.Fatalf("stream ended before the outcome: status=%d reads=%d body=%s", response.Code, s.reads, response.Body.String())
+				}
+				events := parseSSEFrames(t, response.Body)
+				if outcome == "disconnect" {
+					if len(events) != 0 || s.status != active {
+						t.Fatalf("disconnect changed the run or emitted an error: status=%s events=%v", s.status, events)
+					}
+					return
+				}
+				if len(events) != 1 {
+					t.Fatalf("events=%v, want one outcome event", events)
+				}
+				if outcome == "event" {
+					if events[0]["type"] != "done" || s.status != active {
+						t.Fatalf("delayed reply failed or read route changed run status: status=%s events=%v", s.status, events)
+					}
+				} else if reason, _ := events[0]["error"].(string); events[0]["type"] != "error" || !strings.Contains(reason, outcome) {
+					t.Fatalf("terminal %s signal lost: %v", outcome, events)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
A running model that takes longer than 30 seconds to produce its first stream event currently receives a dispatcher-timeout error even though the run is still active. Keep waiting while the stored run is queued or running; dispatch continues to own execution deadlines.

Validation: `make check`, regenerated OpenAPI, focused delayed-event/terminal-state/disconnect regressions, and an independent blind review with race-enabled repeated tests. The delayed-running cases fail against the baseline. No changes to event payloads, dispatch deadlines, authorization or post-first-event handling.
