### PR TITLE
fix(web): identify interaction requesters and operation context

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,6 +312,11 @@ description and keep ownership on the side listed here.
 
 ### Human interaction lifecycle
 
+- Interaction reads expose the run's recorded requester type and ID. Resolve
+  current user names only through active membership in that interaction's
+  workspace; missing names retain the recorded identity. Web decision surfaces
+  share operation and argument presentation without inferring unreported scope.
+
 - `agent_interactions` is the canonical durable record for permission prompts
   and `AskUserQuestion` / `requestUserInput` requests. The Web approval inbox,
   conversation SSE notices, and IM cards are presentation surfaces over that

--- a/apps/web/src/components/admin/InteractionDecisionCard.tsx
+++ b/apps/web/src/components/admin/InteractionDecisionCard.tsx
@@ -10,14 +10,15 @@ import type {
   AgentInteractionQuestion,
   ResolveAgentInteractionRequest,
 } from "../../lib/api-types"
-import { firstInteractionQuestion, interactionQuestions } from "../../lib/interaction-questions"
+import { interactionQuestions } from "../../lib/interaction-questions"
 import { useRelativeTime, useTimeUntil } from "../../lib/relative-time"
 import { cn } from "../../lib/utils"
 import { Badge } from "../ui/badge"
 import { Button } from "../ui/button"
 import { Input } from "../ui/input"
 import { Property, PropertyList } from "../ui/property-list"
