### PR TITLE
fix(codex): refresh turn context when mode is omitted

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,6 +289,8 @@ description and keep ownership on the side listed here.
 - Codex app-server usage totals are cumulative per thread. Treat restored usage
   before `turn/started` as the baseline and persist only the current turn's
   delta; repeated snapshots must not increase recorded usage.
+- Omitted Codex mode means `default`, matching the Agent UI. Send the current
+  instructions through that turn mode; cold resume alone may retain old instructions.
 - OpenCode JSON CLI tool parts arrive after execution. Translate each terminal
   call once into paired tool-call/result records for existing trace consumers.
   These records describe completed work; they are not permission requests or

--- a/apps/parsar-daemon/internal/agent/codex/options.go
+++ b/apps/parsar-daemon/internal/agent/codex/options.go
@@ -105,9 +105,10 @@ type SessionPlan struct {
 func BuildSessionPlan(runID, agentStateKey, workDir string, opts map[string]any) (SessionPlan, error) {
 	cleanup := func() {}
 	plan := SessionPlan{
-		ApprovalPolicy: AskForApproval{String: "never"},
-		Sandbox:        SandboxDangerFullAcces,
-		Cleanup:        cleanup,
+		CollaborationMode: CollaborationModeDefault,
+		ApprovalPolicy:    AskForApproval{String: "never"},
+		Sandbox:           SandboxDangerFullAcces,
+		Cleanup:           cleanup,
 	}
 
 	resolvedCwd, err := resolveWorkDirCodex(workDir)

--- a/apps/parsar-daemon/internal/agent/codex/options_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/options_test.go
@@ -143,6 +143,24 @@ func TestBuildSessionPlan_ParsesCollaborationMode(t *testing.T) {
 	}
 }
 
+func TestBuildSessionPlan_OmittedModeRetainsCurrentInstructions(t *testing.T) {
+	t.Setenv("PARSAR_HOME", t.TempDir())
+	for _, mode := range []string{"", "default"} {
+		opts := map[string]any{"system_prompt": "current reference", "model": "MiniMax-M3"}
+		if mode != "" {
+			opts["mode"] = mode
+		}
+		plan, err := BuildSessionPlan("run", "conv/agent/codex", "", opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer plan.Cleanup()
+		if plan.CollaborationMode != CollaborationModeDefault || plan.SystemPrompt != "current reference" || plan.Model != "MiniMax-M3" {
+			t.Fatalf("mode %q did not retain the default turn instructions: %+v", mode, plan)
+		}
+	}
+}
+
 func TestBuildSessionPlan_RejectsUnknownCollaborationMode(t *testing.T) {
 	_, err := BuildSessionPlan("run-1", "conv-1/agent-1/codex", "", map[string]any{
 		"mode": "autopilot",


### PR DESCRIPTION
Codex Agents created without an explicit mode skipped the turn-level instruction update, so resumed conversations could keep answering from an old knowledge version. Treat an omitted mode as `default`, matching the Agent UI and the existing explicit-default path. Explicit Plan mode, model selection, permissions, and other engines retain their behavior.

Validation: `make check`; Codex package tests; independent blind review with no blockers. With the candidate daemon on the existing test runtime, the previously failing MiniMax-M3 conversation returned the updated reference, then `NO-REFERENCE` after unbinding; a fresh unbound conversation also returned `NO-REFERENCE`. No history or runtime storage was recreated. Local Docker remained stopped (the gate skipped its Docker migration smoke test).
