### PR TITLE
fix(web): validate current skill content before import

### DIFF
--- a/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
@@ -153,9 +153,9 @@ export function AddCapabilityVersionDialog({
   const skillSpecReady =
     kind !== "skill"
       ? true
-      : !!skillOssKey ||
-        !!inheritedOssLabel ||
-        (!!spec && isImportSpecReady(kind, spec, inlineSecrets))
+      : spec
+        ? isImportSpecReady(kind, spec, inlineSecrets)
+        : rawText === "" && !!inheritedOssLabel
 
   const mcpSpecReady =
     kind !== "mcp" ? true : !!spec && isImportSpecReady(kind, spec, inlineSecrets)

--- a/apps/web/src/pages/admin/capabilities/importValidation.ts
+++ b/apps/web/src/pages/admin/capabilities/importValidation.ts
@@ -26,7 +26,7 @@ export function startsWithEnvPlaceholder(value: string | undefined): boolean {
 /**
  * Returns true when the spec + provisional inline secrets are commit-ready.
  *
- * skill: non-empty instruction.
+ * skill: non-empty slug and instruction, matching server validation.
  * mcp: every env entry "ready" — literal not a `$…` placeholder,
  *      credential_ref has a kind code, inline_secret has either a
  *      server-allocated secret_id or a queued plaintext.
@@ -36,7 +36,9 @@ export function isImportSpecReady(
   spec: CanonicalSpec,
   inlineSecrets: ImportInlineSecretInput[],
 ): boolean {
-  if (kind === "skill") return (spec.skill?.instruction?.length ?? 0) > 0
+  if (kind === "skill") {
+    return Boolean(spec.skill?.slug?.trim() && spec.skill?.instruction?.trim())
+  }
 
   const servers = spec.mcp?.servers ?? []
   if (servers.length === 0) return false


### PR DESCRIPTION
After previewing a valid Skill, replacing it with content without frontmatter leaves the import button enabled because the dialog retains the previous name and readiness only checks the body. Require a nonblank slug and instruction from the current parsed Skill, matching server validation. Both creation and version import use this check. Version import may still reuse its existing ZIP when no new content is supplied, but that ZIP no longer bypasses validation of newly parsed content. MCP readiness is unchanged.

Validation: `make check` passed. A baseline comparison reproduced the missing-name acceptance and checked blank values, valid CJK names, and MCP credential readiness. Browser regression covered valid → missing metadata → restored metadata and the new-version dialog. Only the shared readiness helper and the version dialog’s Skill guard change.
