### PR TITLE
fix(web): enable OpenCode creation and Skill selection

### DIFF
--- a/apps/web/src/lib/agent-view-model.ts
+++ b/apps/web/src/lib/agent-view-model.ts
@@ -93,8 +93,9 @@ export function agentEngineSupportsCapability(engine: AgentEngine, capabilityTyp
     case "claude_code":
       return true
     case "codex":
-    case "opencode":
       return capabilityType === "mcp" || capabilityType === "system_prompt"
+    case "opencode":
+      return capabilityType === "skill" || capabilityType === "mcp" || capabilityType === "system_prompt"
     case "pi":
       return capabilityType === "skill" || capabilityType === "system_prompt"
   }

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -714,7 +714,7 @@ export function CreateAgentDialog({
   const hasConnector = true
   const connector = mode === "edit" && agent ? agent.connector_type : connectorForExecutionMode(executionMode)
   const hasModel = activeModels.length > 0
-  const requiresModel = connector !== "agent_daemon" || agentEngine === "claude_code" || agentEngine === "codex" || agentEngine === "pi"
+  const requiresModel = connector !== "agent_daemon" || agentEngine === "claude_code" || agentEngine === "codex" || agentEngine === "pi" || agentEngine === "opencode"
   const selectedModelUnavailable = mode === "edit" && requiresModel && selectedModelID !== "" && selectedModel === null
   const hasRequiredModel = !requiresModel || (selectedModel !== null && !incompatibleModelIDs.has(selectedModel.id))
   const publicModelBindingValid = mode !== "create" || visibility !== "public"
@@ -1144,7 +1144,7 @@ export function CreateAgentDialog({
                         value={agentEngine}
                         onValueChange={(nextValue) => {
                           const next = nextValue
-                          if (next === "claude_code" || next === "codex" || next === "pi") setAgentEngine(next)
+                          if (next === "claude_code" || next === "codex" || next === "pi" || next === "opencode") setAgentEngine(next)
                         }}
                         disabled={pending}
                         aria-label={t("agents.form.fields.agentEngine")}
@@ -1152,7 +1152,7 @@ export function CreateAgentDialog({
                         <SelectOption value="claude_code">{t("agents.engine.claudeCode.title")}</SelectOption>
                         <SelectOption value="codex">{t("agents.engine.codex.title")}</SelectOption>
                         <SelectOption value="pi">{t("agents.engine.pi.title")}</SelectOption>
-                        <SelectOption value="opencode" disabled>{t("agents.engine.opencode.title")}</SelectOption>
+                        <SelectOption value="opencode">{t("agents.engine.opencode.title")}</SelectOption>
                       </Select>
                     </Field>
                   )}


### PR DESCRIPTION
FDEs can now select OpenCode in the existing Agent form, choose a managed model and paired runtime, and create an Agent using Skills and MCP tools. OpenCode follows the existing model credential flow, and the shared compatibility rule now recognizes its native Skill support in Agent configuration and marketplace installation.

Scope is the OpenCode entry and these existing gates. External Agent remains separate; runtime installation, backend APIs, other engines, credential policy and edit hydration/version behavior are unchanged. The selected runtime still needs OpenCode installed.

Validation: `make check`; compatibility matrix verification; real browser creation against the remote backend using OpenCode 1.18.29 + MiniMax M3, with model/runtime/bindings persisted. The new Agent read the current Skill policy and queried the test MCP. Marketplace installation then enabled a second Skill, which returned its expected verification phrase. A fresh independent blind review found no issues.
