### PR TITLE
fix(deploy): preserve Claude history across runtime recreation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,20 @@ description and keep ownership on the side listed here.
 - After pulling, the installer prepares its server data mount for the image's
   actual UID/GID and verifies writability before starting services. Only the
   preparation container runs as root; the server retains its configured user.
+- Default Compose keeps Claude Code configuration and native session files in
+  `/root/.parsar/claude-code`, on the runtime's existing persistent home volume.
+  The first installer upgrade stops the old runtime, backs up its legacy
+  `~/.claude/` and `~/.claude.json` under the install directory, and migrates
+  them before container replacement. Conflicting history aborts the upgrade.
+  Do not remove the old container or its volumes before this migration.
+  Direct Compose/Dokploy users must run `./install.sh migrate-runtime-history`
+  followed by their existing Compose global options (such as `-p`, `-f`, and
+  `--env-file`) once before upgrading. This migration-only command does not
+  rewrite `.env`, change data mounts/secrets, pull images, or start services.
+  Then use the original Compose upgrade command. Wait for active runs to finish
+  before upgrading; the runtime is stopped during migration.
+  Backups contain private session/configuration data; retain them securely until
+  resume is verified. Already-deleted native histories cannot be reconstructed.
 - `install.sh` may still write stable random overrides such as
   `PARSAR_MASTER_KEY` and `PARSAR_SHARED_RUNTIME_TOKEN` for safer local
   installs, but raw Compose/Dokploy deployments must not depend on those
@@ -119,6 +133,8 @@ description and keep ownership on the side listed here.
 - Keep `install.sh` a thin Compose wrapper. Its CLI is limited to installation
   location, web bind/port, image overrides, and validation. Uncommon deployment
   settings belong in the Compose environment rather than new installer flags.
+  The one-time history migration subcommand passes existing Compose global
+  options through unchanged so raw deployments retain their configuration.
 - Services exposed through a deployment platform may gain an ingress network,
   but they must remain explicitly attached to the Compose `default` network
   when they depend on internal service DNS names such as `postgres`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 # Run with: docker compose up -d
 # Open http://127.0.0.1:18080 and configure integrations in the web UI.
 # Production deployments should override the three dev-only secrets below.
+# Existing deployments: use install.sh migrate-runtime-history once before
+# recreating containers. See CONTRIBUTING.md#install-and-image-freshness.
 name: parsar
 
 services:
@@ -59,6 +61,7 @@ services:
         condition: service_healthy
     environment:
       PARSAR_SHARED_RUNTIME_TOKEN: "${PARSAR_SHARED_RUNTIME_TOKEN:-parsar-local-runtime-token-change-me}"
+      CLAUDE_CONFIG_DIR: /root/.parsar/claude-code
     command: ["/opt/parsar/bin/runtime-entrypoint.sh"]
     volumes:
       - parsar-runtime-home:/root/.parsar

--- a/install.sh
+++ b/install.sh
@@ -9,6 +9,7 @@ Install or upgrade Parsar with Docker Compose.
 
 Usage:
   ./install.sh [options]
+  ./install.sh migrate-runtime-history [Docker Compose global options]
   curl -fsSL https://raw.githubusercontent.com/MiniMax-AI-Dev/parsar/main/install.sh | bash
 
 Options:
@@ -23,6 +24,7 @@ Options:
   --help               Show this help.
 
 Advanced Compose settings can be added directly to ~/.parsar/.env.
+The migration-only command preserves existing Compose configuration and services.
 USAGE
 }
 
@@ -120,6 +122,57 @@ prepare_data_directory() {
     || die "server data directory is not writable by its configured user"
 }
 
