### PR TITLE
fix(web): distinguish unknown usage costs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -632,6 +632,11 @@ split relevant pieces out first rather than growing the file further.
 
 ### Frontend shared logic
 
+- Usage cost displays treat stored zero/missing values as unknown: the current
+  contract cannot distinguish free usage from unavailable pricing. Preserve raw
+  records; sum finite positive costs only and label incomplete totals. Do not
+  estimate prices or infer cost availability from provider names or token counts.
+
 - Ordinary toasts expire even while hovered and provide a localized close
   button. Keyboard focus inside pauses their countdown until focus leaves.
   Persistent action prompts remain owned by their caller. Toast removal must

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -2116,6 +2116,11 @@
     "page": {
       "title": "Usage"
     },
+    "cost": {
+      "unknown": "Unknown",
+      "partial": "Known costs only; some costs are unknown.",
+      "incomplete": "Zero or missing cost values are treated as unknown. Totals marked * include known costs only."
+    },
     "stats": {
       "runs": "Runs",
       "inputTokens": "Input tokens",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -2116,6 +2116,11 @@
     "page": {
       "title": "用量"
     },
+    "cost": {
+      "unknown": "未知",
+      "partial": "仅汇总已知费用，部分记录费用未知。",
+      "incomplete": "零值或缺失的费用暂按未知展示；带 * 的汇总仅包含已知费用。"
+    },
     "stats": {
       "runs": "Run 数",
       "inputTokens": "Input tokens",

--- a/apps/web/src/lib/usage-cost.ts
+++ b/apps/web/src/lib/usage-cost.ts
@@ -1,0 +1,4 @@
+export function knownUsageCost(value: number | null | undefined): number | null {
+  // The current usage contract stores missing prices and actual zero costs alike.
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null
+}

--- a/apps/web/src/pages/admin/UsagePage.tsx
+++ b/apps/web/src/pages/admin/UsagePage.tsx
@@ -16,6 +16,7 @@ import { useUsage } from "../../lib/api-governance"
 import type { UsageLog } from "../../lib/api-types"
 import { useWorkspaceId } from "../../lib/workspace"
 import { SectionHead } from "../../components/ui/section"
+import { knownUsageCost } from "../../lib/usage-cost"
 
 /* ------------------------------------------------------------------ */
 /*  Aggregation                                                        */
@@ -26,6 +27,7 @@ interface UsageSummary {
   inputTokens: number
   outputTokens: number
   costUsd: number
+  unknownCosts: number
 }
 
 function summarize(logs: UsageLog[]): UsageSummary {
@@ -34,12 +36,15 @@ function summarize(logs: UsageLog[]): UsageSummary {
     inputTokens: 0,
     outputTokens: 0,
     costUsd: 0,
+    unknownCosts: 0,
   }
   for (const u of logs) {
     if (u.agent_run_id) summary.runs.add(u.agent_run_id)
     summary.inputTokens += u.input_tokens ?? 0
     summary.outputTokens += u.output_tokens ?? 0
-    summary.costUsd += u.cost_usd ?? 0
+    const cost = knownUsageCost(u.cost_usd)
+    summary.costUsd += cost ?? 0
+    if (cost === null) summary.unknownCosts += 1
   }
   return summary
 }
@@ -51,6 +56,7 @@ interface ByModelRow {
   inputTokens: number
   outputTokens: number
   costUsd: number
+  unknownCosts: number
   callCount: number
 }
 
@@ -67,13 +73,16 @@ function groupByModel(logs: UsageLog[]): ByModelRow[] {
         inputTokens: 0,
         outputTokens: 0,
         costUsd: 0,
+        unknownCosts: 0,
         callCount: 0,
       }
       map.set(key, row)
     }
     row.inputTokens += u.input_tokens ?? 0
     row.outputTokens += u.output_tokens ?? 0
-    row.costUsd += u.cost_usd ?? 0
+    const cost = knownUsageCost(u.cost_usd)
+    row.costUsd += cost ?? 0
+    if (cost === null) row.unknownCosts += 1
     row.callCount += 1
   }
   return [...map.values()].sort((a, b) => b.costUsd - a.costUsd)
