### PR TITLE
fix(usage): attribute managed runs to their model provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -640,6 +640,15 @@ split relevant pieces out first rather than growing the file further.
   their domain instead of writing a parallel one, and must not inline an
   ad hoc `switch { case errors.Is(...) }` in the handler body.
 
+### Usage attribution
+
+- Managed daemon runs record the provider type from the same successful model
+  resolution that builds the prompt options. Never re-read the catalog when usage
+  arrives. Preserve adapter measurements and raw fields; `raw.parsar_usage` records
+  `agent_kind`, `reported_provider`, and `provider_source` (`managed_model` or
+  `adapter`). Unmanaged runs retain adapter provider labels, and completions with
+  no reported usage remain empty. Historical rows are not inferred or rewritten.
+
 ### Frontend shared logic
 
 - Capability usage views distinguish loading, failed, and successful empty reads.

--- a/server/internal/connector/agentdaemon/capability_runtime_dispatch_test.go
+++ b/server/internal/connector/agentdaemon/capability_runtime_dispatch_test.go
@@ -211,7 +211,7 @@ func TestBuildAgentOptions_CodexSkillIsEnabled(t *testing.T) {
 		AgentConfig:             map[string]any{"agent_kind": "codex"},
 	}
 
-	opts, err := c.buildAgentOptions(context.Background(), in)
+	opts, _, err := c.buildAgentOptions(context.Background(), in)
 	if err != nil {
 		t.Fatalf("buildAgentOptions: %v", err)
 	}
@@ -249,7 +249,7 @@ func TestBuildAgentOptions_OpenCodeMCPDoesNotNotice(t *testing.T) {
 		AgentConfig:             map[string]any{"agent_kind": "opencode"},
 	}
 
-	opts, err := c.buildAgentOptions(context.Background(), in)
+	opts, _, err := c.buildAgentOptions(context.Background(), in)
 	if err != nil {
 		t.Fatalf("buildAgentOptions: %v", err)
 	}

