### PR TITLE
fix: preserve cancelled run terminal events

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,6 +261,9 @@ description and keep ownership on the side listed here.
   dispatch deadline or cancellation may stop connector work, but it must not
   prevent the server from recording the resulting completed, failed, or
   cancelled state.
+- Once cancellation is persisted, late connector completion/failure events must
+  not create conflicting run lifecycle records. Preserve nonterminal diagnostic
+  events and existing history; cancellation owns the terminal outcome.
 - Manual run retries create a new Run ID through `/agent-runs/{runID}/retry`.
   Preserve the source run's terminal status, events and output; reuse its trigger
   message, and execute as the current requester. One source run maps to one retry

--- a/server/internal/db/queries/store.sql
+++ b/server/internal/db/queries/store.sql
@@ -2910,6 +2910,8 @@ select
   @created_at
 from agent_runs r
 where r.id = @agent_run_id::uuid
+  and not (r.status = 'cancelled' and @event_kind::text in ('run.completed', 'run.failed'))
+for share of r
 on conflict (agent_run_id, sequence) do nothing
 returning
   id::text,

--- a/server/internal/db/sqlc/store.sql.go
+++ b/server/internal/db/sqlc/store.sql.go
@@ -6712,6 +6712,8 @@ select
   $5
 from agent_runs r
 where r.id = $6::uuid
+  and not (r.status = 'cancelled' and $2::text in ('run.completed', 'run.failed'))
+for share of r
 on conflict (agent_run_id, sequence) do nothing
 returning
   id::text,

--- a/server/internal/store/agent_run_events.go
+++ b/server/internal/store/agent_run_events.go
@@ -74,6 +74,15 @@ func (s *Store) RecordAgentRunEvent(ctx context.Context, input RecordAgentRunEve
 	})
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
+			if input.EventKind == "run.completed" || input.EventKind == "run.failed" {
+				run, readErr := queries.GetAgentRunForRead(ctx, runID)
+				if readErr == nil && run.Status == "cancelled" {
+					return nil
+				}
+				if readErr != nil && !errors.Is(readErr, pgx.ErrNoRows) {
+					return readErr
+				}
+			}
 			return fmt.Errorf("%w: %s", ErrUnknownAgentRun, input.RunID)
 		}
 		return err

--- a/server/internal/store/agent_run_events_cancel_test.go
+++ b/server/internal/store/agent_run_events_cancel_test.go
@@ -1,0 +1,126 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/db/sqlc"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestAgentRunEventsRespectPersistedCancellation(t *testing.T) {
+	for _, terminal := range []string{"run.failed", "run.completed"} {
+		for _, cancelled := range []bool{false, true} {
+			name := terminal + "/active"
+			if cancelled {
+				name = terminal + "/cancelled"
+			}
+			t.Run(name, func(t *testing.T) {
+				ctx := context.Background()
+				s := New(openTestDB(t))
+				ids := mustSeedDevFixture(t, ctx, s)
+				result, err := s.SendUserMessageToConversation(ctx, SendUserMessageToConversationInput{
+					ConversationID: ids.ConversationID, UserID: ids.UserID,
+					Content: "terminal event check", MentionedAgentIDs: []string{ids.ProductAgentID},
+				})
+				if err != nil || len(result.RunIDs) != 1 {
+					t.Fatalf("create run: %v, ids=%v", err, result.RunIDs)
+				}
+				runID := result.RunIDs[0]
+				record := func(kind string) {
+					t.Helper()
+					if err := s.RecordAgentRunEvent(ctx, RecordAgentRunEventInput{RunID: runID, EventKind: kind}); err != nil {
+						t.Fatalf("record %s: %v", kind, err)
+					}
+				}
+				record("run.started")
+				want := []string{"run.started"}
+				if cancelled {
+					if ok, err := s.CancelAgentRun(ctx, runID, "user_cancelled"); err != nil || !ok {
+						t.Fatalf("cancel run: %v, changed=%v", err, ok)
+					}
+					record("run.cancelled")
+					want = append(want, "run.cancelled")
+				}
+				record(terminal)
+				if !cancelled {
+					want = append(want, terminal)
+				}
+				record("session.error")
+				want = append(want, "session.error")
+				events, err := s.ListAgentRunEvents(ctx, runID, 0)
+				if err != nil || len(events) != len(want) {
+					t.Fatalf("list events: %v, got %v, want %v", err, events, want)
+				}
+				for i, event := range events {
+					if event.EventKind != want[i] || event.Sequence != int64(i+1) {
+						t.Fatalf("event %d: kind=%s sequence=%d, want %s/%d", i, event.EventKind, event.Sequence, want[i], i+1)
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestTerminalEventLocksRunUntilCommit(t *testing.T) {
+	ctx := context.Background()
+	s := New(openTestDB(t))
+	ids := mustSeedDevFixture(t, ctx, s)
+	result, err := s.SendUserMessageToConversation(ctx, SendUserMessageToConversationInput{
+		ConversationID: ids.ConversationID, UserID: ids.UserID,
+		Content: "concurrent cancellation check", MentionedAgentIDs: []string{ids.ProductAgentID},
+	})
+	if err != nil || len(result.RunIDs) != 1 {
+		t.Fatalf("create run: %v, ids=%v", err, result.RunIDs)
+	}
+	runID := result.RunIDs[0]
+	runUUID, err := uuid(runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eventTx, err := beginTx(ctx, s.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eventTx.Rollback(ctx)
+	now := timestamptz(time.Now())
+	_, err = sqlc.New(eventTx).InsertAgentRunEvent(ctx, sqlc.InsertAgentRunEventParams{
+		AgentRunID: runUUID, Sequence: 1, EventKind: "run.failed", Payload: []byte(`{}`),
+		OccurredAt: now, CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelTx, err := beginTx(ctx, s.db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancelTx.Rollback(ctx)
+	// A status-only UPDATE needs this lock, so cancellation cannot commit first.
+	_, err = cancelTx.Exec(ctx, "select id from agent_runs where id = $1 for no key update nowait", runUUID)
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != "55P03" {
+		t.Fatalf("status update should wait for event commit, got %v", err)
+	}
+	if err := cancelTx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := eventTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := s.CancelAgentRun(ctx, runID, "user_cancelled"); err != nil || !ok {
+		t.Fatalf("cancel after event commit: %v, changed=%v", err, ok)
+	}
+}
+
+func TestTerminalAgentRunEventStillRejectsUnknownRun(t *testing.T) {
+	s := New(openTestDB(t))
+	err := s.RecordAgentRunEvent(context.Background(), RecordAgentRunEventInput{
+		RunID: "00000000-0000-0000-0000-000000000099", EventKind: "run.failed",
+	})
+	if !errors.Is(err, ErrUnknownAgentRun) {
+		t.Fatalf("unknown run error = %v", err)
+	}
+}


### PR DESCRIPTION
A cancelled run could later record `run.failed` or `run.completed` when its connector finished, leaving contradictory lifecycle history. Ignore those late terminal records once cancellation is persisted, and serialize the status check with cancellation. Diagnostic events and existing history remain available.

Scope: run event persistence only. No API, streaming, retry, or authorization changes.

Validation: `make sqlc-generate`, `make check`, and isolated PostgreSQL regression tests for both terminal event types, active/cancelled runs, preserved diagnostics and sequence numbers, unknown runs, and concurrent status-update locking. A fresh independent review found no actionable issues. Local Docker remained stopped; database tests used a separate remote test database.
