### PR TITLE
fix(daemon): bypass Codex approvals on new and resumed threads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,13 @@ description and keep ownership on the side listed here.
 
 ### Agent CLI adapter contract
 
+- Daemon-managed Codex sessions use `approvalPolicy=never` and
+  `sandbox=danger-full-access` on both `thread/start` and `thread/resume`,
+  including conversations created under an older policy. The daemon owns
+  these defaults; no `PARSAR_CODEX_*` approval environment switch is required.
+  Explicit engine approval requests still use the durable interaction lifecycle;
+  user-input requests continue to wait for a human answer.
+
 - Agent creation and editing store behavior instructions in `system_prompt`.
   Preserve saved text when opening the form; clearing it sends an empty string.
 - OpenCode model selectors use `provider/model`. Its Anthropic SDK base URL

--- a/apps/parsar-daemon/internal/agent/codex/approval_policy.go
+++ b/apps/parsar-daemon/internal/agent/codex/approval_policy.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 )
 
-// SilentGranularPolicy disables every Codex approval surface. It is retained
-// for wire-compatibility tests and explicit callers; daemon sessions default
-// to HumanApprovalPolicy so normal runs never auto-accept requests.
+// SilentGranularPolicy disables every granular Codex approval gate.
 func SilentGranularPolicy() AskForApproval {
 	g := GranularAskForApproval{} // zero value = every gate false
 	return AskForApproval{Granular: &g}
@@ -58,7 +56,7 @@ func (a AskForApproval) MarshalJSON() ([]byte, error) {
 		}{Granular: a.Granular})
 	}
 	// Neither set — preserve the historical zero-value encoding. Production
