### PR TITLE
fix(daemon): show OpenCode tool execution records

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,10 @@ description and keep ownership on the side listed here.
   defaults.
 - Claude Code streaming deltas and their per-block assistant copies must be
   emitted once; preserve separate text blocks even when their content matches.
+- OpenCode JSON CLI tool parts arrive after execution. Translate each terminal
+  call once into paired tool-call/result records for existing trace consumers.
+  These records describe completed work; they are not permission requests or
+  measurements of the original tool duration.
 - Every daemon-side agent adapter must use a shared process runner for CLI
   subprocesses. New adapters must not hand-roll separate `Start`, stdin,
   cancellation, timeout, and `Wait` loops.

--- a/apps/parsar-daemon/internal/agent/opencode/parser.go
+++ b/apps/parsar-daemon/internal/agent/opencode/parser.go
@@ -19,6 +19,7 @@ type translator struct {
 	rawLines  []string
 	usage     proto.Usage
 	stepUsage usageInfo
+	toolsSeen map[string]bool
 }
 
 type translation struct {
@@ -52,6 +53,8 @@ func (t *translator) Translate(line []byte) (translation, error) {
 		return t.translatePartDelta(head.Properties)
 	case "text":
 		return t.translateTextPart(head.Part)
+	case "tool_use":
+		return t.translateToolPart(head.Part)
 	case "message.updated", "message.updated.1":
 		t.captureUsage(head.Properties)
 		return translation{}, nil
@@ -62,6 +65,48 @@ func (t *translator) Translate(line []byte) (translation, error) {
 		t.captureGenericUsage(line)
 		return translation{}, nil
 	}
+}
+
+func (t *translator) translateToolPart(raw json.RawMessage) (translation, error) {
+	var p struct {
+		Type   string `json:"type"`
+		CallID string `json:"callID"`
+		Tool   string `json:"tool"`
+		State  struct {
+			Status string         `json:"status"`
+			Input  map[string]any `json:"input"`
+			Output string         `json:"output"`
+			Error  string         `json:"error"`
+		} `json:"state"`
+	}
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return translation{}, fmt.Errorf("opencode: parse tool part: %w", err)
+	}
+	if p.Type != "tool" || p.CallID == "" || p.Tool == "" ||
+		(p.State.Status != "completed" && p.State.Status != "error") || t.toolsSeen[p.CallID] {
+		return translation{}, nil
+	}
+	result := map[string]any{"output": p.State.Output, "is_error": p.State.Status == "error"}
+	if p.State.Status == "error" {
+		result["output"] = p.State.Error
+	}
+	// JSON CLI tool parts arrive only after execution. Pair the call and
+	// result for existing trace consumers; neither frame requests approval.
+	call := proto.ToolCallPayload{ID: p.CallID, Name: p.Tool, Stage: "before", Args: p.State.Input}
+	before, err := proto.NewEnvelope(proto.TypeToolCall, t.runID, call)
+	if err != nil {
+		return translation{}, err
+	}
+	call.Stage, call.Result = "after", result
+	after, err := proto.NewEnvelope(proto.TypeToolCall, t.runID, call)
+	if err != nil {
+		return translation{}, err
+	}
+	if t.toolsSeen == nil {
+		t.toolsSeen = make(map[string]bool)
+	}
+	t.toolsSeen[p.CallID] = true
+	return translation{Envelopes: []proto.Envelope{before, after}}, nil
 }
 
 func (t *translator) translatePartDelta(raw json.RawMessage) (translation, error) {

--- a/apps/parsar-daemon/internal/agent/opencode/parser_tools_test.go
+++ b/apps/parsar-daemon/internal/agent/opencode/parser_tools_test.go
@@ -1,0 +1,96 @@
+package opencode_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/opencode"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestTranslateCompletedToolsPreservesTraceAndReply(t *testing.T) {
+	tr := opencode.NewTranslatorForTest("run-tools")
+	for i, tool := range []string{"skill", "bash", "qa-service-desk_get_test_ticket", "read", "read"} {
+		id := fmt.Sprintf("call_%d", i)
+		line := []byte(fmt.Sprintf(`{"type":"tool_use","part":{"type":"tool","callID":%q,"tool":%q,"state":{"status":"completed","input":{"name":"qa-onboarding-zip","limit":3,"enabled":true},"output":"synthetic result"}}}`, id, tool))
+		tx, err := tr.Translate(line)
+		if err != nil || len(tx.Envelopes) != 2 {
+			t.Fatalf("tool %s: envelopes=%#v err=%v", id, tx.Envelopes, err)
+		}
+		for j, stage := range []string{"before", "after"} {
+			env := tx.Envelopes[j]
+			call := decodePayload[proto.ToolCallPayload](t, env)
+			if env.Type != proto.TypeToolCall || env.ID != "run-tools" || call.ID != id || call.Name != tool || call.Stage != stage {
+				t.Fatalf("tool envelope=%#v payload=%#v", env, call)
+			}
+			if call.Args["name"] != "qa-onboarding-zip" || call.Args["limit"] != float64(3) || call.Args["enabled"] != true {
+				t.Fatalf("typed args = %#v", call.Args)
+			}
+			if stage == "before" && call.Result != nil {
+				t.Fatalf("call already has result: %#v", call.Result)
+			}
+			if stage == "after" && (call.Result["output"] != "synthetic result" || call.Result["is_error"] != false) {
+				t.Fatalf("tool result = %#v", call.Result)
+			}
+		}
+		duplicate, err := tr.Translate(line)
+		if err != nil || len(duplicate.Envelopes) != 0 {
+			t.Fatalf("duplicate call %s: %#v, %v", id, duplicate, err)
+		}
+	}
+	if _, err := tr.Translate([]byte(`{"type":"text","part":{"type":"text","text":"third working day"}}`)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tr.Translate([]byte(`{"type":"step_finish","part":{"tokens":{"input":12,"output":4},"cost":0.01}}`)); err != nil {
+		t.Fatal(err)
+	}
+	envs := tr.TerminalEnvelopes(nil, "", false)
+	done := decodePayload[proto.DonePayload](t, envs[len(envs)-1])
+	if done.Content != "third working day" || done.Usage.InputTokens != 12 || done.Usage.OutputTokens != 4 || done.Usage.CostUSD != 0.01 {
+		t.Fatalf("done = %#v", done)
+	}
+}
+
+func TestTranslateFailedToolRemainsToolFailure(t *testing.T) {
+	tr := opencode.NewTranslatorForTest("run-error")
+	tx, err := tr.Translate([]byte(`{"type":"tool_use","part":{"type":"tool","callID":"call_error","tool":"read","state":{"status":"error","input":{"filePath":"/missing"},"error":"File not found"}}}`))
+	if err != nil || len(tx.Envelopes) != 2 {
+		t.Fatalf("envelopes=%#v err=%v", tx.Envelopes, err)
+	}
+	result := decodePayload[proto.ToolCallPayload](t, tx.Envelopes[1])
+	if result.Result["is_error"] != true || result.Result["output"] != "File not found" || result.Args["filePath"] != "/missing" {
+		t.Fatalf("failed tool = %#v", result)
+	}
+	// A recoverable tool error must not become a run error or contaminate text.
+	_, _ = tr.Translate([]byte(`{"type":"text","part":{"type":"text","text":"Please supply a valid path."}}`))
+	for _, env := range tr.TerminalEnvelopes(nil, "", false) {
+		if env.Type == proto.TypeError {
+			t.Fatal("tool failure became run failure")
+		}
+		if env.Type == proto.TypeDone && decodePayload[proto.DonePayload](t, env).Content != "Please supply a valid path." {
+			t.Fatal("tool failure leaked into final text")
+		}
+	}
+}
+
+func TestTranslateToolRequiresTerminalIdentity(t *testing.T) {
+	for _, part := range []string{
+		`null`,
+		`{"type":"text","callID":"c","tool":"read","state":{"status":"completed"}}`,
+		`{"type":"tool","tool":"read","state":{"status":"completed"}}`,
+		`{"type":"tool","callID":"c","state":{"status":"completed"}}`,
+		`{"type":"tool","callID":"c","tool":"read","state":{"status":"pending"}}`,
+		`{"type":"tool","callID":"c","tool":"read","state":{"status":"running"}}`,
+	} {
+		tr := opencode.NewTranslatorForTest("run-ignored")
+		tx, err := tr.Translate([]byte(`{"type":"tool_use","part":` + part + `}`))
+		if err != nil || len(tx.Envelopes) != 0 {
+			t.Fatalf("unexpected events for %s: %#v, %v", part, tx, err)
+		}
+		// An incomplete frame must not consume the eventual terminal call ID.
+		tx, err = tr.Translate([]byte(`{"type":"tool_use","part":{"type":"tool","callID":"c","tool":"read","state":{"status":"completed","output":""}}}`))
+		if err != nil || len(tx.Envelopes) != 2 {
+			t.Fatalf("terminal events missing: %#v, %v", tx, err)
+		}
+	}
+}


### PR DESCRIPTION
OpenCode could complete Skill and MCP calls while Parsar showed only the final answer, with no tool trace. Its terminal JSON tool events now produce paired call/result records containing the native call ID, tool name, arguments and result, including explicit tool failures. Repeated terminal frames do not duplicate steps.

This is limited to the OpenCode output translator, focused tests and its contributor contract. Tool execution, permissions, model configuration, other adapters and creation availability are unchanged. OpenCode reports these events after execution, so the pair does not measure the native tool duration.

Validation: focused adapter tests and `make check` passed. On the existing remote verification installation, OpenCode 1.18.29 completed a real Skill/MCP run with four persisted call/result pairs visible in both the conversation and Runs page. A missing-file read produced one failed tool result while the Agent completed its reply. A fresh independent blind review found no actionable issues.
