### PR TITLE
fix(web): manage disabled agents from the console

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -540,8 +540,9 @@ split relevant pieces out first rather than growing the file further.
 - Agent management opts into disabled records with a separate query-cache key.
   Ordinary Agent selectors keep active-only reads; status mutations invalidate
   both list variants and the detail before their pending state ends. Agent status
-  operation state and feedback belong above the detail rail/modal presentations
-  so changing presentation cannot drop an in-flight outcome.
+  operation state and feedback belong to the management page, above its selected
+  detail and rail/modal presentations. Serialize status submissions until the
+  current operation settles; changing details cannot drop an in-flight outcome.
 
 - Tool-result failure is independent of the run's final status. Live and
   persisted tool views share the explicit result-failure predicate; ending a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -537,6 +537,12 @@ split relevant pieces out first rather than growing the file further.
 
 ### Frontend shared logic
 
+- Agent management opts into disabled records with a separate query-cache key.
+  Ordinary Agent selectors keep active-only reads; status mutations invalidate
+  both list variants and the detail before their pending state ends. Agent status
+  operation state and feedback belong above the detail rail/modal presentations
+  so changing presentation cannot drop an in-flight outcome.
+
 - Tool-result failure is independent of the run's final status. Live and
   persisted tool views share the explicit result-failure predicate; ending a
   tool event does not itself imply success. Do not infer failure from prose.

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1566,7 +1566,8 @@
     },
     "filters": {
       "label": "Filter",
-      "allConnectors": "All connectors"
+      "allConnectors": "All connectors",
+      "allStatuses": "All statuses"
     },
     "exposure": {
       "conversation": {
@@ -1587,6 +1588,13 @@
         "off": "Not configured",
         "notYet": "Coming"
       }
+    },
+    "statusAction": {
+      "enable": "Enable",
+      "disable": "Disable",
+      "enabled": "“{{name}}” enabled.",
+      "disabled": "“{{name}}” disabled.",
+      "failed": "Could not update Agent status"
     }
   },
   "connectors": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1566,7 +1566,8 @@
     },
     "filters": {
       "label": "筛选",
-      "allConnectors": "全部连接方式"
+      "allConnectors": "全部连接方式",
+      "allStatuses": "全部状态"
     },
     "exposure": {
       "conversation": {
@@ -1587,6 +1588,13 @@
         "off": "未配置",
         "notYet": "即将支持"
       }
+    },
+    "statusAction": {
+      "enable": "启用",
+      "disable": "停用",
+      "enabled": "已启用“{{name}}”。",
+      "disabled": "已停用“{{name}}”。",
+      "failed": "未能更新 Agent 状态"
     }
   },
   "connectors": {

--- a/apps/web/src/lib/api-agents.ts
+++ b/apps/web/src/lib/api-agents.ts
@@ -54,10 +54,11 @@ function normalizeAgentId(a: Agent): Agent {
   return agentID ? { ...a, id: agentID } : a
 }
 
-async function listAgents(workspaceID: string | null): Promise<ListAgentsResponse> {
+async function listAgents(workspaceID: string | null, includeDisabled: boolean): Promise<ListAgentsResponse> {
   if (!workspaceID) return { agents: [] }
   const res = await apiRequest<ListAgentsResponse>(
-    `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/agents`
+    `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/agents`,
+    { query: { include_disabled: includeDisabled || undefined } }
   )
   return { ...res, agents: (res.agents ?? []).map(normalizeAgentId) }
 }
@@ -238,10 +239,10 @@ async function updateAgentProfileRequest(
 
 /* --- React Query hooks -------------------------------------------------- */
 
-export function useAgents(workspaceID: string | null) {
+export function useAgents(workspaceID: string | null, includeDisabled = false) {
   return useQuery({
-    queryKey: KEY_AGENTS(workspaceID ?? "_none"),
-    queryFn: () => listAgents(workspaceID),
+    queryKey: [...KEY_AGENTS(workspaceID ?? "_none"), includeDisabled],
+    queryFn: () => listAgents(workspaceID, includeDisabled),
     retry: noUnreachableRetry,
     staleTime: 30_000,
   })
@@ -661,19 +662,15 @@ export function usePollAgentFeishuProvisioning(workspaceID: string | null) {
   })
 }
 
-export function useSetAgentStatus(workspaceID: string | null) {
+export function useSetAgentStatus(workspaceID: string | null, agentID: string) {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: async ({
-      agentID,
-      enabled,
-    }: {
-      agentID: string
-      enabled: boolean
-    }) => setAgentStatus(agentID, enabled),
-    onSuccess: (_agent, variables) => {
-      void qc.invalidateQueries({ queryKey: KEY_AGENTS(workspaceID ?? "_none") })
-      void qc.invalidateQueries({ queryKey: KEY_AGENT_DETAIL(workspaceID ?? "_none", variables.agentID) })
+    mutationFn: (enabled: boolean) => setAgentStatus(agentID, enabled),
+    onSuccess: async () => {
+      await Promise.all([
+        qc.invalidateQueries({ queryKey: KEY_AGENTS(workspaceID ?? "_none") }),
+        qc.invalidateQueries({ queryKey: KEY_AGENT_DETAIL(workspaceID ?? "_none", agentID) }),
+      ])
     },
   })
 }

--- a/apps/web/src/lib/api-agents.ts
+++ b/apps/web/src/lib/api-agents.ts
@@ -662,11 +662,11 @@ export function usePollAgentFeishuProvisioning(workspaceID: string | null) {
   })
 }
 
-export function useSetAgentStatus(workspaceID: string | null, agentID: string) {
+export function useSetAgentStatus(workspaceID: string | null) {
   const qc = useQueryClient()
   return useMutation({
-    mutationFn: (enabled: boolean) => setAgentStatus(agentID, enabled),
-    onSuccess: async () => {
+    mutationFn: ({ agentID, enabled }: { agentID: string; enabled: boolean }) => setAgentStatus(agentID, enabled),
+    onSuccess: async (_agent, { agentID }) => {
       await Promise.all([
         qc.invalidateQueries({ queryKey: KEY_AGENTS(workspaceID ?? "_none") }),
         qc.invalidateQueries({ queryKey: KEY_AGENT_DETAIL(workspaceID ?? "_none", agentID) }),

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -134,14 +134,17 @@ export function AgentsPage() {
   // vanishing — the same pattern every ledger uses.
   const [railID, setRailID] = useState<string | null>(entityId)
   if (entityId && entityId !== railID) setRailID(entityId)
-  const agentRail = railID ? (
-    <AgentDetailRail
-      id={railID}
-      open={!!entityId}
-      onClose={() => navigate("agents")}
-      onClosed={() => setRailID(null)}
-    />
-  ) : null
+  const agentRail = (
+    <AgentStatusControl workspaceID={wid}>{(renderStatusAction) => railID ? (
+        <AgentDetailRail
+          id={railID}
+          renderStatusAction={renderStatusAction}
+          open={!!entityId}
+          onClose={() => navigate("agents")}
+          onClosed={() => setRailID(null)}
+        />
+    ) : null}</AgentStatusControl>
+  )
 
   return (
     <AdminLayout activeMenu="agents" fullBleed>
@@ -386,11 +389,12 @@ function AgentsLoadingSkeleton() {
  * rail's widest brief: identity in the header, its verbs in the footer, and
  * the expand button for the times the config form wants room.
  */
-export function AgentDetailRail({ id, open, onClose, onClosed }: {
+export function AgentDetailRail({ id, open, onClose, onClosed, renderStatusAction }: {
   id: string
   open: boolean
   onClose: () => void
   onClosed: () => void
+  renderStatusAction: (agent: Agent) => ReactNode
 }) {
   const { t } = useTranslation("admin")
   const { navigate, tab: requestedTab } = useAdminView()
@@ -441,7 +445,6 @@ export function AgentDetailRail({ id, open, onClose, onClosed }: {
 
   const model = defaultModelOf(agent, models, t("agents.modelUnavailable"))
   return (
-    <AgentStatusControl key={agent.id} agent={agent} workspaceID={wid}>{(statusAction) => (
     <DetailRail
       open={open}
       onClose={onClose}
@@ -457,7 +460,7 @@ export function AgentDetailRail({ id, open, onClose, onClosed }: {
       footer={
         <AgentDetailActions
           agent={agent}
-          statusAction={statusAction}
+          statusAction={renderStatusAction(agent)}
           workspaceID={wid}
           workspaceName={currentWorkspace?.name}
           workspaceRole={workspaceRole}
@@ -519,6 +522,5 @@ export function AgentDetailRail({ id, open, onClose, onClosed }: {
         </TabsContent>
       </Tabs>
     </DetailRail>
-    )}</AgentStatusControl>
   )
 }

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -5,7 +5,6 @@ import { Bot, Plus, Search, Wrench } from "lucide-react"
 import { AdminLayout } from "../../components/layout/AdminLayout"
 import { PageHeader } from "../../components/layout/PageHeader"
 import { DetailRail, RailLayout } from "../../components/ui/detail-rail"
-import { FilterGroup, FilterMenu, FilterOption } from "../../components/ui/filter-menu"
 import { ScopeRequiredState } from "../../components/admin/ScopeRequiredState"
 import { ResourceAuditTimeline } from "../../components/admin/ResourceAuditTimeline"
 import { Button } from "../../components/ui/button"
@@ -36,10 +35,7 @@ import { useModels } from "../../lib/api-models"
 import { useMyWorkspaces } from "../../lib/api-workspaces"
 import { useMarketplaceList } from "../../lib/api-marketplace"
 import {
-  AGENT_CONNECTOR_TYPES,
   searchAgents,
-  agentConnectorKey,
-  agentConnectorLabel,
   defaultModelOf,
 } from "../../lib/agent-view-model"
 import type { Agent } from "../../lib/api-types"
@@ -49,9 +45,11 @@ import { useRelativeTime } from "../../lib/relative-time"
 import { CreateAgentDialog } from "./CreateAgentDialog"
 import { AgentConfigTab } from "./agents/AgentConfigTab"
 import { AgentDetailActions } from "./agents/AgentDetailActions"
+import { AgentStatusControl } from "./agents/AgentStatusControl"
 import { AgentExposureTab } from "./agents/AgentExposureTab"
 import { AgentDynamicsTab } from "./agents/AgentDynamicsTab"
 import { AgentsListTable } from "./agents/AgentsListTable"
+import { AgentsFilters, type AgentStatusFilter } from "./agents/AgentsFilters"
 import { AgentStatusBadge } from "./agents/AgentStatusBadge"
 import { DeleteAgentDialog } from "./agents/DeleteAgentDialog"
 import { DetailSection } from "./agents/DetailSection"
@@ -94,6 +92,7 @@ export function AgentsPage() {
   const wid = useWorkspaceId()
   const [keyword, setKeyword] = useState("")
   const [connectorFilter, setConnectorFilter] = useState("")
+  const [statusFilter, setStatusFilter] = useState<AgentStatusFilter>("")
   const [createOpen, setCreateOpen] = useState(false)
   const [editAgent, setEditAgent] = useState<Agent | null>(null)
   const [cloneAgent, setCloneAgent] = useState<Agent | null>(null)
@@ -101,14 +100,18 @@ export function AgentsPage() {
   const toast = useToast()
   const fmtAgo = useRelativeTime()
 
-  const query = useAgents(wid)
+  const workspacesQ = useMyWorkspaces()
+  const currentWorkspace = workspacesQ.data?.workspaces.find((w) => w.id === wid)
+  const workspaceRole = currentWorkspace?.role
+  const workspaceName = currentWorkspace?.name
+  const { canManage, canChat } = agentActionPermissions(workspaceRole)
+  const query = useAgents(wid, canManage)
   const createMut = useCreateAgent(wid)
   const cloneMut = useCreateAgent(wid)
   const modelsQ = useModels(wid)
   const updateMut = useUpdateAgent(wid)
   const updateProfileMut = useUpdateAgentProfile(wid)
   const deleteMut = useDeleteAgent(wid)
-  const workspacesQ = useMyWorkspaces()
   const agents = useMemo(() => {
     const list = query.data?.agents ?? []
     // Sort: newest first (by enabled_at / created_at descending)
@@ -119,25 +122,7 @@ export function AgentsPage() {
     })
   }, [query.data])
   const models = useMemo(() => modelsQ.data?.models ?? [], [modelsQ.data])
-  // Counted over the agents the search already narrowed to, so the menu
-  // describes the list on screen rather than one the reader cannot see.
-  // The known set is always listed — a connector with nothing on it is
-  // usually what you opened the menu to check — plus any type actually in
-  // use, because `connector_type` is unconstrained text on the server.
   const searched = useMemo(() => searchAgents(agents, keyword, models, t), [agents, keyword, models, t])
-  const connectorCounts = useMemo(() => {
-    const counts = new Map<string, number>(AGENT_CONNECTOR_TYPES.map((c) => [c, 0]))
-    for (const agent of searched) {
-      const key = agentConnectorKey(agent.connector_type)
-      counts.set(key, (counts.get(key) ?? 0) + 1)
-    }
-    return counts
-  }, [searched])
-  const connectorOptions = useMemo(() => [...connectorCounts.keys()], [connectorCounts])
-  const currentWorkspace = workspacesQ.data?.workspaces.find((w) => w.id === wid)
-  const workspaceRole = currentWorkspace?.role
-  const workspaceName = currentWorkspace?.name
-  const { canManage, canChat } = agentActionPermissions(workspaceRole)
   const { startChat: startChatWith, pendingID: chatPendingID } = useAgentChat(wid, canChat)
   const pendingCapability = usePendingCapability(wid)
 
@@ -183,22 +168,14 @@ export function AgentsPage() {
                   onChange={(event) => setKeyword(event.target.value)}
                 />
               </div>
-              <FilterMenu
-                label={t("agents.filters.label")}
-                summary={connectorFilter ? agentConnectorLabel(connectorFilter) : null}
-              >
-                <FilterGroup value={connectorFilter} onValueChange={setConnectorFilter}>
-                  <FilterOption value="" label={t("agents.filters.allConnectors")} count={searched.length} />
-                  {connectorOptions.map((connector) => (
-                    <FilterOption
-                      key={connector}
-                      value={connector}
-                      label={agentConnectorLabel(connector)}
-                      count={connectorCounts.get(connector) ?? 0}
-                    />
-                  ))}
-                </FilterGroup>
-              </FilterMenu>
+              <AgentsFilters
+                agents={searched}
+                connectorFilter={connectorFilter}
+                statusFilter={canManage ? statusFilter : ""}
+                onConnectorChange={setConnectorFilter}
+                onStatusChange={setStatusFilter}
+                canManage={canManage}
+              />
               {canManage && <Button onClick={() => setCreateOpen(true)}>
                 <Plus strokeWidth={1.5} aria-hidden="true" />
                 {t("agents.actions.create")}
@@ -246,7 +223,7 @@ export function AgentsPage() {
           />
         ) : (
           <AgentsListTable
-            agents={agents}
+            agents={canManage && statusFilter ? agents.filter((agent) => agent.status === statusFilter) : agents}
             workspaceRole={workspaceRole}
             models={models}
             keyword={keyword}
@@ -254,6 +231,7 @@ export function AgentsPage() {
             onClearFilters={() => {
               setKeyword("")
               setConnectorFilter("")
+              setStatusFilter("")
             }}
             selectedID={entityId}
             chatPendingID={chatPendingID}
@@ -463,6 +441,7 @@ export function AgentDetailRail({ id, open, onClose, onClosed }: {
 
   const model = defaultModelOf(agent, models, t("agents.modelUnavailable"))
   return (
+    <AgentStatusControl key={agent.id} agent={agent} workspaceID={wid}>{(statusAction) => (
     <DetailRail
       open={open}
       onClose={onClose}
@@ -478,6 +457,7 @@ export function AgentDetailRail({ id, open, onClose, onClosed }: {
       footer={
         <AgentDetailActions
           agent={agent}
+          statusAction={statusAction}
           workspaceID={wid}
           workspaceName={currentWorkspace?.name}
           workspaceRole={workspaceRole}
@@ -539,5 +519,6 @@ export function AgentDetailRail({ id, open, onClose, onClosed }: {
         </TabsContent>
       </Tabs>
     </DetailRail>
+    )}</AgentStatusControl>
   )
 }

--- a/apps/web/src/pages/admin/agents/AgentDetailActions.tsx
+++ b/apps/web/src/pages/admin/agents/AgentDetailActions.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, type ReactNode } from "react"
 import { Loader2, MessageSquare, Pencil, Trash2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
@@ -18,6 +18,7 @@ export function AgentDetailActions({
   workspaceRole,
   models,
   onToast,
+  statusAction,
 }: {
   agent: Agent
   workspaceID: string | null
@@ -25,6 +26,7 @@ export function AgentDetailActions({
   workspaceRole?: UserWorkspace["role"]
   models: Model[]
   onToast: ShowToast
+  statusAction: ReactNode
 }) {
   const { t } = useTranslation("admin")
   const { navigate } = useAdminView()
@@ -44,7 +46,7 @@ export function AgentDetailActions({
   }
 
   return (
-    <>
+    <div className="flex min-w-0 w-full flex-wrap items-center gap-2">
       <Button
         variant="outline"
         disabled={agent.status !== "active" || chatPending}
@@ -58,6 +60,7 @@ export function AgentDetailActions({
         {t("agents.actions.chat")}
       </Button>
       {canManage && <>
+      {statusAction}
       <Button
         variant="outline"
         disabled={deleteMut.isPending}
@@ -127,6 +130,6 @@ export function AgentDetailActions({
         }}
       />
       </>}
-    </>
+    </div>
   )
 }

--- a/apps/web/src/pages/admin/agents/AgentStatusControl.tsx
+++ b/apps/web/src/pages/admin/agents/AgentStatusControl.tsx
@@ -8,37 +8,43 @@ import { useToast } from "../../../components/ui/toast"
 import { useSetAgentStatus } from "../../../lib/api-agents"
 import type { Agent } from "../../../lib/api-types"
 
-export function AgentStatusControl({ agent, workspaceID, children }: { agent: Agent; workspaceID: string | null; children: (action: ReactNode) => ReactNode }) {
+export function AgentStatusControl({ workspaceID, children }: { workspaceID: string | null; children: (renderAction: (agent: Agent) => ReactNode) => ReactNode }) {
   const { t } = useTranslation(["admin", "common"])
-  const mutation = useSetAgentStatus(workspaceID, agent.id)
+  const mutation = useSetAgentStatus(workspaceID)
   const toast = useToast()
   const scope = useRef<HTMLElement | null>(null)
-  const enable = agent.status === "disabled"
-  const Icon = mutation.isPending ? Loader2 : enable ? Play : Pause
+  const requestedAgent = useRef<Agent | null>(null)
 
-  const action = (
-    <Button data-agent-status-action={agent.id} variant="outline" disabled={mutation.isPending} onClick={() => {
-      if (mutation.isPending) return
-      mutation.mutate(enable, {
-        onSuccess: () => toast.show(t(enable ? "agents.statusAction.enabled" : "agents.statusAction.disabled", { name: agent.name })),
-      })
-    }}>
-      <Icon className={mutation.isPending ? "animate-spin" : undefined} strokeWidth={1.5} aria-hidden="true" />
-      {t(enable ? "agents.statusAction.enable" : "agents.statusAction.disable")}
-    </Button>
-  )
+  const renderAction = (agent: Agent) => {
+    const enable = agent.status === "disabled"
+    const pending = mutation.isPending && mutation.variables.agentID === agent.id
+    const Icon = pending ? Loader2 : enable ? Play : Pause
+    return (
+      <Button data-agent-status-action={agent.id} variant="outline" disabled={mutation.isPending} onClick={() => {
+        if (mutation.isPending) return
+        requestedAgent.current = agent
+        mutation.mutate({ agentID: agent.id, enabled: enable }, {
+          onSuccess: () => toast.show(t(enable ? "agents.statusAction.enabled" : "agents.statusAction.disabled", { name: agent.name })),
+        })
+      }}>
+        <Icon className={pending ? "animate-spin" : undefined} strokeWidth={1.5} aria-hidden="true" />
+        {t(enable ? "agents.statusAction.enable" : "agents.statusAction.disable")}
+      </Button>
+    )
+  }
 
   return (
     <>
-      {children(action)}
+      {children(renderAction)}
       {mutation.isError && <ErrorDialog
         title={t("agents.statusAction.failed")}
-        message={t("common:errors.submitRetryHint")}
+        message={`${requestedAgent.current?.name ?? ""}: ${t("common:errors.submitRetryHint")}`}
         detail={mutation.error.message}
         onClose={() => mutation.reset()}
         onRestoreFocus={() => {
-          const buttons = document.querySelectorAll<HTMLButtonElement>(`[data-agent-status-action="${CSS.escape(agent.id)}"]`)
+          const buttons = document.querySelectorAll<HTMLButtonElement>(`[data-agent-status-action="${CSS.escape(requestedAgent.current?.id ?? "")}"]`)
           const target = buttons[buttons.length - 1]
+            ?? document.querySelector<HTMLElement>("[data-agent-status-action], input[type=search]")
           scope.current = target?.parentElement ?? null
           target?.focus()
         }}

--- a/apps/web/src/pages/admin/agents/AgentStatusControl.tsx
+++ b/apps/web/src/pages/admin/agents/AgentStatusControl.tsx
@@ -1,0 +1,49 @@
+import { useRef, type ReactNode } from "react"
+import { Loader2, Pause, Play } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "../../../components/ui/button"
+import { ErrorDialog } from "../../../components/ui/error-dialog"
+import { useToast } from "../../../components/ui/toast"
+import { useSetAgentStatus } from "../../../lib/api-agents"
+import type { Agent } from "../../../lib/api-types"
+
+export function AgentStatusControl({ agent, workspaceID, children }: { agent: Agent; workspaceID: string | null; children: (action: ReactNode) => ReactNode }) {
+  const { t } = useTranslation(["admin", "common"])
+  const mutation = useSetAgentStatus(workspaceID, agent.id)
+  const toast = useToast()
+  const scope = useRef<HTMLElement | null>(null)
+  const enable = agent.status === "disabled"
+  const Icon = mutation.isPending ? Loader2 : enable ? Play : Pause
+
+  const action = (
+    <Button data-agent-status-action={agent.id} variant="outline" disabled={mutation.isPending} onClick={() => {
+      if (mutation.isPending) return
+      mutation.mutate(enable, {
+        onSuccess: () => toast.show(t(enable ? "agents.statusAction.enabled" : "agents.statusAction.disabled", { name: agent.name })),
+      })
+    }}>
+      <Icon className={mutation.isPending ? "animate-spin" : undefined} strokeWidth={1.5} aria-hidden="true" />
+      {t(enable ? "agents.statusAction.enable" : "agents.statusAction.disable")}
+    </Button>
+  )
+
+  return (
+    <>
+      {children(action)}
+      {mutation.isError && <ErrorDialog
+        title={t("agents.statusAction.failed")}
+        message={t("common:errors.submitRetryHint")}
+        detail={mutation.error.message}
+        onClose={() => mutation.reset()}
+        onRestoreFocus={() => {
+          const buttons = document.querySelectorAll<HTMLButtonElement>(`[data-agent-status-action="${CSS.escape(agent.id)}"]`)
+          const target = buttons[buttons.length - 1]
+          scope.current = target?.parentElement ?? null
+          target?.focus()
+        }}
+        focusScopeRef={scope}
+      />}
+    </>
+  )
+}

--- a/apps/web/src/pages/admin/agents/AgentsFilters.tsx
+++ b/apps/web/src/pages/admin/agents/AgentsFilters.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from "react-i18next"
+import { FilterGroup, FilterMenu, FilterOption, FilterSeparator } from "../../../components/ui/filter-menu"
+import { AGENT_CONNECTOR_TYPES, agentConnectorKey, agentConnectorLabel } from "../../../lib/agent-view-model"
+import type { Agent } from "../../../lib/api-types"
+
+export type AgentStatusFilter = Agent["status"] | ""
+const STATUSES: Agent["status"][] = ["active", "disabled", "error"]
+
+export function AgentsFilters({ agents, connectorFilter, statusFilter, onConnectorChange, onStatusChange, canManage }: {
+  agents: Agent[]
+  connectorFilter: string
+  statusFilter: AgentStatusFilter
+  onConnectorChange: (value: string) => void
+  onStatusChange: (value: AgentStatusFilter) => void
+  canManage: boolean
+}) {
+  const { t } = useTranslation("admin")
+  const statusMatches = agents.filter((agent) => !statusFilter || agent.status === statusFilter)
+  const connectorMatches = agents.filter((agent) => !connectorFilter || agentConnectorKey(agent.connector_type) === connectorFilter)
+  const counts = new Map<string, number>(AGENT_CONNECTOR_TYPES.map((key) => [key, 0]))
+  for (const agent of statusMatches) {
+    const key = agentConnectorKey(agent.connector_type)
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+  const summary = [statusFilter && t(`agents.status.${statusFilter}`), connectorFilter && agentConnectorLabel(connectorFilter)].filter(Boolean).join(" · ")
+
+  return (
+    <FilterMenu label={t("agents.filters.label")} summary={summary || null}>
+      {canManage && <>
+        <FilterGroup value={statusFilter} onValueChange={(value) => onStatusChange(value as AgentStatusFilter)}>
+          <FilterOption value="" label={t("agents.filters.allStatuses")} count={connectorMatches.length} />
+          {STATUSES.map((status) => <FilterOption key={status} value={status} label={t(`agents.status.${status}`)} count={connectorMatches.filter((agent) => agent.status === status).length} />)}
+        </FilterGroup>
+        <FilterSeparator />
+      </>}
+      <FilterGroup value={connectorFilter} onValueChange={onConnectorChange}>
+        <FilterOption value="" label={t("agents.filters.allConnectors")} count={statusMatches.length} />
+        {[...counts].map(([connector, count]) => <FilterOption key={connector} value={connector} label={agentConnectorLabel(connector)} count={count} />)}
+      </FilterGroup>
+    </FilterMenu>
+  )
+}


### PR DESCRIPTION
Disabling an Agent previously removed it from the console with no way to find or re-enable it. Workspace owners and admins can now keep disabled Agents in the management list, filter by status, and enable or disable an Agent from its details. One operation owner preserves pending and outcome feedback across Agent selection, closing/reopening details and the rail/expanded view. Failures use the shared error dialog, and list/detail refresh before another submission. Footer actions wrap at narrow widths.

Ordinary Agent selectors and member/viewer lists retain active-only reads. The existing lifecycle API, scheduling, running tasks and authorization are unchanged. The management filter was extracted from the oversized page to keep this change scoped.

Validation: `make check`, web build and browser checks covering disable/enable, refresh, combined filters, request failure/retry/focus, Owner/Admin and Member/Viewer controls, the active-only scheduled-task selector, 320px rail layout, and pending/result continuity while switching Agents and closing, expanding or collapsing details.