-import { VerbatimBlock } from "../ui/verbatim"
+import { InteractionRequestDetails } from "./InteractionRequestDetails"
+import { interactionTitle, interactionRequester } from "../../lib/interaction-presentation"
 
 /**
  * One approval / user-input request, flat: a status badge and title, the
@@ -73,10 +74,7 @@ export function InteractionDecisionCard({
   }
 
   const kindLabel = t(`approvals.kind.${interaction.kind === "permission" ? "permission" : "userChoice"}`)
-  const title =
-    interaction.kind === "permission"
-      ? String(interaction.request.resource || interaction.request.action || t("approvals.kind.permission"))
-      : firstInteractionQuestion(interaction)?.question
+  const title = interactionTitle(interaction, t)
 
   return (
     <article
@@ -101,6 +99,7 @@ export function InteractionDecisionCard({
       </div>
 
       <PropertyList>
+        <Property label={t("approvals.detail.requester")} className="h-auto min-h-7 items-start whitespace-normal py-1"><span className="break-words" title={`${interaction.requested_by_type || ""} ${interaction.requested_by_id || ""}`}>{interactionRequester(interaction, t)}</span></Property>
         <Property label={t("approvals.detail.agent")}>{interaction.agent_name || "—"}</Property>
         <Property label={t("approvals.detail.conversation")}>
           <span className="truncate" title={interaction.conversation_title || interaction.conversation_id}>
@@ -112,9 +111,7 @@ export function InteractionDecisionCard({
       </PropertyList>
 
       {interaction.kind === "permission" ? (
-        <VerbatimBlock className="max-h-52">
-          {JSON.stringify(interaction.request.payload ?? {}, null, 2)}
-        </VerbatimBlock>
+        <InteractionRequestDetails interaction={interaction} />
       ) : (
         <div className="space-y-4">
           {questions.map((question, index) => {

--- a/apps/web/src/components/admin/InteractionDecisionCard.tsx
+++ b/apps/web/src/components/admin/InteractionDecisionCard.tsx
@@ -99,7 +99,7 @@ export function InteractionDecisionCard({
       </div>
 
       <PropertyList>
-        <Property label={t("approvals.detail.requester")} className="h-auto min-h-7 items-start whitespace-normal py-1"><span className="break-words" title={`${interaction.requested_by_type || ""} ${interaction.requested_by_id || ""}`}>{interactionRequester(interaction, t)}</span></Property>
+        <Property label={t("approvals.detail.requester")} className="h-auto min-h-7 items-start whitespace-normal py-1"><span className="min-w-0 break-words" title={`${interaction.requested_by_type || ""} ${interaction.requested_by_id || ""}`}>{interactionRequester(interaction, t)}</span></Property>
         <Property label={t("approvals.detail.agent")}>{interaction.agent_name || "—"}</Property>
         <Property label={t("approvals.detail.conversation")}>
           <span className="truncate" title={interaction.conversation_title || interaction.conversation_id}>

--- a/apps/web/src/components/admin/InteractionList.tsx
+++ b/apps/web/src/components/admin/InteractionList.tsx
@@ -1,0 +1,73 @@
+import { useTranslation } from "react-i18next"
+import type { AgentInteraction, AgentInteractionStatus } from "../../lib/api-types"
+import { interactionRequester, interactionTitle, INTERACTION_STATUS_ICONS } from "../../lib/interaction-presentation"
+import { useRelativeTime } from "../../lib/relative-time"
+import { Ledger, LedgerGroup, LedgerHeader, LedgerRow, col } from "../ui/ledger"
+import { Property, PropertyList } from "../ui/property-list"
+import { StatusIcon } from "../ui/status-icon"
+
+const GROUP_ORDER: AgentInteractionStatus[] = ["pending", "resolving", "approved", "answered", "denied", "cancelled", "expired"]
+const COLUMNS = [col.icon(), col.title(0), col.text(0), col.text(0), col.age(80)]
+
+export function InteractionList({ rows, selectedID, label, onSelect }: {
+  rows: AgentInteraction[]
+  selectedID?: string
+  label: string
+  onSelect: (id: string) => void
+}) {
+  const { t } = useTranslation("admin")
+  const fmtAgo = useRelativeTime()
+  return (
+    <Ledger columns={COLUMNS} className="@container/interactions" role="listbox" aria-label={label}>
+      <LedgerHeader className="@max-2xl/interactions:hidden">
+        <span />
+        <span>{t("approvals.table.request")}</span>
+        <span>{t("approvals.detail.requester")}</span>
+        <span>{t("approvals.detail.agent")}</span>
+        <span>{t("runs.table.age")}</span>
+      </LedgerHeader>
+      {GROUP_ORDER.map((status) => {
+        const group = rows.filter((row) => row.status === status)
+        if (!group.length) return null
+        return (
+          <LedgerGroup key={status} label={t(`approvals.status.${status}`)} count={group.length}>
+            {group.map((row) => {
+              const title = interactionTitle(row, t)
+              const requester = interactionRequester(row, t)
+              const fields = [
+                { label: t("approvals.detail.requester"), value: requester },
+                { label: t("approvals.detail.agent"), value: row.agent_name || "—" },
+                { label: t("runs.table.age"), value: fmtAgo(row.created_at) },
+              ]
+              return (
+                <LedgerRow key={row.id} selected={row.id === selectedID} onClick={() => onSelect(row.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") { event.preventDefault(); onSelect(row.id) }
+                  }}
+                  className="h-auto min-h-12 py-2"
+                >
+                  <span className="@max-2xl/interactions:hidden"><StatusIcon status={INTERACTION_STATUS_ICONS[row.status]} title={t(`approvals.status.${row.status}`)} /></span>
+                  <div className="min-w-0 @max-2xl/interactions:col-span-full">
+                    <div className="flex min-w-0 items-start gap-1.5">
+                      <span className="hidden @max-2xl/interactions:block"><StatusIcon status={INTERACTION_STATUS_ICONS[row.status]} title={t(`approvals.status.${row.status}`)} /></span>
+                      <span className="min-w-0 break-words font-medium" title={title}>{title}</span>
+                    </div>
+                    <div className="mt-1 truncate text-xs text-fg-muted" title={row.conversation_title || row.conversation_id}>
+                      {t("approvals.detail.conversation")}: {row.conversation_title || row.conversation_id}
+                    </div>
+                    <PropertyList className="mt-2 hidden @max-2xl/interactions:grid">
+                      {fields.map((field) => <Property key={field.label} label={field.label} className="h-auto min-h-7 items-start whitespace-normal py-1">
+                        <span className="break-words">{field.value}</span>
+                      </Property>)}
+                    </PropertyList>
+                  </div>
+                  {fields.map((field) => <span key={field.label} className="truncate text-xs @max-2xl/interactions:hidden" title={field.value}>{field.value}</span>)}
+                </LedgerRow>
+              )
+            })}
+          </LedgerGroup>
+        )
+      })}
+    </Ledger>
+  )
+}

--- a/apps/web/src/components/admin/InteractionList.tsx
+++ b/apps/web/src/components/admin/InteractionList.tsx
@@ -57,7 +57,7 @@ export function InteractionList({ rows, selectedID, label, onSelect }: {
                     </div>
                     <PropertyList className="mt-2 hidden @max-2xl/interactions:grid">
                       {fields.map((field) => <Property key={field.label} label={field.label} className="h-auto min-h-7 items-start whitespace-normal py-1">
-                        <span className="break-words">{field.value}</span>
+                        <span className="min-w-0 break-words">{field.value}</span>
                       </Property>)}
                     </PropertyList>
                   </div>

--- a/apps/web/src/components/admin/InteractionRequestDetails.tsx
+++ b/apps/web/src/components/admin/InteractionRequestDetails.tsx
@@ -8,7 +8,7 @@ export function InteractionRequestDetails({ interaction }: { interaction: AgentI
   const payload = interaction.request.payload
   const entries = payload && typeof payload === "object" && !Array.isArray(payload) ? Object.entries(payload) : null
   const empty = payload == null || (typeof payload === "object" && Object.keys(payload).length === 0)
-  const valueText = (value: unknown) => typeof value === "string" ? value : JSON.stringify(value, null, 2)
+  const valueText = (value: unknown) => JSON.stringify(value, null, 2)
 
   return (
     <section className="space-y-3">
@@ -31,7 +31,6 @@ export function InteractionRequestDetails({ interaction }: { interaction: AgentI
           ))}
         </PropertyList>
       ) : <VerbatimBlock className="w-full min-w-0 max-h-52 break-all">{valueText(payload)}</VerbatimBlock>}
-      {interaction.kind === "permission" && interaction.status === "pending" && <p className="text-xs text-fg-muted">{t("approvals.detail.onceScope")}</p>}
     </section>
   )
 }

--- a/apps/web/src/components/admin/InteractionRequestDetails.tsx
+++ b/apps/web/src/components/admin/InteractionRequestDetails.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from "react-i18next"
+import type { AgentInteraction } from "../../lib/api-types"
+import { Property, PropertyList } from "../ui/property-list"
+import { VerbatimBlock } from "../ui/verbatim"
+
+export function InteractionRequestDetails({ interaction }: { interaction: AgentInteraction }) {
+  const { t } = useTranslation("admin")
+  const payload = interaction.request.payload
+  const entries = payload && typeof payload === "object" && !Array.isArray(payload) ? Object.entries(payload) : null
+  const empty = payload == null || (typeof payload === "object" && Object.keys(payload).length === 0)
+  const valueText = (value: unknown) => typeof value === "string" ? value : JSON.stringify(value, null, 2)
+
+  return (
+    <section className="space-y-3">
+      {typeof interaction.request.action === "string" && interaction.request.action && (
+        <PropertyList>
+          <Property label={t("approvals.detail.operation")} mono className="h-auto min-h-7 items-start whitespace-normal py-1">
+            <span className="break-all">{interaction.request.action}</span>
+          </Property>
+        </PropertyList>
+      )}
+      <h3 className="text-base font-semibold">{t("approvals.detail.payload")}</h3>
+      {empty ? (
+        <p className="text-sm text-fg-muted">{t("approvals.detail.noParameters")}</p>
+      ) : entries ? (
+        <PropertyList>
+          {entries.map(([key, value]) => (
+            <Property key={key} label={key} className="h-auto min-h-7 items-start whitespace-normal py-1">
+              <VerbatimBlock className="w-full min-w-0 max-h-52 break-all">{valueText(value)}</VerbatimBlock>
+            </Property>
+          ))}
+        </PropertyList>
+      ) : <VerbatimBlock className="w-full min-w-0 max-h-52 break-all">{valueText(payload)}</VerbatimBlock>}
+      {interaction.kind === "permission" && interaction.status === "pending" && <p className="text-xs text-fg-muted">{t("approvals.detail.onceScope")}</p>}
+    </section>
+  )
+}

--- a/apps/web/src/components/conversation/ApprovalBar.tsx
+++ b/apps/web/src/components/conversation/ApprovalBar.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState, type KeyboardEvent } from "react"
 import { useTranslation } from "react-i18next"
 import { Check, Loader2, Square, Terminal, Wrench, X } from "lucide-react"
 
-import { useAdminView } from "../../lib/admin-router"
 import { interactionRequester, readableInteractionOperation } from "../../lib/interaction-presentation"
 import { useResolveAgentInteraction } from "../../lib/api-interactions"
 import type { AgentInteraction } from "../../lib/api-types"
@@ -71,7 +70,6 @@ export function ApprovalBar({
   stop?: { onStop: () => void; pending?: boolean; label: string }
 }) {
   const { t } = useTranslation("admin")
-  const { navigate } = useAdminView()
   const resolve = useResolveAgentInteraction(workspaceID)
   const [submitting, setSubmitting] = useState<Decision | null>(null)
   const [error, setError] = useState<{ id: string; message: string } | null>(null)
@@ -174,8 +172,10 @@ export function ApprovalBar({
       )}
 
       <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
-        <Button variant="link" size="sm" className="mr-auto" onClick={() => navigate("approvals", { id: current.id })}>
-          {t("approvals.detail.viewRequest")}
+        <Button asChild variant="link" size="sm" className="mr-auto">
+          <a href={`/?ws=${encodeURIComponent(workspaceID)}&admin=approvals&id=${encodeURIComponent(current.id)}`}>
+            {t("approvals.detail.viewRequest")}
+          </a>
         </Button>
         {errorText && <InlineError className="mr-auto min-w-0 flex-1">{errorText}</InlineError>}
         <Button

--- a/apps/web/src/components/conversation/ApprovalBar.tsx
+++ b/apps/web/src/components/conversation/ApprovalBar.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState, type KeyboardEvent } from "react"
 import { useTranslation } from "react-i18next"
 import { Check, Loader2, Square, Terminal, Wrench, X } from "lucide-react"
 
+import { useAdminView } from "../../lib/admin-router"
+import { interactionRequester, readableInteractionOperation } from "../../lib/interaction-presentation"
 import { useResolveAgentInteraction } from "../../lib/api-interactions"
 import type { AgentInteraction } from "../../lib/api-types"
 import { cn } from "../../lib/utils"
@@ -69,6 +71,7 @@ export function ApprovalBar({
   stop?: { onStop: () => void; pending?: boolean; label: string }
 }) {
   const { t } = useTranslation("admin")
+  const { navigate } = useAdminView()
   const resolve = useResolveAgentInteraction(workspaceID)
   const [submitting, setSubmitting] = useState<Decision | null>(null)
   const [error, setError] = useState<{ id: string; message: string } | null>(null)
@@ -85,7 +88,8 @@ export function ApprovalBar({
 
   if (!current) return null
 
-  const { tool, summary, detail } = describe(current, t("conversations.permission.unknownTool"))
+  const { tool: rawTool, summary, detail } = describe(current, t("conversations.permission.unknownTool"))
+  const tool = readableInteractionOperation(rawTool)
   const ToolIcon = tool.toLowerCase() === "bash" ? Terminal : Wrench
   const agent = current.agent_name || t("approvals.detail.agent")
   const errorText = error?.id === current.id ? error.message : ""
@@ -145,7 +149,7 @@ export function ApprovalBar({
     >
       <div className="flex h-7 items-center gap-2 text-xs text-fg-muted">
         <ToolIcon className="h-3.5 w-3.5 shrink-0" strokeWidth={1.5} aria-hidden="true" />
-        <span className="min-w-0 flex-1 truncate">{tool}</span>
+        <span className="min-w-0 flex-1 truncate" title={rawTool}>{tool}</span>
         {!isNaN(remaining) && (
           <span role="timer" className="shrink-0 font-mono tabular-nums">
             {interactions.length > 1 ? `1 / ${interactions.length} · ` : ""}
@@ -157,7 +161,10 @@ export function ApprovalBar({
       <p className="m-0 mt-1 text-sm text-fg">
         {t("conversations.approval.body", { agent, tool })}
       </p>
-      {summary && (
+      <p className="m-0 mt-1 break-words text-xs text-fg-muted">
+        {t("approvals.detail.requester")}: {interactionRequester(current, t)}
+      </p>
+      {summary && summary !== rawTool && (
         <p
           className="m-0 mt-1 truncate font-mono text-xs text-fg-muted"
           title={detail && detail !== summary ? `${summary}\n${detail}` : summary}
@@ -166,7 +173,10 @@ export function ApprovalBar({
         </p>
       )}
 
-      <div className="mt-3 flex items-center justify-end gap-2">
+      <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
+        <Button variant="link" size="sm" className="mr-auto" onClick={() => navigate("approvals", { id: current.id })}>
+          {t("approvals.detail.viewRequest")}
+        </Button>
         {errorText && <InlineError className="mr-auto min-w-0 flex-1">{errorText}</InlineError>}
         <Button
           variant="outline"

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -238,7 +238,6 @@
       "requesterUnknown": "Unknown requester",
       "operation": "Operation",
       "noParameters": "The runtime did not report any arguments.",
-      "onceScope": "Allow once applies only to this request.",
       "viewRequest": "View request details"
     },
     "empty": {

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -226,14 +226,20 @@
     "detail": {
       "agent": "Agent",
       "conversation": "Conversation",
-      "payload": "Payload preview",
+      "payload": "Arguments",
       "createdAt": "Created",
       "expiresIn": "Expires in",
       "alreadyDecided": "This approval has been handled — actions are no longer available.",
       "readOnly": "Read-only access. Workspace owners, admins, and members can respond.",
       "openRun": "Open Run Detail",
       "openConversation": "Open Conversation",
-      "decidedBy": "Decided by"
+      "decidedBy": "Decided by",
+      "requester": "Requested by",
+      "requesterUnknown": "Unknown requester",
+      "operation": "Operation",
+      "noParameters": "The runtime did not report any arguments.",
+      "onceScope": "Allow once applies only to this request.",
+      "viewRequest": "View request details"
     },
     "empty": {
       "title": "No approvals",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -238,7 +238,6 @@
       "requesterUnknown": "申请人未知",
       "operation": "操作",
       "noParameters": "执行层未上报操作参数。",
-      "onceScope": "「仅允许本次」只对当前请求生效。",
       "viewRequest": "查看请求详情"
     },
     "empty": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -226,14 +226,20 @@
     "detail": {
       "agent": "Agent",
       "conversation": "关联对话",
-      "payload": "Payload 摘要",
+      "payload": "操作参数",
       "createdAt": "创建于",
       "expiresIn": "剩余时间",
       "alreadyDecided": "这条审批已经处理过，不能再操作。",
       "readOnly": "当前为只读模式。工作区所有者、管理员和成员可以处理。",
       "openRun": "打开 Run Detail",
       "openConversation": "打开 Conversation",
-      "decidedBy": "决定人"
+      "decidedBy": "决定人",
+      "requester": "申请人",
+      "requesterUnknown": "申请人未知",
+      "operation": "操作",
+      "noParameters": "执行层未上报操作参数。",
+      "onceScope": "「仅允许本次」只对当前请求生效。",
+      "viewRequest": "查看请求详情"
     },
     "empty": {
       "title": "暂时没有审批",

--- a/apps/web/src/lib/api-types.ts
+++ b/apps/web/src/lib/api-types.ts
@@ -621,6 +621,9 @@ export type AgentInteractionStatus =
   "pending" | "resolving" | "approved" | "denied" | "answered" | "cancelled" | "expired"
 
 export interface AgentInteraction {
+  requested_by_type?: string
+  requested_by_id?: string
+  requested_by_name?: string
   id: string
   workspace_id: string
   conversation_id: string

--- a/apps/web/src/lib/interaction-presentation.ts
+++ b/apps/web/src/lib/interaction-presentation.ts
@@ -1,0 +1,27 @@
+import type { TFunction } from "i18next"
+import type { StatusKind } from "../components/ui/status-icon"
+import type { AgentInteraction, AgentInteractionStatus } from "./api-types"
+import { firstInteractionQuestion } from "./interaction-questions"
+
+export const INTERACTION_STATUS_ICONS: Record<AgentInteractionStatus, StatusKind> = {
+  pending: "queued", resolving: "running", approved: "completed", answered: "completed",
+  denied: "failed", cancelled: "cancelled", expired: "interrupted",
+}
+
+export function interactionTitle(row: AgentInteraction, t: TFunction<"admin">): string {
+  if (row.kind !== "permission") return firstInteractionQuestion(row)?.question || t("approvals.kind.userChoice")
+  const raw = String(row.request.resource || row.request.action || t("approvals.kind.permission"))
+  return readableInteractionOperation(raw)
+}
+
+export function interactionRequester(row: AgentInteraction, t: TFunction<"admin">): string {
+  if (row.requested_by_type === "user" && row.requested_by_name) return row.requested_by_name
+  const type = row.requested_by_type
+    ? t(`audit.actor.${row.requested_by_type}`, { defaultValue: row.requested_by_type })
+    : t("approvals.detail.requesterUnknown")
+  return row.requested_by_id ? `${type} · ${row.requested_by_id}` : type
+}
+
+export function readableInteractionOperation(value: string): string {
+  return value.replace(/^mcp__(.+?)__(.+)$/, "$1 / $2")
+}

--- a/apps/web/src/lib/interaction-presentation.ts
+++ b/apps/web/src/lib/interaction-presentation.ts
@@ -15,7 +15,9 @@ export function interactionTitle(row: AgentInteraction, t: TFunction<"admin">): 
 }
 
 export function interactionRequester(row: AgentInteraction, t: TFunction<"admin">): string {
-  if (row.requested_by_type === "user" && row.requested_by_name) return row.requested_by_name
+  if (row.requested_by_type === "user" && row.requested_by_name) {
+    return row.requested_by_id ? `${row.requested_by_name} · ${row.requested_by_id}` : row.requested_by_name
+  }
   const type = row.requested_by_type
     ? t(`audit.actor.${row.requested_by_type}`, { defaultValue: row.requested_by_type })
     : t("approvals.detail.requesterUnknown")

--- a/apps/web/src/pages/admin/ApprovalsPage.tsx
+++ b/apps/web/src/pages/admin/ApprovalsPage.tsx
@@ -279,7 +279,7 @@ function InteractionRail({
       )}
 
       <PropertyList className="mt-3">
-        <Property label={t("approvals.detail.requester")} className="h-auto min-h-7 items-start whitespace-normal py-1"><span className="break-words" title={`${interaction.requested_by_type || ""} ${interaction.requested_by_id || ""}`}>{interactionRequester(interaction, t)}</span></Property>
+        <Property label={t("approvals.detail.requester")} className="h-auto min-h-7 items-start whitespace-normal py-1"><span className="min-w-0 break-words" title={`${interaction.requested_by_type || ""} ${interaction.requested_by_id || ""}`}>{interactionRequester(interaction, t)}</span></Property>
         <Property label={t("approvals.detail.conversation")} mono>
           <button
             type="button"

--- a/apps/web/src/pages/admin/ApprovalsPage.tsx
+++ b/apps/web/src/pages/admin/ApprovalsPage.tsx
@@ -1,8 +1,10 @@
-import { useMemo, useState, type KeyboardEvent } from "react"
+import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
-import type { TFunction } from "i18next"
 import { AlertTriangle, ArrowUpRight, Inbox, Loader2 } from "lucide-react"
 
+import { InteractionList } from "../../components/admin/InteractionList"
+import { InteractionRequestDetails } from "../../components/admin/InteractionRequestDetails"
+import { interactionTitle, interactionRequester, INTERACTION_STATUS_ICONS } from "../../lib/interaction-presentation"
 import { ScopeRequiredState } from "../../components/admin/ScopeRequiredState"
 import { AdminLayout } from "../../components/layout/AdminLayout"
 import { PageHeader } from "../../components/layout/PageHeader"
@@ -13,27 +15,20 @@ import { ErrorState } from "../../components/ui/error-state"
 import { Input } from "../../components/ui/input"
 import {
   InitialTile,
-  Ledger,
-  LedgerGroup,
-  LedgerHeader,
   LedgerId,
-  LedgerRow,
-  col,
 } from "../../components/ui/ledger"
 import { Property, PropertyList } from "../../components/ui/property-list"
 import { Skeleton } from "../../components/ui/skeleton"
-import { StatusIcon, type StatusKind } from "../../components/ui/status-icon"
-import { VerbatimBlock } from "../../components/ui/verbatim"
+import { StatusIcon } from "../../components/ui/status-icon"
 import { useAdminView } from "../../lib/admin-router"
 import { ApiError } from "../../lib/api-client"
 import { useAgentInteractions, useResolveAgentInteraction } from "../../lib/api-interactions"
 import type {
   AgentInteraction,
   AgentInteractionQuestion,
-  AgentInteractionStatus,
   ResolveAgentInteractionRequest,
 } from "../../lib/api-types"
-import { firstInteractionQuestion, interactionQuestions } from "../../lib/interaction-questions"
+import { interactionQuestions } from "../../lib/interaction-questions"
 import { useRelativeTime, useTimeUntil } from "../../lib/relative-time"
 import { useWorkspaceId } from "../../lib/workspace"
 
@@ -41,35 +36,11 @@ import { useWorkspaceId } from "../../lib/workspace"
 /*  List page: the approvals ledger + decision rail                    */
 /* ------------------------------------------------------------------ */
 
