### PR TITLE
fix(web): complete marketplace installs in a dialog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -537,6 +537,13 @@ split relevant pieces out first rather than growing the file further.
 
 ### Frontend shared logic
 
+- Marketplace-to-Agent installation uses the same capability version and
+  credential confirmation dialog as Agent configuration. Keep pending install
+  intent in the existing route until completion or cancellation; clear it before
+  showing the installed Agent configuration. Confirm a marketplace capability
+  using its published version metadata; its source workspace version history is
+  not a cross-workspace read API. Do not duplicate credential rules.
+
 - Agent management opts into disabled records with a separate query-cache key.
   Ordinary Agent selectors keep active-only reads; status mutations invalidate
   both list variants and the detail before their pending state ends. Agent status

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1516,10 +1516,20 @@
       }
     },
     "pendingCapability": {
-      "banner": "You are preparing to add \"{{name}}\" (from {{source}}). Choose an Agent to enable it.",
-      "detailBanner": "You are adding \"{{name}}\" (from {{source}}). Use Enable in the Available section below to finish.",
-      "loading": "Loading the capability you are preparing to add…",
-      "cancel": "Cancel"
+      "title": "Add {{cap}} to an Agent",
+      "capability": "capability",
+      "description": "Choose an Agent, then confirm the version and credentials.",
+      "chooseAgent": "Choose an Agent",
+      "chooseAnother": "Choose another Agent",
+      "continue": "Continue",
+      "manageCredentials": "Manage my credentials and return",
+      "notAllowed": "Your workspace role cannot add capabilities to Agents.",
+      "loadError": "Could not load installation options",
+      "notFound": "This capability is no longer available in the marketplace.",
+      "alreadyAdded": "This capability is already added to {{agent}}.",
+      "viewConfig": "View Agent configuration",
+      "empty": "No compatible Agents",
+      "emptyDescription": "Create an Agent with an engine that supports this capability, then return here."
     },
     "listActions": {
       "cancel": "Cancel",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1516,10 +1516,20 @@
       }
     },
     "pendingCapability": {
-      "banner": "你正在准备装「{{name}}」（来自 {{source}}）。请选择一个 Agent 启用此能力。",
-      "detailBanner": "你正在装「{{name}}」（来自 {{source}}）。在下方工作区可装段点击启用即可完成。",
-      "loading": "正在加载准备装到 Agent 的能力…",
-      "cancel": "取消"
+      "title": "将 {{cap}} 添加到 Agent",
+      "capability": "能力",
+      "description": "选择 Agent，然后确认版本和凭据。",
+      "chooseAgent": "选择 Agent",
+      "chooseAnother": "重新选择 Agent",
+      "continue": "继续",
+      "manageCredentials": "管理我的凭据并返回",
+      "notAllowed": "你的工作区角色无法为 Agent 添加能力。",
+      "loadError": "无法加载安装选项",
+      "notFound": "此能力已不在商城中。",
+      "alreadyAdded": "此能力已添加到 {{agent}}。",
+      "viewConfig": "查看 Agent 配置",
+      "empty": "没有兼容的 Agent",
+      "emptyDescription": "请先创建支持此能力的 Agent，再回到这里安装。"
     },
     "listActions": {
       "cancel": "取消",

--- a/apps/web/src/lib/api-capabilities.ts
+++ b/apps/web/src/lib/api-capabilities.ts
@@ -175,7 +175,12 @@ export async function listAgentCapabilities(
 }
 
 function normalizeCapability(capability: Capability): Capability {
-  return { ...capability, id: capability.id ?? capability.capability_id ?? "", latest_version: capability.latest_version ?? capability.latest_published_version }
+  return {
+    ...capability,
+    id: capability.id ?? capability.capability_id ?? "",
+    latest_version: capability.latest_version ?? capability.latest_published_version,
+    from_marketplace: capability.from_marketplace ?? ("self_published" in capability && capability.self_published === false),
+  }
 }
 
 function normalizeAgentCapability(item: AgentCapability): AgentCapability {

--- a/apps/web/src/lib/capability-config.ts
+++ b/apps/web/src/lib/capability-config.ts
@@ -1,0 +1,37 @@
+import type { Capability, CapabilityVersion } from "./api-types"
+import { useCapabilityVersionsQuery } from "./api-capabilities"
+
+function latestCapabilityVersion(capability: Capability): CapabilityVersion | undefined {
+  return capability.latest_version_id
+    ? {
+        id: capability.latest_version_id,
+        capability_id: capability.id,
+        version: capability.latest_version ?? capability.latest_published_version ?? "—",
+        created_at: capability.latest_version_created_at ?? capability.created_at ?? new Date().toISOString(),
+      } as CapabilityVersion
+    : undefined
+}
+
+export function requiredCredentialKinds(capability: Capability) {
+  return (capability.required_credentials ?? []).filter((rc) => rc.required)
+}
+
+export function catalogIDFromVersion(version: CapabilityVersion | undefined) {
+  const payload = version?.source_payload
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return ""
+  const catalogID = (payload as Record<string, unknown>).catalog_id
+  return typeof catalogID === "string" ? catalogID.trim() : ""
+}
+
+export function useCapabilityVersions(
+  workspaceID: string | null,
+  capability: Capability | undefined,
+  enabled: boolean,
+) {
+  const fromMarketplace = capability?.from_marketplace === true
+  const versionsQ = useCapabilityVersionsQuery(workspaceID, enabled && !fromMarketplace ? capability?.id ?? null : null)
+  const published = capability ? latestCapabilityVersion(capability) : undefined
+  const versions = fromMarketplace ? (published ? [published] : []) : versionsQ.data?.versions ?? []
+  const latest = versions[0] ?? published
+  return { latest, versions, versionsQ }
+}

--- a/apps/web/src/pages/admin/AgentsPage.tsx
+++ b/apps/web/src/pages/admin/AgentsPage.tsx
@@ -1,6 +1,6 @@
 import { type ReactNode, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { Bot, Plus, Search, Wrench } from "lucide-react"
+import { Bot, Plus, Search } from "lucide-react"
 
 import { AdminLayout } from "../../components/layout/AdminLayout"
 import { PageHeader } from "../../components/layout/PageHeader"
@@ -33,7 +33,6 @@ import {
 } from "../../lib/api-agents"
 import { useModels } from "../../lib/api-models"
 import { useMyWorkspaces } from "../../lib/api-workspaces"
-import { useMarketplaceList } from "../../lib/api-marketplace"
 import {
   searchAgents,
   defaultModelOf,
@@ -45,6 +44,7 @@ import { useRelativeTime } from "../../lib/relative-time"
 import { CreateAgentDialog } from "./CreateAgentDialog"
 import { AgentConfigTab } from "./agents/AgentConfigTab"
 import { AgentDetailActions } from "./agents/AgentDetailActions"
+import { MarketplaceInstallDialog } from "./agents/MarketplaceInstallDialog"
 import { AgentStatusControl } from "./agents/AgentStatusControl"
 import { AgentExposureTab } from "./agents/AgentExposureTab"
 import { AgentDynamicsTab } from "./agents/AgentDynamicsTab"
@@ -53,38 +53,6 @@ import { AgentsFilters, type AgentStatusFilter } from "./agents/AgentsFilters"
 import { AgentStatusBadge } from "./agents/AgentStatusBadge"
 import { DeleteAgentDialog } from "./agents/DeleteAgentDialog"
 import { DetailSection } from "./agents/DetailSection"
-
-function usePendingCapability(workspaceID: string | null) {
-  const id = new URLSearchParams(window.location.search).get("pendingCapability")
-  const marketplaceQ = useMarketplaceList(workspaceID)
-  const capability = (marketplaceQ.data ?? []).find((item) => item.id === id)
-  return { id, capability }
-}
-
-/**
- * One-line notice under the topbar: a 14px icon (state lives there), ink
- * text, an optional control on the right. A hairline, never a tinted box.
- */
-function InlineNotice({ icon, children, action }: { icon: ReactNode; children: ReactNode; action?: ReactNode }) {
-  return (
-    <div className="flex min-h-9 shrink-0 items-center gap-2 border-b border-line px-4 py-1.5 text-sm text-fg" role="status">
-      {icon}
-      <span className="min-w-0 flex-1">{children}</span>
-      {action}
-    </div>
-  )
-}
-
-function PendingCapabilityBanner({ children, onCancel, cancelLabel }: { children: ReactNode; onCancel: () => void; cancelLabel: string }) {
-  return (
-    <InlineNotice
-      icon={<Wrench className="h-3.5 w-3.5 shrink-0 text-fg-muted" strokeWidth={1.5} aria-hidden="true" />}
-      action={<Button variant="outline" size="sm" onClick={onCancel}>{cancelLabel}</Button>}
-    >
-      {children}
-    </InlineNotice>
-  )
-}
 
 export function AgentsPage() {
   const { t, i18n } = useTranslation("admin")
@@ -124,7 +92,7 @@ export function AgentsPage() {
   const models = useMemo(() => modelsQ.data?.models ?? [], [modelsQ.data])
   const searched = useMemo(() => searchAgents(agents, keyword, models, t), [agents, keyword, models, t])
   const { startChat: startChatWith, pendingID: chatPendingID } = useAgentChat(wid, canChat)
-  const pendingCapability = usePendingCapability(wid)
+  const pendingCapabilityID = new URLSearchParams(window.location.search).get("pendingCapability")
 
   const err = query.error
   const isUnreachable = err instanceof ApiError && err.envelope.unreachable
@@ -186,16 +154,6 @@ export function AgentsPage() {
             </>
           }
         />
-        {pendingCapability.id && (
-          <PendingCapabilityBanner
-            cancelLabel={t("agents.pendingCapability.cancel")}
-            onCancel={() => navigate("agents", { pendingCapability: null })}
-          >
-            {pendingCapability.capability
-              ? t("agents.pendingCapability.banner", { name: pendingCapability.capability.name, source: pendingCapability.capability.source_workspace_name ?? "—" })
-              : t("agents.pendingCapability.loading")}
-          </PendingCapabilityBanner>
-        )}
         {!wid ? (
           <div className="px-6"><ScopeRequiredState scope="workspace" resourceName={pageTitle} /></div>
         ) : query.isLoading ? (
@@ -248,6 +206,16 @@ export function AgentsPage() {
           />
         )}
       </RailLayout>
+
+      {pendingCapabilityID && <MarketplaceInstallDialog
+        capabilityID={pendingCapabilityID}
+        workspaceID={wid}
+        agentID={entityId}
+        workspaceRole={workspaceRole}
+        onSelectAgent={(id) => navigate("agents", { id, tab: id ? "config" : null })}
+        onDismiss={() => navigate("agents", { pendingCapability: null })}
+        onInstalled={(id) => navigate("agents", { id, tab: "config", pendingCapability: null })}
+      />}
 
       <CreateAgentDialog
         open={createOpen && canManage}
@@ -409,7 +377,6 @@ export function AgentDetailRail({ id, open, onClose, onClosed, renderStatusActio
   const models = modelsQ.data?.models ?? []
   const currentWorkspace = workspacesQ.data?.workspaces.find((w) => w.id === wid)
   const workspaceRole = currentWorkspace?.role
-  const pendingCapability = usePendingCapability(wid)
 
   // Switching to another agent swaps the rail's content rather than replaying
   // its entrance, so the per-agent state is reset here instead of by a remount.
@@ -469,18 +436,6 @@ export function AgentDetailRail({ id, open, onClose, onClosed, renderStatusActio
         />
       }
     >
-      {pendingCapability.id && (
-        <PendingCapabilityBanner
-          cancelLabel={t("agents.pendingCapability.cancel")}
-          onCancel={() => navigate("agents", { id: agent.id, tab: "config", pendingCapability: null, view: railView })}
-        >
-          {t("agents.pendingCapability.detailBanner", {
-            name: pendingCapability.capability?.name ?? pendingCapability.id,
-            source: pendingCapability.capability?.source_workspace_name ?? "—",
-          })}
-        </PendingCapabilityBanner>
-      )}
-
       <Tabs
         value={requestedTab ?? "dynamics"}
         onValueChange={(tab) => navigate("agents", { id: agent.id, tab, view: railView })}

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type ReactNode } from "react"
-import { Check, Loader2, Power, Replace, Search, Trash2 } from "lucide-react"
+import { Loader2, Power, Search, Trash2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { SandboxPanel } from "../../../components/admin/SandboxPanel"
@@ -8,8 +8,6 @@ import { Button } from "../../../components/ui/button"
 import { EmptyState } from "../../../components/ui/empty-state"
 import { ErrorState } from "../../../components/ui/error-state"
 import { Input } from "../../../components/ui/input"
-import { Field } from "../../../components/ui/label"
-import { Select, SelectOption } from "../../../components/ui/select"
 import { Skeleton } from "../../../components/ui/skeleton"
 import { StatusIcon, type StatusKind } from "../../../components/ui/status-icon"
 import {
@@ -33,9 +31,7 @@ import { ApiError } from "../../../lib/api-client"
 import {
   useAgentCapabilitiesQuery,
   useCapabilitiesQuery,
-  useCapabilityVersionsQuery,
   useDeleteAgentCapabilityMutation,
-  useEnableAgentCapabilityMutation,
   useToggleBuiltinCapabilityMutation,
 } from "../../../lib/api-capabilities"
 import { useMyCredentials } from "../../../lib/api-credentials"
@@ -44,8 +40,7 @@ import { agentCapabilityFollowsLatest, agentCapabilityVersion } from "../../../l
 import { agentExecutionPlacement } from "../../../lib/agent-runtime"
 import { agentEngineLabel, agentEngineOf, agentEngineSupportsCapability, agentEnginesSupportingCapability } from "../../../lib/agent-view-model"
 import { credentialBinding, hasCredentialKind, sharedSecretsForKind } from "../../../lib/credential-bindings"
-import type { Agent, AgentCapability, AgentDetail, Capability, CapabilityVersion, Secret, UserCredential } from "../../../lib/api-types"
-import { CredentialBindingSelect } from "../../../components/admin/CredentialBindingSelect"
+import type { Agent, AgentCapability, AgentDetail, Capability, Secret, UserCredential } from "../../../lib/api-types"
 import { CapabilityTypeBadge } from "../CapabilitiesPage"
 import { UpgradeCapabilityDialog } from "../capabilities/UpgradeCapabilityDialog"
 import { credentialKindLabel } from "../capability-ui"
@@ -53,10 +48,10 @@ import { AgentConfigSummary } from "./AgentConfigSummary"
 import { DetailSection, InlineError } from "./DetailSection"
 import type { ShowToast } from "../../../components/ui/toast"
 
-type CapabilityCardItem = { capability?: Capability; binding?: AgentCapability }
+import { CapabilityVersionDialog } from "./CapabilityVersionDialog"
+import { catalogIDFromVersion, requiredCredentialKinds, useCapabilityVersions } from "../../../lib/capability-config"
 
-/* Native <select> inside the shared CredentialBindingSelect, dressed as ui/Select. */
-const SELECT_CLASS = "app-shadow-control h-7 w-full rounded-md border border-line-strong bg-surface px-2 text-sm text-fg focus-visible:border-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+type CapabilityCardItem = { capability?: Capability; binding?: AgentCapability }
 
 function runtimeOf(agent: Agent): "local" | "sandbox" {
   const placement = agentExecutionPlacement(agent)
@@ -93,21 +88,6 @@ function tCapabilityFallback(capabilityID: string) {
   return `Capability ${capabilityID.slice(0, 8)}`
 }
 
-function latestCapabilityVersion(capability: Capability): CapabilityVersion | undefined {
-  return capability.latest_version_id
-    ? {
-        id: capability.latest_version_id,
-        capability_id: capability.id,
-        version: capability.latest_version ?? capability.latest_published_version ?? "—",
-        created_at: capability.latest_version_created_at ?? capability.created_at ?? new Date().toISOString(),
-      } as CapabilityVersion
-    : undefined
-}
-
-function requiredCredentialKinds(capability: Capability) {
-  return (capability.required_credentials ?? []).filter((rc) => rc.required)
-}
-
 function boundSharedSecretID(agent: Agent, binding: AgentCapability | undefined, kind: string) {
   const capabilityBinding = credentialBinding(binding?.configuration, kind)
   if (capabilityBinding) return capabilityBinding.secretID
@@ -118,24 +98,6 @@ function hasUsableCredential(agent: Agent, binding: AgentCapability | undefined,
   const sharedID = boundSharedSecretID(agent, binding, kind)
   if (sharedID && sharedSecretsForKind(sharedSecrets, kind, catalogID).some((secret) => secret.id === sharedID)) return true
   return agent.visibility !== "public" && hasCredentialKind(credentials, kind)
-}
-
-function catalogIDFromVersion(version: CapabilityVersion | undefined) {
-  const payload = version?.source_payload
-  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return ""
-  const catalogID = (payload as Record<string, unknown>).catalog_id
-  return typeof catalogID === "string" ? catalogID.trim() : ""
-}
-
-function useCapabilityVersions(
-  workspaceID: string | null,
-  capability: Capability | undefined,
-  enabled: boolean,
-) {
-  const versionsQ = useCapabilityVersionsQuery(workspaceID, enabled ? capability?.id ?? null : null)
-  const versions = versionsQ.data?.versions ?? []
-  const latest = versions[0] ?? (capability ? latestCapabilityVersion(capability) : undefined)
-  return { latest, versions, versionsQ }
 }
 
 /** One hairline-separated capability row: name and flags left, controls right. */
@@ -294,67 +256,6 @@ function mutationError(error: unknown) {
 function MutationError({ error }: { error: unknown }) {
   const message = mutationError(error)
   return message ? <InlineError>{message}</InlineError> : null
-}
-
-function VersionSelect({ versions, value, onChange }: { versions: CapabilityVersion[]; value: string; onChange: (value: string) => void }) {
-  const { t } = useTranslation("admin")
-  return (
-    <Select aria-label={t("agents.detail.capabilities.enableDialog.version")} value={value} onValueChange={(nextValue) => onChange(nextValue)}>
-      {versions.map((version, index) => (
-        <SelectOption key={version.id} value={version.id}>v{version.version}{index === 0 ? ` · ${t("agents.detail.capabilities.switchDialog.latest")}` : ""}</SelectOption>
-      ))}
-    </Select>
-  )
-}
-
-function EnableCredentialBindingList({
-  requiredKinds,
-  credentials,
-  sharedSecrets,
-  catalogID,
-  publicAgent,
-  bindings,
-  onChange,
-}: {
-  requiredKinds: { kind: string }[]
-  credentials: UserCredential[]
-  sharedSecrets: Secret[]
-  catalogID: string
-  publicAgent: boolean
-  bindings: Record<string, string>
-  onChange: (kind: string, secretID: string) => void
-}) {
-  const { t, i18n } = useTranslation("admin")
-  return (
-    <div className="flex flex-col gap-3">
-      {requiredKinds.map((rc) => {
-        const kindSecrets = sharedSecretsForKind(sharedSecrets, rc.kind, catalogID)
-        const selectedSecretID = bindings[rc.kind] ?? ""
-        const hasPersonal = !publicAgent && hasCredentialKind(credentials, rc.kind)
-        const ready = !!selectedSecretID || hasPersonal
-        return (
-          <Field key={rc.kind} label={credentialKindLabel(rc.kind, i18n.language, rc.kind)}>
-            <CredentialBindingSelect
-              label={credentialKindLabel(rc.kind, i18n.language, rc.kind)}
-              value={selectedSecretID}
-              secrets={kindSecrets}
-              allowPersonal={!publicAgent}
-              personalLabel={t("credentialCheck.sourcePersonal")}
-              personalPlaceholder={t("credentialCheck.sharedPlaceholder")}
-              sharedLabel={t("credentialCheck.sourceShared")}
-              onChange={(value) => onChange(rc.kind, value)}
-              className={SELECT_CLASS}
-            />
-            {!ready && (
-              <InlineError className="mt-1 text-xs">
-                {publicAgent ? t("credentialCheck.sharedNoneAvailable") : t("credentialCheck.personalYouMissing")}
-              </InlineError>
-            )}
-          </Field>
-        )
-      })}
-    </div>
-  )
 }
 
 /** `v1.4.0`, or nothing at all — never a placeholder dash. */
@@ -566,176 +467,6 @@ function CapabilityCard({
         ) : undefined
       }
     />
-  )
-}
-
-function CapabilityVersionDialog({
-  mode,
-  agent,
-  capability,
-  credentials = [],
-  sharedSecrets = [],
-  workspaceID,
-  binding,
-  trigger,
-  disabled = false,
-  onToast,
-}: {
-  mode: "enable" | "switch"
-  agent: Agent
-  capability: Capability
-  credentials?: UserCredential[]
-  sharedSecrets?: Secret[]
-  workspaceID: string | null
-  binding?: AgentCapability
-  /** Draws the control that opens this dialog; defaults to a row action. */
-  trigger?: (open: () => void) => ReactNode
-  disabled?: boolean
-  onToast: ShowToast
-}) {
-  const { t } = useTranslation("admin")
-  const [open, setOpen] = useState(false)
-  const mut = useEnableAgentCapabilityMutation(workspaceID, agent.id)
-  const [selection, setSelected] = useState("")
-  const changeOpen = (next: boolean) => {
-    setOpen(next)
-    setSelected("")
-  }
-  const [credentialBindingChoices, setCredentialBindingChoices] = useState<Record<string, string>>({})
-  const { latest, versions, versionsQ } = useCapabilityVersions(workspaceID, capability, open)
-  const currentVersion = agentCapabilityVersion(binding, capability, versions)
-  const selected = selection || currentVersion?.id || ""
-  const selectedVersion = selected
-    ? versions.find((version) => version.id === selected) ?? (mode === "enable" ? latest : versions[0])
-    : mode === "enable" ? latest : versions[0]
-  const requiredKinds = useMemo(
-    () => mode === "enable" ? requiredCredentialKinds(capability) : [],
-    [capability, mode],
-  )
-  const catalogID = catalogIDFromVersion(selectedVersion)
-  const defaultCredentialBindings = useMemo(() => {
-    const defaults: Record<string, string> = {}
-    for (const rc of requiredKinds) {
-      const kindSecrets = sharedSecretsForKind(sharedSecrets, rc.kind, catalogID)
-      const oauthSecret = kindSecrets.find(() => rc.kind === "mcp_oauth")
-      if (oauthSecret) defaults[rc.kind] = oauthSecret.id
-      else if (agent.visibility === "public" && kindSecrets[0]) defaults[rc.kind] = kindSecrets[0].id
-    }
-    return defaults
-  }, [agent.visibility, catalogID, requiredKinds, sharedSecrets])
-  const credentialBindings = { ...defaultCredentialBindings, ...credentialBindingChoices }
-  const missingRequiredCredential = requiredKinds.some((rc) => {
-    const selectedSecretID = credentialBindings[rc.kind]
-    if (selectedSecretID && sharedSecretsForKind(sharedSecrets, rc.kind, catalogID).some((secret) => secret.id === selectedSecretID)) {
-      return false
-    }
-    return agent.visibility === "public" || !hasCredentialKind(credentials, rc.kind)
-  })
-  const canSubmit = !!selectedVersion
-    && !mut.isPending
-    && !disabled
-    && (mode === "enable" ? !missingRequiredCredential : binding?.pinning_mode === "latest" || selectedVersion.id !== currentVersion?.id)
-
-  const submit = () => {
-    if (!selectedVersion) return
-    const capabilityBindings = Object.fromEntries(
-      requiredKinds.map(({ kind }) => {
-        const secretID = credentialBindings[kind]
-        return [kind, secretID
-          ? { source: "shared", secret_id: secretID }
-          : { source: "personal" }]
-      }),
-    )
-    mut.mutate({
-      capabilityVersionID: selectedVersion.id,
-      configuration: mode === "enable"
-        ? { credential_bindings: capabilityBindings }
-        : binding?.configuration,
-    }, {
-      onSuccess: () => {
-        changeOpen(false)
-        onToast(mode === "enable"
-          ? t("agents.detail.capabilities.toast.enabled", { cap: capability.name, agent: agent.name, version: selectedVersion.version })
-          : t("agents.detail.capabilities.toast.switched", { cap: capability.name, version: selectedVersion.version }))
-      },
-    })
-  }
-  const isSwitch = mode === "switch"
-  const confirmLabel = isSwitch
-    ? selectedVersion
-      ? t("agents.detail.capabilities.actions.switchConfirm", { version: selectedVersion.version })
-      : t("agents.detail.capabilities.actions.switchVersion")
-    : t("agents.detail.capabilities.actions.enableConfirm")
-
-  return (
-    <Dialog open={open} onOpenChange={changeOpen}>
-      {trigger ? (
-        trigger(() => changeOpen(true))
-      ) : isSwitch ? (
-        <ActionIconButton
-          icon={Replace}
-          label={t("agents.detail.capabilities.actions.switchVersion")}
-          disabled={disabled}
-          onClick={() => changeOpen(true)}
-        />
-      ) : (
-        <Button variant="outline" size="sm" disabled={disabled} onClick={() => changeOpen(true)}>
-          {t("agents.detail.capabilities.actions.enable")}
-        </Button>
-      )}
-      <DialogContent>
-        <DialogHeader>
-          <DialogTitle>{t(isSwitch ? "agents.detail.capabilities.switchDialog.title" : "agents.detail.capabilities.enableDialog.title", { agent: agent.name, cap: capability.name })}</DialogTitle>
-          <DialogDescription>{t(isSwitch ? "agents.detail.capabilities.switchDialog.description" : "agents.detail.capabilities.enableDialog.description")}</DialogDescription>
-        </DialogHeader>
-        <div className="flex flex-col gap-3">
-          {isSwitch ? (
-            versionsQ.isLoading ? <Skeleton className="h-28 w-full" /> : (
-              <ul className="m-0 list-none p-0">
-                {versions.map((version, index) => (
-                  <li key={version.id}>
-                    <label className="flex h-7 cursor-pointer items-center gap-2 text-sm text-fg">
-                      <input type="radio" name="capability-version" className="h-3.5 w-3.5 accent-accent" checked={selected === version.id} onChange={() => setSelected(version.id)} />
-                      <span className="font-mono text-xs">v{version.version}</span>
-                      {index === 0 && <span className="text-xs text-fg-muted">· {t("agents.detail.capabilities.switchDialog.latest")}</span>}
-                      {version.id === currentVersion?.id && <span className="text-xs text-fg-muted">· {t("agents.detail.capabilities.switchDialog.current")}</span>}
-                    </label>
-                  </li>
-                ))}
-              </ul>
-            )
-          ) : (
-            <>
-              <Field label={t("agents.detail.capabilities.enableDialog.version")}>
-                {versionsQ.isLoading ? <Skeleton className="h-7 w-full" /> : <VersionSelect versions={versions} value={selectedVersion?.id ?? ""} onChange={setSelected} />}
-              </Field>
-              {requiredKinds.length > 0 ? (
-                <EnableCredentialBindingList
-                  requiredKinds={requiredKinds}
-                  credentials={credentials}
-                  sharedSecrets={sharedSecrets}
-                  catalogID={catalogID}
-                  publicAgent={agent.visibility === "public"}
-                  bindings={credentialBindings}
-                  onChange={(kind, secretID) => setCredentialBindingChoices((current) => ({ ...current, [kind]: secretID }))}
-                />
-              ) : (
-                <p className="flex items-center gap-1.5 text-sm text-fg">
-                  <Check className="h-3.5 w-3.5 shrink-0 text-status-completed" strokeWidth={1.5} aria-hidden="true" />
-                  {t("agents.detail.capabilities.enableDialog.noCredential")}
-                </p>
-              )}
-            </>
-          )}
-          {isSwitch && <p className="text-sm text-fg-muted">{t("agents.detail.capabilities.switchDialog.notice", { agent: agent.name })}</p>}
-          <MutationError error={mut.error} />
-        </div>
-        <DialogFooter>
-          <Button variant="outline" onClick={() => changeOpen(false)} disabled={mut.isPending}>{t("agents.detail.capabilities.actions.cancel")}</Button>
-          <Button disabled={!canSubmit} onClick={submit}>{mut.isPending && <Loader2 className="animate-spin" strokeWidth={1.5} aria-hidden="true" />}{confirmLabel}</Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   )
 }
 

--- a/apps/web/src/pages/admin/agents/CapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/agents/CapabilityVersionDialog.tsx
@@ -113,7 +113,7 @@ export function CapabilityVersionDialog({
   onOpenChange?: (open: boolean) => void
   onInstalled?: () => void
   onBack?: () => void
-  credentialHelp?: ReactNode
+  credentialHelp?: (pending: boolean) => ReactNode
 }) {
   const { t } = useTranslation(["admin", "common"])
   const [localOpen, setOpen] = useState(false)
@@ -260,7 +260,7 @@ export function CapabilityVersionDialog({
             </>
           )}
           {isSwitch && <p className="text-sm text-fg-muted">{t("agents.detail.capabilities.switchDialog.notice", { agent: agent.name })}</p>}
-          {credentialHelp}
+          {credentialHelp?.(mut.isPending)}
           {versionsQ.error instanceof Error && <InlineError>{versionsQ.error.message}</InlineError>}
           {mut.error instanceof Error && <InlineError>{mut.error.message}</InlineError>}
         </div>

--- a/apps/web/src/pages/admin/agents/CapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/agents/CapabilityVersionDialog.tsx
@@ -1,0 +1,275 @@
+import { useMemo, useState, type ReactNode } from "react"
+import { Check, Loader2, Replace } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { ActionIconButton } from "../../../components/ui/action-button"
+import { Button } from "../../../components/ui/button"
+import { Field } from "../../../components/ui/label"
+import { Select, SelectOption } from "../../../components/ui/select"
+import { Skeleton } from "../../../components/ui/skeleton"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../../../components/ui/dialog"
+import { CredentialBindingSelect } from "../../../components/admin/CredentialBindingSelect"
+import type { ShowToast } from "../../../components/ui/toast"
+import { useEnableAgentCapabilityMutation } from "../../../lib/api-capabilities"
+import { agentCapabilityVersion } from "../../../lib/agent-capability-version"
+import { catalogIDFromVersion, requiredCredentialKinds, useCapabilityVersions } from "../../../lib/capability-config"
+import { hasCredentialKind, sharedSecretsForKind } from "../../../lib/credential-bindings"
+import type { Agent, AgentCapability, Capability, CapabilityVersion, Secret, UserCredential } from "../../../lib/api-types"
+import { credentialKindLabel } from "../capability-ui"
+import { InlineError } from "./DetailSection"
+
+/* Native <select> inside the shared CredentialBindingSelect, dressed as ui/Select. */
+const SELECT_CLASS = "app-shadow-control h-7 w-full rounded-md border border-line-strong bg-surface px-2 text-sm text-fg focus-visible:border-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent"
+
+function VersionSelect({ versions, value, onChange }: { versions: CapabilityVersion[]; value: string; onChange: (value: string) => void }) {
+  const { t } = useTranslation("admin")
+  return (
+    <Select aria-label={t("agents.detail.capabilities.enableDialog.version")} value={value} onValueChange={(nextValue) => onChange(nextValue)}>
+      {versions.map((version, index) => (
+        <SelectOption key={version.id} value={version.id}>v{version.version}{index === 0 ? ` · ${t("agents.detail.capabilities.switchDialog.latest")}` : ""}</SelectOption>
+      ))}
+    </Select>
+  )
+}
+
+function EnableCredentialBindingList({
+  requiredKinds,
+  credentials,
+  sharedSecrets,
+  catalogID,
+  publicAgent,
+  bindings,
+  onChange,
+}: {
+  requiredKinds: { kind: string }[]
+  credentials: UserCredential[]
+  sharedSecrets: Secret[]
+  catalogID: string
+  publicAgent: boolean
+  bindings: Record<string, string>
+  onChange: (kind: string, secretID: string) => void
+}) {
+  const { t, i18n } = useTranslation("admin")
+  return (
+    <div className="flex flex-col gap-3">
+      {requiredKinds.map((rc) => {
+        const kindSecrets = sharedSecretsForKind(sharedSecrets, rc.kind, catalogID)
+        const selectedSecretID = bindings[rc.kind] ?? ""
+        const hasPersonal = !publicAgent && hasCredentialKind(credentials, rc.kind)
+        const ready = !!selectedSecretID || hasPersonal
+        return (
+          <Field key={rc.kind} label={credentialKindLabel(rc.kind, i18n.language, rc.kind)}>
+            <CredentialBindingSelect
+              label={credentialKindLabel(rc.kind, i18n.language, rc.kind)}
+              value={selectedSecretID}
+              secrets={kindSecrets}
+              allowPersonal={!publicAgent}
+              personalLabel={t("credentialCheck.sourcePersonal")}
+              personalPlaceholder={t("credentialCheck.sharedPlaceholder")}
+              sharedLabel={t("credentialCheck.sourceShared")}
+              onChange={(value) => onChange(rc.kind, value)}
+              className={SELECT_CLASS}
+            />
+            {!ready && (
+              <InlineError className="mt-1 text-xs">
+                {publicAgent ? t("credentialCheck.sharedNoneAvailable") : t("credentialCheck.personalYouMissing")}
+              </InlineError>
+            )}
+          </Field>
+        )
+      })}
+    </div>
+  )
+}
+
+export function CapabilityVersionDialog({
+  mode,
+  agent,
+  capability,
+  credentials = [],
+  sharedSecrets = [],
+  workspaceID,
+  binding,
+  trigger,
+  disabled = false,
+  onToast,
+  open: controlledOpen,
+  onOpenChange,
+  onInstalled,
+  onBack,
+  credentialHelp,
+}: {
+  mode: "enable" | "switch"
+  agent: Agent
+  capability: Capability
+  credentials?: UserCredential[]
+  sharedSecrets?: Secret[]
+  workspaceID: string | null
+  binding?: AgentCapability
+  /** Draws the control that opens this dialog; defaults to a row action. */
+  trigger?: (open: () => void) => ReactNode
+  disabled?: boolean
+  onToast: ShowToast
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  onInstalled?: () => void
+  onBack?: () => void
+  credentialHelp?: ReactNode
+}) {
+  const { t } = useTranslation(["admin", "common"])
+  const [localOpen, setOpen] = useState(false)
+  const open = controlledOpen ?? localOpen
+  const mut = useEnableAgentCapabilityMutation(workspaceID, agent.id)
+  const [selection, setSelected] = useState("")
+  const changeOpen = (next: boolean) => {
+    if (mut.isPending) return
+    setOpen(next)
+    onOpenChange?.(next)
+    setSelected("")
+  }
+  const [credentialBindingChoices, setCredentialBindingChoices] = useState<Record<string, string>>({})
+  const { latest, versions, versionsQ } = useCapabilityVersions(workspaceID, capability, open)
+  const currentVersion = agentCapabilityVersion(binding, capability, versions)
+  const selected = selection || currentVersion?.id || ""
+  const selectedVersion = selected
+    ? versions.find((version) => version.id === selected) ?? (mode === "enable" ? latest : versions[0])
+    : mode === "enable" ? latest : versions[0]
+  const requiredKinds = useMemo(
+    () => mode === "enable" ? requiredCredentialKinds(capability) : [],
+    [capability, mode],
+  )
+  const catalogID = catalogIDFromVersion(selectedVersion)
+  const defaultCredentialBindings = useMemo(() => {
+    const defaults: Record<string, string> = {}
+    for (const rc of requiredKinds) {
+      const kindSecrets = sharedSecretsForKind(sharedSecrets, rc.kind, catalogID)
+      const oauthSecret = kindSecrets.find(() => rc.kind === "mcp_oauth")
+      if (oauthSecret) defaults[rc.kind] = oauthSecret.id
+      else if (agent.visibility === "public" && kindSecrets[0]) defaults[rc.kind] = kindSecrets[0].id
+    }
+    return defaults
+  }, [agent.visibility, catalogID, requiredKinds, sharedSecrets])
+  const credentialBindings = { ...defaultCredentialBindings, ...credentialBindingChoices }
+  const missingRequiredCredential = requiredKinds.some((rc) => {
+    const selectedSecretID = credentialBindings[rc.kind]
+    if (selectedSecretID && sharedSecretsForKind(sharedSecrets, rc.kind, catalogID).some((secret) => secret.id === selectedSecretID)) {
+      return false
+    }
+    return agent.visibility === "public" || !hasCredentialKind(credentials, rc.kind)
+  })
+  const canSubmit = !!selectedVersion
+    && !versionsQ.isLoading
+    && !versionsQ.isError
+    && !mut.isPending
+    && !disabled
+    && (mode === "enable" ? !missingRequiredCredential : binding?.pinning_mode === "latest" || selectedVersion.id !== currentVersion?.id)
+
+  const submit = () => {
+    if (!selectedVersion || !canSubmit) return
+    const capabilityBindings = Object.fromEntries(
+      requiredKinds.map(({ kind }) => {
+        const secretID = credentialBindings[kind]
+        return [kind, secretID
+          ? { source: "shared", secret_id: secretID }
+          : { source: "personal" }]
+      }),
+    )
+    mut.mutate({
+      capabilityVersionID: selectedVersion.id,
+      configuration: mode === "enable"
+        ? { credential_bindings: capabilityBindings }
+        : binding?.configuration,
+    }, {
+      onSuccess: () => {
+        if (onInstalled) onInstalled()
+        else {
+          setOpen(false)
+          onOpenChange?.(false)
+          setSelected("")
+        }
+        onToast(mode === "enable"
+          ? t("agents.detail.capabilities.toast.enabled", { cap: capability.name, agent: agent.name, version: selectedVersion.version })
+          : t("agents.detail.capabilities.toast.switched", { cap: capability.name, version: selectedVersion.version }))
+      },
+    })
+  }
+  const isSwitch = mode === "switch"
+  const confirmLabel = isSwitch
+    ? selectedVersion
+      ? t("agents.detail.capabilities.actions.switchConfirm", { version: selectedVersion.version })
+      : t("agents.detail.capabilities.actions.switchVersion")
+    : t("agents.detail.capabilities.actions.enableConfirm")
+
+  return (
+    <Dialog open={open} onOpenChange={changeOpen}>
+      {trigger ? (
+        trigger(() => changeOpen(true))
+      ) : isSwitch ? (
+        <ActionIconButton
+          icon={Replace}
+          label={t("agents.detail.capabilities.actions.switchVersion")}
+          disabled={disabled}
+          onClick={() => changeOpen(true)}
+        />
+      ) : (
+        <Button variant="outline" size="sm" disabled={disabled} onClick={() => changeOpen(true)}>
+          {t("agents.detail.capabilities.actions.enable")}
+        </Button>
+      )}
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t(isSwitch ? "agents.detail.capabilities.switchDialog.title" : "agents.detail.capabilities.enableDialog.title", { agent: agent.name, cap: capability.name })}</DialogTitle>
+          <DialogDescription>{t(isSwitch ? "agents.detail.capabilities.switchDialog.description" : "agents.detail.capabilities.enableDialog.description")}</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3">
+          {isSwitch ? (
+            versionsQ.isLoading ? <Skeleton className="h-28 w-full" /> : (
+              <ul className="m-0 list-none p-0">
+                {versions.map((version, index) => (
+                  <li key={version.id}>
+                    <label className="flex h-7 cursor-pointer items-center gap-2 text-sm text-fg">
+                      <input type="radio" name="capability-version" className="h-3.5 w-3.5 accent-accent" checked={selected === version.id} onChange={() => setSelected(version.id)} />
+                      <span className="font-mono text-xs">v{version.version}</span>
+                      {index === 0 && <span className="text-xs text-fg-muted">· {t("agents.detail.capabilities.switchDialog.latest")}</span>}
+                      {version.id === currentVersion?.id && <span className="text-xs text-fg-muted">· {t("agents.detail.capabilities.switchDialog.current")}</span>}
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            )
+          ) : (
+            <>
+              <Field label={t("agents.detail.capabilities.enableDialog.version")}>
+                {versionsQ.isLoading ? <Skeleton className="h-7 w-full" /> : <VersionSelect versions={versions} value={selectedVersion?.id ?? ""} onChange={setSelected} />}
+              </Field>
+              {requiredKinds.length > 0 ? (
+                <EnableCredentialBindingList
+                  requiredKinds={requiredKinds}
+                  credentials={credentials}
+                  sharedSecrets={sharedSecrets}
+                  catalogID={catalogID}
+                  publicAgent={agent.visibility === "public"}
+                  bindings={credentialBindings}
+                  onChange={(kind, secretID) => setCredentialBindingChoices((current) => ({ ...current, [kind]: secretID }))}
+                />
+              ) : (
+                <p className="flex items-center gap-1.5 text-sm text-fg">
+                  <Check className="h-3.5 w-3.5 shrink-0 text-status-completed" strokeWidth={1.5} aria-hidden="true" />
+                  {t("agents.detail.capabilities.enableDialog.noCredential")}
+                </p>
+              )}
+            </>
+          )}
+          {isSwitch && <p className="text-sm text-fg-muted">{t("agents.detail.capabilities.switchDialog.notice", { agent: agent.name })}</p>}
+          {credentialHelp}
+          {versionsQ.error instanceof Error && <InlineError>{versionsQ.error.message}</InlineError>}
+          {mut.error instanceof Error && <InlineError>{mut.error.message}</InlineError>}
+        </div>
+        <DialogFooter>
+          {onBack && <Button variant="outline" disabled={mut.isPending} onClick={onBack}>{t("agents.pendingCapability.chooseAnother")}</Button>}
+          <Button variant="outline" onClick={() => changeOpen(false)} disabled={mut.isPending}>{t("agents.detail.capabilities.actions.cancel")}</Button>
+          <Button disabled={!canSubmit} onClick={submit}>{mut.isPending && <Loader2 className="animate-spin" strokeWidth={1.5} aria-hidden="true" />}{confirmLabel}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/pages/admin/agents/MarketplaceInstallDialog.tsx
+++ b/apps/web/src/pages/admin/agents/MarketplaceInstallDialog.tsx
@@ -1,0 +1,109 @@
+import { useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { Button } from "../../../components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../../../components/ui/dialog"
+import { EmptyState } from "../../../components/ui/empty-state"
+import { ErrorState } from "../../../components/ui/error-state"
+import { Field } from "../../../components/ui/label"
+import { Select, SelectOption } from "../../../components/ui/select"
+import { Skeleton } from "../../../components/ui/skeleton"
+import { useToast } from "../../../components/ui/toast"
+import { useAgents } from "../../../lib/api-agents"
+import { useAgentCapabilitiesQuery } from "../../../lib/api-capabilities"
+import { useMyCredentials } from "../../../lib/api-credentials"
+import { useMarketplaceList } from "../../../lib/api-marketplace"
+import { useSecrets } from "../../../lib/api-secrets"
+import { agentEngineOf, agentEngineSupportsCapability } from "../../../lib/agent-view-model"
+import { CapabilityVersionDialog } from "./CapabilityVersionDialog"
+
+export function MarketplaceInstallDialog({ capabilityID, workspaceID, agentID, workspaceRole, onSelectAgent, onDismiss, onInstalled }: {
+  capabilityID: string
+  workspaceID: string | null
+  agentID: string | null
+  workspaceRole?: string
+  onSelectAgent: (id: string | null) => void
+  onDismiss: () => void
+  onInstalled: (id: string) => void
+}) {
+  const { t } = useTranslation(["admin", "common"])
+  const toast = useToast()
+  const [choice, setChoice] = useState(agentID ?? "")
+  const marketplaceQ = useMarketplaceList(workspaceID)
+  const agentsQ = useAgents(workspaceID)
+  const capability = marketplaceQ.data?.find((item) => item.id === capabilityID)
+  const agents = (agentsQ.data?.agents ?? []).filter((agent) => capability && agentEngineSupportsCapability(agentEngineOf(agent), capability.type))
+  const agent = agents.find((item) => item.id === agentID)
+  const bindingsQ = useAgentCapabilitiesQuery(workspaceID, agent?.id ?? null)
+  const credentialsQ = useMyCredentials()
+  const secretsQ = useSecrets(workspaceID)
+  const sharedSecrets = useMemo(() => (secretsQ.data?.secrets ?? []).filter((secret) => secret.kind === "capability_inline" && secret.status === "active"), [secretsQ.data])
+  const allowed = workspaceRole === "owner" || workspaceRole === "admin" || workspaceRole === "member"
+  const loading = marketplaceQ.isLoading || agentsQ.isLoading || !workspaceRole
+    || (!!agent && (bindingsQ.isLoading || credentialsQ.isLoading || secretsQ.isLoading))
+  const error = marketplaceQ.error ?? agentsQ.error ?? (agent ? bindingsQ.error ?? credentialsQ.error ?? secretsQ.error : null)
+  const installed = bindingsQ.data?.installed.some((item) => item.capability_id === capabilityID)
+
+  if (allowed && !loading && !error && capability && agent && !installed) {
+    const current = window.location.pathname + window.location.search
+    const credentialHelp = agent.visibility !== "public" && capability.required_credentials?.some((item) => item.required)
+      ? <a className="text-sm text-fg underline underline-offset-4" href={`?profile=credentials&returnTo=${encodeURIComponent(current)}`}>{t("agents.pendingCapability.manageCredentials")}</a>
+      : undefined
+    return <CapabilityVersionDialog
+      key={`${capability.id}:${agent.id}`}
+      mode="enable"
+      agent={agent}
+      capability={{ ...capability, from_marketplace: true }}
+      workspaceID={workspaceID}
+      credentials={credentialsQ.data?.credentials ?? []}
+      sharedSecrets={sharedSecrets}
+      open
+      onOpenChange={(open) => { if (!open) onDismiss() }}
+      onBack={() => onSelectAgent(null)}
+      onInstalled={() => onInstalled(agent.id)}
+      trigger={() => null}
+      credentialHelp={credentialHelp}
+      onToast={toast.show}
+    />
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onDismiss() }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("agents.pendingCapability.title", { cap: capability?.name ?? t("agents.pendingCapability.capability") })}</DialogTitle>
+          <DialogDescription>{t("agents.pendingCapability.description")}</DialogDescription>
+        </DialogHeader>
+        {loading ? <Skeleton className="h-24 w-full" /> : !allowed ? (
+          <p className="text-sm text-fg-muted">{t("agents.pendingCapability.notAllowed")}</p>
+        ) : error ? (
+          <ErrorState title={t("agents.pendingCapability.loadError")} detail={error instanceof Error ? error.message : undefined} onRetry={() => {
+            void marketplaceQ.refetch()
+            void agentsQ.refetch()
+            if (agent) { void bindingsQ.refetch(); void credentialsQ.refetch(); void secretsQ.refetch() }
+          }} />
+        ) : !capability ? (
+          <p className="text-sm text-fg-muted">{t("agents.pendingCapability.notFound")}</p>
+        ) : installed && agent ? (
+          <p className="text-sm text-fg">{t("agents.pendingCapability.alreadyAdded", { agent: agent.name })}</p>
+        ) : agents.length === 0 ? (
+          <EmptyState size="compact" title={t("agents.pendingCapability.empty")} description={t("agents.pendingCapability.emptyDescription")} />
+        ) : (
+          <Field label={t("agents.pendingCapability.chooseAgent")}>
+            <Select aria-label={t("agents.pendingCapability.chooseAgent")} value={choice} onValueChange={setChoice}>
+              <SelectOption value="">{t("agents.pendingCapability.chooseAgent")}</SelectOption>
+              {agents.map((item) => <SelectOption key={item.id} value={item.id}>{item.name}</SelectOption>)}
+            </Select>
+          </Field>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={onDismiss}>{t("common:actions.cancel")}</Button>
+          {allowed && !loading && !error && capability && (installed && agent ? (
+            <Button onClick={() => onInstalled(agent.id)}>{t("agents.pendingCapability.viewConfig")}</Button>
+          ) : (
+            <Button disabled={!agents.some((item) => item.id === choice)} onClick={() => onSelectAgent(choice)}>{t("agents.pendingCapability.continue")}</Button>
+          ))}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/pages/admin/agents/MarketplaceInstallDialog.tsx
+++ b/apps/web/src/pages/admin/agents/MarketplaceInstallDialog.tsx
@@ -46,7 +46,7 @@ export function MarketplaceInstallDialog({ capabilityID, workspaceID, agentID, w
   if (allowed && !loading && !error && capability && agent && !installed) {
     const current = window.location.pathname + window.location.search
     const credentialHelp = agent.visibility !== "public" && capability.required_credentials?.some((item) => item.required)
-      ? <a className="text-sm text-fg underline underline-offset-4" href={`?profile=credentials&returnTo=${encodeURIComponent(current)}`}>{t("agents.pendingCapability.manageCredentials")}</a>
+      ? (pending: boolean) => <a className="text-sm text-fg underline underline-offset-4 aria-disabled:opacity-50" aria-disabled={pending || undefined} tabIndex={pending ? -1 : undefined} href={pending ? undefined : `?profile=credentials&returnTo=${encodeURIComponent(current)}`}>{t("agents.pendingCapability.manageCredentials")}</a>
       : undefined
     return <CapabilityVersionDialog
       key={`${capability.id}:${agent.id}`}


### PR DESCRIPTION
Marketplace installation previously left a persistent banner and required finding the capability again inside Agent configuration. The existing route now opens a dialog to select a compatible Agent and confirm its version and credentials. Completion clears the pending intent, opens the Agent Config and shows feedback; cancellation clears the intent, and an already-added capability links to its configuration.

The shared confirmation dialog is extracted from AgentConfigTab, retaining the existing enable/switch and credential-binding logic. Marketplace capabilities confirm the published version supplied by the catalog; the source workspace version-history endpoint remains private. Backend APIs, permissions, publication, upgrades and execution are unchanged.

Validation: make check, web build, and browser checks for compatible Agent selection, published version display, pending and failure/retry, successful binding and route cleanup, existing-install handling, missing credentials and return navigation, and cancellation.
