### PR TITLE
fix(web): keep conversations following the latest output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -619,6 +619,11 @@ Standalone shared conversations size to the viewport, including loading and
 unavailable states. Keep their mobile sizing scoped to that shell; the desktop
 console's minimum width and shared message behavior remain independent.
 
+The console and shared conversation view use the same thread scroll hook.
+Opening a conversation and successful sends follow the latest content. Scrolling
+back or choosing a turn preserves the reading position during streaming and
+polling; returning to the bottom resumes following.
+
 Dialogs / drawers / modals and detail panels **must not show a horizontal
 scrollbar**. End users report "I can't see the bottom" far more often than
 "my screen is too narrow", and horizontal scroll almost always means a

--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query"
 import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
+  ArrowDown,
   ArrowUp,
   ArrowUpRight,
   Loader2,
@@ -49,6 +50,7 @@ import { isRuntimeCapabilityError } from "../../lib/message-kind"
 import { conversationRecoveryLinks } from "../../lib/conversation-recovery-links"
 import { isFailedToolResult } from "../../lib/tool-result"
 import { useRelativeTime } from "../../lib/relative-time"
+import { useThreadScroll } from "../../lib/use-thread-scroll"
 import { credentialKindLabel } from "../../pages/admin/capability-ui"
 import { ToolCardSlot, SingleSlot, ListSlot } from "../plugin/SlotRenderer"
 
