### PR TITLE
fix(web): fit shared conversations to mobile viewports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -580,6 +580,10 @@ split relevant pieces out first rather than growing the file further.
 
 ## Web UI hard rules
 
+Standalone shared conversations size to the viewport, including loading and
+unavailable states. Keep their mobile sizing scoped to that shell; the desktop
+console's minimum width and shared message behavior remain independent.
+
 Dialogs / drawers / modals and detail panels **must not show a horizontal
 scrollbar**. End users report "I can't see the bottom" far more often than
 "my screen is too narrow", and horizontal scroll almost always means a

--- a/apps/web/src/pages/SharedConversationPage.tsx
+++ b/apps/web/src/pages/SharedConversationPage.tsx
@@ -114,7 +114,7 @@ function SharedShell({ agent, children }: {
   children: React.ReactNode
 }) {
   return (
-    <div className="flex h-screen flex-col bg-surface">
+    <div data-shared-conversation className="flex h-dvh min-w-0 flex-col bg-surface">
       <header className="flex h-14 shrink-0 items-center gap-3 border-b border-line px-6">
         <BrandMark size={18} />
         {agent && (
@@ -123,7 +123,7 @@ function SharedShell({ agent, children }: {
             <InitialTile name={agent.name} />
             <span className="min-w-0 truncate text-sm font-medium text-fg">{agent.name}</span>
             {agent.description && (
-              <span className="min-w-0 flex-1 truncate text-xs text-fg-muted">{agent.description}</span>
+              <span className="hidden min-w-0 flex-1 truncate text-xs text-fg-muted sm:block">{agent.description}</span>
             )}
           </>
         )}
@@ -131,7 +131,7 @@ function SharedShell({ agent, children }: {
           <ThemeMenu />
         </div>
       </header>
-      <main className="flex min-h-0 flex-1 flex-col">{children}</main>
+      <main className="flex min-h-0 flex-1 flex-col [&>*]:min-h-0">{children}</main>
     </div>
   )
 }

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -340,6 +340,10 @@ samp,
     caret-color: var(--color-accent);
   }
 
+  body:has([data-shared-conversation]) {
+    min-width: 0;
+  }
+
   button,
   a,
   input,


### PR DESCRIPTION
Shared conversations inherited the console's 960px minimum width, clipping replies and the composer on phones. Let the standalone shell follow the viewport and constrain the message area so long conversations scroll above a visible composer. Hide the secondary header description on narrow screens to preserve the Agent name.

Scope: shared-page sizing only. Console dimensions, authentication, permissions, and message behavior are unchanged.

Validation: `make check`, web build, and self-review passed. Browser checks covered 320/390/768/1200px widths, short 600px height, light/dark themes, long paths/code, unavailable conversations, and preserved 960px console sizing. Shared-page scrolling width matches the viewport and the Send button remains within it. Fixed-size iframes used the real frontend and read-only remote data; this does not claim physical-device keyboard testing.