--- a/server/internal/connector/agentdaemon/capability_runtime_test.go
+++ b/server/internal/connector/agentdaemon/capability_runtime_test.go
@@ -208,7 +208,7 @@ func TestResolveCapabilityAdditions_NilStoreNoOp(t *testing.T) {
 
 func TestBuildAgentOptions_DefaultClaudeCodeUsesBypassPermissions(t *testing.T) {
 	c := &Connector{log: discardLogger()}
-	opts, err := c.buildAgentOptions(context.Background(), defaultPromptInput())
+	opts, _, err := c.buildAgentOptions(context.Background(), defaultPromptInput())
 	if err != nil {
 		t.Fatalf("buildAgentOptions: %v", err)
 	}

--- a/server/internal/connector/agentdaemon/connector.go
+++ b/server/internal/connector/agentdaemon/connector.go
@@ -367,7 +367,7 @@ func (c *Connector) streamPrompt(ctx context.Context, in connector.PromptInput, 
 		"allow_remote", allowRemote)
 	agentKind := resolveAgentKind(in)
 
-	agentOptions, err := c.buildAgentOptions(ctx, in)
+	agentOptions, modelProvider, err := c.buildAgentOptions(ctx, in)
 	if err != nil {
 		c.log.Warn("agent_daemon: buildAgentOptions failed", "run_id", in.RunID, "err", err.Error())
 		return errorChannel(in.RunID, err.Error()), nil
@@ -545,7 +545,7 @@ func (c *Connector) streamPrompt(ctx context.Context, in connector.PromptInput, 
 	c.log.Info("agent_daemon: spawning runStreamLoop (will push prompt_request to daemon)",
 		"run_id", in.RunID, "device_id", bind.DeviceID, "agent_kind", agentKind)
 	out := make(chan connector.PromptEvent, 32)
-	go c.runStreamLoop(ctx, sess, in, bind, req, upstream, out)
+	go c.runStreamLoop(ctx, sess, in, bind, req, upstream, out, usageAttribution{agentKind: agentKind, modelProvider: modelProvider})
 	return out, nil
 }
 
@@ -641,6 +641,7 @@ func (c *Connector) runStreamLoop(
 	req proto.Envelope,
 	upstream <-chan proto.Envelope,
 	out chan<- connector.PromptEvent,
+	attribution usageAttribution,
 ) {
 	defer close(out)
 	defer sess.Unsubscribe(in.RunID)
@@ -679,7 +680,7 @@ func (c *Connector) runStreamLoop(
 				// channel was closed.
 				return
 			}
-			c.handleUpstream(ctx, env, in, bind, &seq, out)
+			c.handleUpstream(ctx, env, in, bind, &seq, out, attribution)
 			if env.Type == proto.TypeDone {
 				return
 			}
@@ -698,6 +699,7 @@ func (c *Connector) handleUpstream(
 	bind binding.Binding,
 	seq *uint64,
 	out chan<- connector.PromptEvent,
+	attribution usageAttribution,
 ) {
 	switch env.Type {
 	case proto.TypeDelta:
@@ -791,7 +793,7 @@ func (c *Connector) handleUpstream(
 			c.log.Warn("agent_daemon: decode usage", "err", err, "run_id", in.RunID)
 			return
 		}
-		u := usageFromProto(p.Usage)
+		u := attribution.fromProto(p.Usage)
 		out <- connector.PromptEvent{Type: connector.EventUsage, Usage: &u}
 
 	case proto.TypeError:
@@ -810,7 +812,7 @@ func (c *Connector) handleUpstream(
 		final := &connector.PromptOutput{
 			Content:    p.Content,
 			Transcript: p.Transcript,
-			Usage:      usageFromProto(p.Usage),
+			Usage:      attribution.fromProto(p.Usage),
 			Metadata:   p.Metadata,
 		}
 		// Best-effort: persist the engine session id so the next turn can resume.
@@ -1201,21 +1203,6 @@ func errorChannel(_ string, message string) <-chan connector.PromptEvent {
 	ch <- connector.PromptEvent{Type: connector.EventDone, Final: &connector.PromptOutput{}}
 	close(ch)
 	return ch
-}
-
-// usageFromProto translates wire-stable proto.Usage into the server's
-// store.UsageInput. The indirection exists so the proto package can
-// stay at module root (importable by apps/parsar-daemon) without depending
-// on server/internal/store.
-func usageFromProto(u proto.Usage) store.UsageInput {
-	return store.UsageInput{
-		Provider:     u.Provider,
-		Model:        u.Model,
-		InputTokens:  u.InputTokens,
-		OutputTokens: u.OutputTokens,
-		CostUSD:      u.CostUSD,
-		Raw:          u.Raw,
-	}
 }
 
 // promptAttachmentsFromStore translates server-side

--- a/server/internal/connector/agentdaemon/knowledge_test.go
+++ b/server/internal/connector/agentdaemon/knowledge_test.go
@@ -60,7 +60,7 @@ func TestKnowledgeAbsentAndCombinedLimit(t *testing.T) {
 
 func TestBuildAgentOptionsInjectsKnowledge(t *testing.T) {
 	c := &Connector{log: discardLogger(), capabilities: stubCapabilityStore{rows: []store.EnabledCapabilityRead{{CapabilityID: "kb", Type: "knowledge", CanonicalSpec: knowledgeSpecJSON(t, "PARSAR-KNOWLEDGE-OK")}}}}
-	opts, err := c.buildAgentOptions(t.Context(), defaultPromptInput())
+	opts, _, err := c.buildAgentOptions(t.Context(), defaultPromptInput())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/internal/connector/agentdaemon/managed_model_resolution.go
+++ b/server/internal/connector/agentdaemon/managed_model_resolution.go
@@ -1,0 +1,189 @@
+package agentdaemon
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+// injectManagedModel writes the Parsar-managed model selection into the
+// daemon prompt_request. claude_code receives ANTHROPIC_* env + model flag;
+// opencode receives a rendered opencode.json blob plus the model selector.
+func (c *Connector) injectManagedModel(ctx context.Context, in connector.PromptInput, opts map[string]any, agentKind string) (string, error) {
+	agentKind = strings.TrimSpace(agentKind)
+	modelID := resolveModelID(in)
+	if modelID == "" {
+		c.log.Warn("agent_daemon: injectManagedModel skipped — no model_id or default_model_id found",
+			"run_id", in.RunID,
+			"agent_kind", agentKind,
+			"agent_config_keys", mapKeys(in.AgentConfig))
+		return "", nil
+	}
+	c.log.Info("agent_daemon: injectManagedModel resolving",
+		"run_id", in.RunID,
+		"agent_kind", agentKind,
+		"model_id", modelID,
+		"has_model_resolver", c.modelResolver != nil,
+		"has_secrets", c.secrets != nil)
+	if c.modelResolver == nil {
+		return "", ErrManagedModelResolverMissing
+	}
+	if c.secrets == nil {
+		return "", ErrManagedModelSecretsMissing
+	}
+
+	// Decision table:
+	//   has shared model_credential_binding → ResolveModelRuntime (metadata
+	//                                         only); the workspace secret is
+	//                                         consumed below.
+	//   otherwise                           → ResolveModelRuntimeForUser
+	//                                         (per-user for credential_ref;
+	//                                         a no-op for inline_secret).
+	// store.ResolveModelRuntimeForUser still rejects credential_ref + empty
+	// initiator — that surfaces the "missing credentials" notice via the err branch below.
+	// Mirrors capability_runtime.resolveCredentialValues: binding wins over
+	// initiator presence, never the other way.
+	modelBinding, hasModelBinding := ParseModelCredentialBinding(in.AgentConfig)
+	var (
+		mr  store.ModelRuntime
+		err error
+	)
+	if hasModelBinding {
+		mr, err = c.modelResolver.ResolveModelRuntime(ctx, in.WorkspaceID, modelID)
+	} else {
+		mr, err = c.modelResolver.ResolveModelRuntimeForUser(ctx, modelID, in.ConversationInitiatorID)
+	}
+	if err != nil {
+		if mr.CredentialMode == "credential_ref" && !hasModelBinding {
+			c.emitModelCredentialMissingNotice(ctx, in, mr)
+			return "", fmt.Errorf("%w: model_id=%s user_id=%s: %v",
+				ErrManagedModelPersonalCredMissing, modelID, in.ConversationInitiatorID, err)
+		}
+		return "", fmt.Errorf("agent_daemon: resolve model %s: %w", modelID, err)
+	}
+
+	// Agent-level shared binding promotes a credential_ref model to a
+	// shared-secret path: resolve once via the workspace secrets table
+	// instead of the caller's user_credentials. Enables public/tenant
+	// agents (where callers may not have personal LLM keys configured)
+	// and lark guests (no platform user_id at all).
+
+	var apiKey string
+	switch {
+	case mr.CredentialMode == "credential_ref" && hasModelBinding:
+		secret, err := c.modelResolver.GetSecretPayload(ctx, in.WorkspaceID, modelBinding.SecretID)
+		if err != nil {
+			return "", fmt.Errorf("agent_daemon: load shared model secret model_id=%s secret_id=%s: %w", modelID, modelBinding.SecretID, err)
+		}
+		if secret.Status != "active" {
+			return "", fmt.Errorf("%w: secret_id=%s status=%s", ErrManagedModelSecretMissing, modelBinding.SecretID, secret.Status)
+		}
+		payload, err := c.secrets.Decrypt(secret.EncryptedPayload)
+		if err != nil {
+			return "", fmt.Errorf("agent_daemon: decrypt shared model secret model_id=%s secret_id=%s: %w", modelID, modelBinding.SecretID, err)
+		}
+		if v, _ := payload["api_key"].(string); strings.TrimSpace(v) != "" {
+			apiKey = v
+		} else if v, _ := payload["value"].(string); strings.TrimSpace(v) != "" {
+			apiKey = v
+		}
+	case mr.CredentialMode == "credential_ref":
+		if strings.TrimSpace(in.ConversationInitiatorID) == "" {
+			return "", fmt.Errorf("%w: model_id=%s", ErrManagedModelUserIDMissing, modelID)
+		}
+		if len(mr.EncryptedPayload) == 0 {
+			c.emitModelCredentialMissingNotice(ctx, in, mr)
+			return "", fmt.Errorf("%w: model_id=%s user_id=%s",
+				ErrManagedModelPersonalCredMissing, modelID, in.ConversationInitiatorID)
+		}
+		payload, err := c.secrets.Decrypt(mr.EncryptedPayload)
+		if err != nil {
+			return "", fmt.Errorf("agent_daemon: decrypt user credential for model %s: %w", modelID, err)
+		}
+		if v, _ := payload["value"].(string); strings.TrimSpace(v) != "" {
+			apiKey = v
+		} else if v, _ := payload["api_key"].(string); strings.TrimSpace(v) != "" {
+			apiKey = v
+		}
+	default:
+		if strings.TrimSpace(mr.SecretID) == "" {
+			return "", fmt.Errorf("%w: model_id=%s", ErrManagedModelSecretMissing, modelID)
+		}
+		secret, err := c.modelResolver.GetSecretPayload(ctx, in.WorkspaceID, mr.SecretID)
+		if err != nil {
+			return "", fmt.Errorf("agent_daemon: load model secret %s: %w", mr.SecretID, err)
+		}
+		if secret.Status != "active" {
+			return "", fmt.Errorf("%w: secret_id=%s status=%s", ErrManagedModelSecretMissing, mr.SecretID, secret.Status)
+		}
+		payload, err := c.secrets.Decrypt(secret.EncryptedPayload)
+		if err != nil {
+			return "", fmt.Errorf("agent_daemon: decrypt model secret %s: %w", mr.SecretID, err)
+		}
+		if v, _ := payload["api_key"].(string); strings.TrimSpace(v) != "" {
+			apiKey = v
+		} else if v, _ := payload["value"].(string); strings.TrimSpace(v) != "" {
+			apiKey = v
+		}
+	}
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return "", fmt.Errorf("%w: model_id=%s payload missing api_key/value", ErrManagedModelSecretMissing, modelID)
+	}
+
+	switch agentKind {
+	case "claude_code":
+		if err := injectClaudeManagedModel(opts, modelID, mr, apiKey); err != nil {
+			return "", err
+		}
+		c.log.Info("agent_daemon: injectManagedModel ok",
+			"run_id", in.RunID,
+			"agent_kind", agentKind,
+			"model_id", modelID,
+			"model_key", mr.ModelKey,
+			"has_base_url", strings.TrimSpace(mr.BaseURL) != "",
+			"env_key_count", len(copyStringAnyMap(opts["env"])))
+		return strings.TrimSpace(mr.ProviderType), nil
+	case "opencode":
+		if err := injectOpenCodeManagedModel(opts, modelID, mr, apiKey); err != nil {
+			return "", err
+		}
+		c.log.Info("agent_daemon: injectManagedModel ok",
+			"run_id", in.RunID,
+			"agent_kind", agentKind,
+			"model_id", modelID,
+			"model_key", mr.ModelKey,
+			"provider_slug", mr.ProviderType,
+			"has_opencode_json", stringFromMap(opts, "opencode_json") != "")
+		return strings.TrimSpace(mr.ProviderType), nil
+	case "codex":
+		if err := injectCodexManagedModel(opts, modelID, mr, apiKey); err != nil {
+			return "", err
+		}
+		c.log.Info("agent_daemon: injectManagedModel ok",
+			"run_id", in.RunID,
+			"agent_kind", agentKind,
+			"model_id", modelID,
+			"model_key", mr.ModelKey,
+			"provider_slug", mr.ProviderType,
+			"env_key_count", len(copyStringAnyMap(opts["env"])))
+		return strings.TrimSpace(mr.ProviderType), nil
+	case "pi":
+		if err := injectPiManagedModel(opts, modelID, mr, apiKey); err != nil {
+			return "", err
+		}
+		c.log.Info("agent_daemon: injectManagedModel ok",
+			"run_id", in.RunID,
+			"agent_kind", agentKind,
+			"model_id", modelID,
+			"model_key", mr.ModelKey,
+			"provider_slug", mr.ProviderType,
+			"pi_model", stringFromMap(opts, "model"))
+		return strings.TrimSpace(mr.ProviderType), nil
+	default:
+		return "", fmt.Errorf("%w: %q", ErrUnsupportedAgentKind, agentKind)
+	}
+}

--- a/server/internal/connector/agentdaemon/model_injection.go
+++ b/server/internal/connector/agentdaemon/model_injection.go
@@ -52,7 +52,7 @@ const ModelCredentialMissingCapabilityID = "__model__"
 // After model resolution, enabled Skill capabilities for the agent
 // are rendered through the daemon-side system-prompt slot so both
 // claude_code and opencode receive the same high-level instructions.
-func (c *Connector) buildAgentOptions(ctx context.Context, in connector.PromptInput) (map[string]any, error) {
+func (c *Connector) buildAgentOptions(ctx context.Context, in connector.PromptInput) (map[string]any, string, error) {
 	agentKind := resolveAgentKind(in)
 	opts := renderStaticAgentOptions(in)
 	c.log.Info("agent_daemon: buildAgentOptions static opts rendered",
@@ -72,7 +72,7 @@ func (c *Connector) buildAgentOptions(ctx context.Context, in connector.PromptIn
 		// Capability resolution failure (DB blip, malformed canonical_spec,
 		// missing credential) surfaces as a hard prompt failure so the
 		// user knows their capability never made it into the run.
-		return nil, err
+		return nil, "", err
 	}
 	c.log.Info("agent_daemon: capability additions resolved",
 		"run_id", in.RunID,
@@ -88,11 +88,12 @@ func (c *Connector) buildAgentOptions(ctx context.Context, in connector.PromptIn
 	c.applySpecMemoryInjection(ctx, opts, in)
 	c.applyIMHistoryPromptInjection(ctx, opts, in)
 	if err := appendKnowledgeContext(opts, additions.Knowledge); err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	if err := c.injectManagedModel(ctx, in, opts, agentKind); err != nil {
+	modelProvider, err := c.injectManagedModel(ctx, in, opts, agentKind)
+	if err != nil {
 		c.log.Error("agent_daemon: injectManagedModel failed", "run_id", in.RunID, "err", err)
-		return nil, err
+		return nil, "", err
 	}
 	// Claude Code defaults to bypassPermissions so already-bound MCPs and
 	// other trusted tool calls do not stop on repeated approvals.
@@ -112,186 +113,7 @@ func (c *Connector) buildAgentOptions(ctx context.Context, in connector.PromptIn
 	// nudge. SystemMessages may be nil on dev / smoke contexts;
 	// emitDisabledCapabilityNotices guards on it internally.
 	c.emitDisabledCapabilityNotices(ctx, in, additions.Disabled)
-	return opts, nil
-}
-
-// injectManagedModel writes the Parsar-managed model selection into the
-// daemon prompt_request. claude_code receives ANTHROPIC_* env + model flag;
-// opencode receives a rendered opencode.json blob plus the model selector.
-func (c *Connector) injectManagedModel(ctx context.Context, in connector.PromptInput, opts map[string]any, agentKind string) error {
-	agentKind = strings.TrimSpace(agentKind)
-	modelID := resolveModelID(in)
-	if modelID == "" {
-		c.log.Warn("agent_daemon: injectManagedModel skipped — no model_id or default_model_id found",
-			"run_id", in.RunID,
-			"agent_kind", agentKind,
-			"agent_config_keys", mapKeys(in.AgentConfig))
-		return nil
-	}
-	c.log.Info("agent_daemon: injectManagedModel resolving",
-		"run_id", in.RunID,
-		"agent_kind", agentKind,
-		"model_id", modelID,
-		"has_model_resolver", c.modelResolver != nil,
-		"has_secrets", c.secrets != nil)
-	if c.modelResolver == nil {
-		return ErrManagedModelResolverMissing
-	}
-	if c.secrets == nil {
-		return ErrManagedModelSecretsMissing
-	}
-
-	// Decision table:
-	//   has shared model_credential_binding → ResolveModelRuntime (metadata
-	//                                         only); the workspace secret is
-	//                                         consumed below.
-	//   otherwise                           → ResolveModelRuntimeForUser
-	//                                         (per-user for credential_ref;
-	//                                         a no-op for inline_secret).
-	// store.ResolveModelRuntimeForUser still rejects credential_ref + empty
-	// initiator — that surfaces the "missing credentials" notice via the err branch below.
-	// Mirrors capability_runtime.resolveCredentialValues: binding wins over
-	// initiator presence, never the other way.
-	modelBinding, hasModelBinding := ParseModelCredentialBinding(in.AgentConfig)
-	var (
-		mr  store.ModelRuntime
-		err error
-	)
-	if hasModelBinding {
-		mr, err = c.modelResolver.ResolveModelRuntime(ctx, in.WorkspaceID, modelID)
-	} else {
-		mr, err = c.modelResolver.ResolveModelRuntimeForUser(ctx, modelID, in.ConversationInitiatorID)
-	}
-	if err != nil {
-		if mr.CredentialMode == "credential_ref" && !hasModelBinding {
-			c.emitModelCredentialMissingNotice(ctx, in, mr)
-			return fmt.Errorf("%w: model_id=%s user_id=%s: %v",
-				ErrManagedModelPersonalCredMissing, modelID, in.ConversationInitiatorID, err)
-		}
-		return fmt.Errorf("agent_daemon: resolve model %s: %w", modelID, err)
-	}
-
-	// Agent-level shared binding promotes a credential_ref model to a
-	// shared-secret path: resolve once via the workspace secrets table
-	// instead of the caller's user_credentials. Enables public/tenant
-	// agents (where callers may not have personal LLM keys configured)
-	// and lark guests (no platform user_id at all).
-
-	var apiKey string
-	switch {
-	case mr.CredentialMode == "credential_ref" && hasModelBinding:
-		secret, err := c.modelResolver.GetSecretPayload(ctx, in.WorkspaceID, modelBinding.SecretID)
-		if err != nil {
-			return fmt.Errorf("agent_daemon: load shared model secret model_id=%s secret_id=%s: %w", modelID, modelBinding.SecretID, err)
-		}
-		if secret.Status != "active" {
-			return fmt.Errorf("%w: secret_id=%s status=%s", ErrManagedModelSecretMissing, modelBinding.SecretID, secret.Status)
-		}
-		payload, err := c.secrets.Decrypt(secret.EncryptedPayload)
-		if err != nil {
-			return fmt.Errorf("agent_daemon: decrypt shared model secret model_id=%s secret_id=%s: %w", modelID, modelBinding.SecretID, err)
-		}
-		if v, _ := payload["api_key"].(string); strings.TrimSpace(v) != "" {
-			apiKey = v
-		} else if v, _ := payload["value"].(string); strings.TrimSpace(v) != "" {
-			apiKey = v
-		}
-	case mr.CredentialMode == "credential_ref":
-		if strings.TrimSpace(in.ConversationInitiatorID) == "" {
-			return fmt.Errorf("%w: model_id=%s", ErrManagedModelUserIDMissing, modelID)
-		}
-		if len(mr.EncryptedPayload) == 0 {
-			c.emitModelCredentialMissingNotice(ctx, in, mr)
-			return fmt.Errorf("%w: model_id=%s user_id=%s",
-				ErrManagedModelPersonalCredMissing, modelID, in.ConversationInitiatorID)
-		}
-		payload, err := c.secrets.Decrypt(mr.EncryptedPayload)
-		if err != nil {
-			return fmt.Errorf("agent_daemon: decrypt user credential for model %s: %w", modelID, err)
-		}
-		if v, _ := payload["value"].(string); strings.TrimSpace(v) != "" {
-			apiKey = v
-		} else if v, _ := payload["api_key"].(string); strings.TrimSpace(v) != "" {
-			apiKey = v
-		}
-	default:
-		if strings.TrimSpace(mr.SecretID) == "" {
-			return fmt.Errorf("%w: model_id=%s", ErrManagedModelSecretMissing, modelID)
-		}
-		secret, err := c.modelResolver.GetSecretPayload(ctx, in.WorkspaceID, mr.SecretID)
-		if err != nil {
-			return fmt.Errorf("agent_daemon: load model secret %s: %w", mr.SecretID, err)
-		}
-		if secret.Status != "active" {
-			return fmt.Errorf("%w: secret_id=%s status=%s", ErrManagedModelSecretMissing, mr.SecretID, secret.Status)
-		}
-		payload, err := c.secrets.Decrypt(secret.EncryptedPayload)
-		if err != nil {
-			return fmt.Errorf("agent_daemon: decrypt model secret %s: %w", mr.SecretID, err)
-		}
-		if v, _ := payload["api_key"].(string); strings.TrimSpace(v) != "" {
-			apiKey = v
-		} else if v, _ := payload["value"].(string); strings.TrimSpace(v) != "" {
-			apiKey = v
-		}
-	}
-	apiKey = strings.TrimSpace(apiKey)
-	if apiKey == "" {
-		return fmt.Errorf("%w: model_id=%s payload missing api_key/value", ErrManagedModelSecretMissing, modelID)
-	}
-
-	switch agentKind {
-	case "claude_code":
-		if err := injectClaudeManagedModel(opts, modelID, mr, apiKey); err != nil {
-			return err
-		}
-		c.log.Info("agent_daemon: injectManagedModel ok",
-			"run_id", in.RunID,
-			"agent_kind", agentKind,
-			"model_id", modelID,
-			"model_key", mr.ModelKey,
-			"has_base_url", strings.TrimSpace(mr.BaseURL) != "",
-			"env_key_count", len(copyStringAnyMap(opts["env"])))
-		return nil
-	case "opencode":
-		if err := injectOpenCodeManagedModel(opts, modelID, mr, apiKey); err != nil {
-			return err
-		}
-		c.log.Info("agent_daemon: injectManagedModel ok",
-			"run_id", in.RunID,
-			"agent_kind", agentKind,
-			"model_id", modelID,
-			"model_key", mr.ModelKey,
-			"provider_slug", mr.ProviderType,
-			"has_opencode_json", stringFromMap(opts, "opencode_json") != "")
-		return nil
-	case "codex":
-		if err := injectCodexManagedModel(opts, modelID, mr, apiKey); err != nil {
-			return err
-		}
-		c.log.Info("agent_daemon: injectManagedModel ok",
-			"run_id", in.RunID,
-			"agent_kind", agentKind,
-			"model_id", modelID,
-			"model_key", mr.ModelKey,
-			"provider_slug", mr.ProviderType,
-			"env_key_count", len(copyStringAnyMap(opts["env"])))
-		return nil
-	case "pi":
-		if err := injectPiManagedModel(opts, modelID, mr, apiKey); err != nil {
-			return err
-		}
-		c.log.Info("agent_daemon: injectManagedModel ok",
-			"run_id", in.RunID,
-			"agent_kind", agentKind,
-			"model_id", modelID,
-			"model_key", mr.ModelKey,
-			"provider_slug", mr.ProviderType,
-			"pi_model", stringFromMap(opts, "model"))
-		return nil
-	default:
-		return fmt.Errorf("%w: %q", ErrUnsupportedAgentKind, agentKind)
-	}
+	return opts, modelProvider, nil
 }
 
 func injectClaudeManagedModel(opts map[string]any, modelID string, mr store.ModelRuntime, apiKey string) error {

--- a/server/internal/connector/agentdaemon/model_injection_test.go
+++ b/server/internal/connector/agentdaemon/model_injection_test.go
@@ -429,7 +429,7 @@ func TestInjectManagedModel_DefaultAuthScheme_InjectsAPIKey(t *testing.T) {
 	in.AgentConfig = map[string]any{"model_id": "model-default"}
 	opts := renderStaticAgentOptions(in)
 
-	if err := c.injectManagedModel(context.Background(), in, opts, "claude_code"); err != nil {
+	if _, err := c.injectManagedModel(context.Background(), in, opts, "claude_code"); err != nil {
 		t.Fatalf("injectManagedModel: %v", err)
 	}
 
@@ -484,7 +484,7 @@ func TestInjectManagedModel_BearerAuthScheme_InjectsAuthToken(t *testing.T) {
 	in.AgentConfig = map[string]any{"model_id": "model-bearer"}
 	opts := renderStaticAgentOptions(in)
 
-	if err := c.injectManagedModel(context.Background(), in, opts, "claude_code"); err != nil {
+	if _, err := c.injectManagedModel(context.Background(), in, opts, "claude_code"); err != nil {
 		t.Fatalf("injectManagedModel: %v", err)
 	}
 
@@ -689,7 +689,7 @@ func TestInjectManagedModel_CredentialRef_EmitsNoticeOnUserLookupErr(t *testing.
 	in.AgentConfig = map[string]any{"model_id": "model-byok"}
 	opts := renderStaticAgentOptions(in)
 
-	err = c.injectManagedModel(context.Background(), in, opts, "claude_code")
+	_, err = c.injectManagedModel(context.Background(), in, opts, "claude_code")
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}
@@ -756,7 +756,7 @@ func TestInjectManagedModel_CredentialRef_EmitsNoticeOnEmptyPayload(t *testing.T
 	in.AgentConfig = map[string]any{"model_id": "model-byok"}
 	opts := renderStaticAgentOptions(in)
 
-	err = c.injectManagedModel(context.Background(), in, opts, "claude_code")
+	_, err = c.injectManagedModel(context.Background(), in, opts, "claude_code")
 	if !errors.Is(err, ErrManagedModelPersonalCredMissing) {
 		t.Fatalf("err = %v, want wrapped ErrManagedModelPersonalCredMissing", err)
 	}
@@ -799,7 +799,7 @@ func TestInjectManagedModel_CredentialRef_UserIDMissingDoesNotEmit(t *testing.T)
 	in.AgentConfig = map[string]any{"model_id": "model-byok"}
 	opts := renderStaticAgentOptions(in)
 
-	err = c.injectManagedModel(context.Background(), in, opts, "claude_code")
+	_, err = c.injectManagedModel(context.Background(), in, opts, "claude_code")
 	if !errors.Is(err, ErrManagedModelUserIDMissing) {
 		t.Fatalf("err = %v, want wrapped ErrManagedModelUserIDMissing", err)
 	}
@@ -1384,7 +1384,7 @@ func TestInjectManagedModel_PiSwitchWired(t *testing.T) {
 	in.AgentConfig = map[string]any{"model_id": "model-pi"}
 	opts := renderStaticAgentOptions(in)
 
-	if err := c.injectManagedModel(context.Background(), in, opts, "pi"); err != nil {
+	if _, err := c.injectManagedModel(context.Background(), in, opts, "pi"); err != nil {
 		t.Fatalf("injectManagedModel(pi): %v", err)
 	}
 	if got := opts["model"]; got != "parsar/claude-opus-4-7" {
@@ -1466,7 +1466,7 @@ func TestInjectManagedModel_SharedBinding_BypassesUserResolver(t *testing.T) {
 	in.AgentConfig = sharedBindingConfig()
 	opts := renderStaticAgentOptions(in)
 
-	if err := c.injectManagedModel(context.Background(), in, opts, "claude_code"); err != nil {
+	if _, err := c.injectManagedModel(context.Background(), in, opts, "claude_code"); err != nil {
 		t.Fatalf("injectManagedModel: %v", err)
 	}
 	if resolver.resolveUserCalls != 0 {
@@ -1509,7 +1509,7 @@ func TestInjectManagedModel_SharedBinding_GuestCallerSucceeds(t *testing.T) {
 	in.AgentConfig = sharedBindingConfig()
 	opts := renderStaticAgentOptions(in)
 
-	if err := c.injectManagedModel(context.Background(), in, opts, "claude_code"); err != nil {
+	if _, err := c.injectManagedModel(context.Background(), in, opts, "claude_code"); err != nil {
 		t.Fatalf("injectManagedModel: %v", err)
 	}
 	if resolver.resolveUserCalls != 0 {
@@ -1567,7 +1567,7 @@ func TestInjectManagedModel_NoBinding_PersonalPathUsesUserResolver(t *testing.T)
 	in.AgentConfig = map[string]any{"model_id": "model-byok"}
 	opts := renderStaticAgentOptions(in)
 
-	if err := c.injectManagedModel(context.Background(), in, opts, "claude_code"); err != nil {
+	if _, err := c.injectManagedModel(context.Background(), in, opts, "claude_code"); err != nil {
 		t.Fatalf("injectManagedModel: %v", err)
 	}
 	if resolver.resolveUserCalls != 1 {

--- a/server/internal/connector/agentdaemon/usage_attribution.go
+++ b/server/internal/connector/agentdaemon/usage_attribution.go
@@ -1,0 +1,41 @@
+package agentdaemon
+
+import (
+	"maps"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+type usageAttribution struct {
+	agentKind     string
+	modelProvider string
+}
+
+// Attribute to the launched model, not a later catalog edit or CLI provider alias.
+func (a usageAttribution) fromProto(u proto.Usage) store.UsageInput {
+	result := store.UsageInput{
+		Provider: u.Provider, Model: u.Model,
+		InputTokens: u.InputTokens, OutputTokens: u.OutputTokens,
+		CostUSD: u.CostUSD, Raw: u.Raw,
+	}
+	// A completion without reported usage must not create a usage record.
+	if u.Provider == "" && u.Model == "" && u.InputTokens == 0 && u.OutputTokens == 0 && u.CostUSD == 0 && len(u.Raw) == 0 {
+		return result
+	}
+	source := "adapter"
+	if a.modelProvider != "" {
+		result.Provider = a.modelProvider
+		source = "managed_model"
+	}
+	result.Raw = maps.Clone(u.Raw)
+	if result.Raw == nil {
+		result.Raw = make(map[string]any)
+	}
+	result.Raw["parsar_usage"] = map[string]any{
+		"agent_kind":        a.agentKind,
+		"reported_provider": u.Provider,
+		"provider_source":   source,
+	}
+	return result
+}

--- a/server/internal/connector/agentdaemon/usage_attribution_test.go
+++ b/server/internal/connector/agentdaemon/usage_attribution_test.go
@@ -1,0 +1,118 @@
+package agentdaemon
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/agentdaemon/binding"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/connector"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/secrets"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func TestManagedUsageUsesLaunchedProviderAcrossEngines(t *testing.T) {
+	for kind, reported := range map[string]string{"claude_code": "claude_code", "codex": "openai", "pi": "parsar", "opencode": "opencode"} {
+		t.Run(kind, func(t *testing.T) {
+			c, _, session, conn, binder := newWiredHarness(t, "dev-1", "conv-1", "pa-1")
+			defer session.Close("test done")
+			feedAgentKinds(t, conn, session, []proto.SupportedAgentKind{{Kind: kind, Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Usage: true}}})
+			if err := binder.Bind(t.Context(), binding.Binding{ConversationID: "conv-1", AgentID: "pa-1", DeviceID: "dev-1", AgentKind: kind, WorkDir: "/workspace"}); err != nil {
+				t.Fatal(err)
+			}
+			secretService, err := secrets.New("test-master-key")
+			if err != nil {
+				t.Fatal(err)
+			}
+			encrypted, err := secretService.Encrypt(map[string]any{"api_key": "sk-private-test-value"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			resolver := &fakeModelResolver{
+				runtime: store.ModelRuntime{ModelID: "model-1", ModelKey: "MiniMax-M3", ProviderType: "minimax-cn", Adapter: "@ai-sdk/anthropic", BaseURL: "https://model.example.com", SecretID: "secret-1", ProviderConfig: map[string]any{"supported_endpoint_types": []string{"anthropic", "openai", "openai-response"}}},
+				secret:  store.SecretPayload{SecretRead: store.SecretRead{Status: "active"}, EncryptedPayload: encrypted},
+			}
+			c.modelResolver, c.secrets = resolver, secretService
+			input := basicInput()
+			input.WorkspaceID = "ws-1"
+			input.AgentConfig = map[string]any{"agent_kind": kind, "model_id": "model-1"}
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+			defer cancel()
+			stream, err := c.StreamPrompt(ctx, input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !waitForWrite(t, conn, proto.TypePromptRequest, 2*time.Second) {
+				t.Fatal("prompt was not dispatched")
+			}
+			// A later catalog edit must not reattribute an already-started run.
+			resolver.runtime.ProviderType = "different-provider"
+			native := proto.Usage{Provider: reported, Model: "MiniMax-M3", InputTokens: 123, OutputTokens: 7, CostUSD: 0.25, Raw: map[string]any{"native_counter": float64(9)}}
+			usage, _ := proto.NewEnvelope(proto.TypeUsage, input.RunID, proto.UsagePayload{Usage: native})
+			done, _ := proto.NewEnvelope(proto.TypeDone, input.RunID, proto.DonePayload{Content: "ok", Usage: native})
+			conn.Feed(usage)
+			conn.Feed(done)
+			var measured []store.UsageInput
+			for event := range stream {
+				if event.Type == connector.EventError {
+					t.Fatal(event.Error)
+				}
+				if event.Usage != nil {
+					measured = append(measured, *event.Usage)
+				}
+				if event.Final != nil {
+					measured = append(measured, event.Final.Usage)
+				}
+			}
+			if len(measured) != 2 || !reflect.DeepEqual(measured[0], measured[1]) {
+				t.Fatalf("usage/done mismatch: %#v", measured)
+			}
+			got := measured[0]
+			if got.Provider != "minimax-cn" || got.Model != native.Model || got.InputTokens != native.InputTokens || got.OutputTokens != native.OutputTokens || got.CostUSD != native.CostUSD {
+				t.Fatalf("attribution or measurements changed: %#v", got)
+			}
+			want := map[string]any{"agent_kind": kind, "reported_provider": reported, "provider_source": "managed_model"}
+			if !reflect.DeepEqual(got.Raw["parsar_usage"], want) || got.Raw["native_counter"] != float64(9) {
+				t.Fatalf("metadata/raw fields lost: %#v", got.Raw)
+			}
+			encoded, err := json.Marshal(got)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(encoded), "sk-private-test-value") {
+				t.Fatal("credential leaked into usage")
+			}
+			if resolver.resolveCalls+resolver.resolveUserCalls != 1 {
+				t.Fatal("model resolved again while handling usage")
+			}
+		})
+	}
+}
+
+func TestUsageAttributionPreservesUnmanagedAndAbsentUsage(t *testing.T) {
+	attribution := usageAttribution{agentKind: "codex", modelProvider: "minimax-cn"}
+	if got := attribution.fromProto(proto.Usage{}); !reflect.DeepEqual(got, store.UsageInput{}) {
+		t.Fatalf("absent usage became a record: %#v", got)
+	}
+	native := proto.Usage{Provider: "native-provider", Model: "native-model", InputTokens: 10, Raw: map[string]any{"native": true}}
+	unmanaged := (usageAttribution{agentKind: "pi"}).fromProto(native)
+	if unmanaged.Provider != native.Provider || unmanaged.Model != native.Model || unmanaged.InputTokens != 10 {
+		t.Fatalf("unmanaged usage changed: %#v", unmanaged)
+	}
+	if got := unmanaged.Raw["parsar_usage"].(map[string]any)["provider_source"]; got != "adapter" {
+		t.Fatal(got)
+	}
+	if len(native.Raw) != 1 {
+		t.Fatal("source raw map was mutated")
+	}
+	for _, usage := range []proto.Usage{{InputTokens: 10}, {Provider: "native-provider", CostUSD: 0}} {
+		got := attribution.fromProto(usage)
+		if got.Provider != "minimax-cn" || got.InputTokens != usage.InputTokens || got.CostUSD != usage.CostUSD {
+			t.Fatalf("reported usage dropped: %#v", got)
+		}
+	}
+}


### PR DESCRIPTION
Managed runs using the same model currently record different usage providers depending on the engine: Claude Code reports `claude_code`, Codex reports `openai`, Pi reports `parsar`, and OpenCode reports `opencode`. New managed runs now use the provider type resolved for their launch, so their usage groups under the configured provider. The actual engine and original provider label remain in `raw.parsar_usage`.

Both streaming usage and completion use the launch attribution. Native model identifiers, token/cost measurements and raw fields are retained. Unmanaged providers and completions without usage keep their existing behavior. This does not change credentials, execution options, history, schemas, UI layout, or cost availability.

Validation: `make check` passed (the Docker-dependent Postgres smoke check skipped with local Docker off); connector tests cover all four engines, catalog edits after launch, streaming/completion agreement, unmanaged and absent usage, raw preservation and credential exclusion. Fresh independent blind review found no actionable issues and independently reran the connector tests.

Remote validation: all four engines completed real MiniMax-M3 runs with exactly one usage record each. The Usage page groups them under `minimax-cn`; light/dark browser checks passed. Database and runtime containers were preserved during the server-only update.

Tracks the provider-attribution portion of Feishu BUG-010. Precise free-versus-unavailable cost reporting remains separate.
