### PR TITLE
fix(web): edit credentials for an enabled capability binding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -651,6 +651,10 @@ split relevant pieces out first rather than growing the file further.
 
 ### Frontend shared logic
 
+- Editing a capability's credentials from Agent Config updates only that binding's
+  credential choices. Preserve its stored version, pinning mode, and other
+  configuration; resolve per-binding choices before Agent-wide defaults.
+
 - Capability usage views distinguish loading, failed, and successful empty reads.
   Failed reads offer retry; incomplete Agent binding counts remain unknown. Query
   status must update even when a failed request leaves cached data unchanged.

--- a/apps/web/src/components/admin/CredentialBindingSelect.tsx
+++ b/apps/web/src/components/admin/CredentialBindingSelect.tsx
@@ -10,6 +10,7 @@ interface CredentialBindingSelectProps {
   personalLabel: string
   sharedLabel: string
   personalPlaceholder?: string
+  unavailableLabel?: string
   createNewLabel?: string
   onChange: (value: string) => void
   className?: string
@@ -25,6 +26,7 @@ export function CredentialBindingSelect({
   personalLabel,
   sharedLabel,
   personalPlaceholder,
+  unavailableLabel,
   createNewLabel,
   onChange,
   className,
@@ -39,6 +41,7 @@ export function CredentialBindingSelect({
     >
       {allowPersonal && <SelectOption value="">{personalLabel}</SelectOption>}
       {!allowPersonal && !value && <SelectOption value="">{personalPlaceholder ?? personalLabel}</SelectOption>}
+      {unavailableLabel && value && !secrets.some((secret) => secret.id === value) && <SelectOption value={value} disabled>{unavailableLabel}</SelectOption>}
       {secrets.map((secret) => (
         <SelectOption key={secret.id} value={secret.id}>
           {sharedLabel}: {secret.name}

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1438,7 +1438,17 @@
           "blocked": "Not usable",
           "deprecated": "Deprecated"
         },
-        "pickerHint": "Choose a Skill, tool, or reference documents for this Agent. Enabling it takes effect on the next run; runtime availability is checked during execution."
+        "pickerHint": "Choose a Skill, tool, or reference documents for this Agent. Enabling it takes effect on the next run; runtime availability is checked during execution.",
+        "credentials": {
+          "edit": "Change credentials",
+          "title": "Credentials for {{name}}",
+          "description": "Choose which credentials this capability uses.",
+          "saved": "Credentials updated for {{name}}.",
+          "unavailable": "Previously selected credential is unavailable",
+          "required": "Choose an available credential to continue.",
+          "loadError": "Unable to load credential options",
+          "saveError": "Could not save credential changes"
+        }
       },
       "sandbox": {
         "title": "Persistent Sandbox",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1438,7 +1438,17 @@
           "blocked": "不可用",
           "deprecated": "已废弃"
         },
-        "pickerHint": "为此 Agent 选择 Skill、工具或参考资料。启用后在下次运行生效，执行时会检查运行环境是否可用。"
+        "pickerHint": "为此 Agent 选择 Skill、工具或参考资料。启用后在下次运行生效，执行时会检查运行环境是否可用。",
+        "credentials": {
+          "edit": "更换凭据",
+          "title": "{{name}} 的凭据",
+          "description": "选择此能力使用的凭据。",
+          "saved": "已更新 {{name}} 的凭据。",
+          "unavailable": "之前选择的凭据已不可用",
+          "required": "请选择可用凭据后再保存。",
+          "loadError": "无法加载凭据选项",
+          "saveError": "凭据修改未保存"
+        }
       },
       "sandbox": {
         "title": "长期 Sandbox",

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -49,6 +49,7 @@ import { DetailSection, InlineError } from "./DetailSection"
 import type { ShowToast } from "../../../components/ui/toast"
 
 import { CapabilityVersionDialog } from "./CapabilityVersionDialog"
+import { CapabilityCredentialsDialog } from "./CapabilityCredentialsDialog"
 import { catalogIDFromVersion, requiredCredentialKinds, useCapabilityVersions } from "../../../lib/capability-config"
 
 type CapabilityCardItem = { capability?: Capability; binding?: AgentCapability }
@@ -271,6 +272,7 @@ function CapabilityCard({
   sharedSecrets,
   mode,
   onToast,
+  canEditCredentials = false,
 }: {
   item: CapabilityCardItem
   agent: Agent
@@ -279,6 +281,7 @@ function CapabilityCard({
   sharedSecrets: Secret[]
   mode: "enabled" | "available"
   onToast: ShowToast
+  canEditCredentials?: boolean
 }) {
   const { t, i18n } = useTranslation("admin")
   const capability = item.capability
@@ -446,6 +449,9 @@ function CapabilityCard({
           />
         ) : binding ? (
           <>
+            {canEditCredentials && binding.enabled && capability.required_credentials?.some((credential) => credential.required) && (
+              <CapabilityCredentialsDialog agent={agent} binding={binding} capability={capability} workspaceID={workspaceID} onToast={onToast} />
+            )}
             {(versions.length > 1 || (versions.length === 1 && binding.pinning_mode === "latest")) && !versionDeleted && !fromMarketplace && (
               <CapabilityVersionDialog
                 mode="switch"
@@ -676,6 +682,7 @@ function ConfigCapabilitiesSection({
                 credentials={credentials}
                 sharedSecrets={sharedSecrets}
                 mode="enabled"
+                canEditCredentials={isAdmin}
                 onToast={onToast}
               />
             )

--- a/apps/web/src/pages/admin/agents/CapabilityCredentialsDialog.tsx
+++ b/apps/web/src/pages/admin/agents/CapabilityCredentialsDialog.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react"
+import { KeyRound } from "lucide-react"
+import { useTranslation } from "react-i18next"
+import { CredentialBindingSelect } from "../../../components/admin/CredentialBindingSelect"
+import { ErrorState } from "../../../components/ui/error-state"
+import { ActionIconButton } from "../../../components/ui/action-button"
+import { Button } from "../../../components/ui/button"
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../../../components/ui/dialog"
+import { Field } from "../../../components/ui/label"
+import { Skeleton } from "../../../components/ui/skeleton"
+import type { ShowToast } from "../../../components/ui/toast"
+import { useCapabilityVersionsQuery, useEnableAgentCapabilityMutation } from "../../../lib/api-capabilities"
+import { useSecrets } from "../../../lib/api-secrets"
+import type { Agent, AgentCapability, Capability } from "../../../lib/api-types"
+import { catalogIDFromVersion, requiredCredentialKinds } from "../../../lib/capability-config"
+import { credentialBinding, sharedSecretsForKind } from "../../../lib/credential-bindings"
+import { credentialKindLabel } from "../capability-ui"
+
+interface Props {
+  agent: Agent
+  binding: AgentCapability
+  capability: Capability
+  workspaceID: string | null
+  onToast: ShowToast
+}
+
+export function CapabilityCredentialsDialog(props: Props) {
+  const { t } = useTranslation("admin")
+  const [open, setOpen] = useState(false)
+  const mut = useEnableAgentCapabilityMutation(props.workspaceID, props.agent.id)
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!mut.isPending) { setOpen(next); mut.reset() } }}>
+      <ActionIconButton icon={KeyRound} label={t("agents.detail.capabilities.credentials.edit")} onClick={() => setOpen(true)} />
+      {open && <CredentialForm {...props} mut={mut} close={() => { setOpen(false); mut.reset() }} />}
+    </Dialog>
+  )
+}
+
+function CredentialForm({ agent, binding, capability, workspaceID, onToast, close, mut }: Props & { close: () => void; mut: ReturnType<typeof useEnableAgentCapabilityMutation> }) {
+  const { t, i18n } = useTranslation(["admin", "common"])
+  const secretsQ = useSecrets(workspaceID)
+  const foreign = capability.from_marketplace === true || (!!capability.workspace_id && capability.workspace_id !== workspaceID)
+  const versionsQ = useCapabilityVersionsQuery(workspaceID, foreign ? null : binding.capability_id)
+  const localVersion = versionsQ.data?.versions.find((item) => item.id === binding.capability_version_id)
+  const version = foreign ? {
+    id: binding.capability_version_id,
+    required_credentials: binding.required_credentials ?? capability.required_credentials,
+  } : localVersion
+  const [choices, setChoices] = useState<Record<string, string>>({})
+  const secrets = secretsQ.data?.secrets ?? []
+  const fields = requiredCredentialKinds({ ...capability, required_credentials: version?.required_credentials }).map((field) => {
+    const original = credentialBinding(binding.configuration, field.kind) ?? credentialBinding(agent.config, field.kind)
+    const value = choices[field.kind] ?? original?.secretID ?? ""
+    const available = sharedSecretsForKind(secrets, field.kind, catalogIDFromVersion(foreign ? undefined : localVersion))
+    const valid = value ? available.some((secret) => secret.id === value)
+      : agent.visibility !== "public"
+    return { ...field, value, available, valid }
+  })
+  const loading = secretsQ.isLoading || (!foreign && versionsQ.isLoading)
+  const failed = secretsQ.isError || (!foreign && (versionsQ.isError || (versionsQ.isSuccess && !version)))
+  const changes = Object.entries(choices).filter(([kind, value]) => value !== ((credentialBinding(binding.configuration, kind) ?? credentialBinding(agent.config, kind))?.secretID ?? ""))
+  const canSubmit = !loading && !failed && !mut.isPending && changes.length > 0 && fields.every((field) => field.valid)
+  const retry = () => {
+    void secretsQ.refetch()
+    if (!foreign) void versionsQ.refetch()
+  }
+  const save = () => {
+    if (!canSubmit) return
+    const existing = binding.configuration.credential_bindings
+    const credentialBindings = existing && typeof existing === "object" && !Array.isArray(existing) ? { ...existing } : {}
+    for (const [kind, value] of changes) {
+      Object.assign(credentialBindings, { [kind]: value ? { source: "shared", secret_id: value } : { source: "personal" } })
+    }
+    mut.mutate({
+      capabilityVersionID: binding.capability_version_id,
+      pinningMode: binding.pinning_mode ?? "pinned",
+      configuration: { ...binding.configuration, credential_bindings: credentialBindings },
+    }, {
+      onSuccess: () => {
+        onToast(t("agents.detail.capabilities.credentials.saved", { name: capability.name }))
+        close()
+      },
+    })
+  }
+  return (
+    <DialogContent>
+      <DialogHeader>
+        <DialogTitle>{t("agents.detail.capabilities.credentials.title", { name: capability.name })}</DialogTitle>
+        <DialogDescription>{t("agents.detail.capabilities.credentials.description")}</DialogDescription>
+      </DialogHeader>
+      <div className="flex flex-col gap-4">
+        {failed ? <ErrorState appearance="panel" title={t("agents.detail.capabilities.credentials.loadError")} onRetry={retry} />
+          : loading ? <Skeleton className="h-8 w-full" />
+            : fields.map((field) => (
+              <Field key={field.kind} label={credentialKindLabel(field.kind, i18n.language, field.kind)}>
+                <CredentialBindingSelect
+                  label={credentialKindLabel(field.kind, i18n.language, field.kind)}
+                  value={field.value}
+                  secrets={field.available}
+                  allowPersonal={agent.visibility !== "public"}
+                  personalLabel={t("credentialCheck.sourcePersonal")}
+                  sharedLabel={t("credentialCheck.sourceShared")}
+                  personalPlaceholder={t("credentialCheck.sharedPlaceholder")}
+                  unavailableLabel={t("agents.detail.capabilities.credentials.unavailable")}
+                  onChange={(value) => setChoices((previous) => ({ ...previous, [field.kind]: value }))}
+                />
+                {!field.valid && <p className="mt-1 text-xs text-status-failed">{t("agents.detail.capabilities.credentials.required")}</p>}
+              </Field>
+            ))}
+        {mut.error != null && <ErrorState appearance="panel" title={t("agents.detail.capabilities.credentials.saveError")} detail={mut.error instanceof Error ? mut.error.message : undefined} />}
+      </div>
+      <DialogFooter>
+        <Button variant="outline" disabled={mut.isPending} onClick={close}>{t("common:actions.cancel")}</Button>
+        <Button disabled={!canSubmit} onClick={save}>{t("common:actions.save")}</Button>
+      </DialogFooter>
+    </DialogContent>
+  )
+}

--- a/tests/e2e/capability-credentials.spec.ts
+++ b/tests/e2e/capability-credentials.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test, type Page } from "@playwright/test";
+import { json, WORKSPACE_ID as workspace, AGENT_ID as agentID } from "./helpers/conversation-app";
+
+const base = `/api/v1/workspaces/${workspace}`;
+const configuration = { retained: { path: "/qa/context" }, credential_bindings: {
+  github_pat: { source: "shared", secret_id: "key-a" },
+  unrelated: { source: "shared", secret_id: "keep-me" },
+} };
+
+test("changes only the chosen binding credential and preserves its pinned version", async ({ page }) => {
+  const state = await mockCredentials(page);
+  const dialog = await openCredentials(page);
+  await expect(dialog.getByRole("combobox").first()).toContainText("Key A");
+  await expect(dialog.getByRole("button", { name: "Save", exact: true })).toBeDisabled();
+  await choose(page, "Key B");
+  await dialog.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  expect(state.writes).toEqual([{ path: `${base}/agents/${agentID}/capabilities/desk-v1/enable`, method: "POST", body: {
+    pinning_mode: "pinned", configuration: { ...configuration, credential_bindings: {
+      ...configuration.credential_bindings, github_pat: { source: "shared", secret_id: "key-b" },
+    } },
+  } }]);
+});
+
+test("personal selection overrides Agent-wide shared defaults without changing latest mode", async ({ page }) => {
+  const state = await mockCredentials(page, { inherited: true, latest: true });
+  const dialog = await openCredentials(page);
+  await expect(dialog.getByRole("combobox").first()).toContainText("Key A");
+  await dialog.getByRole("combobox").first().click();
+  await page.getByRole("option", { name: "Each caller uses their own token", exact: true }).click();
+  await dialog.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  expect(state.writes).toHaveLength(1);
+  expect(state.writes[0].body).toEqual({ pinning_mode: "latest", configuration: {
+    retained: configuration.retained, credential_bindings: {
+      unrelated: configuration.credential_bindings.unrelated, github_pat: { source: "personal" },
+    },
+  } });
+  expect(state.writes[0].path).toBe(`${base}/agents/${agentID}/capabilities/desk-v1/enable`);
+});
+
+test("rotates a shared key while another kind uses callers' personal credentials", async ({ page }) => {
+  const state = await mockCredentials(page, { personalRemainder: true });
+  const dialog = await openCredentials(page);
+  await expect(dialog.getByRole("combobox")).toHaveCount(2);
+  await choose(page, "Key B");
+  await dialog.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  expect(state.writes).toHaveLength(1);
+  expect(state.writes[0].body.configuration.credential_bindings).toEqual({
+    github_pat: { source: "shared", secret_id: "key-b" }, unrelated: { source: "personal" },
+  });
+});
+
+test("cancel discards choices and reopening shows the saved credential", async ({ page }) => {
+  const state = await mockCredentials(page);
+  const dialog = await openCredentials(page);
+  await choose(page, "Key B");
+  await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+  await page.getByRole("button", { name: "Change credentials", exact: true }).click();
+  await expect(dialog.getByRole("combobox").first()).toContainText("Key A");
+  await expect(dialog.getByRole("button", { name: "Save", exact: true })).toBeDisabled();
+  expect(state.writes).toEqual([]);
+});
+
+test("missing shared credential is explicit and never silently falls back to personal", async ({ page }) => {
+  const state = await mockCredentials(page, { missing: true });
+  const dialog = await openCredentials(page);
+  await expect(dialog.getByRole("combobox").first()).toContainText("Previously selected credential is unavailable");
+  await expect(dialog.getByRole("button", { name: "Save", exact: true })).toBeDisabled();
+  await choose(page, "Key B");
+  await dialog.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  expect(state.writes[0].body.configuration.credential_bindings.github_pat.secret_id).toBe("key-b");
+});
+
+test("read and write failures recover without losing the chosen credential", async ({ page }) => {
+  const state = await mockCredentials(page, { readFailure: true });
+  const dialog = await openCredentials(page);
+  await expect(dialog.getByText("Unable to load credential options", { exact: true })).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Save", exact: true })).toBeDisabled();
+  state.readFailure = false;
+  await dialog.getByRole("button", { name: "Retry", exact: true }).click();
+  await choose(page, "Key B");
+  state.saveFailure = true;
+  await dialog.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(dialog.getByText("Could not save credential changes", { exact: true })).toBeVisible();
+  await expect(dialog.getByRole("combobox").first()).toContainText("Key B");
+  const failedAttempts = state.writes.length;
+  state.saveFailure = false;
+  await dialog.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  expect(state.writes).toHaveLength(failedAttempts + 1);
+  for (const write of state.writes) expect(write).toEqual(state.writes[0]);
+});
+
+test("marketplace binding uses authorized metadata and keeps its stored version", async ({ page }) => {
+  const state = await mockCredentials(page, { foreign: true });
+  const dialog = await openCredentials(page);
+  await choose(page, "Key B");
+  await dialog.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  expect(state.versionReads).toBe(0);
+  expect(state.writes[0].path).toBe(`${base}/agents/${agentID}/capabilities/desk-v1/enable`);
+});
+
+test("viewer sees no credential editing action", async ({ page }) => {
+  const state = await mockCredentials(page, { viewer: true });
+  await page.goto(`/?ws=${workspace}&admin=agents&id=${agentID}&tab=config`);
+  await expect(page.getByText("QA Desk", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Change credentials", exact: true })).toHaveCount(0);
+  expect(state.writes).toEqual([]);
+});
+
+async function openCredentials(page: Page) {
+  await page.goto(`/?ws=${workspace}&admin=agents&id=${agentID}&tab=config`);
+  await page.getByRole("button", { name: "Change credentials", exact: true }).click();
+  return page.getByRole("dialog", { name: "Credentials for QA Desk", exact: true });
+}
+
+async function choose(page: Page, name: string) {
+  await page.getByRole("dialog").getByRole("combobox").first().click();
+  await page.getByRole("option", { name: new RegExp(name) }).click();
+}
+
+async function mockCredentials(page: Page, options: { inherited?: boolean; latest?: boolean; missing?: boolean; readFailure?: boolean; foreign?: boolean; viewer?: boolean; personalRemainder?: boolean } = {}) {
+  const state = { readFailure: options.readFailure ?? false, saveFailure: false, versionReads: 0,
+    writes: [] as Array<{ path: string; method: string; body: { pinning_mode: string; configuration: typeof configuration } }> };
+  const required = [{ kind: "github_pat", required: true }, { kind: "unrelated", required: true }, { kind: "optional", required: false }];
+  const capability = { id: "desk", workspace_id: options.foreign ? "publisher" : workspace, name: "QA Desk", type: "mcp", status: "active",
+    from_marketplace: options.foreign ?? false, latest_version_id: "desk-v2", latest_version: "2.0.0", pinned_version: "1.0.0", required_credentials: required };
+  const binding = { id: "binding-desk", capability_id: "desk", capability_version_id: "desk-v1", enabled: true, version: "1.0.0",
+    pinning_mode: options.latest ? "latest" : "pinned", capability, configuration: structuredClone(configuration) };
+  if (options.personalRemainder) (binding.configuration.credential_bindings as Record<string, unknown>).unrelated = { source: "personal" };
+  if (options.inherited) delete (binding.configuration.credential_bindings as Record<string, unknown>).github_pat;
+  const agent = { id: agentID, workspace_id: workspace, name: "Credential Agent", status: "active", connector_type: "agent_daemon", visibility: "workspace",
+    config: { agent_kind: "claude_code", daemon_mode: "local", credential_bindings: { github_pat: { source: "shared", secret_id: "key-a" } } } };
+  await page.addInitScript(() => { localStorage.setItem("parsar.lang", "en-US"); localStorage.setItem("parsar.theme", "light"); });
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const method = route.request().method();
+    if (method !== "GET") {
+      const body = route.request().postDataJSON();
+      state.writes.push({ path, method, body });
+      if (path !== `${base}/agents/${agentID}/capabilities/desk-v1/enable` || method !== "POST") return json(route, { error: "unexpected_write" }, 400);
+      if (state.saveFailure) return json(route, { error: "credential_unavailable", message: "Synthetic save failure" }, 422);
+      Object.assign(binding, body); return json(route, binding);
+    }
+    if (path === "/api/v1/me") return json(route, { user_id: "qa-user", name: "QA", email: "qa@example.test" });
+    if (path === "/api/v1/me/workspaces") return json(route, { workspaces: [{ id: workspace, name: "QA Credentials", role: options.viewer ? "viewer" : "owner" }] });
+    if (path === "/api/v1/me/credentials") return json(route, { credentials: [] });
+    if (path === `${base}/agents`) return json(route, { agents: [agent] });
+    if (path === `${base}/agents/${agentID}` || path === `/api/v1/agents/${agentID}`) return json(route, agent);
+    if (path === `${base}/agents/${agentID}/capabilities`) return json(route, { installed: [binding], available: [] });
+    if (path === `${base}/capabilities`) return json(route, { capabilities: options.foreign ? [] : [capability] });
+    if (path === `${base}/capabilities/desk/versions`) {
+      state.versionReads++;
+      if (options.foreign) return json(route, { error: "not_found" }, 404);
+      return json(route, { versions: [2, 1].map((n) => ({ id: `desk-v${n}`, capability_id: "desk", version: `${n}.0.0`, required_credentials: required })) });
+    }
+    if (path === `${base}/secrets`) return state.readFailure ? json(route, { error: "unavailable" }, 503)
+      : json(route, { secrets: (options.missing ? ["b"] : ["a", "b"]).map((key) => ({ id: `key-${key}`, name: `Key ${key.toUpperCase()}`, kind: "capability_inline", status: "active", metadata: { credential_kind_code: "github_pat" } })).concat([{ id: "keep-me", name: "Other credential", kind: "capability_inline", status: "active", metadata: { credential_kind_code: "unrelated" } }]) });
+    if (path.endsWith("/models")) return json(route, { models: [] });
+    return json(route, {});
+  });
+  return state;
+}


### PR DESCRIPTION
An enabled capability has no credential editing action in Agent Config, forcing users back through the legacy Agent editor. Add a scoped credential dialog so an authorized workspace member can rotate a shared secret or choose each caller's personal credentials for one binding.

Saving preserves the binding's stored version, pinned/latest mode, other configuration, and Agent-wide defaults. Failed reads can be retried, failed saves retain selections, and missing shared secrets remain explicit. The dialog uses existing APIs and authorization; it does not change legacy Agent editing or version-following behavior. This is a prerequisite toward the remaining BUG-004 work, not full resolution.

Validation: `make check`, scoped ESLint, eight Playwright cases, independent blind review, and real remote API/browser verification of cancel/save/reload. A Claude Code/MiniMax-M3 run received the new synthetic credential; other binding IDs, versions, modes, configuration and Agent config were unchanged. English/light and Chinese/dark screenshots were inspected. Local Docker stayed stopped; the local migration smoke check was skipped as reported by `make check`.
