### PR TITLE
fix(web): preserve capabilities and credentials when cloning agents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,6 +274,10 @@ description and keep ownership on the side listed here.
   Explicit engine approval requests still use the durable interaction lifecycle;
   user-input requests continue to wait for a human answer.
 
+- Agent cloning copies enabled capability bindings, version choices, and configuration.
+  Pinned clones retain the stored version; latest choices resolve from the current catalog.
+  Display, credential checks, and submission use the same version. Shared credentials remain
+  independent per capability, and personal or unavailable credentials require a new choice.
 - Agent creation and editing store behavior instructions in `system_prompt`.
   Preserve saved text when opening the form; clearing it sends an empty string.
 - Property-only Agent edits omit the legacy `capabilities` replacement field

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1509,6 +1509,16 @@
       "clear": "Clear filters"
     },
     "form": {
+      "clone": {
+        "loading": "Loading the source Agent’s capabilities…",
+        "loadFailed": "The source capabilities could not be loaded.",
+        "credentials": "Capabilities and settings are copied, including available shared credentials. Personal or unavailable credentials need a new selection.",
+        "unavailable": "These source capabilities are no longer available for creation. Remove them from this copy to continue.",
+        "remove": "Remove from copy",
+        "manageCredentials": "Add or authorize credentials (opens a new tab)",
+        "refreshCredentials": "Refresh credentials",
+        "credentialsFailed": "Credentials could not be loaded."
+      },
       "title": {
         "create": "New Agent",
         "edit": "Edit Agent"

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1509,6 +1509,16 @@
       "clear": "清除筛选"
     },
     "form": {
+      "clone": {
+        "loading": "正在读取源 Agent 的能力…",
+        "loadFailed": "无法读取源 Agent 的能力。",
+        "credentials": "已复制能力、设置及可用的共享凭证。个人或已失效的凭证需要重新选择。",
+        "unavailable": "以下源能力已无法用于创建 Agent，请从本次克隆中移除后继续。",
+        "remove": "从克隆中移除",
+        "manageCredentials": "添加或授权凭证（在新标签页打开）",
+        "refreshCredentials": "刷新凭证",
+        "credentialsFailed": "无法加载凭证。"
+      },
       "title": {
         "create": "新建 Agent",
         "edit": "编辑 Agent"

--- a/apps/web/src/lib/agent-clone.ts
+++ b/apps/web/src/lib/agent-clone.ts
@@ -1,0 +1,20 @@
+import type { AgentCapability, Capability } from "./api-types"
+import { normalizeMarketplaceCapability } from "./api-marketplace"
+
+export function cloneMarketplaceCapabilities(capabilities: Capability[]): Capability[] {
+  return [...new Map(capabilities.map((capability) => {
+    const cap = normalizeMarketplaceCapability(capability)
+    return [cap.id, { ...cap, from_marketplace: true }]
+  })).values()]
+}
+
+export function withoutCredentialBindings(config: Record<string, unknown>): Record<string, unknown> {
+  const copy = { ...config }
+  delete copy.credential_bindings
+  delete copy.model_credential_binding
+  return copy
+}
+
+export function cloneableAgentCapabilities(bindings: AgentCapability[]): AgentCapability[] {
+  return bindings.filter((binding) => binding.enabled && !binding.built_in)
+}

--- a/apps/web/src/lib/api-marketplace.ts
+++ b/apps/web/src/lib/api-marketplace.ts
@@ -223,7 +223,7 @@ export function mcpDirectoryOAuthStartURL(workspaceID: string, catalogID: string
 	return `/api/v1/workspaces/${encodeURIComponent(workspaceID)}/mcp-directory/${encodeURIComponent(catalogID)}/oauth/start`
 }
 
-function normalizeMarketplaceCapability(item: MarketplaceCapability): MarketplaceCapability {
+export function normalizeMarketplaceCapability(item: MarketplaceCapability): MarketplaceCapability {
   const id = item.id ?? item.capability_id ?? ""
   return { ...item, id, latest_version: item.latest_version ?? item.latest_published_version, created_at: item.created_at ?? item.latest_version_created_at, updated_at: item.updated_at ?? item.latest_version_created_at }
 }

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -21,6 +21,14 @@ import { AgentInstructionsField } from "./agents/AgentInstructionsField"
 import { AgentVisibilityField } from "./agents/AgentVisibilityField"
 import { AgentCloudPreflight } from "./agents/AgentCloudPreflight"
 import { AgentModelPrerequisite } from "./agents/AgentModelPrerequisite"
+import { AgentCloneVersionPicker } from "./agents/AgentCloneVersionPicker"
+import { AgentCloneNotice } from "./agents/AgentCloneNotice"
+import { useAgentCloneCapabilities } from "./agents/useAgentCloneCapabilities"
+import { useAgentCloneCredentials } from "./agents/useAgentCloneCredentials"
+import { AgentCloneCredentials } from "./agents/AgentCloneCredentials"
+import { AgentCloneCredentialRefresh } from "./agents/AgentCloneCredentialRefresh"
+import { sharedSecretsForKind } from "../../lib/credential-bindings"
+import { cloneMarketplaceCapabilities, withoutCredentialBindings } from "../../lib/agent-clone"
 import { Tabs, TabsList, TabsTrigger } from "../../components/ui/tabs"
 import { ApiError } from "../../lib/api-client"
 import { cn } from "../../lib/utils"
@@ -336,10 +344,8 @@ export function CreateAgentDialog({
 
   const capabilitiesQ = useCapabilitiesQuery(workspaceID, capabilitySearch)
   const allCapabilitiesQ = useCapabilitiesQuery(workspaceID, "")
-  // In edit mode, fetch existing per-agent bindings so we can
-  // hydrate the version dropdowns with the current pinning_mode +
-  // capability_version_id. In create mode the response is empty.
-  const existingBindingsQ = useAgentCapabilitiesQuery(workspaceID, mode === "edit" ? agent?.id ?? null : null)
+  const cloneSourceID = mode === "create" && open ? agent?.id ?? null : null
+  const existingBindingsQ = useAgentCapabilitiesQuery(workspaceID, mode === "edit" ? agent?.id ?? null : cloneSourceID)
   const enableBindingMut = useEnableAgentCapabilityMutation(workspaceID, agent?.id ?? null)
   const secretsQ = useSecrets(workspaceID)
   const sharedSecrets: Secret[] = useMemo(
@@ -373,7 +379,7 @@ export function CreateAgentDialog({
     const ownCaps = capabilitiesQ.data?.capabilities ?? []
     const installedCaps = (capabilitiesQ.data?.marketplace_installs ?? []).filter((cap) => cap.visibility !== "workspace")
     const availableCaps = capabilitiesQ.data?.marketplace_available ?? []
-    const workspace: PickerOption[] = [...ownCaps, ...installedCaps].map((cap) => ({
+    const workspace: PickerOption[] = [...ownCaps, ...(cloneSourceID ? cloneMarketplaceCapabilities(installedCaps) : installedCaps)].map((cap) => ({
       id: cap.id,
       name: cap.name,
       type: cap.type,
@@ -421,7 +427,7 @@ export function CreateAgentDialog({
       }
     }
     return live
-  }, [capabilitiesQ.data, mode, capabilities])
+  }, [capabilitiesQ.data, mode, capabilities, cloneSourceID])
   const capabilityTypeCounts = useMemo(() => {
     // Ghost rows have unknown type, so they're excluded from per-type tallies
     // (still count toward "all").
@@ -493,8 +499,8 @@ export function CreateAgentDialog({
       created_at: cap.latest_version_created_at,
       updated_at: cap.latest_version_created_at,
     }))
-    return [...own, ...installed, ...available]
-  }, [allCapabilitiesQ.data])
+    return [...own, ...(cloneSourceID ? cloneMarketplaceCapabilities(installed) : installed), ...available]
+  }, [allCapabilitiesQ.data, cloneSourceID])
   const aggregatedRequiredKinds = useMemo(
     () => mode === "create"
       ? aggregateRequiredCredentialsByID(selectedCapabilityIDs, allCapabilitiesPool)
@@ -539,21 +545,23 @@ export function CreateAgentDialog({
       setHighlightedModelID(null)
       setSystemPrompt(params.get("agent_prompt") ?? (cloneSource ? promptFromAgent(cloneSource, defaultSystemPrompt) : defaultSystemPrompt))
       setCapabilities(cloneSource ? capabilitiesFromAgent(cloneSource) : [])
-      // Capability IDs aren't prefilled on clone: mapping installed names back
-      // to IDs needs an extra round-trip, so users re-pick from the marketplace.
       setSelectedCapabilityIDs([])
       setCapabilityVersionChoices({})
       setCapabilitySearch("")
       setVisibility("workspace")
       setDeviceID(cloneSource ? deviceIDFromAgent(cloneSource) : "")
       setWorkDir(cloneSource ? workDirFromAgent(cloneSource) || defaultWorkDir(initialExecutionMode) : defaultWorkDir(initialExecutionMode))
-      // Clones explicitly drop the source agent's credential bindings: the
-      // copy is a fresh agent and the user re-picks. Without these resets a
-      // previous clone's bindings would leak across dialog opens.
+      // Capability credentials are resolved separately for each cloned binding.
       setCredentialBindings({})
       setInitialCredentialBindings(undefined)
-      // Resolve the pending shared pick when secrets finish loading.
-      setModelBindingChoice({ source: "shared" })
+      // Clones keep valid shared references without choosing a different secret.
+      const sourceModelBinding = agentConfig(cloneSource).model_credential_binding as { source?: string; secret_id?: string } | undefined
+      setModelBindingChoice(sourceModelBinding?.source === "shared" && sourceModelBinding.secret_id
+        ? { source: "shared", existing_secret_id: sourceModelBinding.secret_id }
+        : { source: "shared" })
+      setModelNewSecretExpanded(false)
+      setModelNewSecretDisplayName("")
+      setModelNewSecretPlaintext("")
       setInlineNewSecrets([])
     } else if (agent) {
       setName(agent.name)
@@ -611,6 +619,20 @@ export function CreateAgentDialog({
     setStep(1)
     setCapabilityTypeFilter("all")
   }, [open, mode, agent, agent?.id, defaultAgentDescription, defaultAgentName, defaultSystemPrompt, firstModelID])
+
+  const clone = useAgentCloneCapabilities(open, cloneSourceID,
+    existingBindingsQ.isFetching || existingBindingsQ.isError ? undefined : existingBindingsQ.data?.installed,
+    setSelectedCapabilityIDs, setCapabilityVersionChoices)
+  const cloneCredentials = useAgentCloneCredentials(cloneSourceID, workspaceID, agentConfig(agent),
+    clone.bindings, allCapabilitiesPool, selectedCapabilityIDs, capabilityVersionChoices, sharedSecrets)
+  const cloneLoadFailed = Boolean(cloneSourceID) && (
+    (!clone.ready && existingBindingsQ.isError) || (!allCapabilitiesQ.data && allCapabilitiesQ.isError) ||
+    cloneCredentials.failed || (cloneCredentials.needsCredentials && secretsQ.isError)
+  )
+  const unavailableCloneCapabilities = clone.bindings.filter((binding) =>
+    selectedCapabilityIDs.includes(binding.capability_id) && (
+      !binding.capability_version_id || !allCapabilitiesPool.some((cap) => cap.id === binding.capability_id && cap.latest_version_id)
+    ))
 
   function selectExecutionMode(nextMode: ExecutionMode) {
     setExecutionMode(nextMode)
@@ -731,13 +753,23 @@ export function CreateAgentDialog({
   // on the credential_ref UI so no-credential models stay untouched; with zero
   // secrets it stays pending and the inline new-secret form takes over.
   useEffect(() => {
-    if (mode !== "create") return
+    if (mode !== "create" || cloneSourceID) return
     if (!requiresModel || selectedModel?.credential_mode !== "credential_ref") return
     if (modelBindingChoice.source !== "shared") return
     if ("existing_secret_id" in modelBindingChoice || "new_secret" in modelBindingChoice) return
     if (modelNewSecretExpanded || sharedSecrets.length === 0) return
     setModelBindingChoice({ source: "shared", existing_secret_id: sharedSecrets[0].id })
-  }, [mode, requiresModel, selectedModel, modelBindingChoice, modelNewSecretExpanded, sharedSecrets])
+  }, [mode, cloneSourceID, requiresModel, selectedModel, modelBindingChoice, modelNewSecretExpanded, sharedSecrets])
+  const modelSharedSecrets = cloneSourceID
+    ? sharedSecretsForKind(sharedSecrets, selectedModel?.credential_kind_code || "model_api_key")
+    : sharedSecrets
+  const cloneModelCredentialValid = !cloneSourceID || !requiresModel || selectedModel?.credential_mode !== "credential_ref"
+    || (visibility !== "public" && modelBindingChoice.source === "personal") || (
+    modelBindingChoice.source === "shared" && (
+      ("existing_secret_id" in modelBindingChoice && modelSharedSecrets.some((secret) => secret.id === modelBindingChoice.existing_secret_id)) ||
+      ("new_secret" in modelBindingChoice && !!modelBindingChoice.new_secret.plaintext.trim())
+    )
+  )
   const daemonExecutionEditable = connector === "agent_daemon"
   const needsCloudPreflight = daemonExecutionEditable && executionMode === "sandbox"
     && (mode === "create" || executionModeFromAgent(agent) !== "sandbox")
@@ -812,7 +844,7 @@ export function CreateAgentDialog({
       // the user a clearer error tied to the input instead of a stream error.
       return
     }
-    if (mode === "create" && allCapabilitiesQ.isLoading) return
+    if (mode === "create" && (allCapabilitiesQ.isLoading || !clone.ready || !cloneCredentials.valid || !cloneModelCredentialValid || cloneLoadFailed || unavailableCloneCapabilities.length > 0)) return
     const selectedCapabilities = mode === "create"
       ? allCapabilitiesPool.filter((cap) => selectedCapabilityIDs.includes(cap.id) && cap.latest_version_id)
       : []
@@ -828,7 +860,8 @@ export function CreateAgentDialog({
       const versionID = pinningMode === "pinned"
         ? (choice?.versionID || (cap.latest_version_id as string))
         : (cap.latest_version_id as string)
-      return { capability_version_id: versionID, pinning_mode: pinningMode }
+      return { capability_version_id: cloneSourceID ? cloneCredentials.rows.find((row) => row.capabilityID === cap.id)!.versionID : versionID, pinning_mode: pinningMode,
+        ...(cloneSourceID ? { configuration: cloneCredentials.rows.find((row) => row.capabilityID === cap.id)?.configuration } : {}) }
     })
     const profile = {
       ...(requiresModel ? { model_id: selectedModelID } : {}),
@@ -836,7 +869,7 @@ export function CreateAgentDialog({
       skills: capabilityNames,
     }
     const mergedConfig: Record<string, unknown> = {
-      ...configBaseForSubmit(agent, connector),
+      ...(cloneSourceID ? withoutCredentialBindings(configBaseForSubmit(agent, connector)) : configBaseForSubmit(agent, connector)),
       profile,
       ...(connector === "agent_daemon" ? {
         agent_kind: agentEngine,
@@ -1000,8 +1033,9 @@ export function CreateAgentDialog({
     cloudReady &&
     (connector !== "agent_daemon" || executionMode !== "local_device" || deviceID !== "") &&
     workDirValid &&
-    (mode !== "create" || !allCapabilitiesQ.isLoading) &&
-    (aggregatedRequiredKinds.length === 0 || allCredentialsSatisfied)
+    (mode !== "create" || (!allCapabilitiesQ.isLoading && clone.ready && !cloneLoadFailed && unavailableCloneCapabilities.length === 0)) &&
+    cloneModelCredentialValid &&
+    (cloneSourceID ? cloneCredentials.valid : aggregatedRequiredKinds.length === 0 || allCredentialsSatisfied)
 
   const step1Valid =
     name.trim() !== "" &&
@@ -1010,7 +1044,7 @@ export function CreateAgentDialog({
     publicModelBindingValid &&
     cloudReady &&
     (connector !== "agent_daemon" || executionMode !== "local_device" || deviceID !== "") &&
-    workDirValid
+    workDirValid && cloneModelCredentialValid
   const totalSteps = 2
   const progressPercent = Math.round((step / totalSteps) * 100)
 
@@ -1349,6 +1383,8 @@ export function CreateAgentDialog({
               {requiresModel && selectedModel && selectedModel.credential_mode === "credential_ref" && (
                 <Field label={t("credentialCheck.modelBindingTitle")}>
                   {!publicModelBindingValid && <p className="text-xs text-fg-muted [overflow-wrap:anywhere]" role="status">{t("agents.form.visibility.sharedModelRequired")}</p>}
+                  {cloneSourceID && <AgentCloneCredentialRefresh failed={secretsQ.isError} fetching={secretsQ.isFetching}
+                    onRefresh={() => { void secretsQ.refetch() }} />}
                   <div className="flex flex-col gap-1" role="radiogroup">
                     <label className={cn("flex items-start gap-2 py-1", visibility === "public" ? "cursor-not-allowed opacity-50" : "cursor-pointer")}>
                       <input
@@ -1375,8 +1411,8 @@ export function CreateAgentDialog({
                         onChange={() => {
                           // Default selection on flip-in: existing secret if any, else
                           // mark shared "pending" so the radio selects + form renders.
-                          if (sharedSecrets[0]) {
-                            setModelBindingChoice({ source: "shared", existing_secret_id: sharedSecrets[0].id })
+                          if (modelSharedSecrets[0]) {
+                            setModelBindingChoice({ source: "shared", existing_secret_id: modelSharedSecrets[0].id })
                           } else {
                             setModelBindingChoice({ source: "shared" })
                             setModelNewSecretExpanded(true)
@@ -1389,12 +1425,13 @@ export function CreateAgentDialog({
                         <span className="block">{t("credentialCheck.modelBindingShared")}</span>
                         {modelBindingChoice.source === "shared" && (
                           <div className="mt-1.5 flex flex-col gap-2">
-                            {sharedSecrets.length > 0 && (
+                            {modelSharedSecrets.length > 0 && (
                               <Select
                                 aria-label={t("credentialCheck.modelBindingShared")}
-                                value={"existing_secret_id" in modelBindingChoice ? modelBindingChoice.existing_secret_id : "__new__"}
+                                value={"existing_secret_id" in modelBindingChoice ? (modelSharedSecrets.some((secret) => secret.id === modelBindingChoice.existing_secret_id) ? modelBindingChoice.existing_secret_id : "") : "new_secret" in modelBindingChoice || modelNewSecretExpanded || !cloneSourceID ? "__new__" : ""}
                                 onValueChange={(nextValue) => {
                                   if (nextValue === "__new__") {
+                                    if (cloneSourceID) setModelBindingChoice({ source: "shared" })
                                     setModelNewSecretExpanded(true)
                                     if (!("new_secret" in modelBindingChoice)) {
                                       setModelNewSecretDisplayName("")
@@ -1407,13 +1444,14 @@ export function CreateAgentDialog({
                                 }}
                                 onClick={(e) => e.stopPropagation()}
                               >
-                                {sharedSecrets.map((s) => (
+                                {cloneSourceID && <SelectOption value="">{t("credentialCheck.sharedPlaceholder")}</SelectOption>}
+                                {modelSharedSecrets.map((s) => (
                                   <SelectOption key={s.id} value={s.id}>{s.name}</SelectOption>
                                 ))}
                                 <SelectOption value="__new__">{t("credentialCheck.createNewShared")}</SelectOption>
                               </Select>
                             )}
-                            {sharedSecrets.length === 0 && !modelNewSecretExpanded && !("new_secret" in modelBindingChoice) && (
+                            {modelSharedSecrets.length === 0 && !modelNewSecretExpanded && !("new_secret" in modelBindingChoice) && (
                               <Button
                                 type="button"
                                 variant="outline"
@@ -1499,9 +1537,11 @@ export function CreateAgentDialog({
                                       // If the user cancels and no existing secret has been chosen yet,
                                       // fall the binding back to an existing one (if any) or to personal,
                                       // so we don't leave the shared radio "selected with nothing inside".
-                                      if (!("new_secret" in modelBindingChoice)) {
-                                        if (sharedSecrets[0]) {
-                                          setModelBindingChoice({ source: "shared", existing_secret_id: sharedSecrets[0].id })
+                                      if (cloneSourceID) {
+                                        setModelBindingChoice({ source: "shared" })
+                                      } else if (!("new_secret" in modelBindingChoice)) {
+                                        if (modelSharedSecrets[0]) {
+                                          setModelBindingChoice({ source: "shared", existing_secret_id: modelSharedSecrets[0].id })
                                         } else if (visibility !== "public") {
                                           setModelBindingChoice({ source: "personal" })
                                         }
@@ -1544,6 +1584,13 @@ export function CreateAgentDialog({
 
           {step === 2 && (
             <>
+              {cloneSourceID && <AgentCloneNotice
+                ready={clone.ready && cloneCredentials.ready && !allCapabilitiesQ.isLoading}
+                failed={cloneLoadFailed}
+                unavailable={unavailableCloneCapabilities}
+                onRetry={() => { void existingBindingsQ.refetch(); void allCapabilitiesQ.refetch(); void secretsQ.refetch(); cloneCredentials.retry() }}
+                onRemove={(id) => setSelectedCapabilityIDs((current) => current.filter((selected) => selected !== id))}
+              />}
               <section className="flex flex-col gap-3">
                 <Input value={capabilitySearch} onChange={(e) => setCapabilitySearch(e.target.value)} placeholder={t("agents.form.placeholders.capabilitySearch")} />
                 {capabilityOptions.length === 0 ? (
@@ -1577,7 +1624,7 @@ export function CreateAgentDialog({
                               const checked = mode === "create" ? selectedCapabilityIDs.includes(cap.id) : capabilities.includes(cap.name)
                               const lockedNoVersion = mode === "create" && !cap.latestVersionID
                               const lockedDeprecatedAndUnchecked = cap.deprecated && !checked
-                              const disabled = lockedNoVersion || lockedDeprecatedAndUnchecked
+                              const disabled = lockedNoVersion || lockedDeprecatedAndUnchecked || !clone.ready
                               const ghostTitle = cap.deprecated ? t("agents.form.deprecatedCapabilityTooltip") : undefined
                               return (
                                 <label key={`${sec}:${cap.id || cap.name}`} title={ghostTitle} data-row-index={index} className={cn("flex w-full min-w-0 items-start gap-2 border-b border-line py-2 text-left", disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer hover:app-hover")}>
@@ -1596,7 +1643,14 @@ export function CreateAgentDialog({
                                       {cap.deprecated && <span className="shrink-0"><Badge variant="warning" dot>{t("agents.form.deprecatedCapabilityBadge")}</Badge></span>}
                                       {!cap.deprecated && !checked && cap.latestVersion && <span className="shrink-0 font-mono text-xs text-fg-muted">v{cap.latestVersion}</span>}
                                       {!cap.deprecated && !checked && !cap.latestVersion && <span className="shrink-0"><Badge variant="warning" dot>{t("agents.form.noCapabilityVersion")}</Badge></span>}
-                                      {!cap.deprecated && checked && cap.id && (
+                                      {!cap.deprecated && checked && cap.id && (cloneSourceID ? (
+                                        <AgentCloneVersionPicker
+                                          label={`${cap.name} · ${t("agents.detail.capabilities.enableDialog.version")}`}
+                                          row={cloneCredentials.rows.find((row) => row.capabilityID === cap.id)}
+                                          choice={capabilityVersionChoices[cap.id]}
+                                          onChange={(next) => setCapabilityVersionChoice(cap.id, next)}
+                                        />
+                                      ) : (
                                         <CapabilityVersionPicker
                                           label={`${cap.name} · ${t("agents.detail.capabilities.enableDialog.version")}`}
                                           capabilityID={cap.id}
@@ -1607,7 +1661,7 @@ export function CreateAgentDialog({
                                           choice={capabilityVersionChoices[cap.id]}
                                           onChange={(next) => setCapabilityVersionChoice(cap.id, next)}
                                         />
-                                      )}
+                                      ))}
                                     </span>
                                     {cap.description && !cap.deprecated && <span className="block truncate text-xs text-fg-muted">{cap.description}</span>}
                                   </span>
@@ -1622,7 +1676,8 @@ export function CreateAgentDialog({
                 )}
               </section>
 
-              {aggregatedRequiredKinds.length > 0 && (
+              {cloneSourceID ? <AgentCloneCredentials credentials={cloneCredentials} workspaceID={workspaceID}
+                failed={secretsQ.isError} fetching={secretsQ.isFetching} onRefresh={() => { void secretsQ.refetch() }} /> : aggregatedRequiredKinds.length > 0 && (
                 <section className="flex flex-col gap-3">
                   <h3 className="text-sm font-medium text-fg">{t("agents.form.sections.credentials")}</h3>
                   <CredentialCheckPanel

--- a/apps/web/src/pages/admin/agents/AgentCloneCredentialRefresh.tsx
+++ b/apps/web/src/pages/admin/agents/AgentCloneCredentialRefresh.tsx
@@ -1,0 +1,18 @@
+import { useTranslation } from "react-i18next"
+import { Button } from "../../../components/ui/button"
+import { ErrorState } from "../../../components/ui/error-state"
+
+export function AgentCloneCredentialRefresh({ failed, fetching, onRefresh }: {
+  failed: boolean
+  fetching: boolean
+  onRefresh: () => void
+}) {
+  const { t } = useTranslation("admin")
+  const { t: tc } = useTranslation("common")
+  const action = <Button type="button" variant="outline" size="sm" disabled={fetching} onClick={onRefresh}>
+    {fetching ? tc("states.loading") : t("agents.form.clone.refreshCredentials")}
+  </Button>
+  return failed
+    ? <ErrorState appearance="panel" title={t("agents.form.clone.credentialsFailed")} action={action} />
+    : <div>{action}</div>
+}

--- a/apps/web/src/pages/admin/agents/AgentCloneCredentials.tsx
+++ b/apps/web/src/pages/admin/agents/AgentCloneCredentials.tsx
@@ -1,0 +1,39 @@
+import { useTranslation } from "react-i18next"
+import { CredentialBindingSelect } from "../../../components/admin/CredentialBindingSelect"
+import { Field } from "../../../components/ui/label"
+import { credentialKindLabel } from "../../../lib/credential-kind-ui"
+import type { useAgentCloneCredentials } from "./useAgentCloneCredentials"
+import { AgentCloneCredentialRefresh } from "./AgentCloneCredentialRefresh"
+
+export function AgentCloneCredentials({ credentials, workspaceID, failed, fetching, onRefresh }: {
+  credentials: ReturnType<typeof useAgentCloneCredentials>
+  workspaceID: string | null
+  failed: boolean
+  fetching: boolean
+  onRefresh: () => void
+}) {
+  const { t, i18n } = useTranslation("admin")
+  if (!credentials.needsCredentials) return null
+  return <section className="flex flex-col gap-3">
+    <h3 className="text-sm font-medium text-fg">{t("agents.form.sections.credentials")}</h3>
+    {credentials.rows.filter((row) => row.fields.length > 0).map((row) => (
+      <div key={row.capabilityID} className="space-y-3 rounded-md border border-line p-3">
+        <h4 className="break-words text-sm font-medium">{row.name}</h4>
+        {row.fields.map((field) => (
+          <Field key={field.kind} label={credentialKindLabel(field.kind, i18n.language, field.kind)}>
+            <CredentialBindingSelect
+              label={`${row.name} · ${credentialKindLabel(field.kind, i18n.language, field.kind)}`}
+              value={field.value} secrets={field.available} allowPersonal={false}
+              personalLabel={t("credentialCheck.sharedPlaceholder")}
+              sharedLabel={t("credentialCheck.sourceShared")}
+              onChange={(value) => credentials.choose(row.capabilityID, field.kind, value)}
+            />
+          </Field>
+        ))}
+      </div>
+    ))}
+    <a href={`/?ws=${encodeURIComponent(workspaceID ?? "")}&admin=credentials`} target="_blank" rel="noopener noreferrer"
+      className="text-sm text-fg underline underline-offset-4">{t("agents.form.clone.manageCredentials")}</a>
+    <AgentCloneCredentialRefresh failed={failed} fetching={fetching} onRefresh={onRefresh} />
+  </section>
+}

--- a/apps/web/src/pages/admin/agents/AgentCloneNotice.tsx
+++ b/apps/web/src/pages/admin/agents/AgentCloneNotice.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from "react-i18next"
+import { Button } from "../../../components/ui/button"
+import { ErrorState, InlineNotice } from "../../../components/ui/error-state"
+import type { AgentCapability } from "../../../lib/api-types"
+
+export function AgentCloneNotice({ ready, failed, unavailable, onRetry, onRemove }: {
+  ready: boolean
+  failed: boolean
+  unavailable: AgentCapability[]
+  onRetry: () => void
+  onRemove: (id: string) => void
+}) {
+  const { t } = useTranslation("admin")
+  const { t: tc } = useTranslation("common")
+  if (failed) return <ErrorState appearance="panel" title={t("agents.form.clone.loadFailed")}
+    action={<Button type="button" size="sm" variant="outline" onClick={onRetry}>{tc("actions.retry")}</Button>} />
+  if (!ready) return <p role="status" className="text-sm text-fg-muted">{t("agents.form.clone.loading")}</p>
+  return (
+    <div className="space-y-3 rounded-md border border-line p-3">
+      <InlineNotice>{t("agents.form.clone.credentials")}</InlineNotice>
+      {unavailable.length > 0 && <>
+        <p className="text-sm text-fg">{t("agents.form.clone.unavailable")}</p>
+        {unavailable.map((binding) => (
+          <div key={binding.capability_id} className="flex items-center gap-2">
+            <span className="min-w-0 flex-1 break-words text-sm">{binding.capability?.name ?? binding.name ?? binding.capability_id}</span>
+            <Button type="button" size="sm" variant="outline" onClick={() => onRemove(binding.capability_id)}>{t("agents.form.clone.remove")}</Button>
+          </div>
+        ))}
+      </>}
+    </div>
+  )
+}

--- a/apps/web/src/pages/admin/agents/AgentCloneVersionPicker.tsx
+++ b/apps/web/src/pages/admin/agents/AgentCloneVersionPicker.tsx
@@ -1,0 +1,25 @@
+import { useTranslation } from "react-i18next"
+import { Select, SelectOption } from "../../../components/ui/select"
+import type { useAgentCloneCredentials } from "./useAgentCloneCredentials"
+
+type Choice = { pinningMode: "latest" | "pinned"; versionID: string; pinnedVersion?: string }
+
+export function AgentCloneVersionPicker({ label, row, choice, onChange }: {
+  label: string
+  row: ReturnType<typeof useAgentCloneCredentials>["rows"][number] | undefined
+  choice: Choice | undefined
+  onChange: (choice: Choice) => void
+}) {
+  const { t } = useTranslation("admin")
+  return <Select aria-label={label} value={choice?.pinningMode === "pinned" ? choice.versionID : "__latest__"}
+    disabled={!row?.ready} wrapperClassName="ml-1 w-auto shrink-0" className="w-auto font-mono text-xs"
+    onClick={(event) => event.stopPropagation()}
+    onValueChange={(value) => onChange(value === "__latest__"
+      ? { pinningMode: "latest", versionID: row?.latestVersionID ?? "" }
+      : { pinningMode: "pinned", versionID: value, pinnedVersion: row?.versions.find((version) => version.id === value)?.version })}>
+    <SelectOption value="__latest__">{t("agents.form.versionPicker.latest")}{row?.latestVersion ? ` (v${row.latestVersion})` : ""}</SelectOption>
+    {choice?.pinningMode === "pinned" && !row?.versions.some((version) => version.id === choice.versionID) &&
+      <SelectOption value={choice.versionID}>v{choice.pinnedVersion ?? "?"}</SelectOption>}
+    {row?.versions.map((version) => <SelectOption key={version.id} value={version.id}>v{version.version}</SelectOption>)}
+  </Select>
+}

--- a/apps/web/src/pages/admin/agents/useAgentCloneCapabilities.ts
+++ b/apps/web/src/pages/admin/agents/useAgentCloneCapabilities.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react"
+import { cloneableAgentCapabilities } from "../../../lib/agent-clone"
+import type { AgentCapability } from "../../../lib/api-types"
+
+type VersionChoice = { pinningMode: "latest" | "pinned"; versionID: string; pinnedVersion?: string }
+
+export function useAgentCloneCapabilities(
+  open: boolean,
+  sourceID: string | null,
+  bindings: AgentCapability[] | undefined,
+  setSelectedIDs: Dispatch<SetStateAction<string[]>>,
+  setVersionChoices: Dispatch<SetStateAction<Record<string, VersionChoice>>>,
+) {
+  const [snapshot, setSnapshot] = useState<{ sourceID: string; bindings: AgentCapability[] } | null>(null)
+  useEffect(() => {
+    if (!open || !sourceID) {
+      setSnapshot(null)
+      return
+    }
+    if (snapshot?.sourceID === sourceID || !bindings) return
+    const selected = cloneableAgentCapabilities(bindings)
+    setSelectedIDs(selected.map((binding) => binding.capability_id))
+    setVersionChoices(Object.fromEntries(selected.map((binding) => [binding.capability_id, {
+      pinningMode: binding.pinning_mode === "latest" ? "latest" : "pinned",
+      versionID: binding.capability_version_id,
+      pinnedVersion: binding.version ?? binding.capability?.pinned_version,
+    }])))
+    setSnapshot({ sourceID, bindings: selected })
+  }, [open, sourceID, bindings, snapshot, setSelectedIDs, setVersionChoices])
+  return {
+    ready: !sourceID || snapshot?.sourceID === sourceID,
+    bindings: snapshot?.sourceID === sourceID ? snapshot.bindings : [],
+  }
+}

--- a/apps/web/src/pages/admin/agents/useAgentCloneCredentials.ts
+++ b/apps/web/src/pages/admin/agents/useAgentCloneCredentials.ts
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react"
+import { useQueries } from "@tanstack/react-query"
+import { KEY_CAPABILITY_VERSIONS, listCapabilityVersions } from "../../../lib/api-capabilities"
+import { noUnreachableRetry } from "../../../lib/api-client"
+import type { AgentCapability, Capability, CapabilityVersion, Secret } from "../../../lib/api-types"
+import { credentialBinding, sharedSecretsForKind } from "../../../lib/credential-bindings"
+import { catalogIDFromVersion } from "../../../lib/capability-config"
+import { withoutCredentialBindings } from "../../../lib/agent-clone"
+import { useMarketplaceList } from "../../../lib/api-marketplace"
+
+export function useAgentCloneCredentials(
+  sourceID: string | null,
+  workspaceID: string | null,
+  sourceConfig: Record<string, unknown>,
+  bindings: AgentCapability[],
+  capabilities: Capability[],
+  selectedIDs: string[],
+  versions: Record<string, { pinningMode: "latest" | "pinned"; versionID: string }>,
+  secrets: Secret[],
+) {
+  const [choices, setChoices] = useState<Record<string, Record<string, string>>>({})
+  useEffect(() => setChoices({}), [sourceID])
+  const selected = sourceID ? capabilities.filter((cap) => selectedIDs.includes(cap.id)) : []
+  const hasMarketplace = selected.some((cap) => cap.from_marketplace)
+  const marketplace = useMarketplaceList(hasMarketplace ? workspaceID : null)
+  const queries = useQueries({ queries: selected.map((cap) => ({
+    queryKey: KEY_CAPABILITY_VERSIONS(workspaceID ?? "_none", cap.id),
+    queryFn: () => listCapabilityVersions(workspaceID as string, cap.id),
+    enabled: !!workspaceID && !cap.from_marketplace,
+    retry: noUnreachableRetry,
+    staleTime: 30_000,
+  })) })
+  const rows = selected.map((cap, index) => {
+    const query = queries[index]
+    const choice = versions[cap.id]
+    const versionID = choice?.pinningMode === "pinned" ? choice.versionID : cap.latest_version_id
+    const source = bindings.find((binding) => binding.capability_id === cap.id)
+    const published = marketplace.data?.find((item) => item.id === cap.id && item.latest_version_id === cap.latest_version_id)
+    // Installed and published metadata is the authorized view for foreign capabilities.
+    const foreignVersions = [
+      ...(source ? [{ id: source.capability_version_id, version: source.version ?? source.capability?.pinned_version ?? "?",
+        required_credentials: source.required_credentials ?? source.capability?.required_credentials }] : []),
+      ...(published?.latest_version_id && published.latest_version_id !== source?.capability_version_id
+        ? [{ id: published.latest_version_id, version: published.latest_version ?? "?", required_credentials: published.required_credentials }] : []),
+    ]
+    const availableVersions: Pick<CapabilityVersion, "id" | "version" | "required_credentials" | "source_payload">[] =
+      cap.from_marketplace ? foreignVersions : query.data?.versions ?? []
+    const version = availableVersions.find((item) => item.id === versionID)
+    const fields = (version?.required_credentials ?? []).map((rc) => {
+      const available = sharedSecretsForKind(secrets, rc.kind, catalogIDFromVersion(version as CapabilityVersion | undefined))
+      // A per-capability personal binding overrides an Agent-wide shared one.
+      const original = credentialBinding(source?.configuration, rc.kind) ?? credentialBinding(sourceConfig, rc.kind)
+      const requested = choices[cap.id]?.[rc.kind] ?? original?.secretID ?? ""
+      const value = available.some((secret) => secret.id === requested) ? requested : ""
+      return { ...rc, available, value }
+    })
+    const configuration = withoutCredentialBindings(source?.configuration ?? {})
+    if (fields.length) configuration.credential_bindings = Object.fromEntries(fields
+      .filter((field) => field.value)
+      .map((field) => [field.kind, { source: "shared", secret_id: field.value }]))
+    return { capabilityID: cap.id, name: cap.name, versionID, fields, configuration,
+      versions: availableVersions, latestVersionID: cap.latest_version_id ?? "", latestVersion: cap.latest_version ?? "",
+      ready: !!version,
+      failed: cap.from_marketplace ? !version && (marketplace.isError || marketplace.isSuccess) : query.isError || (query.isSuccess && !version),
+    }
+  })
+  return {
+    rows,
+    ready: rows.every((row) => row.ready),
+    failed: rows.some((row) => row.failed),
+    valid: rows.every((row) => row.ready && row.fields.every((field) => !field.required || field.value)),
+    needsCredentials: rows.some((row) => row.fields.length > 0),
+    retry: () => {
+      if (hasMarketplace) void marketplace.refetch()
+      for (const [index, query] of queries.entries()) if (!selected[index].from_marketplace) void query.refetch()
+    },
+    choose: (capabilityID: string, kind: string, secretID: string) => setChoices((prev) => ({
+      ...prev, [capabilityID]: { ...prev[capabilityID], [kind]: secretID },
+    })),
+  }
+}

--- a/tests/e2e/agent-clone.spec.ts
+++ b/tests/e2e/agent-clone.spec.ts
@@ -1,0 +1,168 @@
+import { expect, test, type Page } from "@playwright/test";
+import { json, WORKSPACE_ID as workspace, AGENT_ID as agentID } from "./helpers/conversation-app";
+
+test("clone retains enabled bindings, independent credentials, and pinned versions", async ({ page }) => {
+  const state = await mockClone(page);
+  const dialog = await openClone(page);
+  await expect(dialog.getByRole("checkbox", { name: /Policy/ })).toBeChecked();
+  await expect(dialog.getByRole("checkbox", { name: /Desk/ })).toBeChecked();
+  await dialog.getByRole("button", { name: "Create Agent", exact: true }).click();
+  await expect.poll(() => state.creates.length).toBe(1);
+  const body = state.creates[0];
+  expect(body.visibility).toBe("workspace");
+  expect(body.initial_capabilities).toEqual([
+    { capability_version_id: "policy-v1", pinning_mode: "pinned", configuration: { retained: "policy", credential_bindings: { mcp_oauth: { source: "shared", secret_id: "notion-key" } } } },
+    { capability_version_id: "desk-v1", pinning_mode: "latest", configuration: { retained: "desk", credential_bindings: { mcp_oauth: { source: "shared", secret_id: "linear-key" } } } },
+  ]);
+  expect(body.config).not.toHaveProperty("credential_bindings");
+  expect(state.otherWrites).toEqual([]);
+});
+
+for (const foreign of [false, true]) {
+test(`latest display, credentials, and submission advance together (${foreign ? "marketplace" : "workspace"})`, async ({ page }) => {
+  await page.clock.install();
+  const state = await mockClone(page, { foreign });
+  const dialog = await openClone(page);
+  await expect(dialog.getByRole("combobox", { name: "Desk · Version" })).toContainText("v1.0.0");
+  state.latest = 2;
+  await page.clock.fastForward(31_000);
+  await page.evaluate(() => { window.dispatchEvent(new Event("offline")); window.dispatchEvent(new Event("online")); });
+  await expect(dialog.getByRole("combobox", { name: "Desk · Version" })).toContainText("v2.0.0");
+  await expect(dialog.getByRole("button", { name: "Create Agent", exact: true })).toBeDisabled();
+  const credential = dialog.getByRole("combobox", { name: /Desk · GitHub/ });
+  await credential.click();
+  await page.getByRole("option", { name: /GitHub key/ }).click();
+  await dialog.getByRole("button", { name: "Create Agent", exact: true }).click();
+  await expect.poll(() => state.creates.length).toBe(1);
+  expect(state.creates[0].initial_capabilities[1]).toEqual({ capability_version_id: "desk-v2", pinning_mode: "latest", configuration: {
+    retained: "desk", credential_bindings: { github_pat: { source: "shared", secret_id: "github-key" } },
+  } });
+  if (foreign) expect(state.versionReads).toEqual([]);
+});
+}
+
+test("marketplace clones use installed metadata without private history reads", async ({ page }) => {
+  const state = await mockClone(page, { foreign: true });
+  const dialog = await openClone(page);
+  await dialog.getByRole("button", { name: "Create Agent", exact: true }).click();
+  await expect.poll(() => state.creates.length).toBe(1);
+  expect(state.versionReads).toEqual([]);
+  expect(state.creates[0].initial_capabilities.map((item: any) => item.capability_version_id)).toEqual(["policy-v1", "desk-v1"]);
+});
+
+test("source failure cannot create an empty clone and retry retains the draft", async ({ page }) => {
+  const state = await mockClone(page, { failure: true });
+  const dialog = await openClone(page);
+  await expect(dialog.getByRole("button", { name: "Create Agent", exact: true })).toBeDisabled();
+  await expect(dialog.getByRole("button", { name: "Retry", exact: true })).toBeVisible();
+  state.failure = false;
+  await dialog.getByRole("button", { name: "Retry", exact: true }).click();
+  await expect(dialog.getByRole("checkbox", { name: /Policy/ })).toBeChecked();
+  await dialog.getByRole("checkbox", { name: /Desk/ }).uncheck();
+  await dialog.getByRole("button", { name: "Create Agent", exact: true }).click();
+  await expect.poll(() => state.creates.length).toBe(1);
+  expect(state.creates[0].name).toBe("Clone draft");
+  expect(state.creates[0].initial_capabilities).toHaveLength(1);
+});
+
+test("closing a clone does not seed ordinary creation", async ({ page }) => {
+  const state = await mockClone(page);
+  const dialog = await openClone(page);
+  await expect(dialog.getByRole("checkbox", { name: /Policy/ })).toBeChecked();
+  await dialog.getByRole("button", { name: "Close", exact: true }).click();
+  await page.getByRole("button", { name: "New Agent", exact: true }).click();
+  await dialog.getByRole("radio", { name: /Cloud isolation/ }).check();
+  await dialog.getByPlaceholder("Search models in this Workspace").click();
+  await dialog.getByRole("option", { name: /QA Model/ }).click();
+  await dialog.getByRole("button", { name: "Next", exact: true }).click();
+  await expect(dialog.getByRole("checkbox", { name: /Policy/ })).not.toBeChecked();
+  await dialog.getByRole("button", { name: "Create Agent", exact: true }).click();
+  await expect.poll(() => state.creates.length).toBe(1);
+  expect(state.creates[0].initial_capabilities).toEqual([]);
+});
+
+for (const source of ["personal", "shared"]) {
+  test(`clone model credentials: ${source}`, async ({ page }) => {
+    const state = await mockClone(page, { modelSource: source });
+    await page.goto(`/?ws=${workspace}&admin=agents`);
+    await page.getByRole("button", { name: "More actions", exact: true }).click();
+    await page.getByRole("menuitem", { name: "Clone", exact: true }).click();
+    const dialog = page.getByRole("dialog", { name: "New Agent", exact: true });
+    if (source === "personal") {
+      await expect(dialog.getByRole("button", { name: "Next", exact: true })).toBeDisabled();
+      await dialog.getByRole("radio", { name: /Each caller/ }).check();
+    }
+    await dialog.getByRole("button", { name: "Next", exact: true }).click();
+    await dialog.getByRole("button", { name: "Create Agent", exact: true }).click();
+    await expect.poll(() => state.creates.length).toBe(1);
+    if (source === "shared") expect(state.creates[0].config.model_credential_binding).toEqual({ source: "shared", secret_id: "model-key" });
+    else expect(state.creates[0].config).not.toHaveProperty("model_credential_binding");
+  });
+}
+
+async function openClone(page: Page) {
+  await page.goto(`/?ws=${workspace}&admin=agents`);
+  await page.getByRole("button", { name: "More actions", exact: true }).click();
+  await page.getByRole("menuitem", { name: "Clone", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "New Agent", exact: true });
+  await dialog.getByRole("textbox", { name: "Name", exact: true }).fill("Clone draft");
+  await dialog.getByRole("button", { name: "Next", exact: true }).click();
+  return dialog;
+}
+
+async function mockClone(page: Page, options: { foreign?: boolean; failure?: boolean; modelSource?: string } = {}) {
+  const state = { latest: 1, failure: options.failure ?? false, creates: [] as any[], otherWrites: [] as string[], versionReads: [] as string[] };
+  const base = `/api/v1/workspaces/${workspace}`;
+  const agent = { id: agentID, workspace_id: workspace, name: "Clone source", status: "active", connector_type: "agent_daemon", visibility: "workspace",
+    config: { agent_kind: "opencode", daemon_mode: "sandbox", model_id: "model-1", credential_bindings: { removed_personal: { source: "personal" } },
+      ...(options.modelSource ? { model_credential_binding: options.modelSource === "shared" ? { source: "shared", secret_id: "model-key" } : { source: "personal" } } : {}),
+    } };
+  const required = (kind: string) => [{ kind, required: true }];
+  const caps = () => ["policy", "desk"].map((id) => ({ id, workspace_id: options.foreign ? "foreign" : workspace, name: id === "policy" ? "Policy" : "Desk", type: "mcp", status: "active",
+    visibility: "public", from_marketplace: options.foreign ?? false, latest_version_id: `${id}-v${id === "policy" ? 2 : state.latest}`, latest_version: `${id === "policy" ? 2 : state.latest}.0.0`,
+    required_credentials: required(id === "desk" && state.latest === 2 ? "github_pat" : "mcp_oauth"),
+  }));
+  const installed = () => caps().map((cap) => ({ id: `binding-${cap.id}`, capability_id: cap.id, capability_version_id: `${cap.id}-v1`, enabled: true,
+    pinning_mode: cap.id === "policy" ? "pinned" : "latest", version: "1.0.0",
+    capability: { ...cap, pinned_version: "1.0.0", required_credentials: required("mcp_oauth") },
+    configuration: { retained: cap.id, credential_bindings: { mcp_oauth: { source: "shared", secret_id: cap.id === "policy" ? "notion-key" : "linear-key" } } },
+  }));
+  await page.addInitScript(() => { localStorage.setItem("parsar.lang", "en-US"); localStorage.setItem("parsar.theme", "light"); });
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const method = route.request().method();
+    if (method !== "GET" && path !== `${base}/agents`) state.otherWrites.push(`${method} ${path}`);
+    if (path === "/api/v1/me") return json(route, { user_id: "user-1", name: "Owner", email: "owner@example.test" });
+    if (path === "/api/v1/me/workspaces") return json(route, { workspaces: [{ id: workspace, name: "Clone test", role: "owner" }] });
+    if (path === `${base}/runtime/status`) return json(route, { available: true, profile: "managed" });
+    if (path === `${base}/agents`) {
+      if (method === "POST") { state.creates.push(route.request().postDataJSON()); return json(route, { agent }, 201); }
+      return json(route, { agents: [agent] });
+    }
+    if (path === `${base}/agents/${agentID}` || path === `/api/v1/agents/${agentID}`) return json(route, agent);
+    if (path === `${base}/agents/${agentID}/capabilities`) return state.failure
+      ? json(route, { error: "forbidden", message: "Synthetic source failure" }, 403)
+      : json(route, { installed: [...installed(), { id: "builtin", capability_id: "builtin", built_in: true, enabled: true }, { id: "disabled", capability_id: "disabled", enabled: false }], available: [] });
+    if (path === `${base}/capabilities`) return json(route, options.foreign ? { capabilities: [], marketplace_installs: caps().map((cap) => ({
+      capability_id: cap.id, source_workspace_id: "foreign", source_workspace_name: "Publisher", name: cap.name, type: cap.type, visibility: "public",
+      pinned_version_id: `${cap.id}-v1`, pinned_version: "1.0.0", latest_version_id: cap.latest_version_id, latest_published_version: cap.latest_version,
+      required_credentials: required("mcp_oauth"),
+    })) } : { capabilities: caps() });
+    if (path === "/api/v1/capabilities/marketplace") return json(route, { capabilities: caps().map(({ id, ...cap }) => ({ ...cap, capability_id: id })) });
+    const match = path.match(/\/capabilities\/(policy|desk)\/versions$/);
+    if (match) {
+      state.versionReads.push(match[1]);
+      if (options.foreign) return json(route, { error: "not_found" }, 404);
+      const id = match[1];
+      return json(route, { versions: [1, 2].map((n) => ({ id: `${id}-v${n}`, capability_id: id, version: `${n}.0.0`,
+        required_credentials: required(id === "desk" && n === 2 ? "github_pat" : "mcp_oauth"), source_payload: { catalog_id: id === "policy" ? "notion" : "linear" },
+      })) });
+    }
+    if (path === `${base}/secrets`) return json(route, { secrets: ["notion", "linear", "github", "model"].map((name) => ({ id: `${name}-key`, name: name === "github" ? "GitHub key" : `${name} key`, kind: "capability_inline", status: "active", auth_type: "oauth2", provider: name,
+      metadata: { credential_kind_code: name === "github" ? "github_pat" : name === "model" ? "model_api_key" : "mcp_oauth" },
+    })) });
+    if (path.endsWith("/models")) return json(route, { models: [{ id: "model-1", name: "QA Model", model_key: "qa-model", status: "active", provider_type: "anthropic", adapter: "anthropic", credential_mode: options.modelSource ? "credential_ref" : "inline_secret", credential_kind_code: "model_api_key", config: {} }] });
+    return json(route, {});
+  });
+  return state;
+}


### PR DESCRIPTION
Cloning an Agent copied its execution settings but silently dropped installed capabilities. The clone now retains enabled bindings and non-credential configuration. Pinned versions stay fixed; latest choices use the current catalog consistently for the displayed version, credential checks, and creation request.

Valid shared credential references stay independent per capability. Personal or unavailable capability references require an explicit replacement, and model credentials preserve an authorized shared selection or require a choice. Source-read failures block an empty clone and can be retried without losing the draft. Marketplace clones use authorized installed/published metadata rather than the publisher’s version history.

Scope: Agent cloning only. Ordinary creation and editing, server authorization, and runtime version resolution are unchanged.

Validation: `make check` and production web build passed. All 18 focused browser cases (8 clone + 10 existing creation/editing cases) passed their assertions; the local Playwright worker teardown hung under Node 24 and 26, so the bounded runner exited at its global timeout. An independent reviewer separately reproduced all 8 passing clone cases and the teardown hang. A real CC/M3 clone preserved both the ZIP Skill and MCP binding without changing its source; a new conversation executed both and returned the expected policy and ticket results. Local Docker remains stopped, so local migration smoke was skipped by the required gate. A fresh independent blind review of the complete final diff found no blocking issues. A real marketplace clone also preserved the published capability, stored version and configuration without modifying its source.

Tracks Feishu BUG-014; supersedes draft #363 after review and deployment.
