### PR TITLE
fix(web): choose invocation scope during Agent creation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -632,6 +632,12 @@ cloud execution. Unknown or unavailable status blocks advancing and submitting;
 ordinary edits to an existing cloud Agent and local execution stay independent.
 Cloud setup opens Runtime's Instances tab separately so form input is retained.
 
+New and cloned Agent forms default invocation scope to workspace, matching the
+server default. Scope choices explain the existing Feishu gate without implying
+anonymous Web/API access. Public creation clears personal model credential choices
+and requires a shared binding for credential-reference models; existing Agents
+and their edit forms keep their stored scope.
+
 Use `EmptyState` with `size="compact"` for detail tabs, subsections, and
 compact result panels. Keep their alignment and spacing in that shared
 component; page-level empty states retain the default size.

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1519,6 +1519,13 @@
         "placeholder": "/Users/me/code/my-app",
         "hintLocal": "The directory the agent runs in on the selected machine — an absolute path, or one starting with `~/`. Leave blank to use a per-conversation scratch dir; created if it does not exist.",
         "hintSandbox": "The directory the agent runs in inside the sandbox container (e.g. /workspace/my-app) — an absolute path, or one starting with `~/`. Leave blank to use a per-conversation scratch dir; created if it does not exist."
+      },
+      "visibility": {
+        "label": "Who can invoke this Agent",
+        "workspace": "Workspace members",
+        "tenant": "Registered Parsar users",
+        "access": "This scope controls Feishu invocation. Web console and API access still require their existing permissions.",
+        "sharedModelRequired": "Public Agents need a shared model credential. Choose one or save a new shared credential to continue."
       }
     },
     "pendingCapability": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1519,6 +1519,13 @@
         "placeholder": "/Users/me/code/my-app",
         "hintLocal": "Agent 在所选设备上运行时的目录，填绝对路径或以 ~/ 开头的路径。留空则每个会话各用一个临时目录；路径不存在时自动创建。",
         "hintSandbox": "Agent 在沙盒容器内运行时的目录（如 /workspace/my-app），填绝对路径或以 ~/ 开头的路径。留空则每个会话各用一个临时目录；路径不存在时自动创建。"
