### PR TITLE
feat(web): preview Skills directory content before installing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,11 @@ description and keep ownership on the side listed here.
 - Skill directory packaging honors the request context while reading files and
   writing the archive. Enforce the ZIP parser's existing byte and entry limits
   during packaging, before upload or parsing can allocate oversized results.
+- Skills.sh previews reuse the install downloader and Skill ZIP parser, require
+  the same owner/admin permission, and create no capability, installation, or
+  upload record. Temporary preview files stay under `~/.parsar/` and are removed
+  after the request. Preview shows current repository content; installation
+  fetches again and does not promise an immutable preview revision.
 
 ### Runtime and execution concepts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,9 @@ description and keep ownership on the side listed here.
 - Skills.sh previews reuse the install downloader and Skill ZIP parser, require
   the same owner/admin permission, and create no capability, installation, or
   upload record. Temporary preview files stay under `~/.parsar/` and are removed
-  after the request. Preview shows current repository content; installation
+  after the request, including the downloader's own temporary files. Previews
+  require Unix process-group cancellation so child downloads cannot outlive the
+  request. Preview shows current repository content; installation
   fetches again and does not promise an immutable preview revision.
 
 ### Runtime and execution concepts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,8 @@ description and keep ownership on the side listed here.
   require Unix process-group cancellation so child downloads cannot outlive the
   request. Preview shows current repository content; installation
   fetches again and does not promise an immutable preview revision.
+  Show the original SKILL.md entry alongside parsed metadata; do not reconstruct
+  its source from canonical fields, which omit unsupported frontmatter.
 
 ### Runtime and execution concepts
 

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -828,6 +828,12 @@
         "copy": "Copy details",
         "copied": "Details copied.",
         "copyFailed": "Copy failed. Select and copy the details above."
+      },
+      "preview": {
+        "description": "Review the current repository content before installing.",
+        "loading": "Loading Skill instructions and files…",
+        "failed": "Could not load this Skill preview",
+        "noDescription": "This Skill does not include a description."
       }
     },
     "mcpDirectory": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -828,6 +828,12 @@
         "copy": "复制详情",
         "copied": "详情已复制。",
         "copyFailed": "复制失败，请选中上方详情手动复制。"
+      },
+      "preview": {
+        "description": "安装前查看仓库中的当前内容。",
+        "loading": "正在读取 Skill 指令和文件…",
+        "failed": "无法加载此 Skill 的预览",
+        "noDescription": "此 Skill 未提供用途说明。"
       }
     },
     "mcpDirectory": {

--- a/apps/web/src/lib/api-skills.ts
+++ b/apps/web/src/lib/api-skills.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { apiRequest, noUnreachableRetry } from "./api-client"
 import { KEY_CAPABILITIES_WORKSPACE, KEY_CAPABILITY_VERSIONS } from "./api-capabilities"
 import type { Capability, CapabilityVersion } from "./api-types"
+import type { ImportPreviewResponse } from "../pages/admin/capabilities/types"
 
 // Browser-safe equivalent of:
 // curl -L https://agent-skill-index.vercel.app/api/skills
@@ -127,6 +128,25 @@ export function useSkillsCatalog() {
     queryFn: listSkillsCatalog,
     retry: noUnreachableRetry,
     staleTime: 60_000,
+  })
+}
+
+export function useSkillPreview(workspaceID: string | null, skill: SkillsCatalogItem, enabled: boolean) {
+  return useQuery({
+    queryKey: ["admin", "skillPreview", workspaceID, skill.source, skill.slug, skill.id],
+    queryFn: ({ signal }) => apiRequest<ImportPreviewResponse>(
+      `/api/v1/workspaces/${encodeURIComponent(workspaceID!)}/skills/preview`,
+      {
+        method: "POST",
+        signal,
+        body: { source: skill.source, slug: skill.slug, registry_id: skill.id, registry: SKILLS_REGISTRY },
+      },
+    ),
+    enabled: !!workspaceID && enabled,
+    retry: false,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   })
 }
 

