### PR TITLE
fix(gateway): acknowledge Feishu reaction notifications

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -801,6 +801,9 @@ Go toolchain; do not use `@latest` for that build-time tool.
   the build on any drift. See `server/internal/api/health.go:livenessHandler`
   and `server/internal/dev/routes.go:listWorkspaceEnabledAgents` for
   the reference style.
+- Feishu WebSocket reaction-created and reaction-deleted notifications are
+  acknowledged without starting runs or changing send/undo reaction state.
+  Keep unsupported-event and malformed-payload errors observable.
 - Feishu WebSocket SDK and lifecycle logs must redact connection URL query
   strings before writing them, without changing the URLs used to connect.
   Omit each field's tail after its first `?`, without requiring a valid URL

--- a/server/internal/gateway/inbound/event_dispatcher.go
+++ b/server/internal/gateway/inbound/event_dispatcher.go
@@ -1,0 +1,28 @@
+package inbound
+
+import (
+	"context"
+
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
+	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
+)
+
+func (m *Manager) newEventDispatcher(appID string) *dispatcher.EventDispatcher {
+	events := dispatcher.NewEventDispatcher("", "")
+	events.OnP2MessageReceiveV1(func(ctx context.Context, event *larkim.P2MessageReceiveV1) error {
+		return m.handleMessage(ctx, appID, event)
+	})
+	events.OnP2CardActionTrigger(func(ctx context.Context, event *callback.CardActionTriggerEvent) (*callback.CardActionTriggerResponse, error) {
+		return m.handleCardAction(ctx, appID, event), nil
+	})
+	// Reaction notifications include our typing indicator. They do not start
+	// runs or update reaction bookkeeping, which belongs to the send/undo path.
+	events.OnP2MessageReactionCreatedV1(func(context.Context, *larkim.P2MessageReactionCreatedV1) error {
+		return nil
+	})
+	events.OnP2MessageReactionDeletedV1(func(context.Context, *larkim.P2MessageReactionDeletedV1) error {
+		return nil
+	})
+	return events
+}

--- a/server/internal/gateway/inbound/event_dispatcher_test.go
+++ b/server/internal/gateway/inbound/event_dispatcher_test.go
@@ -1,0 +1,56 @@
+package inbound
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
+	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
+)
+
+func TestEventDispatcherAcknowledgesReactionNotifications(t *testing.T) {
+	// No store or sender is wired: acknowledging reactions needs neither.
+	m := &Manager{}
+	events := m.newEventDispatcher("cli_test")
+	for _, kind := range []string{"im.message.reaction.created_v1", "im.message.reaction.deleted_v1"} {
+		t.Run(kind, func(t *testing.T) {
+			payload := []byte(fmt.Sprintf(`{"schema":"2.0","header":{"event_type":%q},"event":{"message_id":"om_test","reaction_type":{"emoji_type":"Typing"}}}`, kind))
+			if _, err := events.Do(context.Background(), payload); err != nil {
+				t.Fatalf("reaction notification failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestEventDispatcherPreservesUnsupportedEventErrors(t *testing.T) {
+	events := (&Manager{}).newEventDispatcher("cli_test")
+	_, err := events.Do(t.Context(), []byte(`{"schema":"2.0","header":{"event_type":"im.chat.updated_v1"},"event":{}}`))
+	var missing *dispatcher.NotFoundEventHandlerErr
+	if !errors.As(err, &missing) {
+		t.Fatalf("unregistered event error = %v, want missing handler", err)
+	}
+	_, err = events.Do(t.Context(), []byte(`{"schema":"2.0","header":{"event_type":"im.message.reaction.created_v1"},"event":42}`))
+	if err == nil {
+		t.Fatal("malformed reaction payload was accepted")
+	}
+}
+
+func TestEventDispatcherKeepsMessageAndCardHandlers(t *testing.T) {
+	m := &Manager{logger: log.Bg()}
+	events := m.newEventDispatcher("cli_test")
+	// The existing message handler acknowledges and drops missing message IDs.
+	if _, err := events.Do(t.Context(), []byte(`{"schema":"2.0","header":{"event_type":"im.message.receive_v1"},"event":{}}`)); err != nil {
+		t.Fatalf("message handler not reached: %v", err)
+	}
+	response, err := events.Do(t.Context(), []byte(`{"schema":"2.0","header":{"event_type":"card.action.trigger"},"event":{"action":{"value":{"action":"credential_form_acknowledged"}}}}`))
+	if err != nil {
+		t.Fatalf("card handler not reached: %v", err)
+	}
+	ack, ok := response.(*callback.CardActionTriggerResponse)
+	if !ok || ack.Toast == nil || ack.Toast.Content != "This card has ended" {
+		t.Fatalf("card response = %#v, want existing acknowledgement", response)
+	}
+}

--- a/server/internal/gateway/inbound/manager.go
+++ b/server/internal/gateway/inbound/manager.go
@@ -19,7 +19,6 @@ import (
 	sharedrouter "github.com/MiniMax-AI-Dev/parsar/server/internal/gateway/router"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/interaction"
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
-	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher"
 	"github.com/larksuite/oapi-sdk-go/v3/event/dispatcher/callback"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 	"github.com/larksuite/oapi-sdk-go/v3/ws"
@@ -473,13 +472,7 @@ func (m *Manager) startClientWithSecret(ctx context.Context, route store.FeishuA
 	if appSecret == "" {
 		return errors.New("app_secret is required")
 	}
-	eventDispatcher := dispatcher.NewEventDispatcher("", "")
-	eventDispatcher.OnP2MessageReceiveV1(func(eventCtx context.Context, event *larkim.P2MessageReceiveV1) error {
-		return m.handleMessage(eventCtx, strings.TrimSpace(cfg.AppID), event)
-	})
-	eventDispatcher.OnP2CardActionTrigger(func(eventCtx context.Context, event *callback.CardActionTriggerEvent) (*callback.CardActionTriggerResponse, error) {
-		return m.handleCardAction(eventCtx, strings.TrimSpace(cfg.AppID), event), nil
-	})
+	eventDispatcher := m.newEventDispatcher(strings.TrimSpace(cfg.AppID))
 
 	clientOpts := []ws.ClientOption{
 		ws.WithEventHandler(eventDispatcher),


### PR DESCRIPTION
Feishu emits reaction-created and reaction-deleted notifications during ordinary bot use, including Parsar’s typing indicator. The WebSocket dispatcher currently reports these as missing-handler errors. Acknowledge those notifications without starting work or changing send/undo reaction state.

Keep event registration in a small helper outside the oversized manager file. Existing message and card handlers retain their behavior, and unsupported event types and malformed payloads continue to fail.

Validation: native SDK dispatch tests cover both reaction events, unsupported and malformed events, and the existing message/card routes. `make check` passed; local Docker migration smoke testing was skipped because Docker is unavailable.
