### PR TITLE
fix(web): name expanded details after their content

### DIFF
--- a/apps/web/src/components/ui/detail-rail.tsx
+++ b/apps/web/src/components/ui/detail-rail.tsx
@@ -50,6 +50,7 @@ export function DetailRail({
   const expandLabel = t("actions.expand")
   const collapseLabel = t("actions.collapse")
   const resolvedCloseLabel = closeLabel ?? t("actions.close", { defaultValue: "Close" })
+  const dialogTitle = props["aria-label"]?.trim() || t("layout.details")
   const setModalOpen = (next: boolean) => setExpanded(next)
 
   const frame = (mode: "rail" | "modal") => (
@@ -147,7 +148,7 @@ export function DetailRail({
             aria-label={typeof props["aria-label"] === "string" ? props["aria-label"] : undefined}
             className="app-modal-center app-shadow-floating fixed left-1/2 top-1/2 z-50 flex h-[70vh] w-[70vw] min-w-[720px] max-w-[1200px] flex-col overflow-hidden rounded-lg border border-line bg-surface-subtle focus:outline-none data-[state=open]:animate-modal-in data-[state=closed]:animate-modal-out"
           >
-            <DialogPrimitive.Title className="sr-only">{resolvedCloseLabel}</DialogPrimitive.Title>
+            <DialogPrimitive.Title className="sr-only">{dialogTitle}</DialogPrimitive.Title>
             {frame("modal")}
           </DialogPrimitive.Content>
         </DialogPrimitive.Portal>

--- a/apps/web/src/i18n/locales/en-US/common.json
+++ b/apps/web/src/i18n/locales/en-US/common.json
@@ -242,6 +242,7 @@
     "submit": "Set Password & Join"
   },
   "layout": {
+    "details": "Details",
     "adjusted": "Width adjusted",
     "temporary": "This session only",
     "restore": "Restore"

--- a/apps/web/src/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/i18n/locales/zh-CN/common.json
@@ -242,6 +242,7 @@
     "submit": "设置密码并加入"
   },
   "layout": {
+    "details": "详情",
     "adjusted": "已调整宽度",
     "temporary": "临时",
     "restore": "恢复"


### PR DESCRIPTION
Expanded detail panels used their close action as the hidden dialog title, so assistive technology announced names such as "Back to market list". Use the existing content label as the title, with a localized "Details" fallback when it is absent. Visible layout and expand, collapse, and close actions remain unchanged.

Validation: `make check` passed. Browser checks confirmed the marketplace capability and Agent names are used for expanded dialog titles; the unnamed error panel uses the fallback. Existing collapse/back labels remain intact. This small labeling change was self-reviewed.
