### PR TITLE
fix(server): bound Skill archive packaging and honor cancellation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,9 @@ description and keep ownership on the side listed here.
 - Skills.sh downloads accept an exact `owner/repo` reference and a Skill slug,
   never a local path or a value the CLI could interpret as an option. Validate
   these inputs before invoking the installer.
+- Skill directory packaging honors the request context while reading files and
+  writing the archive. Enforce the ZIP parser's existing byte and entry limits
+  during packaging, before upload or parsing can allocate oversized results.
 
 ### Runtime and execution concepts
 

--- a/server/internal/capability/parser/skill_zip_parser.go
+++ b/server/internal/capability/parser/skill_zip_parser.go
@@ -30,9 +30,9 @@ const maxSkillEntryBytes int64 = 1 << 20
 // canonical_spec jsonb.
 const maxSkillTotalDecompressedBytes int64 = 32 * 1024 * 1024
 
-// maxSkillEntryCount: thousands of entries means a packaged node_modules,
+// MaxSkillZipEntries: thousands of entries means a packaged node_modules,
 // not a Skill.
-const maxSkillEntryCount = 256
+const MaxSkillZipEntries = 256
 
 // ErrInvalidSkillZip wraps hard failures (not a zip, missing SKILL.md,
 // frontmatter broken, oversize). The import handler maps it to 4xx.
@@ -62,8 +62,8 @@ func ParseSkillZip(buf []byte) (SkillParseResult, error) {
 		return SkillParseResult{}, fmt.Errorf("%w: not a valid zip file: %v", ErrInvalidSkillZip, err)
 	}
 
