### PR TITLE
fix(web): surface failed conversation stop requests

### DIFF
--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -20,6 +20,7 @@ import { WorkTrace, type TraceStep } from "./WorkTrace"
 import { RunFailureNotice } from "./RunFailureNotice"
 import { Button } from "../ui/button"
 import { EmptyState } from "../ui/empty-state"
+import { ErrorDialog } from "../ui/error-dialog"
 import { ErrorState, InlineError } from "../ui/error-state"
 import { InitialTile } from "../ui/ledger"
 import { Skeleton } from "../ui/skeleton"
@@ -365,6 +366,7 @@ function ChatStream({
   const agentDeleted = convInfoQ.data?.primary_agent_deleted === true
   const agentName = agent?.name || convInfoQ.data?.primary_agent_name || ""
   const cancelRunMut = useCancelRun(convWorkspaceId)
+  const cancelScopeRef = useRef<HTMLDivElement>(null)
 
   // SSE state: ComposerForm hands us a run_id after send; we open the
   // EventSource and append delta tokens into the streaming message. While
@@ -552,7 +554,7 @@ function ChatStream({
   }, [stream.status, streamErrorMessage, activeRunId, conversationId, qc])
 
   return (
-    <div className="flex min-w-0 flex-1 flex-col" style={THREAD_STYLE}>
+    <div ref={cancelScopeRef} className="flex min-w-0 flex-1 flex-col" style={THREAD_STYLE}>
       {chrome !== "bare" && <ThreadHeader
         folded={folded}
         onExpand={onExpand}
@@ -651,6 +653,19 @@ function ChatStream({
         </div>
       </div>
 
+      {cancelRunMut.error && !runs.some((run) => run.id === cancelRunMut.variables?.runID && run.status === "cancelled") && <ErrorDialog
+        title={t("conversations.composer.stopErrorTitle")}
+        message={t("conversations.composer.stopError")}
+        detail={cancelRunMut.error.message}
+        onClose={() => cancelRunMut.reset()}
+        focusScopeRef={cancelScopeRef}
+        onRestoreFocus={() => {
+          const scope = cancelScopeRef.current
+          const target = scope?.querySelector<HTMLButtonElement>(`button[aria-label="${CSS.escape(t("conversations.composer.stopAria"))}"]`)
+            ?? scope?.querySelector<HTMLTextAreaElement>("textarea")
+          target?.focus()
+        }}
+      />}
       <ComposerFooter>
         <ListSlot slotId="conversation.input.dock" context={{ conversationId }} />
         {chatToast && !runs.some((run) => run.id === chatToast.runID && (run.status === "failed" || run.status === "interrupted")) && (

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -311,6 +311,8 @@
       "send": "Send",
       "sending": "Sending…",
       "stopAria": "Stop generating",
+      "stopErrorTitle": "Could not confirm stop",
+      "stopError": "Check the current run status. If it is still running, try stopping it again.",
       "placeholderGeneric": "Send a message…"
     },
     "sandboxGuard": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -311,6 +311,8 @@
       "send": "发送",
       "sending": "发送中…",
       "stopAria": "停止生成",
+      "stopErrorTitle": "未能确认停止",
+      "stopError": "请查看当前运行状态。如果仍在运行，可以再次点击停止。",
       "placeholderGeneric": "发送消息…"
     },
     "sandboxGuard": {


### PR DESCRIPTION
A failed Stop request currently leaves a conversation running without explaining that cancellation was not confirmed. Show the existing error dialog with a recovery hint and optional technical details, restoring focus to Stop or the composer when dismissed. Suppress the dialog when the refreshed run is already cancelled.

Validation: `make check`, production web build, and browser scenarios for a 503 cancellation failure, dismissal/focus, successful retry, and a 422 response with an already-cancelled stored run. Self-reviewed as a local presentation change; cancellation and stream reconciliation are unchanged.
