### PR TITLE
fix(web): preserve list reading position when opening details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -708,6 +708,9 @@ queries against the list width. Keep the same data and row actions, with
 explicit field labels when column headings are hidden.
 For wrapping row titles, center status icons inside a one-line-height wrapper
 (`h-lh items-center`), aligned to the first line rather than the whole text block.
+The shared Ledger preserves the activated row's viewport position when its
+width changes; after manual scrolling it anchors the current reading position.
+Keep this behavior independent of routing, selection data, and detail focus.
 
 Property groups use the shared `PropertyList` label track: 8rem capped at 40%
 of the available width. Labels wrap and values retain their existing overflow

--- a/apps/web/src/components/ui/ledger.tsx
+++ b/apps/web/src/components/ui/ledger.tsx
@@ -2,6 +2,7 @@
 import * as React from "react"
 import { ChevronDown } from "lucide-react"
 import { cn } from "../../lib/utils"
+import { useLedgerScrollAnchor } from "../../lib/use-ledger-scroll-anchor"
 import { StatusIcon, type StatusKind } from "./status-icon"
 
 /**
@@ -122,6 +123,7 @@ export function Ledger({
   children,
   ...props
 }: { columns: string | LedgerColumn[] } & React.HTMLAttributes<HTMLDivElement>) {
+  const viewportRef = useLedgerScrollAnchor()
   const value = React.useMemo(
     () => ({
       template: typeof columns === "string" ? adaptLegacyTemplate(columns) : ledgerTemplate(columns),
@@ -132,7 +134,7 @@ export function Ledger({
   )
   return (
     <LedgerContext.Provider value={value}>
-      <div className={cn("min-h-0 flex-1 overflow-y-auto", className)} {...props}>
+      <div ref={viewportRef} className={cn("min-h-0 flex-1 overflow-y-auto", className)} {...props}>
         {children}
       </div>
     </LedgerContext.Provider>

--- a/apps/web/src/lib/use-ledger-scroll-anchor.ts
+++ b/apps/web/src/lib/use-ledger-scroll-anchor.ts
@@ -1,0 +1,52 @@
+import { useLayoutEffect, useRef } from "react"
+
+export function useLedgerScrollAnchor() {
+  const ref = useRef<HTMLDivElement>(null)
+  useLayoutEffect(() => {
+    const viewport = ref.current
+    if (!viewport) return
+    let width = viewport.clientWidth
+    let scrollTop = viewport.scrollTop
+    let anchor: { row: HTMLElement; offset: number } | undefined
+    const remember = (target?: EventTarget | null) => {
+      const bounds = viewport.getBoundingClientRect()
+      const clicked = target instanceof Element ? target.closest<HTMLElement>('[role="option"]') : null
+      const row = clicked && viewport.contains(clicked) ? clicked :
+        Array.from(viewport.querySelectorAll<HTMLElement>('[role="option"]'))
+          .find((item) => item.getBoundingClientRect().bottom > bounds.top)
+      anchor = row ? { row, offset: row.getBoundingClientRect().top - bounds.top } : undefined
+    }
+    const onSelect = (event: Event) => remember(event.target)
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Enter" || event.key === " ") remember(event.target)
+    }
+    const onScroll = () => {
+      if (viewport.clientWidth !== width || viewport.scrollTop === scrollTop) return
+      scrollTop = viewport.scrollTop
+      remember()
+    }
+    const observer = new ResizeObserver(() => {
+      if (viewport.clientWidth === width) return
+      width = viewport.clientWidth
+      if (anchor && viewport.contains(anchor.row)) {
+        const offset = anchor.row.getBoundingClientRect().top - viewport.getBoundingClientRect().top
+        viewport.scrollTop += offset - anchor.offset
+        scrollTop = viewport.scrollTop
+      } else remember()
+    })
+    remember()
+    observer.observe(viewport)
+    viewport.addEventListener("pointerdown", onSelect, true)
+    viewport.addEventListener("focusin", onSelect)
+    viewport.addEventListener("keydown", onKeyDown, true)
+    viewport.addEventListener("scroll", onScroll, { passive: true })
+    return () => {
+      observer.disconnect()
+      viewport.removeEventListener("pointerdown", onSelect, true)
+      viewport.removeEventListener("focusin", onSelect)
+      viewport.removeEventListener("keydown", onKeyDown, true)
+      viewport.removeEventListener("scroll", onScroll)
+    }
+  }, [])
+  return ref
+}


### PR DESCRIPTION
Opening an Inbox detail rail could push the selected item off-screen when the narrower list switches to taller rows. Keeping the same scrollTop did not preserve the reading position.

Anchor shared Ledger width changes to the activated row, or the current reading position after manual scrolling. Mouse and keyboard activation retain their existing actions. No changes to APIs, routing, filtering, selection, or detail focus.

Validation: make check passed (local Docker remains off; migration smoke check skipped). Actual Demo browser: Inbox selection retained y=459 before and after opening; Runs retained y=544 and scrollTop=216; Tab navigation followed by Enter retained y=337.5 as row heights changed. Switching and closing details also verified.

Review: independent blind review; the keyboard activation correction was self-reviewed and verified in the real browser.