-const GROUP_ORDER: AgentInteractionStatus[] = [
-  "pending",
-  "resolving",
-  "approved",
-  "answered",
-  "denied",
-  "cancelled",
-  "expired",
-]
-
-const STATUS_ICON: Record<AgentInteractionStatus, StatusKind> = {
-  pending: "queued",
-  resolving: "running",
-  approved: "completed",
-  answered: "completed",
-  denied: "failed",
-  cancelled: "cancelled",
-  expired: "interrupted",
-}
-
-/** status icon · request (+ kind) · agent · run id · age */
-const LEDGER_COLUMNS = [col.icon(), col.title(), col.text(160, 1), col.id(132), col.age(80)]
-
 export function ApprovalsPage() {
   const { t } = useTranslation("admin")
   const { t: tc } = useTranslation("common")
   const { entityId, navigate } = useAdminView()
   const workspaceID = useWorkspaceId()
-  const fmtAgo = useRelativeTime()
 
   // The API serves three status buckets; the ledger shows them as one
   // list grouped by the concrete state so a decision never changes tabs.
@@ -84,15 +55,6 @@ export function ApprovalsPage() {
       ...(expiredQ.data?.interactions ?? []),
     ],
     [pendingQ.data, decidedQ.data, expiredQ.data],
-  )
-
-  const groups = useMemo(
-    () =>
-      GROUP_ORDER.map((status) => ({
-        status,
-        rows: rows.filter((r) => r.status === status),
-      })).filter((g) => g.rows.length > 0),
-    [rows],
   )
 
   const error = pendingQ.error ?? decidedQ.error ?? expiredQ.error