-	// plans always set HumanApprovalPolicy explicitly; an empty marshal would
+	// plans always set a policy explicitly; an empty marshal would
 	// produce `null`, which codex-rs rejects.
 	return json.Marshal(struct {
 		Granular GranularAskForApproval `json:"granular"`

--- a/apps/parsar-daemon/internal/agent/codex/options.go
+++ b/apps/parsar-daemon/internal/agent/codex/options.go
@@ -52,8 +52,7 @@ type SessionPlan struct {
 	// CollaborationMode selects Codex's default or plan tool surface.
 	CollaborationMode CollaborationModeKind
 
-	// ApprovalPolicy + Sandbox steer thread/start. Defaults surface human
-	// approvals and confine writes to the workspace.
+	// ApprovalPolicy + Sandbox apply to both new and resumed threads.
 	ApprovalPolicy AskForApproval
 	Sandbox        SandboxMode
 
@@ -102,13 +101,12 @@ type SessionPlan struct {
 // location, set it via the daemon's process environment (PATH /
 // codexBinary in sessionConfig) rather than per-call.
 //
-// Approval / sandbox keys are not exposed to admin yet. Parsar's Inbox is
-// the default decision surface; per-agent overrides can be added later.
+// Daemon-managed Codex sessions bypass approvals and the engine sandbox.
 func BuildSessionPlan(runID, agentStateKey, workDir string, opts map[string]any) (SessionPlan, error) {
 	cleanup := func() {}
 	plan := SessionPlan{
-		ApprovalPolicy: HumanApprovalPolicy(),
-		Sandbox:        SandboxWorkspaceWrite,
+		ApprovalPolicy: AskForApproval{String: "never"},
+		Sandbox:        SandboxDangerFullAcces,
 		Cleanup:        cleanup,
 	}
 

--- a/apps/parsar-daemon/internal/agent/codex/options_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/options_test.go
@@ -7,16 +7,16 @@ import (
 	"testing"
 )
 
-func TestBuildSessionPlan_DefaultsToHumanApprovalAndWorkspaceWrite(t *testing.T) {
+func TestBuildSessionPlan_DefaultsToBypass(t *testing.T) {
 	plan, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", nil)
 	if err != nil {
 		t.Fatalf("BuildSessionPlan: %v", err)
 	}
-	if IsSilent(&plan.ApprovalPolicy) {
-		t.Fatalf("default policy must surface approvals, got %+v", plan.ApprovalPolicy)
+	if plan.ApprovalPolicy.String != "never" {
+		t.Fatalf("default policy must bypass approvals, got %+v", plan.ApprovalPolicy)
 	}
-	if plan.Sandbox != SandboxWorkspaceWrite {
-		t.Fatalf("default sandbox = %s, want workspace-write", plan.Sandbox)
+	if plan.Sandbox != SandboxDangerFullAcces {
+		t.Fatalf("default sandbox = %s, want danger-full-access", plan.Sandbox)
 	}
 	if plan.Cleanup == nil {
 		t.Fatal("Cleanup must be non-nil")

--- a/apps/parsar-daemon/internal/agent/codex/protocol.go
+++ b/apps/parsar-daemon/internal/agent/codex/protocol.go
@@ -185,7 +185,9 @@ type ThreadStartResult struct {
 }
 
 type ThreadResumeParams struct {
-	ThreadID string `json:"threadId"`
+	ThreadID       string         `json:"threadId"`
+	ApprovalPolicy AskForApproval `json:"approvalPolicy"`
+	Sandbox        SandboxMode    `json:"sandbox"`
 }
 
 // ---------------------------------------------------------------------------
@@ -366,9 +368,8 @@ type ErrorNotification struct {
 }
 
 // ---------------------------------------------------------------------------
-// Approval and user-input ServerRequest params. Daemon sessions use a
-// human approval policy, so server_requests.go defers each matching JSON-RPC
-// response until Web or IM submits the decision.
+// Approval and user-input ServerRequest params. Explicit requests defer their
+// responses until Web or IM submits the decision, even with bypass defaults.
 // ---------------------------------------------------------------------------
 
 type CommandExecutionRequestApprovalParams struct {

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -218,7 +218,7 @@ func (s *Session) run(plan SessionPlan, req proto.PromptRequestPayload) {
 
 	// Resolve thread: resume if possible, else start fresh.
 	if strings.TrimSpace(req.AgentSessionID) != "" {
-		if err := s.resumeThread(req.AgentSessionID); err != nil {
+		if err := s.resumeThread(req.AgentSessionID, plan); err != nil {
 			s.cfg.logger.Warn("codex: thread/resume failed; starting fresh",
 				"run_id", s.runID, "thread_id", req.AgentSessionID, "err", err)
 			if err := s.startThread(plan); err != nil {
@@ -314,8 +314,10 @@ func (s *Session) startThread(plan SessionPlan) error {
 	return nil
 }
 
-func (s *Session) resumeThread(threadID string) error {
-	raw, err := s.rpc.Request(s.cancelCtx, "thread/resume", ThreadResumeParams{ThreadID: threadID})
+func (s *Session) resumeThread(threadID string, plan SessionPlan) error {
+	raw, err := s.rpc.Request(s.cancelCtx, "thread/resume", ThreadResumeParams{
+		ThreadID: threadID, ApprovalPolicy: plan.ApprovalPolicy, Sandbox: plan.Sandbox,
+	})
 	if err != nil {
 		return err
 	}

--- a/apps/parsar-daemon/internal/agent/codex/session_policy_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_policy_test.go
@@ -1,0 +1,62 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+)
+
+func TestThreadRequestsApplyBypassPolicy(t *testing.T) {
+	for _, method := range []string{"thread/start", "thread/resume"} {
+		t.Run(method, func(t *testing.T) {
+			t.Setenv("PARSAR_HOME", t.TempDir())
+			plan, err := BuildSessionPlan("run-policy", "conv/agent/codex", "", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer plan.Cleanup()
+			client, server, cleanup := NewTestClient()
+			defer cleanup()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			session := &Session{rpc: client.JSONRPCClient, cancelCtx: ctx, cfg: sessionConfig{logger: log.With("component", "policy-test")}}
+			done := make(chan error, 1)
+			go func() {
+				if method == "thread/resume" {
+					done <- session.resumeThread("old-thread", plan)
+				} else {
+					done <- session.startThread(plan)
+				}
+			}()
+			var request struct {
+				ID     string         `json:"id"`
+				Method string         `json:"method"`
+				Params map[string]any `json:"params"`
+			}
+			if err := json.NewDecoder(server.FromClient).Decode(&request); err != nil {
+				t.Fatal(err)
+			}
+			if request.Method != method {
+				t.Fatalf("method = %q", request.Method)
+			}
+			if request.Params["approvalPolicy"] != "never" || request.Params["sandbox"] != "danger-full-access" {
+				t.Fatalf("bypass policy missing from %s: %+v", method, request.Params)
+			}
+			if method == "thread/resume" && request.Params["threadId"] != "old-thread" {
+				t.Fatalf("resume lost thread ID: %+v", request.Params)
+			}
+			if err := json.NewEncoder(server.ToClient).Encode(map[string]any{"id": request.ID, "result": map[string]any{"thread": map[string]any{"id": "resolved-thread"}}}); err != nil {
+				t.Fatal(err)
+			}
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			if session.currentThreadID() != "resolved-thread" {
+				t.Fatal("thread response was not applied")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Daemon-managed Codex currently starts with `on-request` approvals and a `workspace-write` sandbox, while resumed conversations receive no policy override. Use `never` and `danger-full-access` for both `thread/start` and `thread/resume`, so existing conversations also adopt bypass defaults on their next daemon prompt.

The daemon adapter owns this policy. Human questions and explicit engine approval requests retain their existing durable interaction handling. Other engines, server APIs, deployment configuration, and running daemon processes are outside this change.

Validation: `make check`, `go test ./apps/parsar-daemon/...`, and start/resume RPC regression tests passed. The installed Codex 0.153.2 JSON schema accepts both policy fields and values on both methods.

Review: independent blind review of the entire diff found no blocking issues.

Closes #413.
