### PR TITLE
fix(web): explain waits before agent output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -701,6 +701,11 @@ Opening a conversation and successful sends follow the latest content. Scrolling
 back or choosing a turn preserves the reading position during streaming and
 polling; returning to the bottom resumes following.
 
+Before a running conversation emits text or tool activity, its trace identifies
+the wait and shows elapsed time. After 30 seconds, explain the option to wait or,
+when permitted, stop; hide that guidance on output, human interaction, or termination. Do not
+infer engine setup or model-request stages without corresponding events.
+
 Dialogs / drawers / modals and detail panels **must not show a horizontal
 scrollbar**. End users report "I can't see the bottom" far more often than
 "my screen is too narrow", and horizontal scroll almost always means a

--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -507,7 +507,12 @@ function ChatStream({
     <RunTrace
       key={run ? run.id : "live"}
       run={run}
-      live={hasActiveStream ? { steps: stream.steps, startedAt: liveStartedAt ?? undefined } : null}
+      canStop={canWrite}
+      live={hasActiveStream ? {
+        steps: stream.steps,
+        startedAt: liveStartedAt ?? undefined,
+        waitingForOutput: !stream.deltaText && !stream.pendingInteraction,
+      } : null}
       attention={
         (!!run && runsAwaitingUser.has(run.id)) ||
         (!!activeRunId && runsAwaitingUser.has(activeRunId)) ||
@@ -811,10 +816,12 @@ function RunTrace({
   run,
   live,
   attention,
+  canStop = false,
 }: {
   run: ConversationTimelineRun | null
-  live: { steps: StreamingStep[]; startedAt?: number } | null
+  live: { steps: StreamingStep[]; startedAt?: number; waitingForOutput: boolean } | null
   attention: boolean
+  canStop?: boolean
 }) {
   const status: StatusKind = live ? "running" : run ? runStatusKind(run) : "running"
   const steps = useMemo(() => {
@@ -830,6 +837,8 @@ function RunTrace({
       startedAt={isoMs(run?.started_at) ?? live?.startedAt}
       finishedAt={isoMs(run?.finished_at)}
       attentionRequired={attention}
+      waitingForOutput={live?.waitingForOutput && !run?.output_message_id}
+      canStop={canStop}
     />
   )
 }

--- a/apps/web/src/components/conversation/WorkTrace.tsx
+++ b/apps/web/src/components/conversation/WorkTrace.tsx
@@ -286,6 +286,8 @@ export function WorkTrace({
   startedAt,
   finishedAt,
   attentionRequired = false,
+  waitingForOutput = false,
+  canStop = false,
   collapseAfterAnswer = true,
   className,
 }: {
@@ -297,6 +299,8 @@ export function WorkTrace({
   finishedAt?: number
   /** A step waits on the user (a pending approval for this run): stay open. */
   attentionRequired?: boolean
+  waitingForOutput?: boolean
+  canStop?: boolean
   /** Fold once the run stops. Default on; the user may reopen it. */
   collapseAfterAnswer?: boolean
   className?: string
@@ -322,11 +326,15 @@ export function WorkTrace({
   const start = startedAt ?? firstStep
   const end = running ? (now > 0 ? now : undefined) : (finishedAt ?? lastStep)
   const elapsed = start !== undefined && end !== undefined ? formatTraceElapsed(end - start) : ""
+  const waiting = status === "running" && waitingForOutput && !hasDetails && !attentionRequired
+  const longWait = waiting && start !== undefined && now - start >= 30_000
 
   const word =
-    status === "running" || status === "queued"
-      ? t("conversations.trace.running")
-      : t(DONE_LABEL[status])
+    waiting
+      ? t("conversations.trace.waitingForOutput")
+      : status === "running" || status === "queued"
+        ? t("conversations.trace.running")
+        : t(DONE_LABEL[status])
   const current = running ? [...steps].reverse().find((s) => s.status === "running") : undefined
 
   const header = (
@@ -334,7 +342,7 @@ export function WorkTrace({
       <StatusIcon status={status} />
       <span className="shrink-0 text-sm text-fg-muted">{word}</span>
       {elapsed && (
-        <span className="shrink-0 text-sm text-fg-muted">
+        <span className="shrink-0 text-sm text-fg-muted" aria-hidden={running || undefined}>
           <span aria-hidden="true">· </span>
           <span className="font-mono text-xs tabular-nums">{elapsed}</span>
         </span>
@@ -372,6 +380,12 @@ export function WorkTrace({
         <div className="flex h-8 w-full items-center gap-2" role="status" aria-live="polite">
           {header}
         </div>
+      )}
+
+      {longWait && (
+        <p className="m-0 pb-2 pl-5.5 text-sm text-fg-muted [overflow-wrap:anywhere]">
+          {t(canStop ? "conversations.trace.waitingHint" : "conversations.trace.waitingReadOnlyHint")}
+        </p>
       )}
 
       {hasDetails && (

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -373,6 +373,9 @@
     },
     "trace": {
       "label": "Work trace",
+      "waitingForOutput": "Waiting for output",
+      "waitingHint": "No text or tool output yet. You can keep waiting or stop this run.",
+      "waitingReadOnlyHint": "No text or tool output yet. It will appear here when available.",
       "running": "Running",
       "completed": "Execution finished",
       "failed": "Failed",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -373,6 +373,9 @@
     },
     "trace": {
       "label": "执行轨迹",
+      "waitingForOutput": "等待输出",
+      "waitingHint": "尚未收到文字或工具输出。可以继续等待，或停止本次执行。",
+      "waitingReadOnlyHint": "尚未收到文字或工具输出，收到后会显示在这里。",
       "running": "运行中",
       "completed": "执行结束",
       "failed": "失败",


### PR DESCRIPTION
Long-running conversations showed only a generic running label before any text or tool output. The shared trace now identifies that wait and adds a concise explanation after 30 seconds, with stop guidance only for users who can cancel. The note clears when output, tool activity, a human request, or termination arrives.

Validation: `make check`; browser fixtures for English/Chinese at 960px covering text, tools, approvals, choices, cancellation and read-only permissions; a real Codex/MiniMax-M3 conversation. Local Docker remained off, so the migration smoke check was skipped. Independent blind review covered the full diff.

No changes to execution, timeouts, permissions, or model latency.
