### PR TITLE
docs: remove obsolete sandbox flag from quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ make docker-build
 ./install.sh --image parsar:dev
 ```
 
-> **Platform.** Docker-managed agent sandboxes require Linux. Non-Linux hosts
-> can start the web control plane with `--no-sandbox`.
+The default Compose stack starts PostgreSQL, the Parsar web control plane,
+and a shared agent runtime together.
 
 ## Contributing
 


### PR DESCRIPTION
The Quick Start told non-Linux users to pass `--no-sandbox`, but the current installer rejects that removed option. Replace the stale platform note with the actual default stack: PostgreSQL, the web control plane, and a shared agent runtime.

Scope: two README lines only. Installer flags, images, and deployment behavior are unchanged.

Validation: reproduced `unknown option: --no-sandbox`; checked current installer help and root Compose services. `make check` passed. Directly reviewed as a documentation correction.
