### PR TITLE
fix(web): refresh active run state until completion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -596,6 +596,9 @@ split relevant pieces out first rather than growing the file further.
   using its published version metadata; its source workspace version history is
   not a cross-workspace read API. Do not duplicate credential rules.
 
+- Shared run queries refresh queued/running records until the server returns a
+  terminal state. Read the final event snapshot at that transition, then stop
+  periodic polling for terminal details and lists without active runs.
 - Agent management opts into disabled records with a separate query-cache key.
   Ordinary Agent selectors keep active-only reads; status mutations invalidate
   both list variants and the detail before their pending state ends. Agent status

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -597,8 +597,9 @@ split relevant pieces out first rather than growing the file further.
   not a cross-workspace read API. Do not duplicate credential rules.
 
 - Shared run queries refresh queued/running records until the server returns a
-  terminal state. Read the final event snapshot at that transition, then stop
-  periodic polling for terminal details and lists without active runs.
+  terminal state. Terminal events may arrive later: allow up to 30 seconds of
+  bounded catch-up reads until the matching event appears. Terminal details and
+  lists without active runs stop periodic polling.
 - Agent management opts into disabled records with a separate query-cache key.
   Ordinary Agent selectors keep active-only reads; status mutations invalidate
   both list variants and the detail before their pending state ends. Agent status

--- a/apps/web/src/lib/api-agents.ts
+++ b/apps/web/src/lib/api-agents.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react"
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { ApiError, apiRequest, noUnreachableRetry } from "./api-client"
 import { KEY_AGENT_CAPABILITIES, KEY_CAPABILITIES_WORKSPACE } from "./api-capabilities"
@@ -267,6 +268,10 @@ export interface UseAgentRunsOptions {
   search?: string
 }
 
+function isLiveRunStatus(status?: AgentRunStatus): boolean {
+  return status === "queued" || status === "running"
+}
+
 export function useAgentRuns(
   workspaceID: string | null,
   options: UseAgentRunsOptions = {},
@@ -278,6 +283,8 @@ export function useAgentRuns(
     queryFn: () => listAgentRuns(workspaceID, statuses, offset, limit, search),
     retry: noUnreachableRetry,
     staleTime: 15_000,
+    refetchInterval: (query) =>
+      query.state.data?.agent_runs.some((run) => isLiveRunStatus(run.status)) ? 5_000 : false,
     // Keep prior pages only when the workspace and filters still match.
     placeholderData: (prev, previousQuery) =>
       previousQuery?.queryKey.slice(0, 5).every((value, index) => value === queryKey[index]) ? prev : undefined,
@@ -335,6 +342,7 @@ export function useAgentRun(runID: string | null, _workspaceIDForMock?: string |
     enabled: !!runID,
     retry: noUnreachableRetry,
     staleTime: 15_000,
+    refetchInterval: (query) => isLiveRunStatus(query.state.data?.status) ? 5_000 : false,
   })
 }
 
@@ -344,8 +352,8 @@ export function useAgentRunEvents(
   options?: { status?: AgentRunStatus; initialEvents?: AgentRunEvent[] }
 ) {
   // Running and queued runs can still emit new events, so keep polling.
-  const live = options?.status === "running" || options?.status === "queued"
-  return useQuery({
+  const live = isLiveRunStatus(options?.status)
+  const query = useQuery({
     queryKey: KEY_RUN_EVENTS(workspaceID ?? "_none", runID ?? "_none"),
     queryFn: () => listAgentRunEvents(workspaceID, runID),
     enabled: !!runID && !!workspaceID,
@@ -354,6 +362,12 @@ export function useAgentRunEvents(
     refetchInterval: live ? 5_000 : false,
     initialData: options?.initialEvents ? { events: options.initialEvents } : undefined,
   })
+  const { refetch } = query
+  // Read the final event snapshot even when detail polling wins the last tick.
+  useEffect(() => {
+    if (runID && workspaceID && !live) void refetch()
+  }, [runID, workspaceID, live, refetch])
+  return query
 }
 
 export function useRetryRun(workspaceID: string | null) {

--- a/apps/web/src/lib/api-agents.ts
+++ b/apps/web/src/lib/api-agents.ts
@@ -351,6 +351,7 @@ export function useAgentRunEvents(
   workspaceID: string | null,
   options?: { status?: AgentRunStatus; initialEvents?: AgentRunEvent[] }
 ) {
+  const qc = useQueryClient()
   // Running and queued runs can still emit new events, so keep polling.
   const live = isLiveRunStatus(options?.status)
   const query = useQuery({
@@ -363,10 +364,20 @@ export function useAgentRunEvents(
     initialData: options?.initialEvents ? { events: options.initialEvents } : undefined,
   })
   const { refetch } = query
-  // Read the final event snapshot even when detail polling wins the last tick.
+  const status = options?.status
+  // Terminal status can precede its event; allow bounded catch-up reads.
   useEffect(() => {
-    if (runID && workspaceID && !live) void refetch()
-  }, [runID, workspaceID, live, refetch])
+    if (!runID || !workspaceID || !status || live) return
+    const readFinal = () => {
+      const snapshot = qc.getQueryData<ListAgentRunEventsResponse>(KEY_RUN_EVENTS(workspaceID, runID))
+      if (!snapshot?.events.some((event) => event.event_kind === `run.${status}`)) {
+        void refetch({ cancelRefetch: false })
+      }
+    }
+    readFinal()
+    const timers = [5_000, 15_000, 30_000].map((delay) => setTimeout(readFinal, delay))
+    return () => timers.forEach(clearTimeout)
+  }, [runID, workspaceID, status, live, qc, refetch])
   return query
 }
 


### PR DESCRIPTION
After retrying a run, the list and detail could remain Running with a Cancel button after the server had already marked it failed. Only the event query refreshed, so users had to reload the page to see the final state.

Refresh shared run queries while their records are queued or running, then stop periodic polling at terminal state. Allow bounded event catch-up for 30 seconds after the terminal state appears, stopping reads as soon as the matching event is present. This also covers the Agent activity views using the same list query, without changing dispatch, retry, cancellation, authorization, or layout.

Validation: `make check` passed (local Docker remains off; the migration smoke check was skipped). Against the actual Demo API, verified automatic failed status after browser Retry, completed status after a tool run, and cancelled status after cancellation from outside the page. Final times, actions and events updated without browser reload. Newly observed cancellation-event and narrow-header issues are tracked separately.

Review: independent blind review of shared query behavior; a local correction to terminal-event catch-up was self-reviewed. A browser harness using the real React Query hooks verifies delayed cancellation events are retrieved and further network reads stop.
