### PR TITLE
fix(web): provide recovery navigation for invalid invitations

### DIFF
--- a/apps/web/src/i18n/locales/en-US/common.json
+++ b/apps/web/src/i18n/locales/en-US/common.json
@@ -226,7 +226,8 @@
   "invite": {
     "loading": "Loading invitation...",
     "invalidTitle": "Invalid Invitation",
-    "invalidDescription": "This invitation link is invalid, expired, or has already been used.",
+    "invalidDescription": "This invitation link is invalid, expired, or has already been used. Ask the person who invited you for a new link.",
+    "backToConsole": "Back to console",
     "title": "Join {{name}}",
     "description": "You've been invited as {{role}}. Set a password to activate your account.",
     "existingDescription": "You're signed in as {{email}}. Accept this invitation to join as {{role}}.",

--- a/apps/web/src/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/i18n/locales/zh-CN/common.json
@@ -226,7 +226,8 @@
   "invite": {
     "loading": "邀请加载中...",
     "invalidTitle": "邀请无效",
-    "invalidDescription": "该邀请链接无效、已过期或已被使用。",
+    "invalidDescription": "该邀请链接无效、已过期或已被使用。请联系邀请人获取新的邀请链接。",
+    "backToConsole": "返回控制台",
     "title": "加入 {{name}}",
     "description": "你被邀请为 {{role}}。设置密码以激活账号。",
     "existingDescription": "你已使用 {{email}} 登录。接受邀请后将以 {{role}} 身份加入。",

--- a/apps/web/src/pages/InviteAcceptPage.tsx
+++ b/apps/web/src/pages/InviteAcceptPage.tsx
@@ -47,7 +47,13 @@ export function InviteAcceptPage({ token }: { token: string }) {
   if (infoQ.isError || !infoQ.data) {
     return (
       <EntryPage>
-        <EntryPanel title={t("invite.invalidTitle")} description={t("invite.invalidDescription")} />
+        <EntryPanel title={t("invite.invalidTitle")} description={t("invite.invalidDescription")}>
+          <Button asChild>
+            <a href={user ? "/" : "/login"} onClick={() => popPendingJoinIntent()}>
+              {t(user ? "invite.backToConsole" : "login.backToLogin")}
+            </a>
+          </Button>
+        </EntryPanel>
       </EntryPage>
     )
   }


### PR DESCRIPTION
Invalid invitations leave visitors at a dead end. Add a login link for guests and a console link for signed-in users, and explain how to request a replacement invitation. Leaving clears the existing return intent so the next login does not send the visitor back to the invalid link.

Valid invitation acceptance, authentication and API behavior are unchanged.

Validation: `make check`, web build and diff checks passed. Browser checks cover keyboard navigation to login, signed-in console navigation, stale return intent followed by login, and the unchanged valid-invitation form. Developer self-review for this small page-local change.
