### PR TITLE
fix(web): keep inbox question options readable

### DIFF
--- a/apps/web/src/pages/admin/ApprovalsPage.tsx
+++ b/apps/web/src/pages/admin/ApprovalsPage.tsx
@@ -315,11 +315,11 @@ function InteractionRail({
                 <ul className="m-0 list-none p-0">
                   {question.options.map((option) => (
                     <li key={option.label} className="border-b border-line last:border-b-0">
-                      <label className="flex min-h-8 cursor-pointer items-center gap-2 py-1.5 text-sm text-fg">
+                      <label className="flex min-h-8 cursor-pointer items-start gap-2 py-1.5 text-sm text-fg">
                         <input
                           type={question.multi_select ? "checkbox" : "radio"}
                           name={`${interaction.id}:${key}`}
-                          className="h-3.5 w-3.5 shrink-0 accent-accent"
+                          className="mt-0.5 h-3.5 w-3.5 shrink-0 accent-accent"
                           checked={selected.includes(option.label)}
                           onChange={() => {
                             setAnswers((current) => ({
@@ -329,9 +329,9 @@ function InteractionRail({
                             if (!question.multi_select) setCustom((current) => ({ ...current, [key]: "" }))
                           }}
                         />
-                        <span className="min-w-0 flex-1 truncate">
-                          {option.label}
-                          {option.description && <span className="text-fg-muted"> · {option.description}</span>}
+                        <span className="min-w-0 flex-1 break-words">
+                          <span className="block">{option.label}</span>
+                          {option.description && <span className="block text-xs text-fg-muted">{option.description}</span>}
                         </span>
                       </label>
                     </li>


### PR DESCRIPTION
Inbox question options truncated their labels and descriptions inside the detail rail, hiding information needed to answer. Options now wrap their full text, place descriptions below labels, and align radio/checkbox controls with the first line, matching the existing conversation card presentation.

Validation: `make check` and the production web build passed. Real answered questions were checked in light/dark rails and expanded details. Read-only browser fixtures verified single/multi-select submission payloads and disabled completed controls. No real decisions were submitted. The Docker-dependent database smoke step was skipped with local Docker disabled; this change touches no database code. Developer self-review covered the five presentation changes in one file.

Tracks Feishu UX-095. Question state, permissions, submission logic, and conversation cards are unchanged.
