### PR TITLE
fix(codex): report token usage for the current turn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,9 @@ description and keep ownership on the side listed here.
   defaults.
 - Claude Code streaming deltas and their per-block assistant copies must be
   emitted once; preserve separate text blocks even when their content matches.
+- Codex app-server usage totals are cumulative per thread. Treat restored usage
+  before `turn/started` as the baseline and persist only the current turn's
+  delta; repeated snapshots must not increase recorded usage.
 - OpenCode JSON CLI tool parts arrive after execution. Translate each terminal
   call once into paired tool-call/result records for existing trace consumers.
   These records describe completed work; they are not permission requests or

--- a/apps/parsar-daemon/internal/agent/codex/protocol.go
+++ b/apps/parsar-daemon/internal/agent/codex/protocol.go
@@ -357,8 +357,12 @@ type AgentMessageDeltaNotification struct {
 type ReasoningDeltaNotification = AgentMessageDeltaNotification
 
 type ThreadTokenUsageUpdatedNotification struct {
-	ThreadID string    `json:"threadId"`
-	Usage    TurnUsage `json:"usage"`
+	ThreadID   string     `json:"threadId"`
+	TurnID     string     `json:"turnId"`
+	Usage      *TurnUsage `json:"usage,omitempty"` // Legacy turn-level payload.
+	TokenUsage *struct {
+		Total *TurnUsage `json:"total"`
+	} `json:"tokenUsage,omitempty"`
 }
 
 type ErrorNotification struct {

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -81,6 +81,9 @@ type Session struct {
 
 	usageMu       sync.Mutex
 	latestUsage   *TurnUsage
+	usageTotal    TurnUsage
+	usageBaseline TurnUsage
+	usageTurnID   string
 	resolvedModel string
 
 	finalTextMu sync.Mutex
@@ -373,7 +376,8 @@ func (s *Session) onThreadStarted(raw json.RawMessage) {
 	}
 }
 
-func (s *Session) onTurnStarted(_ json.RawMessage) {
+func (s *Session) onTurnStarted(raw json.RawMessage) {
+	s.beginUsageTurn(raw)
 	// Reset per-turn buffers. The session is per-prompt so this is
 	// belt-and-suspenders today, but it keeps the buffer semantics
 	// honest when codex emits a fresh turn id mid-session.
@@ -445,17 +449,6 @@ func (s *Session) onItemCompleted(raw json.RawMessage) {
 	if text != "" {
 		s.appendFinalText(text)
 	}
-}
-
-func (s *Session) onUsageUpdated(raw json.RawMessage) {
-	var p ThreadTokenUsageUpdatedNotification
-	if err := json.Unmarshal(raw, &p); err != nil {
-		return
-	}
-	s.usageMu.Lock()
-	u := p.Usage
-	s.latestUsage = &u
-	s.usageMu.Unlock()
 }
 
 func (s *Session) onTurnCompleted(raw json.RawMessage) {

--- a/apps/parsar-daemon/internal/agent/codex/session_usage.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_usage.go
@@ -1,0 +1,59 @@
+package codex
+
+import "encoding/json"
+
+func (s *Session) beginUsageTurn(raw json.RawMessage) {
+	var p TurnStartedNotification
+	if json.Unmarshal(raw, &p) != nil || p.Turn.ID == "" {
+		return
+	}
+	s.usageMu.Lock()
+	defer s.usageMu.Unlock()
+	if s.usageTurnID == p.Turn.ID {
+		return
+	}
+	s.usageTurnID = p.Turn.ID
+	s.usageBaseline = s.usageTotal
+	s.latestUsage = nil
+}
+
+func (s *Session) onUsageUpdated(raw json.RawMessage) {
+	var p ThreadTokenUsageUpdatedNotification
+	if json.Unmarshal(raw, &p) != nil {
+		return
+	}
+	if threadID := s.currentThreadID(); threadID != "" && p.ThreadID != threadID {
+		return
+	}
+	s.usageMu.Lock()
+	defer s.usageMu.Unlock()
+	if p.TokenUsage != nil && p.TokenUsage.Total != nil {
+		// app-server replays the previous thread total after resume and
+		// before turn/started. It establishes a baseline, not new usage.
+		if s.usageTurnID == "" {
+			s.usageTotal = *p.TokenUsage.Total
+			return
+		}
+		if p.TurnID != s.usageTurnID {
+			return
+		}
+		s.usageTotal = *p.TokenUsage.Total
+		u := subtractUsage(s.usageTotal, s.usageBaseline)
+		s.latestUsage = &u
+		return
+	}
+	if p.Usage != nil && (p.TurnID == "" || p.TurnID == s.usageTurnID) {
+		u := *p.Usage
+		s.latestUsage = &u
+	}
+}
+
+func subtractUsage(total, baseline TurnUsage) TurnUsage {
+	return TurnUsage{
+		InputTokens:          max(0, total.InputTokens-baseline.InputTokens),
+		OutputTokens:         max(0, total.OutputTokens-baseline.OutputTokens),
+		CachedInputTokens:    max(0, total.CachedInputTokens-baseline.CachedInputTokens),
+		CacheReadInputTokens: max(0, total.CacheReadInputTokens-baseline.CacheReadInputTokens),
+		TotalTokens:          max(0, total.TotalTokens-baseline.TotalTokens),
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/session_usage_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_usage_test.go
@@ -1,0 +1,91 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestNativeTokenUsageAcrossTurns(t *testing.T) {
+	out := make(chan proto.Envelope, 4)
+	s := &Session{runID: "run", out: out, cancelCtx: context.Background(),
+		cfg: sessionConfig{logger: slog.New(slog.NewTextHandler(io.Discard, nil))}}
+	s.setThreadID("thread")
+	// A resumed thread replays its previous usage before starting this run.
+	s.onUsageUpdated(json.RawMessage(`{"threadId":"thread","turnId":"previous","tokenUsage":{"total":{"inputTokens":1000,"outputTokens":100},"last":{"inputTokens":500,"outputTokens":50}}}`))
+	if s.latestUsage != nil {
+		t.Fatal("restored history was treated as current usage")
+	}
+	s.onTurnStarted(json.RawMessage(`{"threadId":"thread","turn":{"id":"current"}}`))
+	s.onUsageUpdated(json.RawMessage(`{"threadId":"thread","turnId":"current","tokenUsage":{"total":{"inputTokens":1200,"outputTokens":120},"last":{"inputTokens":200,"outputTokens":20}}}`))
+	// The second model request follows a tool call; its last counter is not
+	// the whole turn. Repeating the cumulative snapshot must not add usage.
+	second := json.RawMessage(`{"threadId":"thread","turnId":"current","tokenUsage":{"total":{"inputTokens":1500,"outputTokens":150},"last":{"inputTokens":300,"outputTokens":30}}}`)
+	s.onUsageUpdated(second)
+	s.onUsageUpdated(second)
+	if s.latestUsage == nil || s.latestUsage.InputTokens != 500 || s.latestUsage.OutputTokens != 50 {
+		t.Fatalf("current turn usage = %+v, want 500 input / 50 output", s.latestUsage)
+	}
+	// A subsequent turn in this process uses the last total as its baseline.
+	s.onTurnStarted(json.RawMessage(`{"threadId":"thread","turn":{"id":"next"}}`))
+	if s.latestUsage != nil {
+		t.Fatal("new turn retained previous turn usage")
+	}
+	s.onUsageUpdated(json.RawMessage(`{"threadId":"thread","turnId":"next","tokenUsage":{"total":{"inputTokens":1700,"outputTokens":175},"last":{"inputTokens":200,"outputTokens":25}}}`))
+	s.finalText = "done"
+	s.onTurnCompleted(json.RawMessage(`{"threadId":"thread","turn":{"id":"next","status":"completed"}}`))
+	var usage proto.UsagePayload
+	var done proto.DonePayload
+	for e := range out {
+		switch e.Type {
+		case proto.TypeUsage:
+			if err := json.Unmarshal(e.Payload, &usage); err != nil {
+				t.Fatal(err)
+			}
+		case proto.TypeDone:
+			if err := json.Unmarshal(e.Payload, &done); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	if usage.InputTokens != 200 || usage.OutputTokens != 25 || done.Usage.InputTokens != 200 || done.Content != "done" {
+		t.Fatalf("terminal usage=%+v done=%+v", usage, done)
+	}
+}
+
+func TestNativeTokenUsageFreshThreadAndIgnoredPayloads(t *testing.T) {
+	s := &Session{}
+	s.setThreadID("thread")
+	s.onTurnStarted(json.RawMessage(`{"threadId":"thread","turn":{"id":"current"}}`))
+	s.onUsageUpdated(json.RawMessage(`{"threadId":"thread","turnId":"current","tokenUsage":{"total":{"inputTokens":321,"outputTokens":45}}}`))
+	for _, raw := range []string{
+		`{`,
+		`{"threadId":"thread","turnId":"current"}`,
+		`{"threadId":"thread","turnId":"current","tokenUsage":{}}`,
+		`{"threadId":"thread","turnId":"previous","tokenUsage":{"total":{"inputTokens":999,"outputTokens":99}}}`,
+		`{"threadId":"other","turnId":"current","tokenUsage":{"total":{"inputTokens":999,"outputTokens":99}}}`,
+	} {
+		s.onUsageUpdated(json.RawMessage(raw))
+	}
+	if s.latestUsage == nil || s.latestUsage.InputTokens != 321 || s.latestUsage.OutputTokens != 45 {
+		t.Fatalf("valid usage was lost or overwritten: %+v", s.latestUsage)
+	}
+}
+
+func TestLegacyTurnUsagePayload(t *testing.T) {
+	s := &Session{}
+	s.setThreadID("thread")
+	s.onTurnStarted(json.RawMessage(`{"threadId":"thread","turn":{"id":"current"}}`))
+	s.onUsageUpdated(json.RawMessage(`{"threadId":"thread","usage":{"inputTokens":123,"outputTokens":12}}`))
+	if s.latestUsage == nil || s.latestUsage.InputTokens != 123 || s.latestUsage.OutputTokens != 12 {
+		t.Fatalf("legacy usage = %+v", s.latestUsage)
+	}
+	s.onUsageUpdated(json.RawMessage(`{"threadId":"thread","usage":{"inputTokens":0,"outputTokens":0}}`))
+	if s.latestUsage == nil || s.latestUsage.InputTokens != 0 || s.latestUsage.OutputTokens != 0 {
+		t.Fatalf("explicit zero usage = %+v", s.latestUsage)
+	}
+}


### PR DESCRIPTION
Codex 0.141.0 emits token usage in `tokenUsage.total`; the adapter read the legacy `usage` field, so successful runs were stored with zero tokens. Record the current turn’s cumulative delta and use restored thread totals as its baseline, preserving the legacy payload and ignoring repeated or unrelated snapshots.

Scope is Codex usage translation and focused tests. Price calculation, provider labels, other engines, APIs, and storage are unchanged; the remaining BUG-010 cases stay open.

Validation: `make check`, Codex adapter tests and focused race tests passed. An independent blind reviewer found no in-scope issues. Native CLI baseline reproduced a completed response with zero stored tokens. Patched remote runs matched the native rollout deltas exactly: resumed chat 14,330 input / 13 output tokens; resumed MCP turn with two model requests 29,898 input / 46 output tokens. Tool approval and completion also passed.
