### PR TITLE
fix(web): give Skill previews a compact visual hierarchy

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1039,6 +1039,7 @@
         "skill": "Skill"
       },
       "preview": {
+        "title": "Preview",
         "errorFallback": "Failed to parse",
         "idle": "Paste or upload content to see the preview.",
         "loading": "Parsing…",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1039,6 +1039,7 @@
         "skill": "Skill"
       },
       "preview": {
+        "title": "内容预览",
         "errorFallback": "解析失败",
         "idle": "粘贴或上传内容后，在这里查看预览",
         "loading": "解析中…",

--- a/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
@@ -240,7 +240,7 @@ export function AddCapabilityVersionDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-6xl overflow-x-hidden overflow-y-auto"
+        className={`max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] ${kind === "skill" ? "max-w-4xl" : "max-w-6xl"} overflow-x-hidden overflow-y-auto`}
         onInteractOutside={preventDialogDismissForCredentialMenu}
       >
         <DialogHeader>

--- a/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportCapabilityDialog.tsx
@@ -170,7 +170,7 @@ export function ImportCapabilityDialog({ workspaceID, open, onOpenChange, onCrea
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] max-w-6xl overflow-x-hidden overflow-y-auto"
+        className={`max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] ${kind === "skill" ? "max-w-4xl" : "max-w-6xl"} overflow-x-hidden overflow-y-auto`}
         onInteractOutside={preventDialogDismissForCredentialMenu}
       >
         <DialogHeader>

--- a/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
@@ -266,7 +266,7 @@ export function ImportSkillForm({
                 id="import-skill-markdown"
                 value={raw}
                 onChange={(e) => setRaw(e.target.value)}
-                rows={20}
+                rows={12}
                 placeholder={t(
                   "capabilities.import.skill.placeholder",
                   `---\nname: code-reviewer\ndescription: Review a diff and call out risky changes\n---\n\nYou are a careful code reviewer. When the user pastes a diff, walk through:\n\n1. Correctness — does the change do what it claims?\n2. Risk — what could break in production?\n3. Style — does it match the surrounding conventions?\n\nKeep responses concise.`,
@@ -310,24 +310,27 @@ export function ImportSkillForm({
           )}
         </div>
 
-        <div className={`min-w-0 space-y-3 ${source === "paste" ? "max-w-3xl" : ""}`}>
-          <ImportPreview
-            status={status}
-            errorMessage={errorMessage}
-            warnings={warnings}
-            suggestedName={status === "ready" ? skill?.slug : undefined}
-            description={status === "ready" ? skill?.description : undefined}
-            kind="skill"
-          />
+        <section className="min-w-0">
+          {status !== "idle" && <p className="mb-1 text-xs text-fg-muted">{t("capabilities.import.preview.title")}</p>}
+          <div className={status === "idle" ? "" : "space-y-3 rounded-md border border-line bg-surface-subtle p-4"}>
+            <ImportPreview
+              status={status}
+              errorMessage={errorMessage}
+              warnings={warnings}
+              suggestedName={status === "ready" ? skill?.slug : undefined}
+              description={status === "ready" ? skill?.description : undefined}
+              kind="skill"
+            />
 
-          {status === "ready" && skill && (
-            (skill.files && skill.files.length > 0) ? (
-              <SkillFileTree skill={skill} />
-            ) : (
-              <SinglePreview skill={skill} />
-            )
-          )}
-        </div>
+            {status === "ready" && skill && (
+              (skill.files && skill.files.length > 0) ? (
+                <SkillFileTree skill={skill} />
+              ) : (
+                <SinglePreview skill={skill} />
+              )
+            )}
+          </div>
+        </section>
       </div>
 
       {/* Hidden ossKey passthrough — purely for the dev-tools view; the


### PR DESCRIPTION
Skill import and Add Version displayed a loose preview beside an oversized editor, leaving short content in a large empty pane. Give the Skill preview an aligned label and bounded content panel, reduce the initial editor height, and use a narrower Skill dialog.

Scope is presentation only: MCP sizing, parsers, validation, uploads, and submission payloads are unchanged.

Validation: `make check` passed (Docker unavailable; PostgreSQL smoke check skipped). Browser checks covered import and Add Version, short and long Markdown, parse warnings, ZIP entry, and light/dark layouts at 1280px and 860px; preview text wraps and no dialog horizontal overflow was observed. No synthetic capability/version was submitted. Low-impact presentation change self-reviewed.
