### PR TITLE
fix(web): clear directory filters when viewing workspace capabilities

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -662,7 +662,7 @@
     },
     "emptyFiltered": {
       "title": "No matching capabilities",
-      "description": "Adjust the search or switch to All to see every capability.",
+      "description": "Adjust your search or clear the filters to see available capabilities.",
       "reset": "Clear filters"
     },
     "rowActions": {

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -662,7 +662,7 @@
     },
     "emptyFiltered": {
       "title": "没有匹配的能力",
-      "description": "调整搜索词或切到「全部」tab 看完整列表。",
+      "description": "调整搜索词，或清除筛选以查看可用能力。",
       "reset": "清除筛选"
     },
     "rowActions": {

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -407,7 +407,12 @@ export function CapabilitiesPage() {
       onSelectItem={(item) => navigate("capabilities", { tab: item?.startsWith("mcp:") ? "connectors" : pageTab === "workspace" ? "marketplace" : pageTab, item })}
       onInstall={goToAgentsForCapability}
       onDelete={setDeleteTarget}
-      onViewCapability={(capabilityID) => navigate("capabilities", { id: capabilityID, tab: null, item: null })}
+      onViewCapability={(capabilityID) => {
+        setQuery("")
+        setTypeFilter("")
+        setPage(1)
+        navigate("capabilities", { id: capabilityID, tab: null, item: null })
+      }}
     />
   )
 


### PR DESCRIPTION
Opening an installed capability from a directory retained its repository search and type filter, leaving the workspace list empty beside a valid detail panel. The shared navigation callback now clears those filters and resets pagination before opening the capability. Filtered-empty copy points to the existing Clear filters action.

Scope: explicit directory-to-workspace navigation and its empty-state guidance only. Normal tab switching, installation, bindings and search behavior are unchanged.

Validation: `make check`, diff self-review, and a real Skills directory repository search → Installed navigation confirmed the empty search, visible workspace rows and selected capability. No new install or binding was created during this verification.
