### PR TITLE
fix(web): hide completed Feishu authorization controls

### DIFF
--- a/apps/web/src/components/admin/FeishuConnectorPanel.tsx
+++ b/apps/web/src/components/admin/FeishuConnectorPanel.tsx
@@ -359,13 +359,17 @@ export function FeishuConnectorPanel({
                   )}
                   <div className="flex min-w-0 flex-1 flex-col items-start gap-1.5">
                     <ProvisionStatus status={provision.status} loading={pollProvisionPending} />
-                    <code className="font-mono text-xs text-fg">{provision.userCode}</code>
-                    <Button variant="link" size="sm" className="px-0" asChild>
-                      <a href={provision.verificationUrl} target="_blank" rel="noreferrer">
-                        <span className="truncate">{t("agents.feishuConnector.provision.openLink")}</span>
-                        <ExternalLink strokeWidth={1.5} aria-hidden="true" />
-                      </a>
-                    </Button>
+                    {provision.status !== "success" && (
+                      <>
+                        <code className="font-mono text-xs text-fg">{provision.userCode}</code>
+                        <Button variant="link" size="sm" className="px-0" asChild>
+                          <a href={provision.verificationUrl} target="_blank" rel="noreferrer">
+                            <span className="truncate">{t("agents.feishuConnector.provision.openLink")}</span>
+                            <ExternalLink strokeWidth={1.5} aria-hidden="true" />
+                          </a>
+                        </Button>
+                      </>
+                    )}
                     {provision.message && <p className="text-sm text-fg [overflow-wrap:anywhere]">{provision.message}</p>}
                   </div>
                 </div>


### PR DESCRIPTION
After Feishu QR authorization succeeds, the connection panel still shows the authorization code and link, making the completed state look unfinished. Hide those two controls on success and keep the connection result and next-step guidance.

Pending, failed, and expired states retain their current behavior. No provisioning, polling, configuration, or API changes.

Validation: `make check`; browser checks of pending → success, error, expiry, and restart using synthetic provisioning responses without changing the real connector. Self-reviewed as a local presentation-only correction.