--- a/apps/web/src/lib/api-skills.ts
+++ b/apps/web/src/lib/api-skills.ts
@@ -134,7 +134,7 @@ export function useSkillsCatalog() {
 export function useSkillPreview(workspaceID: string | null, skill: SkillsCatalogItem, enabled: boolean) {
   return useQuery({
     queryKey: ["admin", "skillPreview", workspaceID, skill.source, skill.slug, skill.id],
-    queryFn: ({ signal }) => apiRequest<ImportPreviewResponse>(
+    queryFn: ({ signal }) => apiRequest<ImportPreviewResponse & { entry_markdown: string }>(
       `/api/v1/workspaces/${encodeURIComponent(workspaceID!)}/skills/preview`,
       {
         method: "POST",

--- a/apps/web/src/pages/admin/capabilities/SkillFileTree.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillFileTree.tsx
@@ -26,12 +26,13 @@ import type { CanonicalSkillSpec, SkillFile } from "./types"
 
 interface Props {
   skill: CanonicalSkillSpec
+  entryMarkdown?: string
 }
 
 /* 28px hairline rows; mono file names; chevron rotates when open. */
 const TREE_ROW_CLASS = "flex h-7 w-full items-center gap-2 border-b border-line text-left text-sm transition-colors duration-150 ease-settle hover:app-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/40"
 
-export function SkillFileTree({ skill }: Props) {
+export function SkillFileTree({ skill, entryMarkdown }: Props) {
   const { t } = useTranslation("admin")
   const files = useMemo(() => skill.files ?? [], [skill.files])
 
@@ -39,7 +40,7 @@ export function SkillFileTree({ skill }: Props) {
 
   return (
     <section className="border-t border-line">
-      <SkillMdRow skill={skill} />
+      <SkillMdRow skill={skill} entryMarkdown={entryMarkdown} />
 
       {grouped.references.length > 0 && (
         <GroupRows
@@ -73,13 +74,11 @@ function Chevron({ open }: { open: boolean }) {
   )
 }
 
-function SkillMdRow({ skill }: { skill: CanonicalSkillSpec }) {
+function SkillMdRow({ skill, entryMarkdown }: Props) {
   const { t } = useTranslation("admin")
   const [open, setOpen] = useState(true)
 
-  // Parser drops the raw bytes; rebuild from canonical fields so what
-  // the user sees matches what's been imported.
-  const source = useMemo(() => buildSkillMdSource(skill), [skill])
+  const source = useMemo(() => entryMarkdown ?? buildSkillMdSource(skill), [entryMarkdown, skill])
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>

--- a/apps/web/src/pages/admin/capabilities/SkillPreviewDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillPreviewDialog.tsx
@@ -11,12 +11,13 @@ import { ImportPreview } from "./ImportPreview"
 import { isImportSpecReady } from "./importValidation"
 import { SkillFileTree } from "./SkillFileTree"
 
-export function SkillPreviewDialog({ skill, canImport, installedCapabilityID, installing, onInstall, onViewCapability, onClose, onRestoreFocus }: {
+export function SkillPreviewDialog({ skill, canImport, installedCapabilityID, installing, installReady, onInstall, onViewCapability, onClose, onRestoreFocus }: {
   skill: SkillsCatalogItem
   canImport: boolean
   installedCapabilityID?: string
   installing: boolean
-  onInstall: () => void
+  installReady: boolean
+  onInstall: () => boolean
   onViewCapability: (capabilityID: string) => void
   onClose: () => void
   onRestoreFocus: () => void
@@ -71,7 +72,7 @@ export function SkillPreviewDialog({ skill, canImport, installedCapabilityID, in
           {installedCapabilityID ? (
             <Button onClick={() => { onClose(); onViewCapability(installedCapabilityID) }}>{t("capabilities.mcpDirectory.actions.viewCapability")}</Button>
           ) : canImport ? (
-            <Button disabled={installing || preview.isFetching || !!preview.error || !spec || !isImportSpecReady("skill", spec, [])} onClick={() => { onInstall(); onClose() }}>
+            <Button disabled={!installReady || installing || preview.isFetching || !!preview.error || !spec || !isImportSpecReady("skill", spec, [])} onClick={() => { if (onInstall()) onClose() }}>
               {t(installing ? "capabilities.skillsDirectory.install.installing" : "capabilities.skillsDirectory.install.action")}
             </Button>
           ) : null}

--- a/apps/web/src/pages/admin/capabilities/SkillPreviewDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillPreviewDialog.tsx
@@ -1,0 +1,82 @@
+import { useTranslation } from "react-i18next"
+import { ArrowUpRight, Loader2 } from "lucide-react"
+
+import { Button } from "../../../components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../../../components/ui/dialog"
+import { ErrorState } from "../../../components/ui/error-state"
+import { Property, PropertyList } from "../../../components/ui/property-list"
+import { useSkillPreview, type SkillsCatalogItem } from "../../../lib/api-skills"
+import { useWorkspaceId } from "../../../lib/workspace"
+import { ImportPreview } from "./ImportPreview"
+import { isImportSpecReady } from "./importValidation"
+import { SkillFileTree } from "./SkillFileTree"
+
+export function SkillPreviewDialog({ skill, canImport, installedCapabilityID, installing, onInstall, onViewCapability, onClose, onRestoreFocus }: {
+  skill: SkillsCatalogItem
+  canImport: boolean
+  installedCapabilityID?: string
+  installing: boolean
+  onInstall: () => void
+  onViewCapability: (capabilityID: string) => void
+  onClose: () => void
+  onRestoreFocus: () => void
+}) {
+  const { t } = useTranslation("admin")
+  const { t: common } = useTranslation("common")
+  const preview = useSkillPreview(useWorkspaceId(), skill, canImport)
+  const spec = preview.data?.canonical_spec
+  const content = spec?.skill
+  return (
+    <Dialog open onOpenChange={(open) => { if (!open) onClose() }}>
+      <DialogContent
+        className="flex w-[calc(100%-2rem)] max-w-3xl max-h-[calc(100vh-2rem)] flex-col overflow-hidden"
+        onCloseAutoFocus={(event) => { event.preventDefault(); onRestoreFocus() }}
+      >
+        <DialogHeader className="shrink-0">
+          <DialogTitle className="[overflow-wrap:anywhere]">{preview.data?.suggested_name || skill.name || skill.slug}</DialogTitle>
+          <DialogDescription>{t("capabilities.skillsDirectory.preview.description")}</DialogDescription>
+        </DialogHeader>
+        <div className="min-h-0 min-w-0 space-y-4 overflow-y-auto overflow-x-hidden">
+          <PropertyList>
+            <Property label={t("capabilities.marketplaceDetail.source.title")} className="h-auto min-h-7 whitespace-normal py-1">
+              <a href={`https://github.com/${skill.source}`} target="_blank" rel="noreferrer" className="inline-flex min-w-0 items-center gap-1 text-accent hover:underline [overflow-wrap:anywhere]">
+                {skill.source}<ArrowUpRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              </a>
+            </Property>
+          </PropertyList>
+          {!canImport ? (
+            <p className="text-sm text-fg-muted">{t("capabilities.permission.adminOnly")}</p>
+          ) : preview.isPending ? (
+            <p role="status" className="flex items-center gap-2 text-sm text-fg-muted">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              {t("capabilities.skillsDirectory.preview.loading")}
+            </p>
+          ) : preview.error ? (
+            <ErrorState
+              appearance="panel"
+              title={t("capabilities.skillsDirectory.preview.failed")}
+              detail={preview.error.message}
+              onRetry={() => { void preview.refetch() }}
+            />
+          ) : content ? (
+            <div className="min-w-0 space-y-3">
+              <p className="text-sm [overflow-wrap:anywhere]">{content.description || t("capabilities.skillsDirectory.preview.noDescription")}</p>
+              {!!preview.data?.warnings.length && <ImportPreview status="ready" warnings={preview.data.warnings} />}
+              <SkillFileTree skill={content} />
+            </div>
+          ) : null}
+        </div>
+        <DialogFooter className="shrink-0">
+          <Button variant="outline" onClick={onClose}>{common("actions.close")}</Button>
+          {installedCapabilityID ? (
+            <Button onClick={() => { onClose(); onViewCapability(installedCapabilityID) }}>{t("capabilities.mcpDirectory.actions.viewCapability")}</Button>
+          ) : canImport ? (
+            <Button disabled={installing || preview.isFetching || !!preview.error || !spec || !isImportSpecReady("skill", spec, [])} onClick={() => { onInstall(); onClose() }}>
+              {t(installing ? "capabilities.skillsDirectory.install.installing" : "capabilities.skillsDirectory.install.action")}
+            </Button>
+          ) : null}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/web/src/pages/admin/capabilities/SkillPreviewDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillPreviewDialog.tsx
@@ -63,7 +63,7 @@ export function SkillPreviewDialog({ skill, canImport, installedCapabilityID, in
             <div className="min-w-0 space-y-3">
               <p className="text-sm [overflow-wrap:anywhere]">{content.description || t("capabilities.skillsDirectory.preview.noDescription")}</p>
               {!!preview.data?.warnings.length && <ImportPreview status="ready" warnings={preview.data.warnings} />}
-              <SkillFileTree skill={content} />
+              <SkillFileTree skill={content} entryMarkdown={preview.data?.entry_markdown} />
             </div>
           ) : null}
         </div>

--- a/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
@@ -56,12 +56,13 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
   }
 
   const install = (skill: SkillsCatalogItem) => {
-    if (!canImport || loading || loadError || installed[skill.id]) return
+    if (!canImport || loading || loadError || installed[skill.id]) return false
     installMut.mutate(skill, {
       onSuccess: (result) => {
         setSuccess({ name: result.capability.name, capabilityID: result.capability.id })
       },
     })
+    return true
   }
 
   return (
@@ -73,6 +74,7 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
           canImport={canImport}
           installedCapabilityID={installed[previewSkill.id]}
           installing={pendingID === previewSkill.id}
+          installReady={!loading && !loadError}
           onInstall={() => install(previewSkill)}
           onViewCapability={onViewCapability}
           onClose={() => setPreviewSkill(null)}

--- a/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillsDirectory.tsx
@@ -12,6 +12,7 @@ import { useInstalledSkills, useInstallSkill, useSkillsCatalog, type SkillsCatal
 import { useWorkspaceId } from "../../../lib/workspace"
 import { InlineNotice } from "./notices"
 import { SkillInstallErrorDialog } from "./SkillInstallErrorDialog"
+import { SkillPreviewDialog } from "./SkillPreviewDialog"
 
 interface SkillsDirectoryProps {
   query: string
@@ -33,6 +34,7 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
   const loading = catalogQ.isPending || installedQ.isPending || installedQ.isFetching || installedQ.isPaused
   const loadError = catalogQ.error ?? installedQ.error
   const [success, setSuccess] = useState<{ name: string; capabilityID: string } | null>(null)
+  const [previewSkill, setPreviewSkill] = useState<SkillsCatalogItem | null>(null)
   const numberFormatter = useMemo(() => new Intl.NumberFormat(i18n.language), [i18n.language])
 
   const filtered = useMemo(() => {
@@ -47,6 +49,11 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
   }, [catalogQ.data?.items, query])
   const pendingID = installMut.isPending ? (installMut.variables?.id ?? null) : null
   const failedSkill = installMut.error ? installMut.variables : null
+  const restoreSkillFocus = (id: string) => {
+    const row = directoryRef.current?.querySelector<HTMLElement>(`[data-catalog-id="${CSS.escape(id)}"]`)
+    const target = row ?? directoryRef.current
+    target?.focus()
+  }
 
   const install = (skill: SkillsCatalogItem) => {
     if (!canImport || loading || loadError || installed[skill.id]) return
@@ -59,6 +66,19 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
 
   return (
     <div ref={directoryRef} tabIndex={-1} className="flex min-h-0 flex-1 flex-col" data-testid="skills-directory">
+      {previewSkill && (
+        <SkillPreviewDialog
+          key={previewSkill.id}
+          skill={previewSkill}
+          canImport={canImport}
+          installedCapabilityID={installed[previewSkill.id]}
+          installing={pendingID === previewSkill.id}
+          onInstall={() => install(previewSkill)}
+          onViewCapability={onViewCapability}
+          onClose={() => setPreviewSkill(null)}
+          onRestoreFocus={() => restoreSkillFocus(previewSkill.id)}
+        />
+      )}
       {success && !loading && !loadError && Object.values(installed).includes(success.capabilityID) ? (
         <InlineNotice
           tone="success"
@@ -90,11 +110,7 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
           detail={installMut.error instanceof Error ? installMut.error.message : String(installMut.error)}
           onClose={() => installMut.reset()}
           onRetry={() => install(failedSkill)}
-          onRestoreFocus={() => {
-            const row = directoryRef.current?.querySelector<HTMLElement>(`[data-catalog-id="${CSS.escape(failedSkill.id)}"]`)
-            const target = row ?? directoryRef.current
-            target?.focus()
-          }}
+          onRestoreFocus={() => restoreSkillFocus(failedSkill.id)}
         />
       ) : null}
 
@@ -135,6 +151,7 @@ export function SkillsDirectory({ query, canImport, onViewCapability }: SkillsDi
                 installedCapabilityID={installed[skill.id]}
                 numberFormatter={numberFormatter}
                 onInstall={() => install(skill)}
+                onPreview={() => setPreviewSkill(skill)}
                 onViewCapability={onViewCapability}
               />
             ))}
@@ -152,6 +169,7 @@ function SkillRow({
   installedCapabilityID,
   numberFormatter,
   onInstall,
+  onPreview,
   onViewCapability,
 }: {
   skill: SkillsCatalogItem
@@ -160,21 +178,20 @@ function SkillRow({
   installedCapabilityID?: string
   numberFormatter: Intl.NumberFormat
   onInstall: () => void
+  onPreview: () => void
   onViewCapability: (capabilityID: string) => void
 }) {
   const { t } = useTranslation("admin")
   const sourceType = skill.sourceType ?? skill.source_type
-  // Rows have no detail view; Enter triggers the row's one action.
-  const primary = installedCapabilityID ? () => onViewCapability(installedCapabilityID) : onInstall
   const onKeyDown = (e: KeyboardEvent<HTMLLIElement>) => {
     if (e.target !== e.currentTarget) return
     if (e.key === "Enter") {
       e.preventDefault()
-      primary()
+      onPreview()
     }
   }
   return (
-    <LedgerRow onKeyDown={onKeyDown} data-testid="skills-directory-row" data-catalog-id={skill.id}>
+    <LedgerRow onClick={onPreview} onKeyDown={onKeyDown} data-testid="skills-directory-row" data-catalog-id={skill.id}>
       <LedgerNum muted>{skill.rank ?? "—"}</LedgerNum>
       <span className="flex min-w-0 items-center gap-2">
         <span className="min-w-0 truncate font-medium" title={skill.name || skill.slug}>{skill.name || skill.slug}</span>

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -9028,6 +9028,84 @@ paths:
       summary: List installed Skills.sh skills
       tags:
       - capabilities
+  /api/v1/workspaces/{workspaceID}/skills/preview:
+    post:
+      consumes:
+      - application/json
+      description: Downloads and parses the current repository content with the existing
+        Skills installer and ZIP parser. Owner/admin only. Does not install a capability.
+      operationId: previewSkillsShSkill
+      parameters:
+      - description: Workspace UUID
+        in: path
+        name: workspaceID
+        required: true
+        type: string
+      - description: Skills.sh source
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dev.installSkillRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: canonical_spec, warnings, suggested_name
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "422":
+          description: Unprocessable Entity
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "502":
+          description: Bad Gateway
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Service Unavailable
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Preview a Skills.sh Skill before installation
+      tags:
+      - capabilities
   /api/v1/workspaces/{workspaceID}/spec/fragments:
     get:
       description: Returns spec fragments visible to the workspace. Optional source/tag

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -9051,7 +9051,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: canonical_spec, warnings, suggested_name
+          description: canonical_spec, warnings, suggested_name, entry_markdown
           schema:
             additionalProperties: true
             type: object

--- a/server/internal/capability/parser/skill_parser.go
+++ b/server/internal/capability/parser/skill_parser.go
@@ -14,6 +14,7 @@ type SkillParseResult struct {
 	Spec          canonical.Spec
 	Warnings      []string
 	SuggestedName string
+	EntryMarkdown string
 }
 
 type skillFrontmatter struct {

--- a/server/internal/capability/parser/skill_zip_parser.go
+++ b/server/internal/capability/parser/skill_zip_parser.go
@@ -187,6 +187,7 @@ func ParseSkillZip(buf []byte) (SkillParseResult, error) {
 	}
 	skillRes.Spec.Skill.Files = files
 	skillRes.Warnings = warnings
+	skillRes.EntryMarkdown = string(skillMdBytes)
 	return skillRes, nil
 }
 

--- a/server/internal/capability/parser/skill_zip_source_test.go
+++ b/server/internal/capability/parser/skill_zip_source_test.go
@@ -1,0 +1,22 @@
+package parser
+
+import "testing"
+
+func TestParseSkillZipPreservesEntrySource(t *testing.T) {
+	source := "---\r\n# Keep this comment\r\nname: quoted-skill\r\ndescription: \"Read a report\"\r\nallowed-tools: Read\r\ndisable-model-invocation: true\r\n---\r\n\r\nRead the report.\r\n"
+	for _, name := range []string{"SKILL.md", "wrapped/skill.md"} {
+		t.Run(name, func(t *testing.T) {
+			buf := buildZip(t, []struct{ name, content string }{{name, source}})
+			res, err := ParseSkillZip(buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if res.EntryMarkdown != source {
+				t.Fatalf("entry source changed: %q", res.EntryMarkdown)
+			}
+			if res.Spec.Skill == nil || len(res.Spec.Skill.Files) != 0 {
+				t.Fatal("entry source must stay outside canonical supporting files")
+			}
+		})
+	}
+}

--- a/server/internal/dev/routes.go
+++ b/server/internal/dev/routes.go
@@ -650,8 +650,7 @@ func RegisterRoutesWithStore(r chi.Router, runtimeStore RuntimeStore, opts ...Ro
 			// the all-or-nothing materialization.
 			r.Post("/workspaces/{workspaceID}/capabilities/import/preview", previewCapabilityImport(runtimeStore, cfg.blobStore))
 			r.Post("/workspaces/{workspaceID}/capabilities/import/commit", commitCapabilityImport(runtimeStore, cfg.blobStore))
-			r.Get("/workspaces/{workspaceID}/skills/installed", listSkillsDirectoryInstalls(runtimeStore))
-			r.Post("/workspaces/{workspaceID}/skills/install", installSkillFromRegistry(runtimeStore, cfg.blobStore, cfg.skillInstallRunner, cfg.skillInstallHTTPClient))
+			registerSkillsDirectoryRoutes(r, runtimeStore, cfg)
 			r.Post("/workspaces/{workspaceID}/capabilities/plugins/install", installPlugin(runtimeStore))
 			// Plugin client bundle serving — browser fetches the built
 			// client.js for each enabled plugin.

--- a/server/internal/dev/skills_directory_routes.go
+++ b/server/internal/dev/skills_directory_routes.go
@@ -1,6 +1,16 @@
 package dev
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func registerSkillsDirectoryRoutes(r chi.Router, runtimeStore RuntimeStore, cfg *routerConfig) {
+	r.Get("/workspaces/{workspaceID}/skills/installed", listSkillsDirectoryInstalls(runtimeStore))
+	r.Post("/workspaces/{workspaceID}/skills/install", installSkillFromRegistry(runtimeStore, cfg.blobStore, cfg.skillInstallRunner, cfg.skillInstallHTTPClient))
+	r.Post("/workspaces/{workspaceID}/skills/preview", previewSkillFromRegistry(runtimeStore, cfg.skillInstallRunner))
+}
 
 // listSkillsDirectoryInstalls returns persisted Skills.sh installation identities.
 //

--- a/server/internal/dev/skills_install_routes.go
+++ b/server/internal/dev/skills_install_routes.go
@@ -39,6 +39,14 @@ type skillInstallCommandRunner interface {
 type defaultSkillInstallRunner struct{}
 
 func (defaultSkillInstallRunner) Run(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+	cmd, err := newSkillInstallCommand(ctx, dir, name, args...)
+	if err != nil {
+		return nil, err
+	}
+	return cmd.CombinedOutput()
+}
+
+func newSkillInstallCommand(ctx context.Context, dir string, name string, args ...string) (*exec.Cmd, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Dir = dir
 	env, err := skillInstallCommandEnv()
@@ -46,7 +54,7 @@ func (defaultSkillInstallRunner) Run(ctx context.Context, dir string, name strin
 		return nil, err
 	}
 	cmd.Env = env
-	return cmd.CombinedOutput()
+	return cmd, nil
 }
 
 func skillInstallCommandEnv() ([]string, error) {

--- a/server/internal/dev/skills_preview_routes.go
+++ b/server/internal/dev/skills_preview_routes.go
@@ -11,6 +11,11 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/server/internal/paths"
 )
 
+type skillDirectoryPreviewResponse struct {
+	previewCapabilityImportResponse
+	EntryMarkdown string `json:"entry_markdown"`
+}
+
 // previewSkillFromRegistry downloads into disposable storage without creating
 // a capability, installation identity, or persistent upload.
 //
@@ -22,7 +27,7 @@ import (
 //	@Produce	json
 //	@Param		workspaceID	path	string	true	"Workspace UUID"
 //	@Param		body	body	installSkillRequest	true	"Skills.sh source"
-//	@Success	200	{object}	map[string]interface{}	"canonical_spec, warnings, suggested_name"
+//	@Success	200	{object}	map[string]interface{}	"canonical_spec, warnings, suggested_name, entry_markdown"
 //	@Failure	400	{object}	map[string]string
 //	@Failure	401	{object}	map[string]string
 //	@Failure	403	{object}	map[string]string
@@ -82,10 +87,13 @@ func previewSkillFromRegistry(runtimeStore RuntimeStore, runner skillInstallComm
 			writeImportParseError(w, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, previewCapabilityImportResponse{
-			CanonicalSpec: res.Spec,
-			Warnings:      ensureStringSlice(res.Warnings),
-			SuggestedName: res.SuggestedName,
+		writeJSON(w, http.StatusOK, skillDirectoryPreviewResponse{
+			previewCapabilityImportResponse: previewCapabilityImportResponse{
+				CanonicalSpec: res.Spec,
+				Warnings:      ensureStringSlice(res.Warnings),
+				SuggestedName: res.SuggestedName,
+			},
+			EntryMarkdown: res.EntryMarkdown,
 		})
 	}
 }

--- a/server/internal/dev/skills_preview_routes.go
+++ b/server/internal/dev/skills_preview_routes.go
@@ -72,7 +72,7 @@ func previewSkillFromRegistry(runtimeStore RuntimeStore, runner skillInstallComm
 			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
 			return
 		}
-		zipBytes, err := zipSkillDirectory(skillDir)
+		zipBytes, err := zipSkillDirectory(ctx, skillDir)
 		if err != nil {
 			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
 			return

--- a/server/internal/dev/skills_preview_routes.go
+++ b/server/internal/dev/skills_preview_routes.go
@@ -34,7 +34,7 @@ import (
 //	@Router		/api/v1/workspaces/{workspaceID}/skills/preview [post]
 func previewSkillFromRegistry(runtimeStore RuntimeStore, runner skillInstallCommandRunner) http.HandlerFunc {
 	if runner == nil {
-		runner = defaultSkillInstallRunner{}
+		runner = defaultSkillPreviewRunner{}
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		if _, ok := requireWorkspaceCapabilityAdmin(w, r, runtimeStore); !ok {

--- a/server/internal/dev/skills_preview_routes.go
+++ b/server/internal/dev/skills_preview_routes.go
@@ -1,0 +1,91 @@
+package dev
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/parser"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/paths"
+)
+
+// previewSkillFromRegistry downloads into disposable storage without creating
+// a capability, installation identity, or persistent upload.
+//
+//	@Summary	Preview a Skills.sh Skill before installation
+//	@Description	Downloads and parses the current repository content with the existing Skills installer and ZIP parser. Owner/admin only. Does not install a capability.
+//	@Tags		capabilities
+//	@ID			previewSkillsShSkill
+//	@Accept		json
+//	@Produce	json
+//	@Param		workspaceID	path	string	true	"Workspace UUID"
+//	@Param		body	body	installSkillRequest	true	"Skills.sh source"
+//	@Success	200	{object}	map[string]interface{}	"canonical_spec, warnings, suggested_name"
+//	@Failure	400	{object}	map[string]string
+//	@Failure	401	{object}	map[string]string
+//	@Failure	403	{object}	map[string]string
+//	@Failure	404	{object}	map[string]string
+//	@Failure	422	{object}	map[string]string
+//	@Failure	500	{object}	map[string]string
+//	@Failure	502	{object}	map[string]string
+//	@Failure	503	{object}	map[string]string
+//	@Router		/api/v1/workspaces/{workspaceID}/skills/preview [post]
+func previewSkillFromRegistry(runtimeStore RuntimeStore, runner skillInstallCommandRunner) http.HandlerFunc {
+	if runner == nil {
+		runner = defaultSkillInstallRunner{}
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := requireWorkspaceCapabilityAdmin(w, r, runtimeStore); !ok {
+			return
+		}
+		var body installSkillRequest
+		if err := decodeBody(r, &body); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+			return
+		}
+		if msg := validateInstallSkillRequest(body); msg != "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": msg})
+			return
+		}
+		root, err := paths.Root()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not resolve skill preview directory"})
+			return
+		}
+		previewDir := filepath.Join(root, "tmp", "skill-previews")
+		if err := os.MkdirAll(previewDir, 0o700); err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not create skill preview directory"})
+			return
+		}
+		tmpDir, err := os.MkdirTemp(previewDir, "preview-*")
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "could not create temporary skill directory"})
+			return
+		}
+		defer os.RemoveAll(tmpDir)
+		ctx, cancel := context.WithTimeout(r.Context(), 90*time.Second)
+		defer cancel()
+		skillDir, err := downloadSkillToTemp(ctx, runner, tmpDir, body.Source, body.Slug)
+		if err != nil {
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+			return
+		}
+		zipBytes, err := zipSkillDirectory(skillDir)
+		if err != nil {
+			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
+			return
+		}
+		res, err := parser.ParseSkillZip(zipBytes)
+		if err != nil {
+			writeImportParseError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, previewCapabilityImportResponse{
+			CanonicalSpec: res.Spec,
+			Warnings:      ensureStringSlice(res.Warnings),
+			SuggestedName: res.SuggestedName,
+		})
+	}
+}

--- a/server/internal/dev/skills_preview_routes_test.go
+++ b/server/internal/dev/skills_preview_routes_test.go
@@ -28,7 +28,7 @@ func TestSkillPreviewFromRegistry_ReadOnlyAndCleansUp(t *testing.T) {
 	if res.Code != http.StatusOK {
 		t.Fatalf("preview status = %d: %s", res.Code, res.Body.String())
 	}
-	var result previewCapabilityImportResponse
+	var result skillDirectoryPreviewResponse
 	if err := json.Unmarshal(res.Body.Bytes(), &result); err != nil {
 		t.Fatal(err)
 	}
@@ -38,6 +38,9 @@ func TestSkillPreviewFromRegistry_ReadOnlyAndCleansUp(t *testing.T) {
 	}
 	if skill.Description != "Triage Gmail with Workspace CLI" {
 		t.Fatalf("description = %q", skill.Description)
+	}
+	if !strings.Contains(result.EntryMarkdown, "name: Gmail Triage\n") || !strings.HasSuffix(result.EntryMarkdown, "triage mail.\n") {
+		t.Fatalf("missing original SKILL.md: %q", result.EntryMarkdown)
 	}
 	var count int
 	if err := db.QueryRow(context.Background(), "select count(*) from capability where workspace_id = $1 and type = 'skill'", ids.WorkspaceID).Scan(&count); err != nil {

--- a/server/internal/dev/skills_preview_routes_test.go
+++ b/server/internal/dev/skills_preview_routes_test.go
@@ -1,0 +1,99 @@
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+const skillPreviewTestBody = `{"source":"googleworkspace/cli","slug":"gws-gmail-triage","registry_id":"googleworkspace/cli/gws-gmail-triage","registry":"skills.sh"}`
+
+func TestSkillPreviewFromRegistry_ReadOnlyAndCleansUp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	runner := &fakeSkillInstallRunner{t: t, writeSkill: true}
+	r, db, _ := skillsInstallTestRouter(t, runner)
+	ids := store.DefaultDevFixtureIDs()
+	res := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+ids.WorkspaceID+"/skills/preview", skillPreviewTestBody, ids.UserID)
+	if res.Code != http.StatusOK {
+		t.Fatalf("preview status = %d: %s", res.Code, res.Body.String())
+	}
+	var result previewCapabilityImportResponse
+	if err := json.Unmarshal(res.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	skill := result.CanonicalSpec.Skill
+	if skill == nil || result.SuggestedName != "Gmail Triage" || !strings.Contains(skill.Instruction, "Gmail labels") || len(skill.Files) != 2 {
+		t.Fatalf("missing parsed instructions or files: %+v", result)
+	}
+	if skill.Description != "Triage Gmail with Workspace CLI" {
+		t.Fatalf("description = %q", skill.Description)
+	}
+	var count int
+	if err := db.QueryRow(context.Background(), "select count(*) from capability where workspace_id = $1 and type = 'skill'", ids.WorkspaceID).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("preview created %d capabilities", count)
+	}
+	installs, err := store.New(db).ListSkillsDirectoryInstalls(context.Background(), ids.WorkspaceID)
+	if err != nil || len(installs) != 0 {
+		t.Fatalf("preview persisted installation: %v, %v", installs, err)
+	}
+	if !strings.HasPrefix(runner.lastDir, filepath.Join(os.Getenv("HOME"), ".parsar")+string(os.PathSeparator)) {
+		t.Fatalf("preview storage escaped Parsar root: %s", runner.lastDir)
+	}
+	if _, err := os.Stat(runner.lastDir); !os.IsNotExist(err) {
+		t.Fatalf("preview directory not removed: %v", err)
+	}
+}
+
+func TestSkillPreviewFromRegistry_DeniesBeforeDownload(t *testing.T) {
+	for _, tc := range []struct {
+		name, role, user, body string
+		status                 int
+	}{
+		{"anonymous", "admin", "", skillPreviewTestBody, http.StatusUnauthorized},
+		{"member", "member", "user", skillPreviewTestBody, http.StatusForbidden},
+		{"invalid source", "admin", "user", strings.Replace(skillPreviewTestBody, "googleworkspace/cli", "../cli", 1), http.StatusBadRequest},
+		{"invalid json", "admin", "user", "{", http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &fakeSkillInstallRunner{t: t}
+			rbac := capabilityRBACStore{workspaceRoles: map[string]string{"user": tc.role}}
+			r := chi.NewRouter()
+			RegisterRoutesWithStore(r, rbac, WithSkillInstallRunner(runner), WithAuthMiddleware(auth.NewMiddleware(newStubSessions()).WithDevAuth(true)))
+			req := newRequestWithDevUser(http.MethodPost, "/api/v1/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/skills/preview", tc.body, tc.user)
+			res := httptest.NewRecorder()
+			r.ServeHTTP(res, req)
+			if res.Code != tc.status || runner.called {
+				t.Fatalf("status = %d, runner called = %v, body = %s", res.Code, runner.called, res.Body.String())
+			}
+		})
+	}
+}
+
+func TestSkillPreviewFromRegistry_FailedDownloadCleansUp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	runner := &fakeSkillInstallRunner{t: t, returnError: errors.New("repository unavailable")}
+	rbac := capabilityRBACStore{workspaceRoles: map[string]string{"user": "admin"}}
+	r := chi.NewRouter()
+	r.Post("/workspaces/{workspaceID}/skills/preview", previewSkillFromRegistry(rbac, runner))
+	res := serveCapabilityRoute(t, r, http.MethodPost, "/workspaces/"+store.DefaultDevFixtureIDs().WorkspaceID+"/skills/preview", skillPreviewTestBody, "user")
+	if res.Code != http.StatusBadGateway || !runner.called {
+		t.Fatalf("status = %d, runner called = %v", res.Code, runner.called)
+	}
+	if _, err := os.Stat(runner.lastDir); !os.IsNotExist(err) {
+		t.Fatalf("failed preview directory not removed: %v", err)
+	}
+}

--- a/server/internal/dev/skills_preview_routes_test.go
+++ b/server/internal/dev/skills_preview_routes_test.go
@@ -66,6 +66,9 @@ func TestSkillPreviewFromRegistry_DeniesBeforeDownload(t *testing.T) {
 		{"anonymous", "admin", "", skillPreviewTestBody, http.StatusUnauthorized},
 		{"member", "member", "user", skillPreviewTestBody, http.StatusForbidden},
 		{"invalid source", "admin", "user", strings.Replace(skillPreviewTestBody, "googleworkspace/cli", "../cli", 1), http.StatusBadRequest},
+		{"option slug", "admin", "user", strings.Replace(skillPreviewTestBody, "gws-gmail-triage", "--global", 1), http.StatusBadRequest},
+		{"option owner", "admin", "user", strings.Replace(skillPreviewTestBody, "googleworkspace/cli", "-owner/cli", 1), http.StatusBadRequest},
+		{"local source", "admin", "user", strings.Replace(skillPreviewTestBody, "googleworkspace/cli", "/googleworkspace/cli", 1), http.StatusBadRequest},
 		{"invalid json", "admin", "user", "{", http.StatusBadRequest},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/dev/skills_preview_runner_other.go
+++ b/server/internal/dev/skills_preview_runner_other.go
@@ -1,0 +1,14 @@
+//go:build !unix
+
+package dev
+
+import (
+	"context"
+	"errors"
+)
+
+type defaultSkillPreviewRunner struct{}
+
+func (defaultSkillPreviewRunner) Run(context.Context, string, string, ...string) ([]byte, error) {
+	return nil, errors.New("Skill previews require a Unix server with process-group cancellation support")
+}

--- a/server/internal/dev/skills_preview_runner_unix.go
+++ b/server/internal/dev/skills_preview_runner_unix.go
@@ -1,0 +1,28 @@
+//go:build unix
+
+package dev
+
+import (
+	"context"
+	"syscall"
+	"time"
+)
+
+type defaultSkillPreviewRunner struct{}
+
+func (defaultSkillPreviewRunner) Run(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+	cmd, err := newSkillInstallCommand(ctx, dir, name, args...)
+	if err != nil {
+		return nil, err
+	}
+	// The CLI clones via os.tmpdir(), independently of its working directory.
+	cmd.Env = append(cmd.Env, "TMPDIR="+dir, "TMP="+dir, "TEMP="+dir)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		// npx launches Node and git; killing only npx leaves their output pipes
+		// open and lets downloads outlive the request directory.
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = time.Second
+	return cmd.CombinedOutput()
+}

--- a/server/internal/dev/skills_preview_runner_unix_test.go
+++ b/server/internal/dev/skills_preview_runner_unix_test.go
@@ -1,0 +1,55 @@
+//go:build unix
+
+package dev
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSkillPreviewRunnerScopesTemporaryFiles(t *testing.T) {
+	dir := t.TempDir()
+	out, err := (defaultSkillPreviewRunner{}).Run(context.Background(), dir, "sh", "-c", `printf '%s\n' "$TMPDIR" "$TMP" "$TEMP"`)
+	if err != nil || string(out) != strings.Repeat(dir+"\n", 3) {
+		t.Fatalf("temporary directories = %q, err = %v", out, err)
+	}
+}
+
+func TestSkillPreviewRunnerCancelsDescendants(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := (defaultSkillPreviewRunner{}).Run(ctx, dir, "sh", "-c", `(sleep 2; printf leaked > leaked) & printf ready > ready; wait`)
+		done <- err
+	}()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "ready")); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("preview child did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("cancelled preview returned success")
+		}
+	case <-time.After(1500 * time.Millisecond):
+		t.Fatal("preview kept waiting on a child output pipe")
+	}
+	// A child that survived cancellation would still write into the directory.
+	time.Sleep(2100 * time.Millisecond)
+	if _, err := os.Stat(filepath.Join(dir, "leaked")); !os.IsNotExist(err) {
+		t.Fatalf("preview child outlived cancellation: %v", err)
+	}
+}


### PR DESCRIPTION
Skills directory rows now open a preview of the current Skill description, repository, original SKILL.md and supporting files before installation. Loading, retry, installation and installed-capability navigation stay in the dialog flow, with focus returned to the directory row on close.

The owner/admin-only endpoint uses disposable download storage, bounded packaging and cancellation of the download process group. It creates no capability, upload or installation record. Original SKILL.md source is returned separately from canonical metadata so extended frontmatter and formatting remain visible. Installation still fetches independently; the preview is not a pinned revision. Existing Agent bindings, credentials, publishing, version management and canonical stored data are unchanged.

Validation: full `make check`, regenerated OpenAPI, isolated PostgreSQL preview/install/package tests, process cancellation and original-source preservation tests, and independent blind review with no findings. Real-browser checks covered preview → install → workspace, English/light and Chinese/dark, original metadata, close-focus restoration, service failure/retry and disabled install states. Local Docker stayed off; database route tests ran against an isolated remote PostgreSQL database.
