### PR TITLE
fix(server): reject CLI options in Skill install references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,9 @@ description and keep ownership on the side listed here.
   `git` for server-side Skills.sh installs. Keep the runtime image compatible
   with the pinned `skills` package in `skills_install_routes.go`; the image
   build must fail if these executables are missing.
+- Skills.sh downloads accept an exact `owner/repo` reference and a Skill slug,
+  never a local path or a value the CLI could interpret as an option. Validate
+  these inputs before invoking the installer.
 
 ### Runtime and execution concepts
 

--- a/server/internal/dev/skills_install_routes.go
+++ b/server/internal/dev/skills_install_routes.go
@@ -233,7 +233,7 @@ func validateInstallSkillRequest(body installSkillRequest) string {
 		return "source must be an owner/repo GitHub reference"
 	}
 	if !validSkillSlug(body.Slug) {
-		return "slug is required and may only contain letters, numbers, dot, underscore, and hyphen"
+		return "slug is required, must not start with a hyphen, and may only contain letters, numbers, dot, underscore, and hyphen"
 	}
 	if strings.TrimSpace(body.RegistryID) == "" {
 		return "registry_id is required"
@@ -242,12 +242,12 @@ func validateInstallSkillRequest(body installSkillRequest) string {
 }
 
 func validSkillSourceRef(source string) bool {
-	parts := strings.Split(strings.TrimSpace(strings.Trim(source, "/")), "/")
-	return len(parts) == 2 && validSkillRefPart(parts[0]) && validSkillRefPart(parts[1])
+	parts := strings.Split(strings.TrimSpace(source), "/")
+	return len(parts) == 2 && !strings.HasPrefix(parts[0], "-") && validSkillRefPart(parts[0]) && validSkillRefPart(parts[1])
 }
 
 func validSkillSlug(slug string) bool {
-	return validSkillRefPart(slug)
+	return !strings.HasPrefix(slug, "-") && validSkillRefPart(slug)
 }
 
 func validSkillRefPart(part string) bool {

--- a/server/internal/dev/skills_install_validation_test.go
+++ b/server/internal/dev/skills_install_validation_test.go
@@ -1,0 +1,45 @@
+package dev
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/storage/blob"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func TestSkillInstallRejectsCLIOptionsAndLocalPaths(t *testing.T) {
+	for _, tc := range []struct{ source, slug string }{
+		{"owner/repo", "--global"},
+		{"owner/repo", "-g"},
+		{"owner/repo", "--"},
+		{"-owner/repo", "skill"},
+		{"/owner/repo", "skill"},
+		{"owner/repo/", "skill"},
+	} {
+		t.Run(tc.source+":"+tc.slug, func(t *testing.T) {
+			runner := &fakeSkillInstallRunner{t: t}
+			ids := store.DefaultDevFixtureIDs()
+			rbac := capabilityRBACStore{workspaceRoles: map[string]string{ids.UserID: "admin"}}
+			r := chi.NewRouter()
+			RegisterRoutesWithStore(r, rbac, WithBlobStore(blob.NewMemoryStore("https://api.test")), WithSkillInstallRunner(runner))
+			body := mustJSON(t, installSkillRequest{Source: tc.source, Slug: tc.slug, RegistryID: "test", Registry: skillsRegistryName})
+			res := serveCapabilityRoute(t, r, http.MethodPost, "/api/v1/workspaces/"+ids.WorkspaceID+"/skills/install", body, ids.UserID)
+			if res.Code != http.StatusBadRequest || runner.called {
+				t.Fatalf("status = %d, runner called = %v, response = %s", res.Code, runner.called, res.Body.String())
+			}
+		})
+	}
+}
+
+func TestSkillInstallAcceptsSafeRepositoryReferences(t *testing.T) {
+	for _, source := range []string{"owner/repo", "my-org/skill.repo", "owner/-repo", " owner/repo "} {
+		for _, slug := range []string{"skill", "my-skill", "skill_v1.0"} {
+			if msg := validateInstallSkillRequest(installSkillRequest{Source: source, Slug: slug, RegistryID: "test", Registry: skillsRegistryName}); msg != "" {
+				t.Errorf("rejected source %q, slug %q: %s", source, slug, msg)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Skill installation accepted option-shaped slugs and source strings that the upstream CLI could interpret as local paths. Reject those values before invoking the downloader, while preserving ordinary owner/repo references and safe Skill names.

Scope: input validation only; installation, credentials, permissions and persistence are unchanged.

Validation: the new route tests fail against the baseline because the runner is invoked, then pass with the guard; safe-reference cases pass. `make check` passed and OpenAPI regeneration produced no changes. Tests use a fake downloader and do not execute the unsafe CLI arguments.
