### PR TITLE
fix(web): enlarge shared conversation mobile touch targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -703,6 +703,8 @@ split relevant pieces out first rather than growing the file further.
 Standalone shared conversations size to the viewport, including loading and
 unavailable states. Keep their mobile sizing scoped to that shell; the desktop
 console's minimum width and shared message behavior remain independent.
+Below the small-screen breakpoint, theme and composer action buttons in this
+shell have at least 44px touch targets without changing desktop control sizes.
 
 The console and shared conversation view use the same thread scroll hook.
 Opening a conversation and successful sends follow the latest content. Scrolling

--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -1213,7 +1213,7 @@ function ComposerForm({
           disabled={disabled || (!conversationId && !onSendDirect)}
           className="block max-h-[200px] min-h-[40px] w-full resize-none bg-transparent text-base leading-relaxed text-fg placeholder:text-fg-muted focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
         />
-        <div className="mt-2 flex h-8 items-center justify-end gap-3">
+        <div data-conversation-composer-actions className="mt-2 flex h-8 items-center justify-end gap-3">
           {agentName && (
             <span className="flex min-w-0 items-center gap-1.5 text-xs text-fg-muted">
               <InitialTile name={agentName} />

--- a/apps/web/src/style.css
+++ b/apps/web/src/style.css
@@ -294,6 +294,22 @@ html[data-theme="dark"] {
   text-rendering: optimizeLegibility;
 }
 
+@media (width < 40rem) {
+  [data-shared-conversation] header [role="group"] {
+    gap: 0.5rem;
+  }
+
+  [data-shared-conversation] header button,
+  [data-shared-conversation] [data-conversation-composer-actions] > button {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+  }
+
+  [data-shared-conversation] [data-conversation-composer-actions] {
+    height: 2.75rem;
+  }
+}
+
 /* Page titles: same face, 600, tight tracking. The only 600 on a screen. */
 .font-display {
   font-family: var(--font-display);


### PR DESCRIPTION
Shared conversations kept desktop-sized theme (26×22px) and send/stop (32×32px) controls on phones. Below 640px, these controls now have at least 44×44px targets, with enough toolbar height and spacing. The rules stay inside the shared-conversation shell; desktop controls, icons, handlers and permissions are unchanged.

Validation: `make check` passed (Docker remains stopped; migration smoke skipped). Real browser checks covered 320px/light/English and 390px/dark/Chinese, centered icons, no horizontal overflow, theme taps outside the old hit area, and a send tap at the enlarged button edge. Claude Code/MiniMax-M3 completed that real message with `PARSAR-TOUCH-OK`; the active Stop control also measured 44×44px. Shared desktop and console theme controls retained their original dimensions. Self-reviewed as an isolated sizing correction.