+migrate_runtime_history() {
+  local container config_dir runtime_image backup source
+  container="$(compose ps -aq parsar-runtime)"
+  [ -n "$container" ] || return 0
+  [[ "$container" != *$'\n'* ]] || die "expected one default runtime container"
+  config_dir="$(docker_run inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$container" \
+    | sed -n 's/^CLAUDE_CONFIG_DIR=//p')"
+  [ "$config_dir" != /root/.parsar/claude-code ] || return 0
+  [ -z "$config_dir" ] || die "custom CLAUDE_CONFIG_DIR requires a manual history migration"
+  runtime_image="$(docker_run inspect --format '{{.Image}}' "$container")"
+  backup="$(mktemp -d "$1/runtime-history.XXXXXX")"
+  mkdir "$backup/state"
+  log "Stopping the runtime for history migration; backup: $backup"
+  docker_run stop "$container" >/dev/null
+
+  for source in /root/.claude/. /root/.claude.json; do
+    if ! docker_run cp "$container:$source" "$backup/state/" 2>"$backup/copy-error.log"; then
+      # An unused runtime may not have created either path yet.
+      grep -Fq "Could not find the file $source in container" "$backup/copy-error.log" \
+        || die "history backup failed; old runtime retained. See $backup/copy-error.log"
+    fi
+  done
+
+  # Reuse the old runtime's mounted home; never overwrite a different history.
+  docker_run run --rm --volumes-from "$container" \
+    -v "$backup/state:/parsar-history-backup:ro" --entrypoint /bin/sh "$runtime_image" -ec '
+      target=/root/.parsar/claude-code
+      if [ -e "$target" ]; then
+        diff -qr --no-dereference /parsar-history-backup "$target"
+      else
+        stage=$(mktemp -d /root/.parsar/claude-code-migration.XXXXXX)
+        trap '\''rm -rf "$stage"'\'' EXIT
+        cp -a /parsar-history-backup/. "$stage/"
+        mv "$stage" "$target"
+      fi
+    ' || die "history migration failed; old runtime and backup retained at $backup"
+}
+
+if [ "${1:-}" = migrate-runtime-history ]; then
+  shift
+  compose_args=("$@")
+  compose() { docker_run compose "${compose_args[@]}" "$@"; }
+  umask 077
+  history_backup_root="$(expand_path "${PARSAR_HOME:-$HOME/.parsar}")"
+  mkdir -p "$history_backup_root"
+  detect_docker
+  migrate_runtime_history "$history_backup_root"
+  log "History migration complete; resume with your existing Compose up command"
+  exit 0
+fi
+
 home="${PARSAR_HOME:-$HOME/.parsar}"
 port="${PARSAR_LOCAL_PORT:-18080}"
 bind="${PARSAR_BIND_ADDR:-127.0.0.1}"
@@ -184,6 +237,8 @@ log "Pulling images"
 compose pull parsar-server parsar-runtime
 log "Preparing server data directory"
 prepare_data_directory
+log "Preserving runtime history"
+migrate_runtime_history "$home"
 log "Starting Parsar"
 compose up -d --remove-orphans
 

--- a/scripts/check-installer.sh
+++ b/scripts/check-installer.sh
@@ -13,11 +13,28 @@ cat > "$test_root/bin/docker" <<'MOCK'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$PARSAR_INSTALL_TEST_LOG"
-if [[ "$*" == *' run '* ]]; then
+if [[ "$1" == compose && "$*" == *' run '* ]]; then
   # Compose v2.15 accepts pull_policy in YAML but has no run --pull option.
   [[ "$*" != *'--pull '* && "${PARSAR_IMAGE_PULL_POLICY:-}" == never ]]
   # The installer closes stdin, so Compose must not request an interactive TTY.
   [[ "$*" == *' -T '* ]]
+fi
+if [[ "$*" == *' ps -aq parsar-runtime' && "${PARSAR_INSTALL_TEST_RUNTIME:-}" != "" ]]; then
+  printf 'old-runtime\n'
+elif [[ "$*" == *'range .Config.Env'* ]]; then
+  case "$PARSAR_INSTALL_TEST_RUNTIME" in
+    configured) printf 'CLAUDE_CONFIG_DIR=/root/.parsar/claude-code\n' ;;
+    custom) printf 'CLAUDE_CONFIG_DIR=/custom-history\n' ;;
+  esac
+elif [[ "$*" == *'{{.Image}}'* ]]; then
+  printf 'sha256:old-image\n'
+elif [[ "$1" == cp ]]; then
+  case "$PARSAR_INSTALL_TEST_RUNTIME" in
+    missing) printf 'Error response from daemon: Could not find the file %s in container old-runtime\n' "${2#*:}" >&2; exit 1 ;;
+    copy-failure) printf 'Docker connection failed\n' >&2; exit 1 ;;
+  esac
+elif [[ "$1" == run && "${PARSAR_INSTALL_TEST_RUNTIME:-}" == conflict ]]; then
+  exit 1
 fi
 if [[ "$*" == *'id -u'* ]]; then
   printf '12001:14001'