@@ -146,31 +108,7 @@ export function ApprovalsPage() {
           ) : rows.length === 0 ? (
             <EmptyState icon={Inbox} title={t("approvals.empty.title")} description={t("approvals.empty.description")} />
           ) : (
-            <Ledger columns={LEDGER_COLUMNS} role="listbox" aria-label={pageTitle}>
-              <LedgerHeader>
-                <span />
-                <span>{t("approvals.table.request")}</span>
-                <span>{t("approvals.detail.agent")}</span>
-                <span>{t("runs.table.run")}</span>
-                <span className="text-right">{t("runs.table.age")}</span>
-              </LedgerHeader>
-              {groups.map((g) => (
-                <LedgerGroup key={g.status} label={t(`approvals.status.${g.status}`)} count={g.rows.length}>
-                  {g.rows.map((row) => (
-                    <InteractionRow
-                      key={row.id}
-                      row={row}
-                      selected={row.id === selected?.id}
-                      statusLabel={t(`approvals.status.${row.status}`)}
-                      kindLabel={t(`approvals.kind.${row.kind === "permission" ? "permission" : "userChoice"}`)}
-                      title={interactionTitle(row, t)}
-                      age={fmtAgo(row.created_at)}
-                      onSelect={() => select(row.id)}
-                    />
-                  ))}
-                </LedgerGroup>
-              ))}
-            </Ledger>
+            <InteractionList rows={rows} selectedID={selected?.id} label={pageTitle} onSelect={select} />
           )}
         </div>
 
