### PR TITLE
fix(web): align compact list icons to title first lines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -702,6 +702,8 @@ their existing layout.
 When a list needs a compact presentation beside a detail rail, use container
 queries against the list width. Keep the same data and row actions, with
 explicit field labels when column headings are hidden.
+For wrapping row titles, center status icons inside a one-line-height wrapper
+(`h-lh items-center`), aligned to the first line rather than the whole text block.
 
 Property groups use the shared `PropertyList` label track: 8rem capped at 40%
 of the available width. Labels wrap and values retain their existing overflow

--- a/apps/web/src/components/admin/InteractionList.tsx
+++ b/apps/web/src/components/admin/InteractionList.tsx
@@ -49,7 +49,7 @@ export function InteractionList({ rows, selectedID, label, onSelect }: {
                   <span className="@max-2xl/interactions:hidden"><StatusIcon status={INTERACTION_STATUS_ICONS[row.status]} title={t(`approvals.status.${row.status}`)} /></span>
                   <div className="min-w-0 @max-2xl/interactions:col-span-full">
                     <div className="flex min-w-0 items-start gap-1.5">
-                      <span className="hidden @max-2xl/interactions:block"><StatusIcon status={INTERACTION_STATUS_ICONS[row.status]} title={t(`approvals.status.${row.status}`)} /></span>
+                      <span className="hidden h-lh shrink-0 items-center @max-2xl/interactions:flex"><StatusIcon status={INTERACTION_STATUS_ICONS[row.status]} title={t(`approvals.status.${row.status}`)} /></span>
                       <span className="min-w-0 break-words font-medium" title={title}>{title}</span>
                     </div>
                     <div className="mt-1 truncate text-xs text-fg-muted" title={row.conversation_title || row.conversation_id}>

--- a/apps/web/src/pages/admin/agents/AgentsListTable.tsx
+++ b/apps/web/src/pages/admin/agents/AgentsListTable.tsx
@@ -114,7 +114,7 @@ export function AgentsListTable({
               <span className="@max-3xl/agent-list:hidden"><AgentStatusIcon status={agent.status} /></span>
               <div className="min-w-0 @max-3xl/agent-list:col-span-full">
                 <div className={cn("flex min-w-0 items-center gap-1.5 @max-3xl/agent-list:min-h-7 @max-3xl/agent-list:items-start", canChat && (canManage ? "@max-3xl/agent-list:pr-20" : "@max-3xl/agent-list:pr-12"))}>
-                  <span className="mt-0.5 hidden @max-3xl/agent-list:block"><AgentStatusIcon status={agent.status} /></span>
+                  <span className="hidden h-lh shrink-0 items-center @max-3xl/agent-list:flex"><AgentStatusIcon status={agent.status} /></span>
                   <InitialTile name={agent.name} />
                   <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden @max-3xl/agent-list:flex-col @max-3xl/agent-list:items-start @max-3xl/agent-list:gap-1">
                     <span className="min-w-0 max-w-full shrink-0 truncate font-medium @max-3xl/agent-list:whitespace-normal @max-3xl/agent-list:break-words" title={agent.name}>{agent.name}</span>


### PR DESCRIPTION
Inbox status icons sat above the first line of wrapping request titles. Center the icon in one text line so short and multi-line titles share the same alignment. Apply the same rule to the compact Agent list.

Only two wrapper classes and the contributor rule change; status rendering, titles, row actions, and wide list columns retain their behavior.

Validation: make check passed (local Docker remains off; migration smoke check skipped). Real Demo data at wide and narrow widths confirms 14px icons are centered within the first 18px text line, including two-line requests. Low-impact presentation change, self-reviewed.
