### PR TITLE
test(store): reset connector session bindings between cases

### DIFF
--- a/server/internal/store/store_test.go
+++ b/server/internal/store/store_test.go
@@ -2038,6 +2038,7 @@ func resetTestDB(t *testing.T, db *pgxpool.Pool) {
 	t.Helper()
 	if _, err := db.Exec(context.Background(), `
 		truncate table
+			connector_session_bindings,
 			runtimes,
 			sandboxes,
 			agent_run_events,


### PR DESCRIPTION
Repeating `TestGetAgentRunDetailShowsCompletedOutputMessage` against the same test database fails after its first successful run because `connector_session_bindings` survives `resetTestDB`. Its conversation reference is text without a foreign key, so truncating conversations does not clear these rows.

Include session bindings in the existing test reset list. This is a single test-only cleanup line; all run output and runtime assertions remain unchanged.

Validation: reproduced the baseline first-pass/next-two-fail behavior in a fresh isolated PostgreSQL database, then passed three consecutive runs with the fix. `make check` passed. Directly reviewed as an isolated test fixture correction.
The complete store package also passed against isolated PostgreSQL: 330 passing tests; one existing obsolete bootstrap test is explicitly skipped.