+      },
+      "visibility": {
+        "label": "谁可以调用此 Agent",
+        "workspace": "工作区成员",
+        "tenant": "已注册的 Parsar 用户",
+        "access": "此范围控制飞书调用。Web 控制台和 API 仍需满足各自的访问权限。",
+        "sharedModelRequired": "公开 Agent 需要共享模型凭据。请选择已有凭据，或保存一份新的共享凭据后继续。"
       }
     },
     "pendingCapability": {

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -18,6 +18,7 @@ import { Input } from "../../components/ui/input"
 import { Label } from "../../components/ui/label"
 import { Select, SelectOption } from "../../components/ui/select"
 import { AgentInstructionsField } from "./agents/AgentInstructionsField"
+import { AgentVisibilityField } from "./agents/AgentVisibilityField"
 import { AgentCloudPreflight } from "./agents/AgentCloudPreflight"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
@@ -33,7 +34,7 @@ import { useCapabilitiesQuery, aggregateRequiredCredentials, aggregateRequiredCr
 import { CredentialCheckPanel } from "../../components/admin/CredentialCheckPanel"
 import { useSecrets } from "../../lib/api-secrets"
 import { useRuntimeStatus } from "../../lib/api-runtime"
-import type { UpdateAgentProfileRequest } from "../../lib/api-agents"
+import type { AgentVisibility, UpdateAgentProfileRequest } from "../../lib/api-agents"
 import type {
   AgentInlineNewSecret,
   AgentRuntime,
@@ -294,7 +295,7 @@ export function CreateAgentDialog({
   // picker's loading-state fallback option renders the right number
   // instead of mis-labelling the pinned row with the latest version.
   const [capabilityVersionChoices, setCapabilityVersionChoices] = useState<Record<string, { pinningMode: "latest" | "pinned"; versionID: string; pinnedVersion?: string }>>({})
-  const [visibility, setVisibility] = useState<"workspace" | "tenant" | "public">("public")
+  const [visibility, setVisibility] = useState<AgentVisibility>("workspace")
   const [capabilitySearch, setCapabilitySearch] = useState("")
   const [capabilityTypeFilter, setCapabilityTypeFilter] = useState<"all" | "mcp" | "skill">("all")
   const [deviceID, setDeviceID] = useState("")
@@ -533,8 +534,7 @@ export function CreateAgentDialog({
       setSelectedCapabilityIDs([])
       setCapabilityVersionChoices({})
       setCapabilitySearch("")
-      // Creation is locked to public; the visibility selector is hidden.
-      setVisibility("public")
+      setVisibility("workspace")
       setDeviceID(cloneSource ? deviceIDFromAgent(cloneSource) : "")
       setWorkDir(cloneSource ? workDirFromAgent(cloneSource) || defaultWorkDir(initialExecutionMode) : defaultWorkDir(initialExecutionMode))
       // Clones explicitly drop the source agent's credential bindings: the
@@ -542,9 +542,7 @@ export function CreateAgentDialog({
       // previous clone's bindings would leak across dialog opens.
       setCredentialBindings({})
       setInitialCredentialBindings(undefined)
-      // Create is locked to public, so personal binding is disabled — start on
-      // shared. Left as a pending pick here (secrets may still be loading); the
-      // resolver effect below upgrades it to the first existing secret if any.
+      // Resolve the pending shared pick when secrets finish loading.
       setModelBindingChoice({ source: "shared" })
       setInlineNewSecrets([])
     } else if (agent) {
@@ -718,6 +716,12 @@ export function CreateAgentDialog({
   const requiresModel = connector !== "agent_daemon" || agentEngine === "claude_code" || agentEngine === "codex" || agentEngine === "pi"
   const selectedModelUnavailable = mode === "edit" && requiresModel && selectedModelID !== "" && selectedModel === null
   const hasRequiredModel = !requiresModel || (selectedModel !== null && !incompatibleModelIDs.has(selectedModel.id))
+  const publicModelBindingValid = mode !== "create" || visibility !== "public"
+    || !requiresModel || selectedModel?.credential_mode !== "credential_ref"
+    || (modelBindingChoice.source === "shared" && (
+      ("existing_secret_id" in modelBindingChoice && Boolean(modelBindingChoice.existing_secret_id))
+      || ("new_secret" in modelBindingChoice && Boolean(modelBindingChoice.new_secret.plaintext.trim()))
+    ))
   // Create opens model binding on a pending "shared" pick because secrets may
   // still be loading; once they land, resolve to the first existing one. Gated
   // on the credential_ref UI so no-credential models stay untouched; with zero
@@ -802,7 +806,7 @@ export function CreateAgentDialog({
   async function submit() {
     setSubmitAttempted(true)
     if (!cloudReady) return
-    if (!hasRequiredModel) {
+    if (!hasRequiredModel || !publicModelBindingValid) {
       modelFieldRef.current?.scrollIntoView({ behavior: "smooth", block: "center" })
       return
     }
@@ -889,6 +893,8 @@ export function CreateAgentDialog({
     } else if (mode === "edit") {
       // Explicit null tells the backend to delete the stored binding.
       agentBodyConfig.model_credential_binding = null
+    } else {
+      delete agentBodyConfig.model_credential_binding
     }
     // Compose the inline_new_secrets the server will materialise + bind.
     const inlineSecretsToCreate: AgentInlineNewSecret[] = [...inlineNewSecrets]
@@ -995,6 +1001,7 @@ export function CreateAgentDialog({
     name.trim() !== "" &&
     hasConnector &&
     hasRequiredModel &&
+    publicModelBindingValid &&
     cloudReady &&
     (connector !== "agent_daemon" || executionMode !== "local_device" || deviceID !== "") &&
     workDirValid &&
@@ -1005,6 +1012,7 @@ export function CreateAgentDialog({
     name.trim() !== "" &&
     hasConnector &&
     hasRequiredModel &&
+    publicModelBindingValid &&
     cloudReady &&
     (connector !== "agent_daemon" || executionMode !== "local_device" || deviceID !== "") &&
     workDirValid
@@ -1084,6 +1092,12 @@ export function CreateAgentDialog({
                   <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder={t("agents.form.placeholders.description")} />
                 </Field>
                 <AgentInstructionsField value={systemPrompt} onChange={setSystemPrompt} disabled={pending} />
+                {mode === "create" && (
+                  <AgentVisibilityField value={visibility} disabled={pending} onChange={(next) => {
+                    setVisibility(next)
+                    if (next === "public" && modelBindingChoice.source === "personal") setModelBindingChoice({ source: "shared" })
+                  }} />
+                )}
               </section>
               <section className="flex flex-col gap-3">
               {showExecutionChoices ? (
@@ -1327,6 +1341,7 @@ export function CreateAgentDialog({
               )}
               {requiresModel && selectedModel && selectedModel.credential_mode === "credential_ref" && (
                 <Field label={t("credentialCheck.modelBindingTitle")}>
+                  {!publicModelBindingValid && <p className="text-xs text-fg-muted [overflow-wrap:anywhere]" role="status">{t("agents.form.visibility.sharedModelRequired")}</p>}
                   <div className="flex flex-col gap-1" role="radiogroup">
                     <label className={cn("flex items-start gap-2 py-1", visibility === "public" ? "cursor-not-allowed opacity-50" : "cursor-pointer")}>
                       <input

--- a/apps/web/src/pages/admin/agents/AgentVisibilityField.tsx
+++ b/apps/web/src/pages/admin/agents/AgentVisibilityField.tsx
@@ -1,0 +1,34 @@
+import { useId } from "react"
+import { useTranslation } from "react-i18next"
+import { Label } from "../../../components/ui/label"
+import { Select, SelectOption } from "../../../components/ui/select"
+import type { AgentVisibility } from "../../../lib/api-agents"
+
+export function AgentVisibilityField({ value, onChange, disabled }: {
+  value: AgentVisibility
+  onChange: (value: AgentVisibility) => void
+  disabled: boolean
+}) {
+  const { t } = useTranslation("admin")
+  const id = useId()
+  return (
+    <div className="flex min-w-0 flex-col">
+      <Label htmlFor={id}>{t("agents.form.visibility.label")}</Label>
+      <Select
+        id={id}
+        value={value}
+        onValueChange={(next) => {
+          if (next === "workspace" || next === "tenant" || next === "public") onChange(next)
+        }}
+        disabled={disabled}
+        aria-describedby={`${id}-hint ${id}-access`}
+      >
+        <SelectOption value="workspace">{t("agents.form.visibility.workspace")}</SelectOption>
+        <SelectOption value="tenant">{t("agents.form.visibility.tenant")}</SelectOption>
+        <SelectOption value="public">{t("agents.visibility.public")}</SelectOption>
+      </Select>
+      <span id={`${id}-hint`} className="mt-1 text-xs text-fg-muted [overflow-wrap:anywhere]">{t(`agents.visibility.${value}Hint`)}</span>
+      <span id={`${id}-access`} className="mt-1 text-xs text-fg-muted [overflow-wrap:anywhere]">{t("agents.form.visibility.access")}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
Agent creation silently uses Public visibility and gives FDEs no way to select its audience. New and cloned Agents now default to workspace scope, with explicit workspace, registered-user, and public choices. The field explains that this is the Feishu invocation gate; Web/API access keeps its existing permissions.

Public creation resets personal model credential selections and requires a shared binding for credential-reference models. A clone's submitted model binding follows its current selection. Existing Agent editing, authorization, APIs, capabilities, and runtime behavior remain unchanged.

Validation: `make check`, web build, browser checks of all scope values, keyboard selection, English/light and Chinese/dark layouts, Public credential recovery, and clone personal/shared submissions. All three captured scope payloads were created and read through the remote API, then the temporary Agents were removed. Credential-reference browser cases used synthetic responses. Fresh independent blind review completed with no findings after correction.
