### PR TITLE
fix(web): recover capability usage reads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -642,6 +642,10 @@ split relevant pieces out first rather than growing the file further.
 
 ### Frontend shared logic
 
+- Capability usage views distinguish loading, failed, and successful empty reads.
+  Failed reads offer retry; incomplete Agent binding counts remain unknown. Query
+  status must update even when a failed request leaves cached data unchanged.
+
 - Answered interaction cards display persisted `response.answers` by question ID
   (or `q{index}` fallback), rather than local drafts. Inbox and conversation cards
   share the answer projection; custom secret answers retain password masking.

--- a/apps/web/src/pages/admin/capabilities/CapabilityRow.tsx
+++ b/apps/web/src/pages/admin/capabilities/CapabilityRow.tsx
@@ -21,7 +21,7 @@ export function CapabilityRow({
   version?: string
   source: string
   availabilityLabel: string
-  enabledCount: number
+  enabledCount: number | null
   credentials: string
   age: string
   selected: boolean
@@ -51,7 +51,7 @@ export function CapabilityRow({
           {[
             [t("capabilities.table.version"), version ?? "—"],
             [t("capabilities.marketplaceDetail.source.title"), source],
-            [t("capabilities.table.enabledAgents"), String(enabledCount)],
+            [t("capabilities.table.enabledAgents"), String(enabledCount ?? "—")],
             [t("capabilities.table.credentialsShort"), credentials],
             [t("capabilities.table.updated"), age],
           ].map(([label, value]) => (
@@ -64,7 +64,7 @@ export function CapabilityRow({
       </div>
       <span className="break-all font-mono text-xs @max-xl/capability-list:hidden">{version ?? "—"}</span>
       <span className="break-words text-xs text-fg-muted @max-xl/capability-list:hidden">{source}</span>
-      <LedgerNum className="@max-xl/capability-list:hidden">{enabledCount}</LedgerNum>
+      <LedgerNum className="@max-xl/capability-list:hidden">{enabledCount ?? "—"}</LedgerNum>
       <span className="break-words text-xs text-fg-muted @max-xl/capability-list:hidden">{credentials}</span>
       <span className="break-words text-right text-xs text-fg-muted @max-xl/capability-list:hidden">{age}</span>
       <span className="@max-xl/capability-list:absolute @max-xl/capability-list:right-0 @max-xl/capability-list:top-2 @max-xl/capability-list:h-7 @max-xl/capability-list:w-0" onClick={(e) => e.stopPropagation()} onKeyDown={(e) => e.stopPropagation()}>

--- a/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityRail.tsx
+++ b/apps/web/src/pages/admin/capabilities/MarketplaceCapabilityRail.tsx
@@ -112,9 +112,11 @@ export function MarketplaceCapabilityRail({ id, open, onClose, onClosed }: {
           </PropertyList>
         </RailSection>
 
-        <RailSection title={t("capabilities.marketplaceDetail.enabledAgents.title", { count: agentCount })} className="mt-6">
+        <RailSection title={agentsQ.isLoading || agentsQ.error ? t("capabilities.table.enabledAgents") : t("capabilities.marketplaceDetail.enabledAgents.title", { count: agentCount })} className="mt-6">
           {agentsQ.isLoading ? (
             <Skeleton className="mt-2 h-3 w-full" />
+          ) : agentsQ.error ? (
+            <ErrorState onRetry={() => void agentsQ.refetch()} />
           ) : agents.length === 0 ? (
             <EmptyState size="compact" title={t("capabilities.marketplaceDetail.enabledAgents.empty")} />
           ) : (

--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -225,6 +225,8 @@ export function CapabilitiesPage() {
     [agentCapabilityQueries.map((q) => q.dataUpdatedAt).join(":")],
   )
 
+  const countsUnavailable = agentsQ.isLoading || !!agentsQ.error || agentCapabilityQueries.some((q) => q.isLoading || q.error)
+
   const err = capsQ.error
   const isUnreachable = err instanceof ApiError && err.envelope.unreachable
   const marketPendingID = marketTarget && (publishMut.isPending || unpublishMut.isPending || deprecateMut.isPending || undeprecateMut.isPending)
@@ -292,8 +294,8 @@ export function CapabilitiesPage() {
   const renderRow = (cap: Capability, fromMarketplace: boolean) => {
     const marketCap = cap as TargetMarketplaceInstall
     const enabledCount = fromMarketplace
-      ? marketCap.enabled_agent_count ?? enabledCounts.get(cap.id) ?? 0
-      : enabledCounts.get(cap.id) ?? 0
+      ? marketCap.enabled_agent_count ?? (countsUnavailable ? null : enabledCounts.get(cap.id) ?? 0)
+      : countsUnavailable ? null : enabledCounts.get(cap.id) ?? 0
     const version = fromMarketplace
       ? marketCap.pinned_version ?? marketCap.latest_version ?? marketCap.latest_published_version
       : latestVersions.get(cap.id)?.version
@@ -854,6 +856,9 @@ export function CapabilityRail({ id, open, onClose, onClosed }: {
   const latestVersion = versions[0]
   const installationSummary = useCapabilityEnabledAgents(wid, agentsQ.data?.agents ?? [], capability, versions)
   const enabledCount = installationSummary.installations.length
+  const installationsLoading = agentsQ.isLoading || installationSummary.isLoading
+  const installationsError = agentsQ.error || installationSummary.error
+  const installationsUnavailable = installationsLoading || !!installationsError
 
   const closeLabel = t("capabilities.detail.backToList")
 
@@ -978,7 +983,7 @@ export function CapabilityRail({ id, open, onClose, onClosed }: {
                   key={version.id}
                   version={version}
                   latestLabel={index === 0 ? t("capabilities.versions.latest") : undefined}
-                  count={installationSummary.versionCounts.get(version.id) ?? 0}
+                  count={installationsUnavailable ? null : installationSummary.versionCounts.get(version.id) ?? 0}
                   onOpen={() => setViewVersion(version)}
                 />
               ))}
@@ -987,9 +992,11 @@ export function CapabilityRail({ id, open, onClose, onClosed }: {
         )}
       </RailSection>
 
-      <RailSection title={t("capabilities.detail.enabledAgents.title", { count: enabledCount })} className="mt-6">
-        {installationSummary.isLoading ? (
+      <RailSection title={installationsUnavailable ? t("capabilities.table.enabledAgents") : t("capabilities.detail.enabledAgents.title", { count: enabledCount })} className="mt-6">
+        {installationsLoading ? (
           <Skeleton className="mt-2 h-3 w-full max-w-lg" />
+        ) : installationsError ? (
+          <ErrorState onRetry={() => { void agentsQ.refetch(); void installationSummary.refetch() }} />
         ) : enabledCount === 0 ? (
           <EmptyState size="compact" title={t("capabilities.detail.enabledAgents.empty")} />
         ) : (
@@ -1085,7 +1092,7 @@ export function CapabilityRail({ id, open, onClose, onClosed }: {
   )
 }
 
-function VersionRow({ version, latestLabel, count, onOpen }: { version: CapabilityVersion; latestLabel?: string; count: number; onOpen: () => void }) {
+function VersionRow({ version, latestLabel, count, onOpen }: { version: CapabilityVersion; latestLabel?: string; count: number | null; onOpen: () => void }) {
   const onKeyDown = (e: KeyboardEvent<HTMLLIElement>) => {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault()
@@ -1099,7 +1106,7 @@ function VersionRow({ version, latestLabel, count, onOpen }: { version: Capabili
         {latestLabel && <span className="shrink-0 text-xs text-fg-muted">{latestLabel}</span>}
       </span>
       <span className="break-words font-mono text-xs text-fg">{formatDate(version.created_at)}</span>
-      <LedgerNum muted={count === 0}>{count}</LedgerNum>
+      <LedgerNum muted={count === 0}>{count ?? "—"}</LedgerNum>
     </LedgerRow>
   )
 }

--- a/apps/web/src/pages/admin/capabilities/use-capability-enabled-agents.ts
+++ b/apps/web/src/pages/admin/capabilities/use-capability-enabled-agents.ts
@@ -1,4 +1,3 @@
-import { useMemo } from "react"
 import { useQueries } from "@tanstack/react-query"
 import { KEY_AGENT_CAPABILITIES, listAgentCapabilities } from "../../../lib/api-capabilities"
 import { noUnreachableRetry } from "../../../lib/api-client"
@@ -22,25 +21,27 @@ export function useCapabilityEnabledAgents(wid: string | null, agents: Array<{ i
       staleTime: 30_000,
     })),
   })
-  return useMemo(() => {
-    const latest = versions[0]
-    const versionCounts = new Map<string, number>()
-    const installations: AgentInstallation[] = []
-    if (!capability) return { installations, versionCounts, isLoading: queries.some((q) => q.isLoading) }
-    queries.forEach((q, idx) => {
-      for (const item of q.data?.installed ?? []) {
-        if (!item.enabled || item.capability_id !== capability.id) continue
-        const version = agentCapabilityVersion(item, item.capability, versions)
-        if (version) versionCounts.set(version.id, (versionCounts.get(version.id) ?? 0) + 1)
-        installations.push({
-          agentID: agents[idx].id,
-          agentName: agents[idx].name,
-          version: version?.version ?? "—",
-          latest: !!version && version.id === latest?.id,
-        })
-      }
-    })
-    return { installations, versionCounts, isLoading: queries.some((q) => q.isLoading) }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [capability, agents, versions, queries.map((q) => q.dataUpdatedAt).join(":")])
+  const status = {
+    isLoading: queries.some((q) => q.isLoading),
+    error: queries.find((q) => q.error)?.error,
+    refetch: () => Promise.all(queries.map((q) => q.refetch())),
+  }
+  const latest = versions[0]
+  const versionCounts = new Map<string, number>()
+  const installations: AgentInstallation[] = []
+  if (!capability) return { installations, versionCounts, ...status }
+  queries.forEach((q, idx) => {
+    for (const item of q.data?.installed ?? []) {
+      if (!item.enabled || item.capability_id !== capability.id) continue
+      const version = agentCapabilityVersion(item, item.capability, versions)
+      if (version) versionCounts.set(version.id, (versionCounts.get(version.id) ?? 0) + 1)
+      installations.push({
+        agentID: agents[idx].id,
+        agentName: agents[idx].name,
+        version: version?.version ?? "—",
+        latest: !!version && version.id === latest?.id,
+      })
+    }
+  })
+  return { installations, versionCounts, ...status }
 }

--- a/tests/e2e/capability-usage-recovery.spec.ts
+++ b/tests/e2e/capability-usage-recovery.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test, type Page } from "@playwright/test";
+import { json, WORKSPACE_ID as workspace } from "./helpers/conversation-app";
+
+const capabilityID = "00000000-0000-0000-0000-000000000033";
+type Failure = "all bindings" | "one binding" | "agent directory" | "marketplace";
+
+for (const failure of ["all bindings", "one binding", "agent directory", "marketplace"] as const) {
+  test(`capability usage recovers from failed ${failure}`, async ({ page }) => {
+    const state = await mockUsage(page, failure);
+    await page.goto(`/?ws=${workspace}&admin=capabilities&id=${capabilityID}${failure === "marketplace" ? "&from=marketplace" : ""}`);
+    const rail = page.getByRole("complementary", { name: "QA capability loading", exact: true });
+    const section = rail.locator("section").filter({ has: page.getByRole("heading", { name: /^Agents($| using)/ }) });
+    await expect(section.locator(".animate-pulse")).toHaveCount(1);
+    if (failure !== "marketplace") await expect(rail.getByRole("listbox", { name: "Version history" })).toBeVisible();
+    state.release();
+    await expect(section.getByText("Failed to load", { exact: true })).toBeVisible();
+    await expect(section.locator(".animate-pulse")).toHaveCount(0);
+    await expect(section.getByRole("heading")).toHaveText("Agents");
+    if (failure !== "marketplace") {
+      await expect(rail.getByRole("listbox", { name: "Version history" }).getByRole("option")).toHaveText(/—$/);
+      const row = page.getByRole("listbox", { name: "Capabilities", exact: true }).getByRole("option");
+      await expect(row.locator("dl").getByText("Agents", { exact: true }).locator("..").locator("dd")).toHaveText("—");
+    }
+    state.failing = false;
+    await section.getByRole("button", { name: "Retry", exact: true }).click();
+    await expect(section.getByRole("heading")).toHaveText("Agents using this capability (2)");
+    await expect(section.getByRole("option")).toHaveCount(2);
+    await expect(section).toContainText("QA Agent 1");
+    await expect(section).toContainText("QA Agent 2");
+    if (failure !== "marketplace") await expect(rail.getByRole("listbox", { name: "Version history" }).getByRole("option")).toHaveText(/2$/);
+    expect(state.writes).toEqual([]);
+  });
+}
+
+for (const marketplace of [false, true]) {
+  test(`successful empty usage remains empty (${marketplace ? "marketplace" : "workspace"})`, async ({ page }) => {
+    const state = await mockUsage(page, marketplace ? "marketplace" : "all bindings");
+    state.failing = false;
+    state.empty = true;
+    state.release();
+    await page.goto(`/?ws=${workspace}&admin=capabilities&id=${capabilityID}${marketplace ? "&from=marketplace" : ""}`);
+    const rail = page.getByRole("complementary", { name: "QA capability loading", exact: true });
+    const section = rail.locator("section").filter({ has: page.getByRole("heading", { name: /^Agents using/ }) });
+    await expect(section.getByRole("heading").first()).toHaveText("Agents using this capability (0)");
+    await expect(section.locator(".animate-pulse")).toHaveCount(0);
+    await expect(section.getByRole("button", { name: "Retry", exact: true })).toHaveCount(0);
+    await expect(section.getByRole("listbox")).toHaveCount(0);
+    expect(state.writes).toEqual([]);
+  });
+}
+
+async function mockUsage(page: Page, failure: Failure) {
+  let release!: () => void;
+  const wait = new Promise<void>((resolve) => { release = resolve; });
+  const state = { failing: true, empty: false, writes: [] as string[], release };
+  const base = `/api/v1/workspaces/${workspace}`;
+  const capability = { id: capabilityID, workspace_id: workspace, name: "QA capability loading", type: "skill", status: "active", visibility: "workspace", latest_version_id: "version-1", latest_version: "1.0.0" };
+  const agents = [1, 2].map((id) => ({ id: `agent-${id}`, workspace_id: workspace, name: `QA Agent ${id}`, status: "active", connector_type: "agent_daemon", config: {} }));
+  await page.addInitScript(() => localStorage.setItem("parsar.lang", "en-US"));
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    if (route.request().method() !== "GET") state.writes.push(path);
+    const fail = () => json(route, { error: "temporarily_unavailable", message: "Synthetic read failure" }, 503);
+    if (path === "/api/v1/me") return json(route, { user_id: "user-1", email: "qa@example.com", name: "QA" });
+    if (path === "/api/v1/me/workspaces") return json(route, { user_id: "user-1", workspaces: [{ id: workspace, name: "QA Lab", slug: "qa-lab", role: "owner" }] });
+    if (path === "/api/v1/me/discoverable-workspaces") return json(route, { workspaces: [], total: 0 });
+    if (path === `${base}/agents`) {
+      if (failure === "agent directory") { await wait; if (state.failing) return fail(); }
+      return json(route, { agents });
+    }
+    const agent = agents.find((a) => path === `${base}/agents/${a.id}/capabilities`);
+    if (agent) {
+      if (failure === "all bindings" || (failure === "one binding" && agent.id === "agent-2")) { await wait; if (state.failing) return fail(); }
+      return json(route, { installed: state.empty ? [] : [{ id: `binding-${agent.id}`, capability_id: capabilityID, capability_version_id: "version-1", enabled: true, pinning_mode: "pinned", capability }], available: [] });
+    }
+    if (path === `${base}/capabilities`) return json(route, { capabilities: failure === "marketplace" ? [] : [capability], marketplace_installs: [], total: 1 });
+    if (path === `${base}/capabilities/${capabilityID}`) return json(route, capability);
+    if (path.endsWith("/versions")) return json(route, { versions: [{ id: "version-1", capability_id: capabilityID, version: "1.0.0", spec: {}, created_at: "2026-09-11T00:00:00Z" }] });
+    if (path.endsWith("/marketplace-installs")) return json(route, { installs: failure === "marketplace" ? [{ ...capability, from_marketplace: true, source_workspace_name: "QA source", pinned_version: "1.0.0", enabled_agent_count: 0 }] : [] });
+    if (path.endsWith("/enabled-agents")) { await wait; return state.failing ? fail() : json(route, { agents: state.empty ? [] : agents.map((a) => ({ agent_id: a.id, name: a.name, version: "1.0.0" })) }); }
+    if (path.includes("marketplace")) return json(route, { capabilities: [] });
+    return json(route, {});
+  });
+  return state;
+}


### PR DESCRIPTION
When an Agent capability read failed, the capability detail could keep displaying its loading skeleton indefinitely. Failed directory, binding, and marketplace usage reads now offer Retry; incomplete counts remain unknown until the reads succeed. Successful empty and populated results retain their existing presentation.

This change covers capability usage read states only. It preserves binding mutations, authorization, version resolution, and installation/execution behavior.

Validation: `make check`, web production build, six browser regressions covering complete/partial binding failure, Agent directory failure, marketplace failure, retry recovery, and successful empty results. A fresh independent blind reviewer reviewed the entire diff and independently passed all six browser tests. Light/dark and narrow layout checks passed. The existing local gate skipped its Docker-dependent Postgres smoke test because Docker is unavailable; no database code changed.
