### PR TITLE
fix(web): add select all button to Models page

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -12,6 +12,7 @@
       "title": "Models"
     },
     "actions": {
+      "selectAll": "Select all",
       "addModel": "Add model",
       "importModels": "Import models",
       "test": "Test",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -12,6 +12,7 @@
       "title": "模型"
     },
     "actions": {
+      "selectAll": "全选",
       "addModel": "新建模型",
       "importModels": "导入模型",
       "test": "测试连接",

--- a/apps/web/src/pages/admin/ModelsPage.tsx
+++ b/apps/web/src/pages/admin/ModelsPage.tsx
@@ -287,6 +287,15 @@ export function ModelsPage() {
                   </FilterGroup>
                 </FilterMenu>
               )}
+              {hasModels && (
+                <Button
+                  variant="outline"
+                  onClick={() => setSelectedModelIDs((current) => new Set([...current, ...filteredModels.map((model) => model.id)]))}
+                  disabled={bulkDeleteMut.isPending || filteredModels.every((model) => selectedModelIDs.has(model.id))}
+                >
+                  {t("models.actions.selectAll")}
+                </Button>
+              )}
               <Button variant="outline" onClick={() => setBulkImportOpen(true)} disabled={!wsId}>
                 <Download strokeWidth={1.5} aria-hidden="true" />
                 {t("models.actions.importModels")}


### PR DESCRIPTION
Add a “Select all” button to the Models toolbar using the existing selection state. It selects the current filtered models while retaining previous selections, and is disabled when all visible models are selected, no models match, or bulk deletion is pending. The existing Cancel action clears the selection.

Only 11 lines across the page and its English/Chinese translations change. No changes to deletion behavior or shared components.

Validation: `make check` passed. Self-reviewed as an isolated, low-impact page change using the existing selection behavior.

Closes #421.
