### PR TITLE
fix(web): show placeholders for missing usage labels

### DIFF
--- a/apps/web/src/pages/admin/UsagePage.tsx
+++ b/apps/web/src/pages/admin/UsagePage.tsx
@@ -194,8 +194,8 @@ export function UsagePage() {
               <ul className="m-0 list-none p-0">
                 {byModel.map((m) => (
                   <LedgerRow key={m.key} role="listitem" tabIndex={-1}>
-                    <span className="truncate text-xs text-fg-muted" title={m.provider}>{m.provider}</span>
-                    <span className="truncate font-mono text-xs text-fg" title={m.model}>{m.model}</span>
+                    <span className="truncate text-xs text-fg-muted" title={m.provider}>{m.provider || "—"}</span>
+                    <span className="truncate font-mono text-xs text-fg" title={m.model}>{m.model || "—"}</span>
                     <LedgerNum>{fmtInt(m.callCount)}</LedgerNum>
                     <LedgerNum>{fmtInt(m.inputTokens)}</LedgerNum>
                     <LedgerNum>{fmtInt(m.outputTokens)}</LedgerNum>
@@ -232,8 +232,8 @@ export function UsagePage() {
                     ) : (
                       <span className="text-xs text-fg-muted" title={t("usage.recent.noRun")}>—</span>
                     )}
-                    <span className="truncate text-xs text-fg-muted" title={u.provider}>{u.provider}</span>
-                    <span className="truncate font-mono text-xs text-fg" title={u.model}>{u.model}</span>
+                    <span className="truncate text-xs text-fg-muted" title={u.provider}>{u.provider || "—"}</span>
+                    <span className="truncate font-mono text-xs text-fg" title={u.model}>{u.model || "—"}</span>
                     <LedgerNum>{fmtInt(u.input_tokens)}</LedgerNum>
                     <LedgerNum>{fmtInt(u.output_tokens)}</LedgerNum>
                     <LedgerNum><UsageCost value={u.cost_usd} /></LedgerNum>


### PR DESCRIPTION
Usage records without a model or provider left blank cells in both By model and Recent calls. Both tables now use the existing dash placeholder while preserving populated labels and raw grouping/statistics.

Validation: `make check`, production web build, six existing usage-cost browser cases, and real-data light/English and dark/Chinese browser checks passed. Read-only fixtures also cover missing labels; stored records remain unchanged. The Docker-dependent migration smoke step was skipped because local Docker remains disabled; this PR changes no database code. Developer self-review of the four display expressions found no unrelated behavior changes.

Tracks Feishu UX-094.