-	if len(zr.File) > maxSkillEntryCount {
-		return SkillParseResult{}, fmt.Errorf("%w: skill zip contains %d entries, max %d", ErrInvalidSkillZip, len(zr.File), maxSkillEntryCount)
+	if len(zr.File) > MaxSkillZipEntries {
+		return SkillParseResult{}, fmt.Errorf("%w: skill zip contains %d entries, max %d", ErrInvalidSkillZip, len(zr.File), MaxSkillZipEntries)
 	}
 
 	// detectSingleRoot handles "user packaged with `zip -r foo/`".

--- a/server/internal/capability/parser/skill_zip_parser_test.go
+++ b/server/internal/capability/parser/skill_zip_parser_test.go
@@ -336,9 +336,9 @@ func TestParseSkillZip_NoFrontmatter_StillImports(t *testing.T) {
 }
 
 func TestParseSkillZip_TooManyEntries_Rejected(t *testing.T) {
-	entries := make([]struct{ name, content string }, 0, maxSkillEntryCount+2)
+	entries := make([]struct{ name, content string }, 0, MaxSkillZipEntries+2)
 	entries = append(entries, struct{ name, content string }{"SKILL.md", minimalSkillMd})
-	for i := range maxSkillEntryCount + 1 {
+	for i := range MaxSkillZipEntries + 1 {
 		entries = append(entries, struct{ name, content string }{
 			name:    "references/f" + strings.Repeat("x", 1) + intToStr(i) + ".md",
 			content: "x",
@@ -390,8 +390,8 @@ func TestParseSkillZip_PerEntryOversize_Skipped(t *testing.T) {
 func TestParseSkillZip_CumulativeOversize_Rejected(t *testing.T) {
 	const perEntry = maxSkillEntryBytes / 2
 	entryCount := int(maxSkillTotalDecompressedBytes/perEntry) + 2
-	if entryCount >= maxSkillEntryCount {
-		t.Skipf("perEntry=%d makes entryCount=%d collide with maxSkillEntryCount=%d — pick a smaller perEntry", perEntry, entryCount, maxSkillEntryCount)
+	if entryCount >= MaxSkillZipEntries {
+		t.Skipf("perEntry=%d makes entryCount=%d collide with MaxSkillZipEntries=%d — pick a smaller perEntry", perEntry, entryCount, MaxSkillZipEntries)
 	}
 	chunk := strings.Repeat("y", int(perEntry))
 	entries := make([]struct{ name, content string }, 0, entryCount+1)

--- a/server/internal/dev/skills_install_routes.go
+++ b/server/internal/dev/skills_install_routes.go
@@ -1,7 +1,6 @@
 package dev
 
 import (
-	"archive/zip"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -125,7 +124,7 @@ func installSkillFromRegistry(runtimeStore RuntimeStore, blobStore blob.Store, r
 			writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
 			return
 		}
-		zipBytes, err := zipSkillDirectory(skillDir)
+		zipBytes, err := zipSkillDirectory(r.Context(), skillDir)
 		if err != nil {
 			writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
 			return
@@ -329,51 +328,6 @@ func preferClaudeSkillDir(candidates []string) string {
 		}
 	}
 	return candidates[0]
-}
-
-func zipSkillDirectory(skillDir string) ([]byte, error) {
-	if !containsSkillMD(skillDir) {
-		return nil, fmt.Errorf("skill directory %q is missing SKILL.md", skillDir)
-	}
-	var buf bytes.Buffer
-	zw := zip.NewWriter(&buf)
-	err := filepath.WalkDir(skillDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		if d.Type()&os.ModeSymlink != 0 {
-			return nil
-		}
-		rel, err := filepath.Rel(skillDir, path)
-		if err != nil {
-			return err
-		}
-		rel = filepath.ToSlash(rel)
-		if rel == "." || rel == "" {
-			return nil
-		}
-		file, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-		entry, err := zw.Create(rel)
-		if err != nil {
-			return err
-		}
-		_, err = io.Copy(entry, file)
-		return err
-	})
-	if closeErr := zw.Close(); err == nil {
-		err = closeErr
-	}
-	if err != nil {
-		return nil, fmt.Errorf("could not package skill directory: %w", err)
-	}
-	return buf.Bytes(), nil
 }
 
 func storeSkillZipBytes(ctx context.Context, blobStore blob.Store, httpClient skillInstallHTTPDoer, workspaceID, filename string, data []byte) (string, *importHTTPError) {

--- a/server/internal/dev/skills_zip.go
+++ b/server/internal/dev/skills_zip.go
@@ -1,0 +1,98 @@
+package dev
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/parser"
+)
+
+func zipSkillDirectory(ctx context.Context, skillDir string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !containsSkillMD(skillDir) {
+		return nil, fmt.Errorf("skill directory %q is missing SKILL.md", skillDir)
+	}
+	buf := skillZipBuffer{ctx: ctx}
+	zw := zip.NewWriter(&buf)
+	entryCount := 0
+	err := filepath.WalkDir(skillDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		rel, err := filepath.Rel(skillDir, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "." || rel == "" {
+			return nil
+		}
+		entryCount++
+		if entryCount > parser.MaxSkillZipEntries {
+			return fmt.Errorf("%w: skill exceeds %d files", parser.ErrInvalidSkillZip, parser.MaxSkillZipEntries)
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		entry, err := zw.Create(rel)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(entry, skillContextReader{ctx: ctx, reader: file})
+		return err
+	})
+	if closeErr := zw.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return nil, fmt.Errorf("could not package skill directory: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// Enforce the parser's compressed-size cap while producing the archive.
+type skillZipBuffer struct {
+	bytes.Buffer
+	ctx context.Context
+}
+
+func (b *skillZipBuffer) Write(p []byte) (int, error) {
+	if err := b.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if len(p) > parser.MaxSkillZipBytes-b.Len() {
+		return 0, fmt.Errorf("%w: skill zip exceeds %d bytes", parser.ErrInvalidSkillZip, parser.MaxSkillZipBytes)
+	}
+	return b.Buffer.Write(p)
+}
+
+// Hide os.File.WriteTo so io.Copy checks cancellation between reads.
+type skillContextReader struct {
+	ctx    context.Context
+	reader io.Reader
+}
+
+func (r skillContextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.reader.Read(p)
+}

--- a/server/internal/dev/skills_zip_test.go
+++ b/server/internal/dev/skills_zip_test.go
@@ -1,0 +1,78 @@
+package dev
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/parser"
+)
+
+func TestSkillPackageRejectsOversize(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: example\ndescription: Example\n---\nInstructions."), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	data := make([]byte, parser.MaxSkillZipBytes+1)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "large.bin"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := zipSkillDirectory(context.Background(), dir)
+	if err == nil || out != nil {
+		t.Fatalf("oversize archive returned %d bytes, err = %v", len(out), err)
+	}
+}
+
+func TestSkillPackageRejectsTooManyFiles(t *testing.T) {
+	dir := t.TempDir()
+	for i := range parser.MaxSkillZipEntries {
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("file-%d", i)), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("Instructions"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	out, err := zipSkillDirectory(context.Background(), dir)
+	if !errors.Is(err, parser.ErrInvalidSkillZip) || out != nil {
+		t.Fatalf("too many files: %d bytes, %v", len(out), err)
+	}
+}
+
+func TestSkillPackageRejectsCancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	out, err := zipSkillDirectory(ctx, t.TempDir())
+	if !errors.Is(err, context.Canceled) || out != nil {
+		t.Fatalf("cancelled package: %d bytes, %v", len(out), err)
+	}
+}
+
+func TestSkillPackageCopyStopsBetweenReads(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	source := &cancellingSkillReader{cancel: cancel}
+	_, err := io.Copy(io.Discard, skillContextReader{ctx: ctx, reader: source})
+	if !errors.Is(err, context.Canceled) || source.reads != 1 {
+		t.Fatalf("copy after cancellation: reads = %d, err = %v", source.reads, err)
+	}
+}
+
+type cancellingSkillReader struct {
+	cancel context.CancelFunc
+	reads  int
+}
+
+func (r *cancellingSkillReader) Read(p []byte) (int, error) {
+	r.reads++
+	r.cancel()
+	return len(p), nil
+}


### PR DESCRIPTION
Downloaded Skills were fully compressed before the ZIP parser checked its existing limits, and packaging kept reading after the request was cancelled. Packaging now stops on cancellation and enforces the same 8 MiB compressed-size and 256-entry limits before an archive is uploaded.

The packaging helper is extracted from the install route. Valid archive contents and parser acceptance rules are unchanged; downloader lifecycle, permissions and credentials are outside this PR.

Validation: the oversized-archive regression failed on the baseline and passes after the change; cancellation, entry-count and existing install route tests pass locally and with isolated remote PostgreSQL. `make check` passes; OpenAPI regeneration produced no changes. Local Docker smoke checks are skipped because local Docker stays stopped.