@@ -489,6 +491,8 @@ function ChatStream({
 
   // Turn navigation: one marker per user turn, the active one follows scroll.
   const [viewport, setViewport] = useState<HTMLDivElement | null>(null)
+  const [threadContent, setThreadContent] = useState<HTMLDivElement | null>(null)
+  const { scrollToLatest, scrollToTurn, showScrollToLatest } = useThreadScroll(conversationId, viewport, threadContent)
   const turns = useMemo(
     () =>
       messages
@@ -567,9 +571,9 @@ function ChatStream({
       />}
 
       <div className="relative flex min-h-0 flex-1 flex-col">
-        {chrome !== "bare" && <TurnNavRail turns={turns} activeKey={activeTurnKey} />}
+        {chrome !== "bare" && <TurnNavRail turns={turns} activeKey={activeTurnKey} onJump={scrollToTurn} />}
         <div ref={setViewport} className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-        <div className="mx-auto flex w-full max-w-[var(--thread-max-width)] flex-1 flex-col gap-5 px-4 py-6">
+        <div ref={setThreadContent} className="mx-auto flex w-full max-w-[var(--thread-max-width)] flex-1 flex-col gap-5 px-4 py-6">
           {timelineQ.isLoading ? (
             <Skeleton className="h-16 w-3/4" />
           ) : messages.length === 0 ? (
@@ -652,6 +656,18 @@ function ChatStream({
             ))}
         </div>
         </div>
+        {showScrollToLatest && (
+          <Button
+            variant="outline"
+            size="sm"
+            shape="pill"
+            className="absolute bottom-3 z-10 self-center"
+            onClick={scrollToLatest}
+          >
+            <ArrowDown strokeWidth={1.5} aria-hidden="true" />
+            {t("conversations.scrollToLatest")}
+          </Button>
+        )}
       </div>
 
       {cancelRunMut.error && !runs.some((run) => run.id === cancelRunMut.variables?.runID && run.status === "cancelled") && <ErrorDialog
@@ -698,6 +714,7 @@ function ChatStream({
             agentName={agentName}
             placeholder={agentDeleted ? t("agents.deletedLabel") : t("conversations.composer.placeholder", { agent: agentName })}
             disabled={!canWrite || !agent || agentDeleted || sandboxGuard?.blocked}
+            onAfterSend={async () => scrollToLatest()}
             onRunStarted={startRun}
             onStartError={(message: string) => setChatToast({ text: message })}
             activeRunId={activeRunId}

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -259,6 +259,7 @@
     }
   },
   "conversations": {
+    "scrollToLatest": "Back to latest",
     "page": {
       "title": "Conversations"
     },

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -259,6 +259,7 @@
     }
   },
   "conversations": {
+    "scrollToLatest": "回到最新",
     "page": {
       "title": "对话"
     },

--- a/apps/web/src/lib/use-thread-scroll.ts
+++ b/apps/web/src/lib/use-thread-scroll.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useLayoutEffect, useRef, useState } from "react"
 
 /** Follow new output until the reader scrolls back or selects an earlier turn. */
 export function useThreadScroll(
@@ -7,16 +7,18 @@ export function useThreadScroll(
   content: HTMLElement | null,
 ) {
   const following = useRef(true)
+  const activeConversation = useRef<string | null>(null)
   const previousTop = useRef(0)
   const [showScrollToLatest, setShowScrollToLatest] = useState(false)
 
   const scrollToLatest = useCallback(() => {
+    if (activeConversation.current !== conversationId) return
     following.current = true
     if (!viewport) return
     viewport.scrollTo({ top: viewport.scrollHeight, behavior: "instant" })
     previousTop.current = viewport.scrollTop
     setShowScrollToLatest(false)
-  }, [viewport])
+  }, [conversationId, viewport])
 
   const scrollToTurn = useCallback((key: string) => {
     if (!viewport) return
@@ -29,15 +31,18 @@ export function useThreadScroll(
     })
   }, [viewport])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!viewport || !content) return
+    activeConversation.current = conversationId
     following.current = true
     previousTop.current = viewport.scrollTop
     const atBottom = () => viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop <= 2
     const onScroll = () => {
       const bottom = atBottom()
-      if (bottom) following.current = true
-      else if (viewport.scrollTop < previousTop.current) following.current = false
+      if (viewport.scrollTop < previousTop.current) following.current = false
+      // A smooth jump can start with a tiny upward step still near the bottom.
+      // Only movement back down to the bottom resumes following.
+      else if (bottom && viewport.scrollTop > previousTop.current) following.current = true
       previousTop.current = viewport.scrollTop
       setShowScrollToLatest(!bottom)
     }
@@ -56,6 +61,7 @@ export function useThreadScroll(
     viewport.addEventListener("scroll", onScroll, { passive: true })
     viewport.addEventListener("wheel", onWheel, { passive: true })
     return () => {
+      activeConversation.current = null
       window.cancelAnimationFrame(frame)
       observer.disconnect()
       viewport.removeEventListener("scroll", onScroll)

--- a/apps/web/src/lib/use-thread-scroll.ts
+++ b/apps/web/src/lib/use-thread-scroll.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+/** Follow new output until the reader scrolls back or selects an earlier turn. */
+export function useThreadScroll(
+  conversationId: string,
+  viewport: HTMLElement | null,
+  content: HTMLElement | null,
+) {
+  const following = useRef(true)
+  const previousTop = useRef(0)
+  const [showScrollToLatest, setShowScrollToLatest] = useState(false)
+
+  const scrollToLatest = useCallback(() => {
+    following.current = true
+    if (!viewport) return
+    viewport.scrollTo({ top: viewport.scrollHeight, behavior: "instant" })
+    previousTop.current = viewport.scrollTop
+    setShowScrollToLatest(false)
+  }, [viewport])
+
+  const scrollToTurn = useCallback((key: string) => {
+    if (!viewport) return
+    const turn = viewport.querySelector<HTMLElement>(`[data-turn-key="${CSS.escape(key)}"]`)
+    if (!turn) return
+    following.current = false
+    turn.scrollIntoView({
+      block: "start",
+      behavior: window.matchMedia("(prefers-reduced-motion: reduce)").matches ? "instant" : "smooth",
+    })
+  }, [viewport])
+
+  useEffect(() => {
+    if (!viewport || !content) return
+    following.current = true
+    previousTop.current = viewport.scrollTop
+    const atBottom = () => viewport.scrollHeight - viewport.clientHeight - viewport.scrollTop <= 2
+    const onScroll = () => {
+      const bottom = atBottom()
+      if (bottom) following.current = true
+      else if (viewport.scrollTop < previousTop.current) following.current = false
+      previousTop.current = viewport.scrollTop
+      setShowScrollToLatest(!bottom)
+    }
+    const onWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0) following.current = false
+    }
+    const onResize = () => {
+      // Content growth is not a reader scrolling away from the latest turn.
+      if (following.current) scrollToLatest()
+      else setShowScrollToLatest(!atBottom())
+    }
+    const frame = window.requestAnimationFrame(scrollToLatest)
+    const observer = new ResizeObserver(onResize)
+    observer.observe(viewport)
+    observer.observe(content)
+    viewport.addEventListener("scroll", onScroll, { passive: true })
+    viewport.addEventListener("wheel", onWheel, { passive: true })
+    return () => {
+      window.cancelAnimationFrame(frame)
+      observer.disconnect()
+      viewport.removeEventListener("scroll", onScroll)
+      viewport.removeEventListener("wheel", onWheel)
+    }
+  }, [conversationId, viewport, content, scrollToLatest])
+
+  return { scrollToLatest, scrollToTurn, showScrollToLatest }
+}


### PR DESCRIPTION
Opening a long conversation or sending from an older turn could leave new replies outside the viewport. Conversations now follow the latest output, pause following while the reader scrolls back or selects a turn, and offer a localized Back to latest control. Successful sends and conversation changes resume following.

The shared scroll hook serves both console and shared conversation views; message dispatch, streaming data, approvals, and cancellation are unchanged.

Validation: `make check` passed (local Docker is stopped, so the existing PostgreSQL smoke gate skipped). A real remote OpenCode send completed with the latest response visible. Browser checks covered continuous output, manual upward scrolling, turn navigation, resizing, resuming follow, conversation changes, and the real shared view at 390px. The new hook passes ESLint; full ESLint has the same 48 pre-existing errors and one warning as the clean baseline, tracked separately as CHECK-010.
