### PR TITLE
fix(web): retain agent form during model setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -753,6 +753,9 @@ The Agent form checks workspace runtime status before creating or switching to
 cloud execution. Unknown or unavailable status blocks advancing and submitting;
 ordinary edits to an existing cloud Agent and local execution stay independent.
 Cloud setup opens Runtime's Instances tab separately so form input is retained.
+Missing-model setup follows the same pattern: open Models separately and refresh
+the catalog from the still-open Agent form. Keep its draft in the mounted form;
+do not serialize it into prerequisite URLs or add a second draft lifecycle.
 
 New and cloned Agent forms default invocation scope to workspace, matching the
 server default. Scope choices explain the existing Feishu gate without implying

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1575,8 +1575,10 @@
       },
       "emptyModel": {
         "title": "No usable Model yet",
-        "description": "Go to Models to onboard one. The fields you typed here will be carried over so you can come back.",
-        "cta": "Configure Model"
+        "description": "Configure a model in a new tab, then return here and refresh. Your Agent form stays open with all input preserved.",
+        "cta": "Configure Model (new tab)",
+        "refresh": "Refresh models",
+        "refreshError": "Models could not be refreshed. Please try again."
       },
       "noTagsAdmin": "No skills or MCP tools are available yet. These are optional: save the Agent now, then add capabilities on the Capabilities page and enable them in the Agent’s Config tab.",
       "noTagsMember": "No skills or MCP tools are available yet. These are optional: save the Agent now, then ask a workspace administrator to add capabilities and enable them in the Agent’s Config tab.",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1575,8 +1575,10 @@
       },
       "emptyModel": {
         "title": "还没有可用 Model",
-        "description": "先去 Models 页接入一个模型；当前已填内容会带过去，配完后可以回到新建 Agent。",
-        "cta": "去配置 Model"
+        "description": "在新标签页配置模型，然后回到这里刷新。Agent 表单会保持打开，已填内容都会保留。",
+        "cta": "配置模型（新标签页）",
+        "refresh": "刷新模型",
+        "refreshError": "无法刷新模型，请重试。"
       },
       "noTagsAdmin": "当前还没有可用的 Skill 或 MCP 工具，能力配置是可选的。可以先保存 Agent，之后在「能力」页添加，再到 Agent 的「配置」中启用。",
       "noTagsMember": "当前还没有可用的 Skill 或 MCP 工具，能力配置是可选的。可以先保存 Agent，之后请工作区管理员添加能力，再到 Agent 的「配置」中启用。",

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -1,7 +1,7 @@
 import { Fragment, forwardRef, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 import { useQueryClient } from "@tanstack/react-query"
-import { AlertTriangle, ArrowUpRight, Check, ChevronDown, Eye, EyeOff, Search } from "lucide-react"
+import { AlertTriangle, Check, ChevronDown, Eye, EyeOff, Search } from "lucide-react"
 
 import { Badge } from "../../components/ui/badge"
 import { Button } from "../../components/ui/button"
@@ -20,6 +20,7 @@ import { Select, SelectOption } from "../../components/ui/select"
 import { AgentInstructionsField } from "./agents/AgentInstructionsField"
 import { AgentVisibilityField } from "./agents/AgentVisibilityField"
 import { AgentCloudPreflight } from "./agents/AgentCloudPreflight"
+import { AgentModelPrerequisite } from "./agents/AgentModelPrerequisite"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
 import { cn } from "../../lib/utils"
@@ -747,17 +748,6 @@ export function CreateAgentDialog({
   const showDevicePicker = connector === "agent_daemon" && executionMode === "local_device" && Boolean(workspaceID)
   const errMsg = extractErrorMessage(error)
 
-  function prefillQuery(target: "models" | "runtime") {
-    const url = new URL(window.location.href)
-    url.searchParams.set("admin", target)
-    url.searchParams.delete("id")
-    url.searchParams.set("return_to", "agents.create")
-    if (name.trim()) url.searchParams.set("agent_name", name.trim())
-    if (description.trim()) url.searchParams.set("agent_description", description.trim())
-    if (systemPrompt.trim()) url.searchParams.set("agent_prompt", systemPrompt.trim())
-    return `${url.pathname}${url.search}${url.hash}`
-  }
-
   function toggleCapability(cap: string, capabilityID?: string, latestVersionID?: string) {
     capabilitySelectionEdited.current = true
     let wasChecked = false
@@ -1278,7 +1268,7 @@ export function CreateAgentDialog({
                         ? t("agents.form.errors.modelRequired")
                         : undefined}
                   >
-                {hasModel ? (
+                {hasModel && (
                   <div ref={modelComboboxRef} className="relative">
                     <Search className="pointer-events-none absolute left-2 top-1/2 z-10 h-3.5 w-3.5 -translate-y-1/2 text-fg-muted" strokeWidth={1.5} aria-hidden="true" />
                     <Input
@@ -1349,8 +1339,9 @@ export function CreateAgentDialog({
                       </div>
                     )}
                   </div>
-                ) : (
-                  <DependencyCard title={t("agents.form.emptyModel.title")} description={t("agents.form.emptyModel.description")} href={prefillQuery("models")} cta={t("agents.form.emptyModel.cta")} />
+                )}
+                {activeModels.every((model) => incompatibleModelIDs.has(model.id)) && (
+                  <AgentModelPrerequisite workspaceID={workspaceID} />
                 )}
                   </Field>
                 </div>
@@ -1777,20 +1768,6 @@ function ChoiceCard({ name, title, description, selected, onSelect, disabled = f
         {description && <span className="block text-xs text-fg-muted">{description}</span>}
       </span>
     </label>
-  )
-}
-
-function DependencyCard({ title, description, href, cta }: { title: string; description: string; href: string; cta: string }) {
-  return (
-    <div className="flex flex-col items-start gap-1 py-1">
-      <p className="text-sm font-medium text-fg">{title}</p>
-      <p className="text-xs text-fg-muted">{description}</p>
-      <Button variant="link" size="sm" className="mt-1 px-0" asChild>
-        <a href={href}>
-          {cta} <ArrowUpRight strokeWidth={1.5} aria-hidden="true" />
-        </a>
-      </Button>
-    </div>
   )
 }
 

--- a/apps/web/src/pages/admin/agents/AgentModelPrerequisite.tsx
+++ b/apps/web/src/pages/admin/agents/AgentModelPrerequisite.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react"
+import { ArrowUpRight, RefreshCw } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "../../../components/ui/button"
+import { InlineError } from "../../../components/ui/error-state"
+import { useModels } from "../../../lib/api-models"
+
+export function AgentModelPrerequisite({ workspaceID }: { workspaceID: string | null }) {
+  const { t } = useTranslation("admin")
+  const modelsQ = useModels(workspaceID)
+  const [refreshAttempted, setRefreshAttempted] = useState(false)
+  const setupURL = `/?${new URLSearchParams({ admin: "models", ...(workspaceID ? { ws: workspaceID } : {}) })}`
+
+  return (
+    <div className="flex flex-col items-start gap-1 py-1">
+      <p className="text-sm font-medium text-fg">{t("agents.form.emptyModel.title")}</p>
+      <p className="text-xs text-fg-muted">{t("agents.form.emptyModel.description")}</p>
+      <div className="mt-2 flex flex-wrap gap-2">
+        <Button variant="outline" size="sm" asChild>
+          <a href={setupURL} target="_blank" rel="noreferrer">
+            {t("agents.form.emptyModel.cta")}
+            <ArrowUpRight strokeWidth={1.5} aria-hidden="true" />
+          </a>
+        </Button>
+        <Button variant="outline" size="sm" disabled={modelsQ.isFetching} onClick={() => {
+          setRefreshAttempted(true)
+          void modelsQ.refetch()
+        }}>
+          <RefreshCw strokeWidth={1.5} aria-hidden="true" />
+          {t("agents.form.emptyModel.refresh")}
+        </Button>
+      </div>
+      {refreshAttempted && modelsQ.isError && (
+        <InlineError className="mt-1">{t("agents.form.emptyModel.refreshError")}</InlineError>
+      )}
+    </div>
+  )
+}

--- a/tests/e2e/agent-instructions.spec.ts
+++ b/tests/e2e/agent-instructions.spec.ts
@@ -72,7 +72,62 @@ test("explicit capability selection retains the existing replacement request", a
   expect(writes.updates[0].capabilities).toEqual(["Policy"]);
 });
 
-async function mockAgents(page: Page, withBindings = false) {
+for (const finish of ["create", "cancel"]) {
+  test(`model prerequisite preserves the live form until ${finish}`, async ({ page }) => {
+    const catalog = { available: false, failed: false, adapter: "openai" };
+    const writes = await mockAgents(page, false, catalog);
+    const originalURL = `/?ws=${workspace}&admin=agents`;
+    await page.goto(originalURL);
+    await page.getByRole("button", { name: "New Agent", exact: true }).click();
+    const dialog = page.getByRole("dialog", { name: "New Agent" });
+    await dialog.getByRole("textbox", { name: "Name", exact: true }).fill("Preserved model detour");
+    const prompt = "Keep the first line.\n\nKeep the final line.";
+    await dialog.getByRole("textbox", { name: "Instructions", exact: true }).fill(prompt);
+    await dialog.getByRole("radio", { name: /Cloud isolation/ }).check();
+    for (let detour = 0; detour < 2; detour++) {
+      const popupPromise = page.waitForEvent("popup");
+      await dialog.getByRole("link", { name: "Configure Model (new tab)" }).click();
+      const popup = await popupPromise;
+      await expect(popup).toHaveURL(new RegExp(`\\?admin=models&ws=${workspace}$`));
+      expect(new URL(popup.url()).searchParams.size).toBe(2);
+      await popup.close();
+      await expect(page).toHaveURL(new RegExp(`\\?ws=${workspace}&admin=agents$`));
+      await expect(dialog.getByRole("textbox", { name: "Instructions", exact: true })).toHaveValue(prompt);
+      await expect(dialog.getByRole("radio", { name: /Cloud isolation/ })).toBeChecked();
+    }
+    if (finish === "create") {
+      catalog.failed = true;
+      await dialog.getByRole("button", { name: "Refresh models", exact: true }).click();
+      await expect(dialog.getByRole("alert")).toContainText("Models could not be refreshed");
+      await expect(dialog.getByRole("textbox", { name: "Name", exact: true })).toHaveValue("Preserved model detour");
+      catalog.failed = false;
+      catalog.available = true;
+      await dialog.getByRole("button", { name: "Refresh models", exact: true }).click();
+      await dialog.getByPlaceholder("Search models in this Workspace").click();
+      await expect(dialog.getByRole("option", { name: /QA Model/ })).toBeDisabled();
+      await expect(dialog.getByRole("link", { name: "Configure Model (new tab)" })).toBeVisible();
+      catalog.adapter = "anthropic";
+      await dialog.getByRole("button", { name: "Refresh models", exact: true }).click();
+      await expect(dialog.getByRole("button", { name: "Refresh models", exact: true })).not.toBeVisible();
+      await dialog.getByPlaceholder("Search models in this Workspace").click();
+      await dialog.getByRole("option", { name: /QA Model/ }).click();
+      await dialog.getByRole("button", { name: "Next", exact: true }).click();
+      await dialog.getByRole("button", { name: "Create Agent", exact: true }).click();
+      await expect.poll(() => writes.creates.length).toBe(1);
+      expect(writes.creates[0]).toMatchObject({ name: "Preserved model detour", system_prompt: prompt, default_model_id: "model-1" });
+      await expect(dialog).not.toBeVisible();
+      await page.goto(originalURL);
+    } else {
+      await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+      expect(writes.creates).toHaveLength(0);
+    }
+    await page.getByRole("button", { name: "New Agent", exact: true }).click();
+    await expect(dialog.getByRole("textbox", { name: "Name", exact: true })).not.toHaveValue("Preserved model detour");
+    await expect(dialog.getByRole("textbox", { name: "Instructions", exact: true })).not.toHaveValue(prompt);
+  });
+}
+
+async function mockAgents(page: Page, withBindings = false, catalog = { available: true, failed: false, adapter: "anthropic" }) {
   const writes = { updates: [] as Record<string, unknown>[], creates: [] as Record<string, unknown>[], capabilityWrites: [] as string[] };
   const installed = withBindings ? ["Policy", "Helpdesk"].map((name, index) => ({
     capability_id: `cap-${index}`, capability_version_id: `version-${index}`, name,
@@ -86,7 +141,7 @@ async function mockAgents(page: Page, withBindings = false) {
     config: { agent_kind: "opencode", daemon_mode: "sandbox", system_prompt: "Existing instructions" } as Record<string, unknown>,
   };
   await page.addInitScript(() => localStorage.setItem("i18nextLng", "en-US"));
-  await page.route("**/api/v1/**", async (route) => {
+  await page.context().route("**/api/v1/**", async (route) => {
     const path = new URL(route.request().url()).pathname;
     const method = route.request().method();
     if (method !== "GET" && path.includes("/capabilities")) writes.capabilityWrites.push(path);
@@ -112,9 +167,10 @@ async function mockAgents(page: Page, withBindings = false) {
     if (path === `${base}/capabilities`) return json(route, { capabilities: installed.map((binding) => ({
       ...binding, id: binding.capability_id, workspace_id: workspace, latest_version_id: binding.capability_version_id,
     })) });
-    if (path.endsWith("/models")) return json(route, { models: [{
-      id: "model-1", name: "QA Model", model_key: "qa-model", status: "active", provider_type: "anthropic", adapter: "anthropic", credential_mode: "inline_secret", config: {},
-    }] });
+    if (path.endsWith("/models") && catalog.failed) return json(route, { error: "server_unreachable", message: "Model service unavailable" }, 503);
+    if (path.endsWith("/models")) return json(route, { models: catalog.available ? [{
+      id: "model-1", name: "QA Model", model_key: "qa-model", status: "active", provider_type: catalog.adapter, adapter: catalog.adapter, credential_mode: "inline_secret", config: {},
+    }] : [] });
     return json(route, {});
   });
   return writes;


### PR DESCRIPTION
When an Agent had no usable model, Configure Model navigated away from its form and left the user on Models without a way to resume all their input. Model setup now opens in another tab while the Agent form stays mounted; an explicit Refresh models action loads the updated catalog and supports retry after a read failure.

This follows the existing runtime-prerequisite pattern. No draft is serialized into new prerequisite URLs or persisted separately. Existing create/edit/clone behavior, model and credential APIs, runtime checks and unrelated navigation remain unchanged. The obsolete local dependency card is replaced by a small component, reducing the oversized Agent dialog.

Validation: `make check` passed (Docker stays stopped; migration smoke skipped). Ten browser regressions passed, including repeated setup visits, multiline instructions, execution choice preservation, refresh failure/retry, creation and cancellation followed by fresh creation. English/light and Chinese/dark layouts were visually checked with an empty-catalog fixture.

Configuration and refresh remain available when catalog models are all incompatible with the selected engine. Existing disabled options and protocol checks are preserved. A fresh independent blind review found no actionable issues after the final checks.
