### PR TITLE
fix(skills): simplify missing metadata preview warnings

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -986,6 +986,7 @@
         "descriptionPlaceholder": "One sentence about what this capability does — Claude uses it to decide when to invoke."
       },
       "skill": {
+        "missingName": "Skill name missing",
         "source": {
           "label": "Source",
           "paste": "Paste Markdown",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -986,6 +986,7 @@
         "descriptionPlaceholder": "用一句话说明这个能力做什么,Claude 会用它判断是否调用"
       },
       "skill": {
+        "missingName": "名称待完善",
         "source": {
           "label": "导入方式",
           "paste": "粘贴 Markdown",

--- a/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
@@ -355,8 +355,8 @@ function SinglePreview({
   const { t } = useTranslation("admin")
   return (
     <section className="border-t border-line pt-3">
-      <h4 className="text-sm font-medium text-fg">{skill.title || skill.slug}</h4>
-      <code className="font-mono text-xs text-fg-muted">{skill.slug}</code>
+      <h4 className="text-sm font-medium text-fg">{skill.title || skill.slug || t("capabilities.import.skill.missingName")}</h4>
+      {skill.slug && <code className="font-mono text-xs text-fg-muted">{skill.slug}</code>}
 
       {/* description intentionally omitted — ImportPreview above already
        *  surfaces it on the "ready" line, repeating it here was noisy. */}

--- a/server/internal/capability/parser/skill_parser.go
+++ b/server/internal/capability/parser/skill_parser.go
@@ -53,13 +53,14 @@ func ParseSkill(raw string, format SourceFormat) (SkillParseResult, error) {
 		// name next, then an auto-generated suffix.
 		slug = kebabFromName(front.Name)
 	}
-	if slug == "" {
-		warnings = append(warnings, "frontmatter provided no slug or name — add a name to the YAML frontmatter in SKILL.md, then upload or preview again")
-	}
-
 	title := strings.TrimSpace(front.Title)
 	if title == "" {
 		title = strings.TrimSpace(front.Name)
+	}
+	// Missing or unreadable frontmatter already has a recovery warning.
+	// Keep field warnings when some metadata was recovered.
+	if slug == "" && (front != (skillFrontmatter{}) || len(warnings) == 0) {
+		warnings = append(warnings, "frontmatter provided no slug or name — add a name to the YAML frontmatter in SKILL.md, then upload or preview again")
 	}
 
 	spec := canonical.Spec{
@@ -73,7 +74,7 @@ func ParseSkill(raw string, format SourceFormat) (SkillParseResult, error) {
 			Trigger:     strings.TrimSpace(front.Trigger),
 		},
 	}
-	if title == "" {
+	if title == "" && slug != "" {
 		warnings = append(warnings, "title is empty — add a name or title to the YAML frontmatter in SKILL.md, then upload or preview again")
 	}
 	return SkillParseResult{

--- a/server/internal/capability/parser/skill_parser_test.go
+++ b/server/internal/capability/parser/skill_parser_test.go
@@ -107,6 +107,9 @@ func TestParseSkill_NoFrontmatterStillParses(t *testing.T) {
 	if !hasFrontmatterWarning {
 		t.Fatalf("expected a frontmatter-related warning, got %v", res.Warnings)
 	}
+	if len(res.Warnings) != 1 {
+		t.Fatalf("expected one recovery warning without field-level duplicates, got %v", res.Warnings)
+	}
 }
 
 // TestParseSkill_FrontmatterPresentButEmpty: empty frontmatter ==
@@ -122,6 +125,9 @@ func TestParseSkill_FrontmatterPresentButEmpty(t *testing.T) {
 	}
 	if res.Spec.Skill.Instruction != "body" {
 		t.Fatalf("instruction body should be 'body' (frontmatter stripped), got %q", res.Spec.Skill.Instruction)
+	}
+	if len(res.Warnings) != 1 || !strings.Contains(res.Warnings[0], "add a name") {
+		t.Fatalf("expected one name recovery warning, got %v", res.Warnings)
 	}
 }
 
@@ -153,8 +159,24 @@ func TestParseSkill_MalformedYAMLDegradesToWarning(t *testing.T) {
 	if !hasYAMLWarning {
 		t.Fatalf("expected a YAML-failure warning, got %v", res.Warnings)
 	}
+	if len(res.Warnings) != 1 {
+		t.Fatalf("expected one YAML recovery warning without field-level duplicates, got %v", res.Warnings)
+	}
 	if res.Spec.Skill.Instruction != "body" {
 		t.Fatalf("body should be cleanly stripped of frontmatter, got %q", res.Spec.Skill.Instruction)
+	}
+}
+
+func TestParseSkill_PartialRecoveryKeepsNameWarning(t *testing.T) {
+	res, err := ParseSkill("---\ndescription: Review: changes\n---\nbody\n", SourceFormatMarkdown)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if res.Spec.Skill.Description != "Review: changes" || res.Spec.Skill.Instruction != "body" {
+		t.Fatalf("expected recovered metadata and body, got %+v", res.Spec.Skill)
+	}
+	if len(res.Warnings) != 2 || !strings.Contains(res.Warnings[1], "add a name") {
+		t.Fatalf("expected YAML recovery and missing-name warnings, got %v", res.Warnings)
 	}
 }
 


### PR DESCRIPTION
Importing a Skill without readable frontmatter showed three warnings about the same missing metadata, followed by an empty preview heading and code label. Keep the root recovery warning, show a missing-name heading, and omit the empty slug label. Independent missing-field warnings remain when metadata was partially recovered.

Scope: warning selection and the Skill preview only. Canonical metadata, instruction content, import eligibility, persistence, and other capability types are unchanged.

Validation: parser tests cover missing, empty, unreadable, and partially recovered metadata; the full parser suite and `make check` pass. Browser checks use the candidate UI with the actual candidate parser behind a local QA proxy: one root warning, preserved body, no empty heading/code, and a valid name restores the normal preview and enabled Import action. Directly reviewed as a localized presentation correction.