@@ -88,6 +97,14 @@ function fmtUsd(cost: number): string {
   if (cost < 0.001) return `$${cost.toFixed(5)}`
   if (cost < 1) return `$${cost.toFixed(4)}`
   return `$${cost.toFixed(2)}`
+}
+
+function UsageCost({ value, partial = false }: { value: number; partial?: boolean }) {
+  const { t } = useTranslation("admin")
+  const cost = knownUsageCost(value)
+  if (cost === null) return <span className="font-sans text-fg-muted">{t("usage.cost.unknown")}</span>
+  const amount = fmtUsd(cost)
+  return <span title={partial ? t("usage.cost.partial") : undefined} aria-label={partial ? `${amount} · ${t("usage.cost.partial")}` : undefined}>{amount}{partial ? "*" : ""}</span>
 }
 
 function fmtInt(n: number): string {
@@ -158,8 +175,11 @@ export function UsagePage() {
               <Property label={t("usage.stats.runs")} mono className="tabular-nums">{fmtInt(summary.runs.size)}</Property>
               <Property label={t("usage.stats.inputTokens")} mono className="tabular-nums">{fmtInt(summary.inputTokens)}</Property>
               <Property label={t("usage.stats.outputTokens")} mono className="tabular-nums">{fmtInt(summary.outputTokens)}</Property>
-              <Property label={t("usage.stats.cost")} mono className="tabular-nums">{fmtUsd(summary.costUsd)}</Property>
+              <Property label={t("usage.stats.cost")} mono className="tabular-nums"><UsageCost value={summary.costUsd} partial={summary.unknownCosts > 0} /></Property>
             </PropertyList>
+            {summary.unknownCosts > 0 && (
+              <p className="mt-3 px-6 text-xs text-fg-muted">{t("usage.cost.incomplete")}</p>
+            )}
 
             <SectionHead title={t("usage.byModel.title")} className="mt-6 px-6" />
             <Ledger columns={MODEL_COLUMNS} className="flex-none overflow-visible" role="list" aria-label={t("usage.byModel.title")}>
@@ -179,7 +199,7 @@ export function UsagePage() {
                     <LedgerNum>{fmtInt(m.callCount)}</LedgerNum>
                     <LedgerNum>{fmtInt(m.inputTokens)}</LedgerNum>
                     <LedgerNum>{fmtInt(m.outputTokens)}</LedgerNum>
-                    <LedgerNum>{fmtUsd(m.costUsd)}</LedgerNum>
+                    <LedgerNum><UsageCost value={m.costUsd} partial={m.unknownCosts > 0} /></LedgerNum>
                   </LedgerRow>
                 ))}
               </ul>
@@ -216,7 +236,7 @@ export function UsagePage() {
                     <span className="truncate font-mono text-xs text-fg" title={u.model}>{u.model}</span>
                     <LedgerNum>{fmtInt(u.input_tokens)}</LedgerNum>
                     <LedgerNum>{fmtInt(u.output_tokens)}</LedgerNum>
-                    <LedgerNum>{fmtUsd(u.cost_usd)}</LedgerNum>
+                    <LedgerNum><UsageCost value={u.cost_usd} /></LedgerNum>
                   </LedgerRow>
                 ))}
               </ul>

--- a/tests/e2e/usage-cost.spec.ts
+++ b/tests/e2e/usage-cost.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+import { json, mockApp, WORKSPACE_ID } from "./helpers/conversation-app";
+
+for (const lang of ["en-US", "zh-CN"]) {
+  for (const scenario of ["unknown", "known", "mixed"]) {
+    test(`Usage costs: ${scenario}, ${lang}`, async ({ page }) => {
+      await mockApp(page, "empty", null);
+      await page.addInitScript((language) => localStorage.setItem("parsar.lang", language), lang);
+      const unknown = lang === "en-US" ? "Unknown" : "未知";
+      const costs = scenario === "unknown" ? [0, null, undefined, -1] : scenario === "known" ? [0.1, 0.2] : [0.1, 0];
+      await page.route("**/api/v1/workspaces/*/usage*", (route) => json(route, {
+        usage_logs: costs.map((cost, index) => ({
+          id: `usage-${index}`, agent_run_id: `run-${index}`, provider: "test", model: "example",
+          input_tokens: 10, output_tokens: 2, cost_usd: cost, created_at: "2026-09-10T00:00:00Z",
+        })),
+      }));
+      await page.goto(`/?admin=usage&ws=${WORKSPACE_ID}`);
+      const total = page.locator("dl dd").nth(3);
+      const model = page.getByRole("list", { name: lang === "en-US" ? "By model" : "按模型" }).getByRole("listitem");
+      const recent = page.getByRole("list", { name: lang === "en-US" ? "Recent calls" : "最近调用" });
+      const expected = scenario === "unknown" ? unknown : scenario === "known" ? "$0.3000" : "$0.1000*";
+      await expect(total).toHaveText(expected);
+      await expect(model).toContainText(expected);
+      await expect(page.locator("dl dd").nth(1)).toHaveText(String(costs.length * 10));
+      await expect(recent.getByRole("listitem")).toHaveCount(costs.length);
+      await expect(recent.getByText(unknown, { exact: true })).toHaveCount(scenario === "unknown" ? 4 : scenario === "mixed" ? 1 : 0);
+      await expect(page.getByText(lang === "en-US" ? /Zero or missing cost values/ : /零值或缺失的费用/)).toHaveCount(scenario === "known" ? 0 : 1);
+      if (scenario === "mixed") {
+        await expect(total.locator("span")).toHaveAccessibleName(lang === "en-US" ? /Known costs only/ : /仅汇总已知费用/);
+        await expect(recent.getByText("$0.1000", { exact: true })).toBeVisible();
+      }
+    });
+  }
+}


### PR DESCRIPTION
Usage currently renders unreported costs as `$0`, implying that those runs were free. Display ambiguous zero, absent, or invalid costs as unknown and mark partial summaries and model totals. Preserve positive amounts and the existing token counts, grouping, links, API, and stored records.

The existing contract cannot distinguish a genuine zero charge from missing pricing. This correction deliberately treats both as unknown; it does not estimate prices or backfill usage.

Validation: `make check` passed (local Docker unavailable, migration smoke skipped), six Playwright scenarios covering English/Chinese and known/unknown/mixed costs, and real demo data inspected at 960/1280px in dark/light themes. Independent blind review completed before merge.
