### PR TITLE
fix(web): explain package reuse without exposing storage keys

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -740,7 +740,7 @@
         "description": "Saving assigns the next version automatically. Check each Agent’s Config tab for the version it will use.",
         "prefillFromLatest": "Prefilled from the previous version ({{version}}). Edits become the new version on submit.",
         "inlineSecretLostWarning": "Inline secret(s) from the previous version ({{keys}}) are hidden. Re-enter the plaintext to keep them, or switch to a managed credential.",
-        "reuseExistingZip": "Current version package: {{filename}}. If you do not re-upload, the new version will reuse this package."
+        "reuseExistingZip": "You can reuse the current file package or replace its contents below."
       },
       "viewContent": {
         "title": "View {{version}} content",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -740,7 +740,7 @@
         "description": "保存后会自动生成下一个版本。请在各 Agent 的配置页查看实际使用的版本。",
         "prefillFromLatest": "已用上一版（{{version}}）的内容预填。修改后会作为新版本提交。",
         "inlineSecretLostWarning": "上一版的 inline secret（{{keys}}）已隐藏。如需保留，请重新输入明文；或改成已托管的凭据。",
-        "reuseExistingZip": "当前版本的文件包：{{filename}}。如果不重新上传，新版本将沿用这个文件包。"
+        "reuseExistingZip": "可沿用当前版本的文件包，也可以在下方替换内容。"
       },
       "viewContent": {
         "title": "查看 {{version}} 内容",

--- a/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
@@ -10,7 +10,7 @@
  *     only stores ciphertext).
  *   - Plugin / skill-zip kinds: if the user doesn't upload a new zip, the
  *     server reuses the previous version's OSS bytes (commit handler treats
- *     missing oss_key as "reuse latest"). UI shows the existing filename.
+ *     missing oss_key as "reuse latest"). UI explains package reuse.
  *   - Commits to .../capabilities/{id}/versions/import/commit (after an
  *     optional PATCH for name/description).
  */
@@ -92,9 +92,8 @@ export function AddCapabilityVersionDialog({
   const [skillOssKey, setSkillOssKey] = useState<string | null>(null)
 
   const prefill = usePrefillFromLatest(latestVersion)
-  // For plugin / skill-zip rounds where the user keeps the previous OSS blob,
-  // we display the existing filename (derived from the latest version's oss_key)
-  // so the form feels like "edit", not "blank slate".
+  // Keep the existing reference check for package reuse. Storage keys are not
+  // user-facing filenames.
   const inheritedOssLabel = useMemo(() => {
     const key = latestVersion?.oss_key?.trim()
     if (!key) return null
@@ -263,9 +262,8 @@ export function AddCapabilityVersionDialog({
         {inheritedOssLabel && (kind === "plugin" || kind === "skill") && (
           <InlineNotice>
             {t("capabilities.versions.add.reuseExistingZip", {
-              filename: inheritedOssLabel,
               defaultValue:
-                "Current version package: {{filename}}. If you do not re-upload, the new version will reuse this package.",
+                "You can reuse the current file package or replace its contents below.",
             })}
           </InlineNotice>
         )}


### PR DESCRIPTION
The new-version dialog displayed an internal blob key as a package filename. It now explains that the existing package can be reused or replaced, in English and Chinese. Package validation, upload references and version submission are unchanged.

Validation: `make check`, diff self-review, and real-browser checks in both languages confirmed the storage key is absent and the existing-package submission option stays available. No version was submitted during this copy check. This isolated copy change used self-review under the contributor policy.
