### PR TITLE
fix(web): display persisted question answers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -642,6 +642,10 @@ split relevant pieces out first rather than growing the file further.
 
 ### Frontend shared logic
 
+- Answered interaction cards display persisted `response.answers` by question ID
+  (or `q{index}` fallback), rather than local drafts. Inbox and conversation cards
+  share the answer projection; custom secret answers retain password masking.
+
 - Usage cost displays treat stored zero/missing values as unknown: the current
   contract cannot distinguish free usage from unavailable pricing. Preserve raw
   records; sum finite positive costs only and label incomplete totals. Do not

--- a/apps/web/src/components/admin/InteractionDecisionCard.tsx
+++ b/apps/web/src/components/admin/InteractionDecisionCard.tsx
@@ -10,7 +10,7 @@ import type {
   AgentInteractionQuestion,
   ResolveAgentInteractionRequest,
 } from "../../lib/api-types"
-import { interactionQuestions } from "../../lib/interaction-questions"
+import { interactionQuestions, savedQuestionAnswer } from "../../lib/interaction-questions"
 import { useRelativeTime, useTimeUntil } from "../../lib/relative-time"
 import { cn } from "../../lib/utils"
 import { Badge } from "../ui/badge"
@@ -116,7 +116,8 @@ export function InteractionDecisionCard({
         <div className="space-y-4">
           {questions.map((question, index) => {
             const key = questionKey(question, index)
-            const selected = answers[key] ?? []
+            const saved = savedQuestionAnswer(interaction, question, index)
+            const selected = saved?.selected ?? answers[key] ?? []
             return (
               <fieldset key={key} disabled={!canResolve || !pending || resolve.isPending} className="m-0 min-w-0 border-0 p-0">
                 <legend className="mb-1 text-sm font-medium text-fg">
@@ -157,7 +158,7 @@ export function InteractionDecisionCard({
                     className="mt-2"
                     type={question.is_secret ? "password" : "text"}
                     autoComplete={question.is_secret ? "new-password" : undefined}
-                    value={custom[key] ?? ""}
+                    value={saved?.custom ?? custom[key] ?? ""}
                     onChange={(event) => {
                       const value = event.target.value
                       setCustom((current) => ({ ...current, [key]: value }))

--- a/apps/web/src/lib/interaction-questions.ts
+++ b/apps/web/src/lib/interaction-questions.ts
@@ -22,6 +22,6 @@ export function savedQuestionAnswer(row: AgentInteraction, question: AgentIntera
   const labels = new Set(question.options.map((option) => option.label))
   return {
     selected: values.filter((answer) => labels.has(answer)),
-    custom: values.filter((answer) => !labels.has(answer)).join("\n"),
+    custom: values.filter((answer) => !labels.has(answer)).join(", "),
   }
 }

--- a/apps/web/src/lib/interaction-questions.ts
+++ b/apps/web/src/lib/interaction-questions.ts
@@ -11,3 +11,17 @@ export function firstInteractionQuestion(
 ): AgentInteractionQuestion | undefined {
   return interactionQuestions(row)[0]
 }
+
+export function savedQuestionAnswer(row: AgentInteraction, question: AgentInteractionQuestion, index: number) {
+  if (row.status !== "answered") return undefined
+  const answers = row.response?.answers
+  const value = answers && typeof answers === "object" && !Array.isArray(answers)
+    ? (answers as Record<string, unknown>)[question.id || `q${index}`]
+    : undefined
+  const values = Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []
+  const labels = new Set(question.options.map((option) => option.label))
+  return {
+    selected: values.filter((answer) => labels.has(answer)),
+    custom: values.filter((answer) => !labels.has(answer)).join("\n"),
+  }
+}

--- a/apps/web/src/pages/admin/ApprovalsPage.tsx
+++ b/apps/web/src/pages/admin/ApprovalsPage.tsx
@@ -28,7 +28,7 @@ import type {
   AgentInteractionQuestion,
   ResolveAgentInteractionRequest,
 } from "../../lib/api-types"
-import { interactionQuestions } from "../../lib/interaction-questions"
+import { interactionQuestions, savedQuestionAnswer } from "../../lib/interaction-questions"
 import { useRelativeTime, useTimeUntil } from "../../lib/relative-time"
 import { useWorkspaceId } from "../../lib/workspace"
 
@@ -304,7 +304,8 @@ function InteractionRail({
       ) : (
         questions.map((question, index) => {
           const key = questionKey(question, index)
-          const selected = answers[key] ?? []
+          const saved = savedQuestionAnswer(interaction, question, index)
+          const selected = saved?.selected ?? answers[key] ?? []
           return (
             <RailSection
               key={key}
@@ -341,7 +342,7 @@ function InteractionRail({
                   <Input
                     type={question.is_secret ? "password" : "text"}
                     autoComplete={question.is_secret ? "new-password" : undefined}
-                    value={custom[key] ?? ""}
+                    value={saved?.custom ?? custom[key] ?? ""}
                     onChange={(event) => {
                       const value = event.target.value
                       setCustom((current) => ({ ...current, [key]: value }))

--- a/tests/e2e/interaction-saved-answers.spec.ts
+++ b/tests/e2e/interaction-saved-answers.spec.ts
@@ -43,13 +43,13 @@ for (const surface of ["inbox", "conversation"] as const) {
       { id: "checks", question: "Select checks", multi_select: true, options: [{ label: "Smoke" }, { label: "Audit" }] },
       { question: "Additional note", options: [] },
       { id: "secret", question: "Access token", is_secret: true, options: [] },
-    ] }, response: { answers: { language: ["English"], checks: ["Smoke", "Audit", "Check logs"], q2: ["Bring a laptop"], secret: ["synthetic-only"] } } });
+    ] }, response: { answers: { language: ["English"], checks: ["Smoke", "Audit", "Check logs", "Email team"], q2: ["Bring a laptop"], secret: ["synthetic-only"] } } });
     for (let attempt = 0; attempt < 2; attempt++) {
       const card = page.getByTestId("interaction-card");
       await expect(card.getByRole("radio", { name: "English", exact: true })).toBeChecked();
       await expect(card.getByRole("radio", { name: "Chinese", exact: true })).not.toBeChecked();
       for (const name of ["Smoke", "Audit"]) await expect(card.getByRole("checkbox", { name, exact: true })).toBeChecked();
-      await expect(card.locator('input[type="text"]').nth(0)).toHaveValue("Check logs");
+      await expect(card.locator('input[type="text"]').nth(0)).toHaveValue("Check logs, Email team");
       await expect(card.locator('input[type="text"]').nth(1)).toHaveValue("Bring a laptop");
       const secret = card.locator('input[type="password"]');
       await expect(secret).toHaveValue("synthetic-only");

--- a/tests/e2e/interaction-saved-answers.spec.ts
+++ b/tests/e2e/interaction-saved-answers.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test, type Page } from "@playwright/test";
+import { CONVERSATION_ID, json, mockApp, WORKSPACE_ID } from "./helpers/conversation-app";
+
+const base = {
+  id: "saved-question", request_id: "saved-request", workspace_id: WORKSPACE_ID,
+  conversation_id: CONVERSATION_ID, agent_run_id: "run-1", kind: "user_choice",
+  agent_name: "Test Agent", conversation_title: "Test Conversation",
+  created_at: "2026-09-10T00:00:00Z", expires_at: "2099-01-01T00:00:00Z",
+};
+const language = {
+  id: "language", question: "Choose language", is_other: false,
+  options: [{ label: "English" }, { label: "Chinese" }],
+};
+
+for (const surface of ["inbox", "conversation"] as const) {
+  const url = surface === "inbox"
+    ? `/?ws=${WORKSPACE_ID}&admin=approvals&id=${base.id}`
+    : `/?ws=${WORKSPACE_ID}&admin=conversations&id=${CONVERSATION_ID}`;
+
+  async function setup(page: Page, row: Record<string, unknown>) {
+    await mockApp(page, "existing", null);
+    await page.addInitScript(() => localStorage.setItem("parsar.lang", "en-US"));
+    const state = { row, writes: [] as unknown[] };
+    await page.route("**/api/v1/workspaces/*/interactions**", (route) => {
+      if (route.request().method() === "POST") {
+        state.writes.push(route.request().postDataJSON());
+        state.row = { ...state.row, status: "answered", response: { answers: { language: ["Chinese"] } } };
+        return json(route, { interaction: state.row, applied: false, already_resolved: true });
+      }
+      const bucket = new URL(route.request().url()).searchParams.get("status");
+      // The conversation normally removes completed cards. Keep this fixture
+      // visible to exercise the shared card's answered-state rendering only.
+      const visible = surface === "conversation" ? bucket === "pending"
+        : bucket === (state.row.status === "pending" ? "pending" : "decided");
+      return json(route, { interactions: visible ? [state.row] : [] });
+    });
+    await page.goto(url);
+    return state;
+  }
+
+  test(`${surface}: persisted choices, custom answers and secret masking survive reload`, async ({ page }) => {
+    await setup(page, { ...base, status: "answered", request: { questions: [language,
+      { id: "checks", question: "Select checks", multi_select: true, options: [{ label: "Smoke" }, { label: "Audit" }] },
+      { question: "Additional note", options: [] },
+      { id: "secret", question: "Access token", is_secret: true, options: [] },
+    ] }, response: { answers: { language: ["English"], checks: ["Smoke", "Audit", "Check logs"], q2: ["Bring a laptop"], secret: ["synthetic-only"] } } });
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const card = page.getByTestId("interaction-card");
+      await expect(card.getByRole("radio", { name: "English", exact: true })).toBeChecked();
+      await expect(card.getByRole("radio", { name: "Chinese", exact: true })).not.toBeChecked();
+      for (const name of ["Smoke", "Audit"]) await expect(card.getByRole("checkbox", { name, exact: true })).toBeChecked();
+      await expect(card.locator('input[type="text"]').nth(0)).toHaveValue("Check logs");
+      await expect(card.locator('input[type="text"]').nth(1)).toHaveValue("Bring a laptop");
+      const secret = card.locator('input[type="password"]');
+      await expect(secret).toHaveValue("synthetic-only");
+      await expect(secret).toBeDisabled();
+      await expect(card.getByRole("radio", { name: "English", exact: true })).toBeDisabled();
+      await expect(card.getByRole("button", { name: "Submit answers" })).toHaveCount(0);
+      await page.reload();
+    }
+  });
+
+  test(`${surface}: completed server answer replaces the local draft without changing submission`, async ({ page }) => {
+    const state = await setup(page, { ...base, status: "pending", request: { questions: [language] }, response: {} });
+    const card = page.getByTestId("interaction-card");
+    await card.getByRole("radio", { name: "English", exact: true }).check();
+    await card.getByRole("button", { name: "Submit answers" }).click();
+    await expect(card.getByRole("radio", { name: "Chinese", exact: true })).toBeChecked();
+    await expect(card.getByRole("radio", { name: "English", exact: true })).not.toBeChecked();
+    await expect(card.getByRole("radio", { name: "Chinese", exact: true })).toBeDisabled();
+    expect(state.writes).toEqual([{ answers: { language: ["English"] } }]);
+  });
+}


### PR DESCRIPTION
Reopening an answered Inbox question showed every option unchecked even when the server had saved an answer. Completed question cards now show the persisted selections and custom response, so reopening or refreshing reflects what was actually answered.

The same presentation rule applies to the reusable conversation card. This does not add completed questions to conversation history or change pending drafts, submission payloads, permissions, storage, or the question protocol. Secret custom responses retain password masking.

Validation:
- `make check` and the production web build passed. Docker was kept off; the Docker-dependent PostgreSQL smoke check was skipped by the existing gate.
- Four browser regressions passed for Inbox and the reusable conversation card, covering reload, single/multiple selections, custom responses, secret masking, disabled completion, and an already-resolved server answer superseding a local draft without changing submission.
- The conversation tests deliberately retain a completed response fixture to exercise the reusable card; the production conversation still lists pending interactions only.
- The real saved English response rendered correctly in light/dark Inbox rails, after reload, and in expanded details. The browser regression performed no server writes.

Independent blind review passed; the final reviewer independently ran all four browser tests successfully.
