### PR TITLE
fix(web): reliably dismiss transient toast messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -556,6 +556,11 @@ split relevant pieces out first rather than growing the file further.
 
 ### Frontend shared logic
 
+- Ordinary toasts expire even while hovered and provide a localized close
+  button. Keyboard focus inside pauses their countdown until focus leaves.
+  Persistent action prompts remain owned by their caller. Toast removal must
+  have a timer fallback when exit animation events do not fire.
+
 - Partial bulk model deletion keeps submitted names and per-item results in a
   dismissible dialog. Link references only after confirming the Agent in the
   authorized workspace directory; preserve reference text when lookup fails.

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import { createPortal } from "react-dom"
+import { X } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "./button"
 
 import { InlineNotice, type NoticeTone } from "./error-state"
 import { VerbatimBlock } from "./verbatim"
@@ -78,6 +82,7 @@ const DEFAULT_MS = 4000
 const ERROR_MS = 7000
 /** Older messages leave rather than stacking into a wall. */
 const MAX_VISIBLE = 3
+const EXIT_FALLBACK_MS = 250
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = React.useState<ToastItem[]>([])
@@ -161,17 +166,13 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   )
 }
 
-/**
- * One strip. It counts down on its own and *pauses* while the pointer is on it
- * or focus is inside — resuming with the time that was left, not from the top,
- * so resting a cursor nearby cannot hold a message on screen forever.
- */
 function ToastStrip({ toast, onLeave, onDrop }: {
   toast: ToastItem
   onLeave: (id: number) => void
   onDrop: (id: number) => void
 }) {
-  const [held, setHeld] = React.useState(false)
+  const { t } = useTranslation("common")
+  const [focused, setFocused] = React.useState(false)
   const remaining = React.useRef(toast.durationMs)
   const startedAt = React.useRef(0)
 
@@ -183,29 +184,34 @@ function ToastStrip({ toast, onLeave, onDrop }: {
   }, [toast.message, toast.detail, toast.durationMs])
 
   React.useEffect(() => {
-    if (toast.persist || toast.leaving || held) return
+    if (toast.persist || toast.leaving || focused) return
     startedAt.current = Date.now()
     const timer = window.setTimeout(() => onLeave(toast.id), remaining.current)
     return () => {
       window.clearTimeout(timer)
       remaining.current = Math.max(0, remaining.current - (Date.now() - startedAt.current))
     }
-  }, [held, toast.persist, toast.leaving, toast.id, onLeave, toast.message, toast.detail, toast.durationMs])
+  }, [focused, toast.persist, toast.leaving, toast.id, onLeave, toast.message, toast.detail, toast.durationMs])
+
+  React.useEffect(() => {
+    if (!toast.leaving) return
+    // Animation events may be suppressed by browser settings or CSS overrides.
+    const timer = window.setTimeout(() => onDrop(toast.id), EXIT_FALLBACK_MS)
+    return () => window.clearTimeout(timer)
+  }, [toast.leaving, toast.id, onDrop])
 
   return (
     <div
-      onMouseEnter={() => setHeld(true)}
-      onMouseLeave={() => setHeld(false)}
-      onFocusCapture={() => setHeld(true)}
-      onBlurCapture={() => setHeld(false)}
-      // Every entrance has an exit: the strip is dropped when its own exit
-      // ends, never on a descendant's animation and never mid-flight.
+      onFocusCapture={() => setFocused(true)}
+      onBlurCapture={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setFocused(false)
+      }}
       onAnimationEnd={(e) => {
         if (toast.leaving && e.target === e.currentTarget) onDrop(toast.id)
       }}
       className={cn(
         "app-shadow-floating pointer-events-auto flex w-max max-w-[32rem] flex-col gap-1.5 rounded-lg border border-line bg-surface py-1.5 text-sm text-fg",
-        toast.action ? "pl-3 pr-1.5" : "px-3",
+        toast.action || !toast.persist ? "pl-3 pr-1.5" : "px-3",
         toast.leaving ? "animate-pop-out" : "animate-pop-in",
       )}
     >
