### PR TITLE
fix(web): keep page titles readable beside narrow toolbars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -680,9 +680,10 @@ The authenticated root owns post-login return navigation for password and SSO
 sign-in. Preserve allowed in-app paths, query parameters and fragments through
 the existing session return intent; login forms must not race that navigation.
 
-Pages with a detail rail may opt into wrapping header actions through
-`PageHeader.actionClassName` and an auto-height header. Other pages retain
-the default single-row header layout.
+`PageHeader` keeps its title readable and wraps actions when their combined
+width exceeds the available panel width. Its minimum height remains 64px;
+wrapped rows grow naturally. Keep this behavior in the shared header, with
+`actionClassName` reserved for page-specific action arrangements.
 
 The Agent form checks workspace runtime status before creating or switching to
 cloud execution. Unknown or unavailable status blocks advancing and submitting;

--- a/apps/web/src/components/layout/PageHeader.tsx
+++ b/apps/web/src/components/layout/PageHeader.tsx
@@ -25,7 +25,7 @@ interface PageHeaderProps {
 }
 
 /**
- * The 64px topbar every console page starts with: title on the left
+ * The topbar every console page starts with: title on the left
  * (the only 600 weight on the screen), actions on the right. Sticks to
  * the top of the scrolling main column and spans its full width.
  */
@@ -36,7 +36,7 @@ export function PageHeader({ title, subtitle, subtitleFor, action, actionClassNa
   return (
     <header
       className={cn(
-        "sticky top-0 z-10 -mx-6 mb-8 flex h-16 shrink-0 items-center gap-3 border-b border-line bg-surface px-6",
+        "sticky top-0 z-10 -mx-6 mb-8 flex min-h-16 shrink-0 flex-wrap items-center gap-3 border-b border-line bg-surface px-6 py-3",
         className,
       )}
     >
@@ -46,14 +46,14 @@ export function PageHeader({ title, subtitle, subtitleFor, action, actionClassNa
           `overflow: hidden` sliced the tail off every descender — "Settings"
           lost the foot of its g. The scale's own 24px line is the fix. */}
       {title && (
-        <h1 className="font-display flex min-w-0 items-baseline gap-2 text-xl text-fg">
+        <h1 className="font-display flex min-w-0 max-w-full shrink-0 items-baseline gap-2 text-xl text-fg">
           <span className="truncate">{title}</span>
           {resolvedSubtitle && (
             <span className="shrink-0 text-xs font-normal tracking-normal text-fg-muted">{resolvedSubtitle}</span>
           )}
         </h1>
       )}
-      {action && <div className={cn("ml-auto flex shrink-0 items-center gap-2", actionClassName)}>{action}</div>}
+      {action && <div className={cn("ml-auto flex max-w-full shrink-0 flex-wrap items-center gap-2 [&>*]:max-w-full", actionClassName)}>{action}</div>}
     </header>
   )
 }


### PR DESCRIPTION
Opening a detail rail could squeeze the page title to an ellipsis or hide the Chinese title entirely. The shared page header now protects the title's width and lets its actions wrap when the panel is too narrow, while retaining the normal 64px minimum height on wide panels.

Scope: shared header layout and its contributor rule only. Search, filters, routing, and page data are unchanged.

Validation: `make check`; real browser checks on Runs, Agents, Capabilities, and Audit, including a 1067px viewport, open detail rails, bilingual titles, both themes, and an operable filter menu. Independent review found no actionable issues.
