### PR TITLE
fix(web): collapse empty capability import preview columns

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1034,7 +1034,7 @@
       },
       "preview": {
         "errorFallback": "Failed to parse",
-        "idle": "Paste content on the left to see the parsed result here",
+        "idle": "Paste or upload content to see the preview.",
         "loading": "Parsing…",
         "warnings": "Parse warnings"
       },

--- a/apps/web/src/pages/admin/capabilities/ImportMCPForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportMCPForm.tsx
@@ -140,7 +140,7 @@ export function ImportMCPForm({
         : "idle"
 
   return (
-    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(360px,1fr)]">
+    <div className={`grid gap-4 ${status !== "idle" ? "lg:grid-cols-[minmax(0,1fr)_minmax(360px,1fr)]" : ""}`}>
       {/* ---- LEFT: raw input ---- */}
       <div className="min-w-0">
         <div className="mb-2 flex items-center gap-2">
@@ -183,7 +183,7 @@ export function ImportMCPForm({
       </div>
 
       {/* ---- RIGHT: parsed preview ---- */}
-      <div className="min-w-0 space-y-4 lg:pt-9">
+      <div className={`min-w-0 space-y-4 ${status !== "idle" ? "lg:pt-9" : ""}`}>
         <ImportPreview
           status={status as "idle" | "loading" | "error" | "ready"}
           errorMessage={errorMessage}

--- a/apps/web/src/pages/admin/capabilities/ImportPluginForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportPluginForm.tsx
@@ -164,7 +164,7 @@ export function ImportPluginForm({
   const errMsg = localErr ?? null
 
   return (
-    <div className="grid gap-4 md:grid-cols-2">
+    <div className={`grid gap-4 ${validation || busy ? "md:grid-cols-2" : ""}`}>
       <div className="min-w-0">
         <Label htmlFor="plugin-zip-input">{t("capabilities.import.plugin.uploadLabel", "Upload Plugin zip")}</Label>
         {!file ? (

--- a/apps/web/src/pages/admin/capabilities/ImportPreview.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportPreview.tsx
@@ -42,7 +42,7 @@ export function ImportPreview({
     <div className="space-y-2">
       {status === "idle" && (
         <p className="text-sm text-fg-muted">
-          {t("capabilities.import.preview.idle", "Paste content on the left to see the parsed result here")}
+          {t("capabilities.import.preview.idle", "Paste or upload content to see the preview.")}
         </p>
       )}
 

--- a/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
@@ -257,15 +257,8 @@ export function ImportSkillForm({
         </TabsList>
       </Tabs>
 
-      {/* Layout:
-       *   paste mode → two columns (editor on the left, live preview on
-       *     the right, side-by-side comparison is the point).
-       *   zip mode  → single column. The dropzone is a small target that
-       *     looks lonely in a half-width column, and the preview wants
-       *     every pixel it can get (SKILL.md and supporting files all stack
-       *     vertically). Stack input above preview instead. */}
-      <div className={source === "paste" ? "grid gap-4 md:grid-cols-2" : "grid gap-4"}>
-        <div className={`min-w-0 ${source === "paste" ? "max-w-3xl" : ""}`}>
+      <div className={source === "paste" && status !== "idle" ? "grid gap-4 md:grid-cols-2" : "grid gap-4"}>
+        <div className="min-w-0">
           {source === "paste" ? (
             <>
               <Label htmlFor="import-skill-markdown">{t("capabilities.import.skill.markdown", "Markdown content")}</Label>
@@ -317,8 +310,6 @@ export function ImportSkillForm({
           )}
         </div>
 
-        {/* ---- PREVIEW: half-width beside the editor in paste mode, full
-         *  width under the dropzone in zip mode. ---- */}
         <div className={`min-w-0 space-y-3 ${source === "paste" ? "max-w-3xl" : ""}`}>
           <ImportPreview
             status={status}


### PR DESCRIPTION
Capability import dialogs reserved half their width for an empty preview. Skill, MCP and Plugin inputs now use one column until a preview or validation result is available; parsing and result states retain their existing side-by-side layout. The empty-state copy no longer assumes a left column.

This changes presentation only. Parsing, upload, package reuse, permissions and submission conditions are unchanged.

Validation: full `make check` passed; self-review of the five-file diff. Real-browser checks covered creating a Skill/MCP, adding a Skill version, blank input, parsed results, MCP parse failure, clearing input, ZIP-mode switching, retained input focus, Chinese/dark and English/light presentation, and no horizontal dialog overflow. No capability/version was committed by these layout checks. Local Docker stayed off; the migration smoke test was skipped as reported by the check.