@@ -214,6 +220,18 @@ function ToastStrip({ toast, onLeave, onDrop }: {
           {toast.message}
         </InlineNotice>
         {toast.action}
+        {!toast.persist && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="shrink-0"
+            aria-label={t("actions.close")}
+            onClick={() => onLeave(toast.id)}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        )}
       </div>
       {toast.detail && <VerbatimBlock className="max-h-24">{toast.detail}</VerbatimBlock>}
     </div>

--- a/tests/e2e/toast.spec.ts
+++ b/tests/e2e/toast.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function openToasts(page: Page) {
+  await page.addInitScript(() => localStorage.setItem("i18nextLng", "en-US"));
+  await page.route("**/toast-regression", (route) => route.fulfill({
+    contentType: "text/html",
+    body: `<!doctype html><html><body><div id="root"></div>
+      <script type="module">
+        import RefreshRuntime from '/@react-refresh';
+        RefreshRuntime.injectIntoGlobalHook(window);
+        window.$RefreshReg$ = () => {};
+        window.$RefreshSig$ = () => (type) => type;
+        window.__vite_plugin_react_preamble_installed__ = true;
+        const { default: React } = await import('/node_modules/.vite/deps/react.js');
+        const { default: ReactDOM } = await import('/node_modules/.vite/deps/react-dom_client.js');
+        const { ToastProvider, useToast } = await import('/src/components/ui/toast.tsx');
+        await import('/src/i18n/index.ts');
+        await import('/src/style.css');
+        const h = React.createElement;
+        function Controls() {
+          const { show, dismiss } = useToast();
+          return h('div', { style: { paddingTop: '160px' } },
+            h('button', { onClick: () => show('Saved') }, 'Show success'),
+            h('button', { onClick: () => show('19 deleted, 2 failed', {
+              tone: 'error', detail: 'model_in_use\\nmodel_in_use', key: 'result',
+            }) }, 'Show error'),
+            h('button', { onClick: () => show('Save layout?', {
+              key: 'layout', persist: true,
+              action: h('button', { onClick: () => dismiss('layout') }, 'Keep layout'),
+            }) }, 'Show persistent'),
+          );
+        }
+        ReactDOM.createRoot(document.getElementById('root')).render(h(React.StrictMode, null,
+          h(ToastProvider, null, h(Controls))));
+      </script></body></html>`,
+  }));
+  await page.goto("/toast-regression");
+  await expect(page.getByRole("button", { name: "Show error", exact: true })).toBeVisible();
+}
+
+for (const disabledAnimations of [false, true]) {
+  test(`error toast expires while hovered, animations disabled: ${disabledAnimations}`, async ({ page }) => {
+    await openToasts(page);
+    if (disabledAnimations) await page.addStyleTag({ content: "* { animation: none !important; }" });
+    await page.getByRole("button", { name: "Show error", exact: true }).click();
+    const message = page.getByText("19 deleted, 2 failed", { exact: true });
+    await expect(message).toBeVisible();
+    await message.hover();
+    await expect(message).toHaveCount(0, { timeout: 10_000 });
+    await expect(page.getByText("model_in_use", { exact: false })).toHaveCount(0);
+  });
+}
+
+test("success toast expires and error toast can be closed immediately", async ({ page }) => {
+  await openToasts(page);
+  await page.getByRole("button", { name: "Show success", exact: true }).click();
+  await expect(page.getByText("Saved", { exact: true })).toBeVisible();
+  await expect(page.getByText("Saved", { exact: true })).toHaveCount(0, { timeout: 6000 });
+  await page.getByRole("button", { name: "Show error", exact: true }).click();
+  await page.getByRole("button", { name: "Close", exact: true }).click();
+  await expect(page.getByText("19 deleted, 2 failed", { exact: true })).toHaveCount(0, { timeout: 1000 });
+});
+
+test("keyboard focus pauses expiration and blur resumes it", async ({ page }) => {
+  await openToasts(page);
+  await page.getByRole("button", { name: "Show error", exact: true }).click();
+  await page.getByRole("button", { name: "Close", exact: true }).focus();
+  await page.waitForTimeout(7500);
+  const message = page.getByText("19 deleted, 2 failed", { exact: true });
+  await expect(message).toBeVisible();
+  await page.getByRole("button", { name: "Show success", exact: true }).focus();
+  await expect(message).toHaveCount(0, { timeout: 8000 });
+});
+
+test("persistent prompts remain until their action dismisses them", async ({ page }) => {
+  await openToasts(page);
+  await page.getByRole("button", { name: "Show persistent", exact: true }).click();
+  await page.waitForTimeout(7500);
+  await expect(page.getByText("Save layout?", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Close", exact: true })).toHaveCount(0);
+  await page.getByRole("button", { name: "Keep layout", exact: true }).click();
+  await expect(page.getByText("Save layout?", { exact: true })).toHaveCount(0);
+});


### PR DESCRIPTION
Ordinary toast messages can remain indefinitely while the pointer rests over them, and removal previously depended entirely on an exit animation event. Let ordinary toasts expire while hovered, add a localized close button, and remove exiting toasts with a timer fallback if animation events never arrive.

Keyboard focus still pauses the countdown until focus leaves. Persistent action prompts retain their caller-owned dismissal. This change is confined to shared toast behavior; bulk model deletion, result dialogs, and server APIs are unchanged.

Validation: five Playwright browser regressions cover hovered error toasts with and without animations, success expiry, immediate manual closure, keyboard focus/blur, and persistent prompt dismissal.

`make check` passed, including database integration, web checks, CLI checks, and installer checks.

Independent blind review of the complete diff found no blocking issues.

Closes #415.
