### PR TITLE
fix(web): refresh capability queries after Agent edits

### DIFF
--- a/apps/web/src/lib/api-agents.ts
+++ b/apps/web/src/lib/api-agents.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { ApiError, apiRequest, noUnreachableRetry } from "./api-client"
+import { KEY_AGENT_CAPABILITIES, KEY_CAPABILITIES_WORKSPACE } from "./api-capabilities"
 import type {
   Agent,
   AgentDetail,
@@ -435,6 +436,8 @@ export function useUpdateAgent(workspaceID: string | null) {
     onSuccess: (_change, variables) => {
       void qc.invalidateQueries({ queryKey: KEY_AGENTS(workspaceID ?? "_none") })
       void qc.invalidateQueries({ queryKey: KEY_AGENT_DETAIL(workspaceID ?? "_none", variables.agentID) })
+      void qc.invalidateQueries({ queryKey: KEY_AGENT_CAPABILITIES(workspaceID ?? "_none", variables.agentID) })
+      void qc.invalidateQueries({ queryKey: KEY_CAPABILITIES_WORKSPACE(workspaceID ?? "_none") })
     },
   })
 }


### PR DESCRIPTION
After an Agent edit changed capability bindings, its open Config tab could continue showing the old bindings until a page reload. Successful edits now invalidate that Agent’s capability query and the workspace capability catalog using the existing query keys.

Scope is cache invalidation only. The separate edit hydration and binding-preservation issue (BUG-004) remains outside this PR; request bodies, synchronization, versions, credentials and approval permissions are unchanged.

Validation: `make check`; browser comparison against the baseline confirmed a successful save now refetches both queries and removes the stale binding without reloading. A failed save preserves the form and cached binding state. The browser fixture intercepted writes; existing test Agent bindings were unchanged. Locally reviewed as a three-line change.
