### PR TITLE
fix(web): preserve Agent drafts when closing model menu

### DIFF
--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -279,6 +279,11 @@ export function CreateAgentDialog({
   const [modelID, setModelID] = useState("")
   const [modelSearch, setModelSearch] = useState("")
   const [modelDropdownOpen, setModelDropdownOpen] = useState(false)
+  // Radix's document listener can retain the initial Escape handler.
+  const modelDropdownOpenRef = useRef(false)
+  useEffect(() => {
+    modelDropdownOpenRef.current = modelDropdownOpen
+  }, [modelDropdownOpen])
   const [highlightedModelID, setHighlightedModelID] = useState<string | null>(null)
   const [systemPrompt, setSystemPrompt] = useState(defaultSystemPrompt)
   const [capabilities, setCapabilities] = useState<string[]>([])
@@ -683,12 +688,6 @@ export function CreateAgentDialog({
     }
     if (!modelDropdownOpen) return
 
-    if (event.key === "Escape") {
-      event.preventDefault()
-      setModelDropdownOpen(false)
-      return
-    }
-
     if (event.key === "Enter") {
       event.preventDefault()
       const target = filteredModels.find((m) => m.id === highlightedModelID)
@@ -1047,6 +1046,12 @@ export function CreateAgentDialog({
     >
       <DialogContent
         className="flex max-h-[86vh] flex-col overflow-hidden sm:max-w-2xl"
+        onEscapeKeyDown={(event) => {
+          if (modelDropdownOpenRef.current) {
+            event.preventDefault()
+            setModelDropdownOpen(false)
+          }
+        }}
         onPointerDownOutside={(event) => {
           if (pairDialogOpen) event.preventDefault()
         }}


### PR DESCRIPTION
Pressing Escape in the Agent model menu dismissed the whole form and lost the draft. Let the dialog dismiss its model menu first, reading the current menu state from a ref because its native Escape listener can retain the initial callback. A subsequent Escape keeps the normal dialog behavior.

Validation: `make check`; real-browser create/edit draft retention, second-Escape dismissal, keyboard model selection, and nested engine-selector dismissal. Self-reviewed; limited to this form, with no shared Dialog, model-selection, persistence, or dependency changes.