@@ -185,54 +123,6 @@ export function ApprovalsPage() {
         )}
       </div>
     </AdminLayout>
-  )
-}
-
-function interactionTitle(row: AgentInteraction, t: TFunction<"admin">): string {
-  if (row.kind === "permission") {
-    return String(row.request.resource || row.request.action || t("approvals.kind.permission"))
-  }
-  return firstInteractionQuestion(row)?.question || t("approvals.kind.userChoice")
-}
-
-function InteractionRow({
-  row,
-  selected,
-  statusLabel,
-  kindLabel,
-  title,
-  age,
-  onSelect,
-}: {
-  row: AgentInteraction
-  selected: boolean
-  statusLabel: string
-  kindLabel: string
-  title: string
-  age: string
-  onSelect: () => void
-}) {
-  const agent = row.agent_name || "—"
-  const onKeyDown = (e: KeyboardEvent<HTMLLIElement>) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault()
-      onSelect()
-    }
-  }
-  return (
-    <LedgerRow selected={selected} onClick={onSelect} onKeyDown={onKeyDown}>
-      <StatusIcon status={STATUS_ICON[row.status]} title={statusLabel} />
-      <span className="flex min-w-0 items-center gap-1.5">
-        <span className="truncate font-medium" title={title}>{title}</span>
-        <span className="shrink-0 text-xs text-fg-muted">· {kindLabel}</span>
-      </span>
-      <span className="flex min-w-0 items-center gap-1.5">
-        <InitialTile name={agent} />
-        <span className="truncate">{agent}</span>
-      </span>
-      <LedgerId>{shortId(row.agent_run_id, 16)}</LedgerId>
-      <span className="truncate text-right text-xs text-fg-muted">{age}</span>
-    </LedgerRow>
   )
 }
 
