### PR TITLE
fix(web): keep error feedback words intact when wrapping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -577,8 +577,9 @@ Three concrete rules:
    user to scroll sideways. Exception: append-only terminal log streams may
    keep `overflow-x-auto`, but only when nested inside an
    `overflow-hidden` parent so the scrollbar can't escape the dialog.
-3. Error / warning banners always carry `break-all` so long tokens, URLs,
-   or stack traces can't blow the container open.
+3. Reader-facing error / warning copy uses `overflow-wrap: anywhere` to
+   preserve normal word boundaries while containing long unbroken strings.
+   Verbatim technical details keep the code-block wrapping rules above.
 
 When a dialog uses a multi-column grid, give every column `min-w-0` —
 otherwise long children push the grid track wider instead of wrapping.

--- a/apps/web/src/components/ui/error-dialog.tsx
+++ b/apps/web/src/components/ui/error-dialog.tsx
@@ -30,12 +30,12 @@ export function ErrorDialog({ title, message, detail, onClose, onRestoreFocus, f
         className="w-[calc(100%-2rem)] max-h-[calc(100vh-2rem)] overflow-y-auto overflow-x-hidden"
       >
         <DialogHeader className="min-w-0 pr-4">
-          <DialogTitle className="flex items-start gap-2 break-all">
+          <DialogTitle className="flex items-start gap-2 [overflow-wrap:anywhere]">
             <AlertTriangle className="h-4 w-4 shrink-0 text-status-failed" strokeWidth={1.5} aria-hidden="true" />
             {title}
           </DialogTitle>
         </DialogHeader>
-        <DialogDescription className="break-all text-fg">{message}</DialogDescription>
+        <DialogDescription className="text-fg [overflow-wrap:anywhere]">{message}</DialogDescription>
         {detail && (
           <details className="min-w-0">
             <summary className="cursor-pointer text-sm text-fg-muted focus-visible:outline-accent">

--- a/apps/web/src/components/ui/error-state.tsx
+++ b/apps/web/src/components/ui/error-state.tsx
@@ -43,7 +43,7 @@ export function ErrorState({
       <div className="flex w-full items-start gap-2">
         <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-failed" strokeWidth={1.5} aria-hidden="true" />
         <div className="min-w-0 flex-1 space-y-1">
-          <p className="break-all font-medium text-fg">{resolvedTitle}</p>
+          <p className="font-medium text-fg [overflow-wrap:anywhere]">{resolvedTitle}</p>
           {description && <p className="break-words text-xs text-fg">{description}</p>}
           {appearance === "panel" && detail ? (
             <details className="min-w-0">


### PR DESCRIPTION
Shared error dialogs and error-state titles force English words to break mid-word with `break-all`. Use `overflow-wrap: anywhere` so ordinary words stay intact while long unbroken text remains contained. Update the contributor rule to keep the distinction between reader-facing copy and verbatim technical details.

Validation: `make check`, production web build, and browser inspection of shared components in 360 px and 640 px viewports with English prose, long unbroken strings, and Chinese text. Self-reviewed CSS correction; actions, focus and technical details are unchanged.
