### PR TITLE
fix(web): explain individual bulk model deletion results

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -537,6 +537,9 @@ split relevant pieces out first rather than growing the file further.
 
 ### Frontend shared logic
 
+- Partial bulk model deletion keeps submitted names and per-item results in a
+  dismissible dialog. Link references only after confirming the Agent in the
+  authorized workspace directory; preserve reference text when lookup fails.
 - Audit surfaces share readable action and actor labels. Resolve names only
   from workspace-authorized member/Agent reads and the recorded actor type;
   missing names or failed lookups retain the raw identity. Display names are

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -68,7 +68,13 @@
       "deleteSelected": "Delete selected",
       "title": "Delete {{count}} models?",
       "description": "This permanently deletes the selected models. Models still referenced by active agents will be skipped.",
-      "resultSummary": "{{deleted}} deleted, {{failed}} failed"
+      "resultSummary": "{{deleted}} deleted, {{failed}} failed",
+      "resultsTitle": "Model deletion results",
+      "deleted": "Deleted",
+      "inUse": "Still used by an Agent. Choose another model in its configuration before deleting this model.",
+      "notFound": "This model no longer exists. Refresh the list.",
+      "failed": "This model could not be deleted. Check the details before trying again.",
+      "openAgent": "Open {{name}} configuration"
     },
     "health": {
       "healthy": "Healthy",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -68,7 +68,13 @@
       "deleteSelected": "删除所选",
       "title": "删除 {{count}} 个模型?",
       "description": "这会永久删除所选模型。仍被活跃 Agent 引用的模型会被跳过。",
-      "resultSummary": "已删除 {{deleted}} 个，失败 {{failed}} 个"
+      "resultSummary": "已删除 {{deleted}} 个，失败 {{failed}} 个",
+      "resultsTitle": "模型删除结果",
+      "deleted": "已删除",
+      "inUse": "仍有 Agent 使用此模型。请先在 Agent 配置中更换模型，再删除。",
+      "notFound": "此模型已不存在，请刷新列表。",
+      "failed": "此模型未能删除，请查看详情后重试。",
+      "openAgent": "打开 {{name}} 的配置"
     },
     "health": {
       "healthy": "健康",

--- a/apps/web/src/pages/admin/ModelDeleteDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelDeleteDialogs.tsx
@@ -1,0 +1,132 @@
+import { AlertTriangle, Loader2 } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { AlertDialog, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "../../components/ui/alert-dialog"
+import { Button } from "../../components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog"
+import { StatusIcon } from "../../components/ui/status-icon"
+import { useAgents } from "../../lib/api-agents"
+import type { BulkDeleteModelsResponse } from "../../lib/api-models"
+
+export function ModelDeleteConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  destructive,
+  onConfirm,
+  onCancel,
+  loading,
+}: {
+  open: boolean
+  title: string
+  description: string
+  confirmLabel?: string
+  destructive?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+  loading?: boolean
+}) {
+  const { t } = useTranslation("common")
+  return (
+    <AlertDialog open={open} onOpenChange={(next) => { if (!next && !loading) onCancel() }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            {destructive && (
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-status-failed" strokeWidth={1.5} aria-hidden="true" />
+            )}
+            <span>{title}</span>
+          </AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <Button variant="outline" onClick={onCancel} disabled={loading}>
+            {t("actions.cancel")}
+          </Button>
+          <Button variant={destructive ? "destructive" : "default"} onClick={onConfirm} disabled={loading}>
+            {loading && <Loader2 className="animate-spin" />}
+            {confirmLabel ?? t("actions.confirm")}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+export interface ModelDeleteResult {
+  workspaceID: string | null
+  data: BulkDeleteModelsResponse
+  names: Record<string, string>
+}
+
+export function ModelDeleteResultsDialog({ result, onClose, onCloseAutoFocus }: {
+  result: ModelDeleteResult | null
+  onClose: () => void
+  onCloseAutoFocus: () => void
+}) {
+  const { t } = useTranslation("admin")
+  const { t: tc } = useTranslation("common")
+  const hasReferences = result?.data.failed.some((failure) => failure.references?.length)
+  const agentsQ = useAgents(hasReferences ? result?.workspaceID ?? null : null, true)
+  const visibleAgentIDs = new Set(agentsQ.data?.agents.map((agent) => agent.id) ?? [])
+  if (!result) return null
+  const { data, names, workspaceID } = result
+  const rows = [
+    ...data.failed.map((failure) => ({ id: failure.model_id, failure })),
+    ...data.deleted.map((id) => ({ id, failure: undefined })),
+  ]
+
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent
+        className="max-h-[calc(100dvh-2rem)] max-w-xl overflow-y-auto"
+        onCloseAutoFocus={(event) => { event.preventDefault(); onCloseAutoFocus() }}
+      >
+        <DialogHeader>
+          <DialogTitle>{t("models.bulkDelete.resultsTitle")}</DialogTitle>
+          <DialogDescription>
+            {t("models.bulkDelete.resultSummary", { deleted: data.deleted.length, failed: data.failed.length })}
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="min-w-0 divide-y divide-line">
+          {rows.map(({ id, failure }) => (
+            <li key={id} className="flex min-w-0 items-start gap-2 py-3 first:pt-0 last:pb-0">
+              <StatusIcon status={failure ? "failed" : "completed"} className="mt-0.5 shrink-0" />
+              <div className="min-w-0 flex-1 space-y-1 [overflow-wrap:anywhere]">
+                <p className="font-medium">{names[id] || id}</p>
+                {names[id] && <p className="font-mono text-xs text-fg-muted">{id}</p>}
+                <p className="text-fg-muted">
+                  {!failure ? t("models.bulkDelete.deleted")
+                    : failure.error === "model_in_use" ? t("models.bulkDelete.inUse")
+                      : failure.error === "model_not_found" ? t("models.bulkDelete.notFound")
+                        : t("models.bulkDelete.failed")}
+                </p>
+                {failure?.references?.map((agent) => (
+                  <div key={agent.id} className="min-w-0">
+                    {workspaceID && visibleAgentIDs.has(agent.id) ? (
+                      <a
+                        className="text-accent underline underline-offset-2"
+                        href={`/?${new URLSearchParams({ ws: workspaceID, admin: "agents", id: agent.id, tab: "config" })}`}
+                      >
+                        {t("models.bulkDelete.openAgent", { name: agent.name || agent.id })}
+                      </a>
+                    ) : <span>{agent.name || agent.id}</span>}
+                    <p className="font-mono text-xs text-fg-muted">{agent.id}</p>
+                  </div>
+                ))}
+                {failure && failure.error !== "model_in_use" && failure.error !== "model_not_found" && (
+                  <details className="text-xs text-fg-muted">
+                    <summary className="cursor-pointer">{tc("errors.details")}</summary>
+                    <p className="mt-1 whitespace-pre-wrap font-mono">{failure.error}</p>
+                  </details>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+        <DialogFooter><Button variant="outline" onClick={onClose}>{tc("actions.close")}</Button></DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/pages/admin/ModelsPage.tsx
+++ b/apps/web/src/pages/admin/ModelsPage.tsx
@@ -4,21 +4,13 @@
  *   - credential_ref: each user supplies their own credential from
  *     MyCredentialsPage
  */
-import { useMemo, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { AlertTriangle, Database, Download, Loader2, Plus } from "lucide-react"
+import { Database, Download, Loader2, Plus } from "lucide-react"
 
 import { AdminLayout } from "../../components/layout/AdminLayout"
 import { PageHeader } from "../../components/layout/PageHeader"
 import { ScopeRequiredState } from "../../components/admin/ScopeRequiredState"
-import {
-  AlertDialog,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "../../components/ui/alert-dialog"
 import { Button } from "../../components/ui/button"
 import { EmptyState } from "../../components/ui/empty-state"
 import { ErrorState } from "../../components/ui/error-state"
@@ -39,6 +31,7 @@ import type {
 } from "../../lib/api-models"
 import { CreateModelDialog, EditModelDialog } from "./ModelCrudDialogs"
 import { BulkImportModelsDialog } from "./BulkImportModelsDialog"
+import { ModelDeleteConfirmDialog, ModelDeleteResultsDialog, type ModelDeleteResult } from "./ModelDeleteDialogs"
 import { ModelTestDiagnosticsDialog } from "./ModelTestDiagnosticsDialog"
 import { ModelsTable } from "./ModelsTable"
 import type { Model } from "../../lib/api-types"
@@ -48,54 +41,6 @@ import { useCredentialKindsQuery } from "./capabilities/api"
 import { useAuth } from "../../lib/auth-context"
 import { useToast } from "../../components/ui/toast"
 import { FilterGroup, FilterMenu, FilterOption } from "../../components/ui/filter-menu"
-
-/* --- Confirm dialog ------------------------------------------------------ */
-
-function ConfirmDialog({
-  open,
-  title,
-  description,
-  confirmLabel,
-  destructive,
-  onConfirm,
-  onCancel,
-  loading,
-}: {
-  open: boolean
-  title: string
-  description: string
-  confirmLabel?: string
-  destructive?: boolean
-  onConfirm: () => void
-  onCancel: () => void
-  loading?: boolean
-}) {
-  const { t } = useTranslation("common")
-  return (
-    <AlertDialog open={open} onOpenChange={(next) => { if (!next && !loading) onCancel() }}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle className="flex items-center gap-2">
-            {destructive && (
-              <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-status-failed" strokeWidth={1.5} aria-hidden="true" />
-            )}
-            <span>{title}</span>
-          </AlertDialogTitle>
-          <AlertDialogDescription>{description}</AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <Button variant="outline" onClick={onCancel} disabled={loading}>
-            {t("actions.cancel")}
-          </Button>
-          <Button variant={destructive ? "destructive" : "default"} onClick={onConfirm} disabled={loading}>
-            {loading && <Loader2 className="animate-spin" />}
-            {confirmLabel ?? t("actions.confirm")}
-          </Button>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
-  )
-}
 
 /* --- Loading skeleton ---------------------------------------------------- */
 
@@ -149,6 +94,8 @@ export function ModelsPage() {
   const [editModel, setEditModel] = useState<Model | null>(null)
   const [confirmDelete, setConfirmDelete] = useState<Model | null>(null)
   const [confirmBulkDelete, setConfirmBulkDelete] = useState(false)
+  const bulkDeleteButtonRef = useRef<HTMLButtonElement>(null)
+  const [deleteResult, setDeleteResult] = useState<ModelDeleteResult | null>(null)
   const { show } = useToast()
   const [selectedModelIDs, setSelectedModelIDs] = useState<Set<string>>(() => new Set())
   const [backgroundTestingIDs, setBackgroundTestingIDs] = useState<Set<string>>(() => new Set())
@@ -253,14 +200,15 @@ export function ModelsPage() {
     bulkDeleteMut.mutate(ids, {
       onSuccess: (result) => {
         const failed = result.failed ?? []
-        show(
-          t("models.bulkDelete.resultSummary", { deleted: result.deleted.length, failed: failed.length }),
-          // A partial failure lists models by name; it waits to be dismissed
-          // rather than taking the list with it after seven seconds.
-          failed.length > 0
-            ? { tone: "error", persist: true, detail: failed.map((f) => f.error).join("\n") }
-            : undefined,
-        )
+        if (failed.length > 0) {
+          setDeleteResult({
+            workspaceID: wsId,
+            data: result,
+            names: Object.fromEntries(selectedModels.map((model) => [model.id, model.name])),
+          })
+        } else {
+          show(t("models.bulkDelete.resultSummary", { deleted: result.deleted.length, failed: 0 }))
+        }
         setSelectedModelIDs((current) => {
           const next = new Set(current)
           for (const id of result.deleted) {
@@ -399,6 +347,7 @@ export function ModelsPage() {
               <Button
                 size="sm"
                 variant="destructive"
+                ref={bulkDeleteButtonRef}
                 onClick={() => setConfirmBulkDelete(true)}
                 disabled={bulkDeleteMut.isPending}
               >
@@ -467,7 +416,7 @@ export function ModelsPage() {
         }}
       />
 
-      <ConfirmDialog
+      <ModelDeleteConfirmDialog
         open={!!confirmDelete}
         title={t("models.delete.title", { name: confirmDelete?.name ?? "" })}
         description={t("models.delete.description")}
@@ -481,7 +430,7 @@ export function ModelsPage() {
         onConfirm={performDelete}
       />
 
-      <ConfirmDialog
+      <ModelDeleteConfirmDialog
         open={confirmBulkDelete}
         title={t("models.bulkDelete.title", { count: selectedModels.length })}
         description={t("models.bulkDelete.description")}
@@ -493,6 +442,12 @@ export function ModelsPage() {
           bulkDeleteMut.reset()
         }}
         onConfirm={performBulkDelete}
+      />
+
+      <ModelDeleteResultsDialog
+        result={deleteResult}
+        onClose={() => setDeleteResult(null)}
+        onCloseAutoFocus={() => bulkDeleteButtonRef.current?.focus()}
       />
 
       <ModelTestDiagnosticsDialog


### PR DESCRIPTION
Bulk model deletion previously reduced partial failures to raw error codes. A result dialog now retains the submitted model names, lists successful and failed items, explains protected models, and shows the Agent references returned by the API. Configuration links appear only for Agents confirmed in the authorized workspace directory; lookup failures retain the reference names and IDs.

Failed items remain selected, and closing the result returns focus to the bulk-delete button. All-success feedback, API calls, deletion protection and confirmation behavior are unchanged. The existing confirmation component is moved unchanged out of the oversized Models page.

Validation: `make check`, Web build and self-review. Real frontend fixtures cover mixed results after refresh, all failures, all success, configuration navigation, directory failure, long unknown errors, Escape/focus restoration, English/light and Chinese/dark presentation. No real models were deleted in these browser fixtures.