@@ -36,6 +53,7 @@ run_case() {
   PATH="$test_root/bin:$PATH" \
     PARSAR_INSTALL_TEST_LOG="$test_root/$case_name/docker.log" \
     PARSAR_INSTALL_TEST_FAIL="$failure" \
+    PARSAR_INSTALL_TEST_RUNTIME="${PARSAR_INSTALL_TEST_RUNTIME:-}" \
     bash "$repo_root/install.sh" --home "$test_root/$case_name/home" \
       --compose-file "$repo_root/docker-compose.yml" "$@" > "$test_root/$case_name/output.log" 2>&1
 }
@@ -62,9 +80,44 @@ for failure in ownership writable; do
   fi
 done
 
+for runtime in legacy missing configured; do
+  PARSAR_INSTALL_TEST_RUNTIME="$runtime" run_case "$runtime" ""
+  runtime_log="$test_root/$runtime/docker.log"
+  if [[ "$runtime" == configured ]]; then
+    ! grep -q '^stop ' "$runtime_log"
+    ! grep -q '^cp ' "$runtime_log"
+  else
+    stop_line="$(grep -n '^stop ' "$runtime_log" | cut -d: -f1)"
+    copy_line="$(grep -n '^cp ' "$runtime_log" | head -1 | cut -d: -f1)"
+    migrate_line="$(grep -n '^run --rm --volumes-from old-runtime' "$runtime_log" | cut -d: -f1)"
+    up_line="$(grep -n ' up ' "$runtime_log" | cut -d: -f1)"
+    [[ "$stop_line" -lt "$copy_line" && "$copy_line" -lt "$migrate_line" && "$migrate_line" -lt "$up_line" ]]
+  fi
+done
+
+for runtime in copy-failure conflict custom; do
+  if PARSAR_INSTALL_TEST_RUNTIME="$runtime" run_case "$runtime" ""; then
+    echo "Installer ignored runtime history $runtime" >&2
+    exit 1
+  fi
+  ! grep -q ' up ' "$test_root/$runtime/docker.log"
+done
+
+mkdir -p "$test_root/raw"
+printf 'PARSAR_PG_DATA_DIR=existing-postgres\nPARSAR_MASTER_KEY=existing-secret\n' > "$test_root/raw/original.env"
+cp "$test_root/raw/original.env" "$test_root/raw/before.env"
+PATH="$test_root/bin:$PATH" PARSAR_HOME="$test_root/raw/backups" \
+  PARSAR_INSTALL_TEST_LOG="$test_root/raw/docker.log" PARSAR_INSTALL_TEST_RUNTIME=legacy \
+  bash "$repo_root/install.sh" migrate-runtime-history -p existing-stack \
+    -f "$repo_root/docker-compose.yml" --env-file "$test_root/raw/original.env" > "$test_root/raw/output.log" 2>&1
+cmp "$test_root/raw/before.env" "$test_root/raw/original.env"
+grep -Fq "compose -p existing-stack -f $repo_root/docker-compose.yml --env-file $test_root/raw/original.env ps -aq parsar-runtime" "$test_root/raw/docker.log"
+! grep -Eq ' (pull|up|chown) ' "$test_root/raw/docker.log"
+[[ ! -e "$test_root/raw/backups/.env" && ! -e "$test_root/raw/backups/postgres" ]]
+
 run_case dry "" --dry-run
 if grep -Eq ' (run|pull|up) ' "$test_root/dry/docker.log"; then
   echo 'Dry run started a container or pulled an image' >&2
   exit 1
 fi
-echo 'Installer data preparation checks passed.'
+echo 'Installer data preparation and runtime history checks passed.'


### PR DESCRIPTION
Default Compose runtime replacement loses Claude Code session files even though Parsar retains the conversation session ID, so continuing an existing conversation fails.

Store Claude Code state in the runtime's existing persistent home. Before the first installer upgrade replaces a legacy runtime, stop it, keep a private backup of its native history/configuration, and import that state without overwriting conflicting data. Direct Compose deployments have a migration-only command that preserves their original Compose options, data mounts and secrets. Existing lost history is not reconstructed. No adapter, authorization, or retry behavior changes.

Validation: `make check`; Docker-free installer lifecycle and failure checks; isolated remote Docker tests for unused/legacy runtime migration, repeated migration, byte-for-byte preservation and conflict refusal, dangling symlinks and unchanged raw Compose configuration; real Claude Code conversation resumed after migration and two container recreations. Local Docker stayed off.
