### PR TITLE
fix(web): preserve capabilities during agent property edits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,6 +276,9 @@ description and keep ownership on the side listed here.
 
 - Agent creation and editing store behavior instructions in `system_prompt`.
   Preserve saved text when opening the form; clearing it sends an empty string.
+- Property-only Agent edits omit the legacy `capabilities` replacement field
+  unless the user operates its selection controls. That name list can lag
+  canonical bindings; it must not reconcile bindings during unrelated edits.
 - OpenCode model selectors use `provider/model`. Its Anthropic SDK base URL
   derives from the same endpoint resolver as model probes. OpenAI-compatible
   and OpenAI SDK adapters use the `openai` and `openai-response` endpoint maps,

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -287,6 +287,7 @@ export function CreateAgentDialog({
   const [highlightedModelID, setHighlightedModelID] = useState<string | null>(null)
   const [systemPrompt, setSystemPrompt] = useState(defaultSystemPrompt)
   const [capabilities, setCapabilities] = useState<string[]>([])
+  const capabilitySelectionEdited = useRef(false)
   const [selectedCapabilityIDs, setSelectedCapabilityIDs] = useState<string[]>([])
   // capabilityVersionChoices keys on capability_id and stores the user's
   // per-binding version + mode pick. The dropdown default is "latest"
@@ -515,6 +516,7 @@ export function CreateAgentDialog({
     }
     if (wasOpenRef.current) return
     wasOpenRef.current = true
+    capabilitySelectionEdited.current = false
     const params = new URLSearchParams(window.location.search.replace(/^\?+/, "?"))
     if (mode === "create") {
       // Clone path: an `agent` prop in create mode means prefill from that
@@ -757,6 +759,7 @@ export function CreateAgentDialog({
   }
 
   function toggleCapability(cap: string, capabilityID?: string, latestVersionID?: string) {
+    capabilitySelectionEdited.current = true
     let wasChecked = false
     setCapabilities((prev) => {
       wasChecked = prev.includes(cap)
@@ -913,7 +916,8 @@ export function CreateAgentDialog({
       system_prompt: systemPrompt.trim(),
       connector_type: connector,
       ...(requiresModel ? { default_model_id: selectedModelID } : {}),
-      capabilities: capabilityNames,
+      // The legacy name list can lag canonical bindings added from Config.
+      ...(mode === "create" || capabilitySelectionEdited.current ? { capabilities: capabilityNames } : {}),
       ...(mode === "create" ? { initial_capabilities: initialCapabilities, visibility } : {}),
       config: agentBodyConfig,
       ...(inlineSecretsToCreate.length > 0 ? { inline_new_secrets: inlineSecretsToCreate } : {}),

--- a/tests/e2e/agent-instructions.spec.ts
+++ b/tests/e2e/agent-instructions.spec.ts
@@ -44,8 +44,40 @@ for (const instructions of ["Answer from the approved policy.", ""]) {
   });
 }
 
-async function mockAgents(page: Page) {
-  const writes = { updates: [] as Record<string, unknown>[], creates: [] as Record<string, unknown>[] };
+for (const changePrompt of [false, true]) {
+  test(`property-only edit preserves capability intent: ${changePrompt}`, async ({ page }) => {
+    const writes = await mockAgents(page, true);
+    await page.goto(`/?ws=${workspace}&admin=agents&id=${agentID}&tab=config`);
+    await page.getByRole("button", { name: "Edit", exact: true }).click();
+    const dialog = page.getByRole("dialog", { name: "Edit Agent" });
+    if (changePrompt) await dialog.getByRole("textbox", { name: "Instructions", exact: true }).fill("Updated instructions");
+    await dialog.getByRole("button", { name: "Next", exact: true }).click();
+    await dialog.getByRole("button", { name: "Save", exact: true }).click();
+    await expect(dialog).not.toBeVisible();
+    expect(writes.updates).toHaveLength(1);
+    expect(writes.updates[0]).not.toHaveProperty("capabilities");
+    expect(writes.capabilityWrites).toHaveLength(0);
+  });
+}
+
+test("explicit capability selection retains the existing replacement request", async ({ page }) => {
+  const writes = await mockAgents(page, true);
+  await page.goto(`/?ws=${workspace}&admin=agents&id=${agentID}&tab=config`);
+  await page.getByRole("button", { name: "Edit", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "Edit Agent" });
+  await dialog.getByRole("button", { name: "Next", exact: true }).click();
+  await dialog.getByRole("checkbox", { name: /Policy/ }).check();
+  await dialog.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(dialog).not.toBeVisible();
+  expect(writes.updates[0].capabilities).toEqual(["Policy"]);
+});
+
+async function mockAgents(page: Page, withBindings = false) {
+  const writes = { updates: [] as Record<string, unknown>[], creates: [] as Record<string, unknown>[], capabilityWrites: [] as string[] };
+  const installed = withBindings ? ["Policy", "Helpdesk"].map((name, index) => ({
+    capability_id: `cap-${index}`, capability_version_id: `version-${index}`, name,
+    type: index === 0 ? "skill" : "mcp", version: "1.0.0", pinning_mode: "pinned", configuration: { retained: true },
+  })) : [];
   const base = `/api/v1/workspaces/${workspace}`;
   const agentURL = `${base}/agents/${agentID}`;
   const agent = {
@@ -57,8 +89,10 @@ async function mockAgents(page: Page) {
   await page.route("**/api/v1/**", async (route) => {
     const path = new URL(route.request().url()).pathname;
     const method = route.request().method();
+    if (method !== "GET" && path.includes("/capabilities")) writes.capabilityWrites.push(path);
     if (path === "/api/v1/me") return json(route, { user_id: "user-1", name: "User", email: "user@example.test" });
     if (path === "/api/v1/me/workspaces") return json(route, { workspaces: [{ id: workspace, name: "Instruction test", role: "owner" }] });
+    if (path === `${base}/runtime/status`) return json(route, { available: true, profile: "managed" });
     if (path === `${base}/agents`) {
       if (method === "POST") {
         const input = route.request().postDataJSON();
@@ -74,8 +108,10 @@ async function mockAgents(page: Page) {
       if (method !== "GET") writes.updates.push(route.request().postDataJSON());
       return json(route, agent);
     }
-    if (path === `${agentURL}/capabilities`) return json(route, { available: [], installed: [] });
-    if (path === `${base}/capabilities`) return json(route, { capabilities: [] });
+    if (path === `${agentURL}/capabilities`) return json(route, { available: [], installed });
+    if (path === `${base}/capabilities`) return json(route, { capabilities: installed.map((binding) => ({
+      ...binding, id: binding.capability_id, workspace_id: workspace, latest_version_id: binding.capability_version_id,
+    })) });
     if (path.endsWith("/models")) return json(route, { models: [{
       id: "model-1", name: "QA Model", model_key: "qa-model", status: "active", provider_type: "anthropic", adapter: "anthropic", credential_mode: "inline_secret", config: {},
     }] });


### PR DESCRIPTION
Saving an existing Agent's properties always submitted the legacy capability-name list, which can be stale after mounting Skill/MCP bindings from Config. An unchanged save could therefore delete those bindings. Submit capability replacement only after the user operates the capability selection controls; property-only saves preserve the canonical bindings.

This correction preserves create and explicit capability-edit flows. Full capability-editor hydration, intentional name-based reconciliation, version and credential synchronization remain deferred; this PR does not replace those controls or change backend contracts.

Validation: `make check` passed (local Docker unavailable; migration smoke skipped), eight Playwright creation/editing scenarios, and real browser saves against the demo preserved binding IDs, versions, pinning, configurations and enabled states. A subsequent Claude Code/MiniMax-M3 run invoked the ZIP Skill and MCP, returning third working day, ORBIT-724, and QA-100 ready-for-pickup / HARBOR-381. The existing creation fixture now supplies its required runtime-preflight response. Independent blind review completed before merge.
