### PR TITLE
fix(web): associate shared model credential labels

### DIFF
--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -498,6 +498,7 @@ export function CreateAgentDialog({
   const modelFieldRef = useRef<HTMLDivElement | null>(null)
   const modelComboboxRef = useRef<HTMLDivElement | null>(null)
   const modelListboxID = useId()
+  const modelSecretID = useId()
   const wasOpenRef = useRef(false)
 
   useEffect(() => {
@@ -1436,19 +1437,21 @@ export function CreateAgentDialog({
                             {modelNewSecretExpanded && (
                               <div className="flex flex-col gap-3 border-t border-line pt-3" onClick={(e) => e.stopPropagation()}>
                                 <div className="flex flex-col">
-                                  <Label>{t("credentialCheck.form.displayName")}</Label>
+                                  <Label htmlFor={`${modelSecretID}-name`}>{t("credentialCheck.form.displayName")}</Label>
                                   <Input
+                                    id={`${modelSecretID}-name`}
                                     value={modelNewSecretDisplayName}
                                     onChange={(e) => setModelNewSecretDisplayName(e.target.value)}
                                     placeholder={selectedModel?.name ?? t("credentialCheck.modelBindingTitle")}
                                   />
                                 </div>
                                 <div className="flex flex-col">
-                                  <Label>
+                                  <Label htmlFor={`${modelSecretID}-value`}>
                                     {t("credentialCheck.form.value")}<span aria-hidden="true"> *</span>
                                   </Label>
                                   <div className="relative">
                                     <Input
+                                      id={`${modelSecretID}-value`}
                                       type={modelNewSecretShowPlaintext ? "text" : "password"}
                                       value={modelNewSecretPlaintext}
                                       onChange={(e) => setModelNewSecretPlaintext(e.target.value)}


### PR DESCRIPTION
The Agent form's new shared model credential inputs are identified only by placeholders in the accessibility tree. Associate each visible translated label with its input so assistive technology announces the field purpose and clicking a label focuses the correct control.

This only adds label/ID associations. Credential values, validation, saving, password visibility, and layout remain unchanged.

Validation: `make check`; browser checks of accessible names, label-to-input focus, password show/hide, and saving the synthetic credential into the form. Self-reviewed as a local accessibility correction.
