### PR TITLE
fix(web): reuse pending workspace menu refresh

### DIFF
--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -108,7 +108,7 @@ export function WorkspaceSwitcher() {
     <>
       <DropdownMenu.Root
         onOpenChange={(open) => {
-          if (open) void workspacesQuery.refetch()
+          if (open) void workspacesQuery.refetch({ cancelRefetch: false })
         }}
       >
         <DropdownMenu.Trigger asChild>


### PR DESCRIPTION
Reopening the workspace menu during a pending refresh cancelled and restarted that query. Reuse the in-flight query when opening the menu; once idle, opening still refreshes workspace membership as before. This changes only the menu-open read trigger.

Validation: `make check` passed (Docker stays stopped; migration smoke skipped). Browser request counts reproduced the baseline duplicate (3 → 5), then confirmed reuse (3 → 4) through a failed cached query, Retry, Escape, and reopen; an idle reopen still made a fresh request (4 → 5). Self-reviewed as a one-line read-only correction.
