### PR TITLE
fix(opencode): record the selected model in usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,6 +289,9 @@ description and keep ownership on the side listed here.
   respectively, preserving explicit base paths; absent mappings preserve their
   legacy base URL. Explicit provider SDK options retain precedence over generated
   defaults.
+- OpenCode usage records the model selected by the CLI launch plan, removing
+  only the provider prefix. Without an explicit selection, keep the model unknown;
+  do not infer it from token counts or change cost/provider semantics.
 - Claude Code streaming deltas and their per-block assistant copies must be
   emitted once; preserve separate text blocks even when their content matches.
 - Claude Code failure details may arrive in `error`, `result`, or `errors`.

--- a/apps/parsar-daemon/internal/agent/opencode/options.go
+++ b/apps/parsar-daemon/internal/agent/opencode/options.go
@@ -13,10 +13,11 @@ import (
 
 // BuildResult is the opencode CLI launch plan for one prompt.
 type BuildResult struct {
-	Args    []string
-	Env     []string
-	WorkDir string
-	Cleanup func()
+	Args          []string
+	Env           []string
+	WorkDir       string
+	ModelSelector string
+	Cleanup       func()
 }
 
 // BuildArgs translates the daemon prompt_request into an `opencode
@@ -41,6 +42,7 @@ func BuildArgs(runID, prompt, workDir string, opts map[string]any) (BuildResult,
 	}
 	if model := firstString(opts, "model_selector", "model"); model != "" {
 		args = append(args, "--model", model)
+		result.ModelSelector = model
 	}
 	if agent := stringOpt(opts, "agent"); agent != "" {
 		args = append(args, "--agent", agent)

--- a/apps/parsar-daemon/internal/agent/opencode/session.go
+++ b/apps/parsar-daemon/internal/agent/opencode/session.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -40,6 +41,7 @@ func Factory(ctx context.Context, req proto.PromptRequestPayload, out chan<- pro
 // Session wraps a single `opencode run` subprocess.
 type Session struct {
 	runID string
+	model string
 	cfg   sessionConfig
 
 	cmd *exec.Cmd
@@ -109,9 +111,14 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		buildRes.Cleanup()
 		return nil, fmt.Errorf("opencode: start %q: %w", cfg.opencodeBinary, err)
 	}
+	model := buildRes.ModelSelector
+	if _, key, qualified := strings.Cut(model, "/"); qualified {
+		model = key
+	}
 
 	s := &Session{
 		runID:     req.RunID,
+		model:     model,
 		cfg:       cfg,
 		cmd:       cmd,
 		out:       out,
@@ -158,6 +165,7 @@ func (s *Session) run(stdout io.Reader) {
 	defer s.closeOut()
 
 	tr := newTranslator(s.runID)
+	tr.usage.Model = s.model
 	sc := bufio.NewScanner(stdout)
 	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
 	for sc.Scan() {

--- a/apps/parsar-daemon/internal/agent/opencode/session_model_test.go
+++ b/apps/parsar-daemon/internal/agent/opencode/session_model_test.go
@@ -1,0 +1,57 @@
+package opencode_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/opencode"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestSessionUsageCarriesSelectedModel(t *testing.T) {
+	for _, tc := range []struct {
+		name, selector, fallback, want string
+	}{
+		{"managed selector wins", "anthropic/MiniMax-M3", "old-model", "MiniMax-M3"},
+		{"model path", "openrouter/anthropic/claude", "", "anthropic/claude"},
+		{"legacy model", "", "openai/gpt-4o", "gpt-4o"},
+		{"bare model", "", "MiniMax-M3", "MiniMax-M3"},
+		{"native default remains unknown", "", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := opencodeHelperReq("run_model", "hello", "json-success")
+			req.AgentOptions["model_selector"] = tc.selector
+			req.AgentOptions["model"] = tc.fallback
+			out := make(chan proto.Envelope, 32)
+			session, err := opencode.NewSessionForTest(context.Background(), req, out, opencodeHelperConfig())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer session.Cancel(context.Background())
+			events, closed := drainOpenCode(t, out, 5*time.Second)
+			if !closed {
+				t.Fatal("session did not finish")
+			}
+			count := 0
+			for _, event := range events {
+				var usage proto.Usage
+				switch event.Type {
+				case proto.TypeUsage:
+					usage = decodePayload[proto.UsagePayload](t, event).Usage
+				case proto.TypeDone:
+					usage = decodePayload[proto.DonePayload](t, event).Usage
+				default:
+					continue
+				}
+				count++
+				if usage.Model != tc.want || usage.Provider != "opencode" || usage.InputTokens != 4 || usage.OutputTokens != 2 {
+					t.Fatalf("%s usage = %#v; want model %q with existing provider/tokens", event.Type, usage, tc.want)
+				}
+			}
+			if count != 2 {
+				t.Fatalf("usage and done frames = %d, want 2", count)
+			}
+		})
+	}
+}


### PR DESCRIPTION
OpenCode runs with an explicit model produced token/cost records whose model field was empty. Usage and completion frames now carry the model from the CLI launch plan, stripping only the provider prefix; native default selection remains unknown.

Scope: OpenCode model attribution only. Token counts, costs, provider labels, other adapters, API/database contracts, and historical records are unchanged.

Validation: OpenCode adapter tests cover selector precedence, nested model paths, fallback/absent model settings, and consistent usage/completion metadata. Full `make check` and Linux daemon build passed. A fresh independent blind review found no blocking issues. Local Docker stayed stopped. The updated remote daemon completed a real MiniMax-M3 run with 7,875 input and 17 output tokens; the actual Usage page displays the model and counts.

Tracks the model-attribution part of Feishu BUG-010; broader provider/cost contracts remain separate.
