### PR TITLE
test: match automatic version expectation to v1 fixture

### DIFF
--- a/server/internal/dev/capability_import_routes_test.go
+++ b/server/internal/dev/capability_import_routes_test.go
@@ -507,8 +507,8 @@ func TestCapabilityVersionImportCommit_AssignsNextVersionWhenOmitted(t *testing.
 	if err := json.Unmarshal(res.Body.Bytes(), &response); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if response.CapabilityVersion.Version != "1.0.1" {
-		t.Fatalf("automatic version = %q, want 1.0.1", response.CapabilityVersion.Version)
+	if response.CapabilityVersion.Version != "v2" {
+		t.Fatalf("automatic version = %q, want v2", response.CapabilityVersion.Version)
 	}
 }
 


### PR DESCRIPTION
The omitted-version import test bootstraps `v1` but expected `1.0.1`, so it failed despite the existing version allocator correctly returning `v2`. Match the assertion to the fixture's next version. No production behavior or other assertions change.

Validation: reproduced the original failure and passed the corrected HTTP import test against a separate PostgreSQL database. `make check` passed; its local Docker smoke gate skipped because local Docker remains stopped.
