### PR TITLE
fix(web): keep composite ledger titles within their columns

### DIFF
--- a/apps/web/src/pages/admin/MembersPage.tsx
+++ b/apps/web/src/pages/admin/MembersPage.tsx
@@ -410,8 +410,8 @@ function PendingJoinRequestsGroup({ wsId, requests }: { wsId: string; requests: 
             <LedgerRow key={req.id}>
               <span className="flex min-w-0 items-center gap-1.5">
                 <InitialTile name={name} />
-                <span className="shrink-0 truncate font-medium">{name}</span>
-                <span className="min-w-0 truncate text-xs text-fg-muted" title={req.request_reason || undefined}>
+                <span className="min-w-0 truncate font-medium" title={name}>{name}</span>
+                <span className="min-w-0 flex-1 truncate text-xs text-fg-muted" title={req.request_reason || undefined}>
                   · {req.request_reason || t("members.pendingRequests.noReason")}
                 </span>
               </span>

--- a/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceTab.tsx
@@ -70,7 +70,7 @@ export function MarketplaceTab(props: MarketplaceTabProps) {
 }
 
 /** name (+type, +state, +description) · source · version · workspaces added · credentials · actions */
-const MARKET_COLUMNS = [col.title(), col.meta(120), col.id(96, 0.5), col.num(112), col.meta(150), col.actions(2)]
+const MARKET_COLUMNS = [col.title(280), col.meta(120), col.id(96, 0.5), col.num(112), col.meta(150), col.actions(2)]
 
 function PublishedMarketplaceTab({ itemID, query, typeFilter, hideInstalled, canManage, onSelectItem, onInstall, onDelete, onViewCapability }: MarketplaceTabProps) {
   const { t, i18n } = useTranslation("admin")
@@ -208,14 +208,14 @@ function MarketplaceRow({ capability, language, canManage, selected, onOpen, onI
   return (
     <LedgerRow selected={selected} onClick={onOpen} onKeyDown={rowKeyHandler(onOpen)}>
       <span className="flex min-w-0 items-center gap-2">
-        <span className="shrink-0 truncate font-medium">{capability.name}</span>
+        <span className="min-w-0 truncate font-medium" title={capability.name}>{capability.name}</span>
         <CapabilityTypeBadge type={capability.type} />
         {capability.self_published ? (
           <Badge variant="neutral" dot>{t("capabilities.marketplace.card.selfPublished")}</Badge>
         ) : capability.installed ? (
           <Badge variant="neutral" dot>{t("capabilities.marketplace.card.installedBadge")}</Badge>
         ) : null}
-        {capability.description && <span className="min-w-0 truncate text-xs text-fg-muted">· {capability.description}</span>}
+        {capability.description && <span className="min-w-0 flex-1 truncate text-xs text-fg-muted">· {capability.description}</span>}
       </span>
       <span className="truncate text-xs text-fg-muted">{source || "—"}</span>
       <span className={cn("truncate font-mono text-xs", capability.latest_version ? "text-fg" : "text-fg-muted")}>{capability.latest_version ?? "—"}</span>

--- a/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
@@ -177,9 +177,9 @@ function SkillRow({
     <LedgerRow onKeyDown={onKeyDown} data-testid="skills-directory-row" data-catalog-id={skill.id}>
       <LedgerNum muted>{skill.rank ?? "—"}</LedgerNum>
       <span className="flex min-w-0 items-center gap-2">
-        <span className="shrink-0 truncate font-medium">{skill.name || skill.slug}</span>
+        <span className="min-w-0 truncate font-medium" title={skill.name || skill.slug}>{skill.name || skill.slug}</span>
         {sourceType && <span className="shrink-0 text-xs text-fg-muted">{sourceType}</span>}
-        <span className="min-w-0 truncate text-xs text-fg-muted">· {skill.id}</span>
+        <span className="min-w-0 flex-1 truncate text-xs text-fg-muted">· {skill.id}</span>
       </span>
       <LedgerId>{skill.source}</LedgerId>
       <LedgerNum muted={typeof skill.installs !== "number"}>

--- a/apps/web/src/pages/admin/capabilities/mcp-directory/MCPDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/mcp-directory/MCPDirectory.tsx
@@ -34,7 +34,7 @@ interface MCPDirectoryProps {
 }
 
 /** connector (+badges, +description) · publisher · version · categories · authentication · actions */
-const DIRECTORY_COLUMNS = [col.title(), col.meta(132), col.id(72, 0.4), col.meta(132), col.meta(110), col.actions(1)]
+const DIRECTORY_COLUMNS = [col.title(280), col.meta(132), col.id(72, 0.4), col.meta(132), col.meta(110), col.actions(1)]
 
 export function MCPDirectory({
   itemID,
@@ -238,14 +238,14 @@ function DirectoryRow({ item, canImport, selected, onOpen, onImport, onConnect, 
     <LedgerRow selected={selected} onClick={onOpen} onKeyDown={onKeyDown} data-testid="mcp-directory-row" data-catalog-id={item.id}>
       <span className="flex min-w-0 items-center gap-2">
         <ConnectorIcon item={item} />
-        <span className="shrink-0 truncate font-medium">{item.name}</span>
+        <span className="min-w-0 truncate font-medium" title={item.name}>{item.name}</span>
         {item.verified ? <VerifiedBadge /> : null}
         {item.installed ? (
           <Badge variant="neutral" dot>{t("capabilities.mcpDirectory.actions.installed")}</Badge>
         ) : item.connected ? (
           <Badge variant="neutral" dot>{t("capabilities.mcpDirectory.oauth.connected")}</Badge>
         ) : null}
-        {item.description && <span className="min-w-0 truncate text-xs text-fg-muted">· {item.description}</span>}
+        {item.description && <span className="min-w-0 flex-1 truncate text-xs text-fg-muted">· {item.description}</span>}
       </span>
       <span className="truncate text-xs text-fg-muted">{item.publisher.name}</span>
       <span className="truncate font-mono text-xs text-fg">{item.version || "—"}</span>


### PR DESCRIPTION
Composite ledger titles can overflow into the next column because the name cannot shrink. Allow names to truncate, give supplementary descriptions only the remaining space, and expose full names through their title attribute. Apply the same local rule to marketplace items, connector items, Skills, and pending join requests. Catalogue title columns retain a 280 px floor so routine names remain readable alongside status badges.

Validation: `make check` passed (Docker migration smoke test skipped locally), `git diff --check` passed, and browser checks covered the marketplace rail open/closed, all six connector rows in the narrow rail with their names fully visible, light/dark appearance, and 471 Skills rows without title-cell overflow. Pending member requests received the same self-reviewed class changes; no membership or action behavior changes.