@@ -330,7 +220,7 @@ function InteractionRail({
       closeLabel={t("runs.detail.close")}
       header={
         <>
-          <StatusIcon status={STATUS_ICON[interaction.status]} />
+          <StatusIcon status={INTERACTION_STATUS_ICONS[interaction.status]} />
           <span className="shrink-0 text-base font-medium text-fg">{t(`approvals.status.${interaction.status}`)}</span>
           <LedgerId className="min-w-0 flex-1">{interaction.request_id || interaction.id}</LedgerId>
         </>
@@ -389,6 +279,7 @@ function InteractionRail({
       )}
 
       <PropertyList className="mt-3">
+        <Property label={t("approvals.detail.requester")} className="h-auto min-h-7 items-start whitespace-normal py-1"><span className="break-words" title={`${interaction.requested_by_type || ""} ${interaction.requested_by_id || ""}`}>{interactionRequester(interaction, t)}</span></Property>
         <Property label={t("approvals.detail.conversation")} mono>
           <button
             type="button"
@@ -409,11 +300,7 @@ function InteractionRail({
       </PropertyList>
 
       {isPermission ? (
-        <RailSection title={t("approvals.detail.payload")}>
-          <VerbatimBlock className="mt-1.5 max-h-60">
-            {JSON.stringify(interaction.request.payload ?? {}, null, 2)}
-          </VerbatimBlock>
-        </RailSection>
+        <div className="mt-4"><InteractionRequestDetails interaction={interaction} /></div>
       ) : (
         questions.map((question, index) => {
           const key = questionKey(question, index)
@@ -484,9 +371,4 @@ function questionKey(question: AgentInteractionQuestion, index: number) {
 function toggleAnswer(current: string[], value: string, multi: boolean) {
   if (!multi) return [value]
   return current.includes(value) ? current.filter((item) => item !== value) : [...current, value]
-}
-
-function shortId(s?: string, n = 8): string {
-  if (!s) return "—"
-  return s.length <= n ? s : s.slice(0, n) + "…"
 }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1590,6 +1590,12 @@ definitions:
         type: object
       request_id:
         type: string
+      requested_by_id:
+        type: string
+      requested_by_name:
+        type: string
+      requested_by_type:
+        type: string
       resolution_source:
         type: string
       resolved_actor:
@@ -7327,8 +7333,9 @@ paths:
       - workspaces
   /api/v1/workspaces/{workspaceID}/interactions:
     get:
-      description: Returns durable permission and AskUserQuestion requests. status
-        accepts pending, decided, or expired.
+      description: Returns durable permission and AskUserQuestion requests with recorded
+        requester identity and current workspace member names. status accepts pending,
+        decided, or expired.
       operationId: listAgentInteractions
       parameters:
       - description: Workspace UUID

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -2990,11 +2990,22 @@ select
   ai.resolved_at,
   ai.updated_at,
   coalesce(a.name, '')::text as agent_name,
-  coalesce(c.title, '')::text as conversation_title
+  coalesce(c.title, '')::text as conversation_title,
+  coalesce(r.requested_by_type, '')::text as requested_by_type,
+  coalesce(r.requested_by_id::text, '')::text as requested_by_id,
+  coalesce(nullif(btrim(requester.name), ''), requester.email, '')::text as requested_by_name
 from agent_interactions ai
 join conversations c on c.id = ai.conversation_id
 left join agent_runs r on r.id = ai.agent_run_id
 left join agents a on a.id = r.agent_id
+left join users requester on requester.id = r.requested_by_id
+  and r.requested_by_type = 'user' and requester.deleted_at is null
+  and exists (
+    select 1 from workspace_members wm
+    join workspaces w on w.id = wm.workspace_id and w.deleted_at is null
+    where wm.workspace_id = ai.workspace_id and wm.user_id = requester.id
+      and wm.status = 'active' and wm.deleted_at is null
+  )
 where ai.workspace_id = @workspace_id::uuid
   and (
     @status_group::text = ''
@@ -3025,11 +3036,22 @@ select
   ai.resolved_at,
   ai.updated_at,
   coalesce(a.name, '')::text as agent_name,
-  coalesce(c.title, '')::text as conversation_title
+  coalesce(c.title, '')::text as conversation_title,
+  coalesce(r.requested_by_type, '')::text as requested_by_type,
+  coalesce(r.requested_by_id::text, '')::text as requested_by_id,
+  coalesce(nullif(btrim(requester.name), ''), requester.email, '')::text as requested_by_name
 from agent_interactions ai
 join conversations c on c.id = ai.conversation_id
 left join agent_runs r on r.id = ai.agent_run_id
 left join agents a on a.id = r.agent_id
+left join users requester on requester.id = r.requested_by_id
+  and r.requested_by_type = 'user' and requester.deleted_at is null
+  and exists (
+    select 1 from workspace_members wm
+    join workspaces w on w.id = wm.workspace_id and w.deleted_at is null
+    where wm.workspace_id = ai.workspace_id and wm.user_id = requester.id
+      and wm.status = 'active' and wm.deleted_at is null
+  )
 where ai.id = @interaction_id::uuid;
 
 -- name: GetAgentInteractionByRequestID :one
@@ -3052,11 +3074,22 @@ select
   ai.resolved_at,
   ai.updated_at,
   coalesce(a.name, '')::text as agent_name,
-  coalesce(c.title, '')::text as conversation_title
+  coalesce(c.title, '')::text as conversation_title,
+  coalesce(r.requested_by_type, '')::text as requested_by_type,
+  coalesce(r.requested_by_id::text, '')::text as requested_by_id,
+  coalesce(nullif(btrim(requester.name), ''), requester.email, '')::text as requested_by_name
 from agent_interactions ai
 join conversations c on c.id = ai.conversation_id
 left join agent_runs r on r.id = ai.agent_run_id
 left join agents a on a.id = r.agent_id
+left join users requester on requester.id = r.requested_by_id
+  and r.requested_by_type = 'user' and requester.deleted_at is null
+  and exists (
+    select 1 from workspace_members wm
+    join workspaces w on w.id = wm.workspace_id and w.deleted_at is null
+    where wm.workspace_id = ai.workspace_id and wm.user_id = requester.id
+      and wm.status = 'active' and wm.deleted_at is null
+  )
 where ai.kind = @kind
   and ai.request_id = @request_id
   and ai.agent_run_id = @agent_run_id::uuid

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -4301,11 +4301,22 @@ select
   ai.resolved_at,
   ai.updated_at,
   coalesce(a.name, '')::text as agent_name,
-  coalesce(c.title, '')::text as conversation_title
+  coalesce(c.title, '')::text as conversation_title,
+  coalesce(r.requested_by_type, '')::text as requested_by_type,
+  coalesce(r.requested_by_id::text, '')::text as requested_by_id,
+  coalesce(nullif(btrim(requester.name), ''), requester.email, '')::text as requested_by_name
 from agent_interactions ai
 join conversations c on c.id = ai.conversation_id
 left join agent_runs r on r.id = ai.agent_run_id
 left join agents a on a.id = r.agent_id
+left join users requester on requester.id = r.requested_by_id
+  and r.requested_by_type = 'user' and requester.deleted_at is null
+  and exists (
+    select 1 from workspace_members wm
+    join workspaces w on w.id = wm.workspace_id and w.deleted_at is null
+    where wm.workspace_id = ai.workspace_id and wm.user_id = requester.id
+      and wm.status = 'active' and wm.deleted_at is null
+  )
 where ai.id = $1::uuid
 `
 
@@ -4329,6 +4340,9 @@ type GetAgentInteractionRow struct {
 	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
 	AgentName         string             `json:"agent_name"`
 	ConversationTitle string             `json:"conversation_title"`
+	RequestedByType   string             `json:"requested_by_type"`
+	RequestedByID     string             `json:"requested_by_id"`
+	RequestedByName   string             `json:"requested_by_name"`
 }
 
 func (q *Queries) GetAgentInteraction(ctx context.Context, interactionID pgtype.UUID) (GetAgentInteractionRow, error) {
@@ -4354,6 +4368,9 @@ func (q *Queries) GetAgentInteraction(ctx context.Context, interactionID pgtype.
 		&i.UpdatedAt,
 		&i.AgentName,
 		&i.ConversationTitle,
+		&i.RequestedByType,
+		&i.RequestedByID,
+		&i.RequestedByName,
 	)
 	return i, err
 }
@@ -4378,11 +4395,22 @@ select
   ai.resolved_at,
   ai.updated_at,
   coalesce(a.name, '')::text as agent_name,
-  coalesce(c.title, '')::text as conversation_title
+  coalesce(c.title, '')::text as conversation_title,
+  coalesce(r.requested_by_type, '')::text as requested_by_type,
+  coalesce(r.requested_by_id::text, '')::text as requested_by_id,
+  coalesce(nullif(btrim(requester.name), ''), requester.email, '')::text as requested_by_name
 from agent_interactions ai
 join conversations c on c.id = ai.conversation_id
 left join agent_runs r on r.id = ai.agent_run_id
 left join agents a on a.id = r.agent_id
+left join users requester on requester.id = r.requested_by_id
+  and r.requested_by_type = 'user' and requester.deleted_at is null
+  and exists (
+    select 1 from workspace_members wm
+    join workspaces w on w.id = wm.workspace_id and w.deleted_at is null
+    where wm.workspace_id = ai.workspace_id and wm.user_id = requester.id
+      and wm.status = 'active' and wm.deleted_at is null
+  )
 where ai.kind = $1
   and ai.request_id = $2
   and ai.agent_run_id = $3::uuid
@@ -4416,6 +4444,9 @@ type GetAgentInteractionByRequestIDRow struct {
 	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
 	AgentName         string             `json:"agent_name"`
 	ConversationTitle string             `json:"conversation_title"`
+	RequestedByType   string             `json:"requested_by_type"`
+	RequestedByID     string             `json:"requested_by_id"`
+	RequestedByName   string             `json:"requested_by_name"`
 }
 
 func (q *Queries) GetAgentInteractionByRequestID(ctx context.Context, arg GetAgentInteractionByRequestIDParams) (GetAgentInteractionByRequestIDRow, error) {
@@ -4441,6 +4472,9 @@ func (q *Queries) GetAgentInteractionByRequestID(ctx context.Context, arg GetAge
 		&i.UpdatedAt,
 		&i.AgentName,
 		&i.ConversationTitle,
+		&i.RequestedByType,
+		&i.RequestedByID,
+		&i.RequestedByName,
 	)
 	return i, err
 }
@@ -9518,11 +9552,22 @@ select
   ai.resolved_at,
   ai.updated_at,
   coalesce(a.name, '')::text as agent_name,
-  coalesce(c.title, '')::text as conversation_title
+  coalesce(c.title, '')::text as conversation_title,
+  coalesce(r.requested_by_type, '')::text as requested_by_type,
+  coalesce(r.requested_by_id::text, '')::text as requested_by_id,
+  coalesce(nullif(btrim(requester.name), ''), requester.email, '')::text as requested_by_name
 from agent_interactions ai
 join conversations c on c.id = ai.conversation_id
 left join agent_runs r on r.id = ai.agent_run_id
 left join agents a on a.id = r.agent_id
+left join users requester on requester.id = r.requested_by_id
+  and r.requested_by_type = 'user' and requester.deleted_at is null
+  and exists (
+    select 1 from workspace_members wm
+    join workspaces w on w.id = wm.workspace_id and w.deleted_at is null
+    where wm.workspace_id = ai.workspace_id and wm.user_id = requester.id
+      and wm.status = 'active' and wm.deleted_at is null
+  )
 where ai.workspace_id = $1::uuid
   and (
     $2::text = ''
@@ -9560,6 +9605,9 @@ type ListWorkspaceAgentInteractionsRow struct {
 	UpdatedAt         pgtype.Timestamptz `json:"updated_at"`
 	AgentName         string             `json:"agent_name"`
 	ConversationTitle string             `json:"conversation_title"`
+	RequestedByType   string             `json:"requested_by_type"`
+	RequestedByID     string             `json:"requested_by_id"`
+	RequestedByName   string             `json:"requested_by_name"`
 }
 
 func (q *Queries) ListWorkspaceAgentInteractions(ctx context.Context, arg ListWorkspaceAgentInteractionsParams) ([]ListWorkspaceAgentInteractionsRow, error) {
@@ -9591,6 +9639,9 @@ func (q *Queries) ListWorkspaceAgentInteractions(ctx context.Context, arg ListWo
 			&i.UpdatedAt,
 			&i.AgentName,
 			&i.ConversationTitle,
+			&i.RequestedByType,
+			&i.RequestedByID,
+			&i.RequestedByName,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/dev/routes_interactions.go
+++ b/server/internal/dev/routes_interactions.go
@@ -38,7 +38,7 @@ type resolveAgentInteractionResponse struct {
 // listAgentInteractions returns durable human requests for the workspace.
 //
 //	@Summary		List workspace approval and user-question requests
-//	@Description	Returns durable permission and AskUserQuestion requests. status accepts pending, decided, or expired.
+//	@Description	Returns durable permission and AskUserQuestion requests with recorded requester identity and current workspace member names. status accepts pending, decided, or expired.
 //	@Tags			interactions
 //	@ID				listAgentInteractions
 //	@Produce		json

--- a/server/internal/store/agent_interactions.go
+++ b/server/internal/store/agent_interactions.go
@@ -46,6 +46,9 @@ var (
 )
 
 type AgentInteractionRead struct {
+	RequestedByType   string         `json:"requested_by_type"`
+	RequestedByID     string         `json:"requested_by_id,omitempty"`
+	RequestedByName   string         `json:"requested_by_name,omitempty"`
 	ID                string         `json:"id"`
 	WorkspaceID       string         `json:"workspace_id"`
 	ConversationID    string         `json:"conversation_id"`
@@ -117,7 +120,7 @@ func (s *Store) ListWorkspaceAgentInteractions(ctx context.Context, workspaceID,
 			row.RequestID, row.Kind, row.Status, row.Request, row.Response,
 			row.ResolutionSource, row.ResolvedActor, row.ResolvedBy,
 			row.CreatedAt, row.ExpiresAt, row.ResolvedAt, row.UpdatedAt,
-			row.AgentName, row.ConversationTitle,
+			row.AgentName, row.ConversationTitle, row.RequestedByType, row.RequestedByID, row.RequestedByName,
 		))
 	}
 	return out, nil
@@ -140,7 +143,7 @@ func (s *Store) GetAgentInteraction(ctx context.Context, interactionID string) (
 		row.RequestID, row.Kind, row.Status, row.Request, row.Response,
 		row.ResolutionSource, row.ResolvedActor, row.ResolvedBy,
 		row.CreatedAt, row.ExpiresAt, row.ResolvedAt, row.UpdatedAt,
-		row.AgentName, row.ConversationTitle,
+		row.AgentName, row.ConversationTitle, row.RequestedByType, row.RequestedByID, row.RequestedByName,
 	), nil
 }
 
@@ -163,7 +166,7 @@ func (s *Store) GetAgentInteractionByRequestID(ctx context.Context, kind, reques
 		row.RequestID, row.Kind, row.Status, row.Request, row.Response,
 		row.ResolutionSource, row.ResolvedActor, row.ResolvedBy,
 		row.CreatedAt, row.ExpiresAt, row.ResolvedAt, row.UpdatedAt,
-		row.AgentName, row.ConversationTitle,
+		row.AgentName, row.ConversationTitle, row.RequestedByType, row.RequestedByID, row.RequestedByName,
 	), nil
 }
 
@@ -334,7 +337,7 @@ func interactionRead(
 	id, workspaceID, conversationID, agentRunID, requestID, kind, status string,
 	request, response []byte, resolutionSource, resolvedActor, resolvedBy string,
 	createdAt, expiresAt, resolvedAt, updatedAt pgtype.Timestamptz,
-	agentName, conversationTitle string,
+	agentName, conversationTitle, requestedByType, requestedByID, requestedByName string,
 ) AgentInteractionRead {
 	var resolvedAtPtr *time.Time
 	if resolvedAt.Valid {
@@ -348,6 +351,6 @@ func interactionRead(
 		ResolutionSource: resolutionSource, ResolvedActor: resolvedActor, ResolvedBy: resolvedBy,
 		CreatedAt: pgTime(createdAt), ExpiresAt: pgTime(expiresAt),
 		ResolvedAt: resolvedAtPtr, UpdatedAt: pgTime(updatedAt), AgentName: agentName,
-		ConversationTitle: conversationTitle,
+		ConversationTitle: conversationTitle, RequestedByType: requestedByType, RequestedByID: requestedByID, RequestedByName: requestedByName,
 	}
 }

--- a/server/internal/store/agent_interactions_requester_test.go
+++ b/server/internal/store/agent_interactions_requester_test.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestAgentInteractionRequesterMetadata(t *testing.T) {
+	db := openTestDB(t)
+	ctx := context.Background()
+	s := New(db)
+	ids := mustSeedDevFixture(t, ctx, s)
+	memberID := "e536db30-5f14-437d-bdd7-4f84fb816ec1"
+	if _, err := db.Exec(ctx, `insert into users(id,email,name,created_at,updated_at) values($1,'requester@example.test','QA Member',now(),now())`, memberID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(ctx, `insert into workspace_members(id,workspace_id,user_id,role,created_at,updated_at) values(gen_random_uuid(),$1,$2,'member',now(),now())`, ids.WorkspaceID, memberID); err != nil {
+		t.Fatal(err)
+	}
+	otherWorkspaceID := "e536db30-5f14-437d-bdd7-4f84fb816ec2"
+	if _, err := db.Exec(ctx, `insert into workspaces(id,name,slug,created_at,updated_at) values($1,'Other requester workspace','other-requester-workspace',now(),now())`, otherWorkspaceID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(ctx, `insert into workspace_members(id,workspace_id,user_id,role,created_at,updated_at) values(gen_random_uuid(),$1,$2,'member',now(),now())`, otherWorkspaceID, memberID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(ctx, `update users set name='QA Owner' where id=$1`, ids.UserID); err != nil {
+		t.Fatal(err)
+	}
+	requestIDs := map[string]string{}
+	for i, userID := range []string{ids.UserID, memberID} {
+		result, err := s.SendUserMessageToConversation(ctx, SendUserMessageToConversationInput{
+			ConversationID: ids.ConversationID, UserID: userID, Content: "check the same tool",
+			MentionedAgentIDs: []string{ids.ProductAgentID},
+		})
+		if err != nil || len(result.RunIDs) != 1 {
+			t.Fatalf("create requester run: %v, %v", result, err)
+		}
+		runID := result.RunIDs[0]
+		requestIDs[runID] = fmt.Sprintf("requester-%d", i)
+		if err := s.RecordAgentRunEvent(ctx, RecordAgentRunEventInput{
+			RunID: runID, EventKind: "permission.asked", OccurredAt: time.Now().UTC(),
+			Payload: map[string]any{"request_id": requestIDs[runID], "action": "mcp__service__get_ticket"},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rows, err := s.ListWorkspaceAgentInteractions(ctx, ids.WorkspaceID, "pending", 100)
+	if err != nil || len(rows) != 2 {
+		t.Fatalf("list two requesters: %v, %v", rows, err)
+	}
+	var member AgentInteractionRead
+	for _, row := range rows {
+		want := "QA Owner"
+		if row.RequestedByID == memberID {
+			want = "QA Member"
+			member = row
+		} else if row.RequestedByID != ids.UserID {
+			t.Fatalf("unexpected requester ID: %q", row.RequestedByID)
+		}
+		if row.RequestedByType != "user" || row.RequestedByName != want {
+			t.Fatalf("wrong requester metadata: %+v", row)
+		}
+	}
+	assertReads := func(t *testing.T, wantType, wantName string) {
+		t.Helper()
+		byID, err := s.GetAgentInteraction(ctx, member.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		byRequest, err := s.GetAgentInteractionByRequestID(ctx, "permission", requestIDs[member.AgentRunID], member.AgentRunID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		listed, err := s.ListWorkspaceAgentInteractions(ctx, ids.WorkspaceID, "pending", 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, row := range append(listed, byID, byRequest) {
+			if row.ID != member.ID {
+				continue
+			}
+			if row.RequestedByType != wantType || row.RequestedByID != memberID || row.RequestedByName != wantName {
+				t.Fatalf("requester read mismatch: %+v", row)
+			}
+			if row.Request["action"] != "mcp__service__get_ticket" || row.Status != "pending" {
+				t.Fatalf("request behavior changed: %+v", row)
+			}
+		}
+	}
+	assertReads(t, "user", "QA Member")
+	cases := []struct{ name, query, wantType, wantName string }{
+		{"email fallback", `update users set name=' ' where id=$1`, "user", "requester@example.test"},
+		{"non-user ID collision", `update agent_runs set requested_by_type='agent' where requested_by_id=$1`, "agent", ""},
+		{"restore user identity", `update agent_runs set requested_by_type='user' where requested_by_id=$1`, "user", "requester@example.test"},
+		{"pending membership", `update workspace_members set status='pending' where user_id=$1 and workspace_id in (select workspace_id from agent_runs where requested_by_id=$1)`, "user", ""},
+		{"restore membership", `update workspace_members set status='active' where user_id=$1`, "user", "requester@example.test"},
+		{"deleted account", `update users set deleted_at=now() where id=$1`, "user", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := db.Exec(ctx, tc.query, memberID); err != nil {
+				t.Fatal(err)
+			}
+			assertReads(t, tc.wantType, tc.wantName)
+		})
+	}
+}


### PR DESCRIPTION
When multiple people request the same operation, the interaction inbox now identifies the recorded requester and conversation, and shows readable operation names with the reported arguments. The same requester context is available in conversation decisions and the compact approval bar links directly to its request details.

User names resolve only for active members of the interaction workspace; unavailable or non-user identities retain their recorded type and ID. This changes read metadata and presentation only, without changing approval permissions, lifecycle, or runtime requests.

Validation: `make check`; isolated PostgreSQL requester-metadata and interaction-lifecycle tests; browser checks for owner/member and unknown/non-user identities, long and missing arguments, English/light and Chinese/dark layouts, conversation-to-inbox navigation, approval and question submission payloads. Local Docker remained stopped; PostgreSQL tests ran on the remote test database.
