### PR TITLE
fix(web): clarify Skill directory preview hierarchy

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -830,6 +830,8 @@
         "copyFailed": "Copy failed. Select and copy the details above."
       },
       "preview": {
+        "overview": "Overview",
+        "files": "Files",
         "description": "Review the current repository content before installing.",
         "loading": "Loading Skill instructions and files…",
         "failed": "Could not load this Skill preview",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -830,6 +830,8 @@
         "copyFailed": "复制失败，请选中上方详情手动复制。"
       },
       "preview": {
+        "overview": "用途",
+        "files": "文件内容",
         "description": "安装前查看仓库中的当前内容。",
         "loading": "正在读取 Skill 指令和文件…",
         "failed": "无法加载此 Skill 的预览",

--- a/apps/web/src/pages/admin/capabilities/SkillPreviewDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/SkillPreviewDialog.tsx
@@ -4,7 +4,6 @@ import { ArrowUpRight, Loader2 } from "lucide-react"
 import { Button } from "../../../components/ui/button"
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../../../components/ui/dialog"
 import { ErrorState } from "../../../components/ui/error-state"
-import { Property, PropertyList } from "../../../components/ui/property-list"
 import { useSkillPreview, type SkillsCatalogItem } from "../../../lib/api-skills"
 import { useWorkspaceId } from "../../../lib/workspace"
 import { ImportPreview } from "./ImportPreview"
@@ -38,13 +37,12 @@ export function SkillPreviewDialog({ skill, canImport, installedCapabilityID, in
           <DialogDescription>{t("capabilities.skillsDirectory.preview.description")}</DialogDescription>
         </DialogHeader>
         <div className="min-h-0 min-w-0 space-y-4 overflow-y-auto overflow-x-hidden">
-          <PropertyList>
-            <Property label={t("capabilities.marketplaceDetail.source.title")} className="h-auto min-h-7 whitespace-normal py-1">
-              <a href={`https://github.com/${skill.source}`} target="_blank" rel="noreferrer" className="inline-flex min-w-0 items-center gap-1 text-accent hover:underline [overflow-wrap:anywhere]">
-                {skill.source}<ArrowUpRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-              </a>
-            </Property>
-          </PropertyList>
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-xs">
+            <span className="text-fg-muted">{t("capabilities.marketplaceDetail.source.title")}</span>
+            <a href={`https://github.com/${skill.source}`} target="_blank" rel="noreferrer" className="inline-flex min-w-0 items-center gap-1 text-accent hover:underline [overflow-wrap:anywhere]">
+              {skill.source}<ArrowUpRight className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            </a>
+          </div>
           {!canImport ? (
             <p className="text-sm text-fg-muted">{t("capabilities.permission.adminOnly")}</p>
           ) : preview.isPending ? (
@@ -61,9 +59,15 @@ export function SkillPreviewDialog({ skill, canImport, installedCapabilityID, in
             />
           ) : content ? (
             <div className="min-w-0 space-y-3">
-              <p className="text-sm [overflow-wrap:anywhere]">{content.description || t("capabilities.skillsDirectory.preview.noDescription")}</p>
+              <section className="rounded-md border border-line bg-surface-subtle p-3">
+                <h3 className="text-base font-semibold text-fg">{t("capabilities.skillsDirectory.preview.overview")}</h3>
+                <p className="mt-2 text-sm leading-relaxed [overflow-wrap:anywhere]">{content.description || t("capabilities.skillsDirectory.preview.noDescription")}</p>
+              </section>
               {!!preview.data?.warnings.length && <ImportPreview status="ready" warnings={preview.data.warnings} />}
-              <SkillFileTree skill={content} entryMarkdown={preview.data?.entry_markdown} />
+              <section className="min-w-0">
+                <h3 className="mb-2 text-base font-semibold text-fg">{t("capabilities.skillsDirectory.preview.files")}</h3>
+                <SkillFileTree skill={content} entryMarkdown={preview.data?.entry_markdown} />
+              </section>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
The Skill directory preview separated its source label from the link with a large property column and mixed the description into the file viewer. Use a compact source row, a bounded Overview section, and a Files heading to make each level clear.

Presentation only; repository downloads, original SKILL.md content, file expansion, permissions, and install behavior are unchanged.

Validation: `make check` passed (Docker unavailable; PostgreSQL smoke check skipped). Opened the real PDF directory preview in the browser and verified the complete description, original entry, and enabled install action. Low-impact layout change self-reviewed.
