### PR TITLE
fix(web): wrap plain text detail properties

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -764,8 +764,9 @@ width changes; after manual scrolling it anchors the current reading position.
 Keep this behavior independent of routing, selection data, and detail focus.
 
 Property groups use the shared `PropertyList` label track: 8rem capped at 40%
-of the available width. Labels wrap and values retain their existing overflow
-behavior. Do not size individual groups from their longest label or add
+of the available width. Labels and plain text values wrap, including long
+unbroken identifiers, with matching first-line spacing. Custom value controls
+retain their own overflow behavior. Do not size groups from their longest label or add
 page-specific label widths; groups in the same context must align.
 
 Single-choice form controls use the shared Radix-backed `Select` and

--- a/apps/web/src/components/ui/property-list.tsx
+++ b/apps/web/src/components/ui/property-list.tsx
@@ -24,6 +24,7 @@ export function Property({
   /** Overrides the tooltip; by default a string value becomes its own. */
   title?: string
 }) {
+  const plainText = typeof children === "string" || typeof children === "number"
   return (
     <>
       <dt
@@ -35,7 +36,10 @@ export function Property({
       <dd
         title={title ?? (typeof children === "string" ? children : undefined)}
         className={cn(
-          "m-0 flex h-7 min-w-0 items-center gap-1.5 truncate text-sm text-fg",
+          "m-0 min-w-0 text-sm text-fg",
+          plainText
+            ? "min-h-7 py-1 leading-5 [overflow-wrap:anywhere]"
+            : "flex h-7 items-center gap-1.5 truncate",
           mono && "font-mono text-xs",
           className,
         )}


### PR DESCRIPTION
Long plain-text values, such as the Inbox decision-maker UUID, were clipped by fixed-height detail properties. Shared properties now wrap text and numeric values while keeping their first line aligned with the label. Custom value controls retain their existing layout.

Validation: `make check`; real-browser Inbox and Agent detail checks at 1280px and 960px, verifying complete text, no horizontal overflow and preserved conversation action. Scope is shared presentation and its contributor contract only.
