### PR TITLE
fix(web): configure capability version policy from Agent Config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,8 +226,10 @@ description and keep ownership on the side listed here.
 
 - Agent capability reads retain the stored binding version and expose its
   pinning mode. Displayed current versions match the daemon's resolver:
-  Skill, Plugin, and Bundle can follow latest metadata (including deprecation
-  cutoffs); MCP and System Prompt currently use the stored binding version.
+  Skill, Plugin, Bundle, and Knowledge can follow latest metadata (including
+  deprecation cutoffs); MCP and System Prompt currently use the stored binding
+  version. Config offers automatic-follow choices only for supported types and
+  retains per-binding configuration when changing version policy.
 
 - Cross-workspace installed capabilities remain visible and removable after
   unpublishing. Their installation metadata reports source visibility and only

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1407,7 +1407,9 @@
           "description": "Selecting a version pins this Agent to it for future runs. In-flight runs are unchanged.",
           "latest": "latest",
           "current": "current",
-          "notice": "Only this Agent ({{agent}}) is affected. Other Agents using this capability are unchanged. Takes effect on the next run."
+          "notice": "Only this Agent ({{agent}}) is affected. Other Agents using this capability are unchanged. Takes effect on the next run.",
+          "followLatest": "Follow the latest version",
+          "followDescription": "Follow new versions automatically, or pin this Agent to a specific version. Changes apply to future runs."
         },
         "removeDialog": {
           "title": "Remove \"{{cap}}\" from \"{{agent}}\"?",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1407,7 +1407,9 @@
           "description": "选择一个版本后，此 Agent 的后续运行将固定使用它；进行中的运行不受影响。",
           "latest": "最新",
           "current": "当前",
-          "notice": "切换仅影响本 Agent（{{agent}}）；其它装配此能力的 Agent 不受影响。下次运行生效。"
+          "notice": "切换仅影响本 Agent（{{agent}}）；其它装配此能力的 Agent 不受影响。下次运行生效。",
+          "followLatest": "跟随最新版",
+          "followDescription": "自动跟随后续版本，或为此 Agent 固定一个版本。修改在后续运行中生效。"
         },
         "removeDialog": {
           "title": "从「{{agent}}」移除「{{cap}}」？",

--- a/apps/web/src/lib/agent-capability-version.ts
+++ b/apps/web/src/lib/agent-capability-version.ts
@@ -1,4 +1,8 @@
-import type { AgentCapability, Capability, CapabilityVersion } from "./api-types"
+import type { AgentCapability, Capability, CapabilityVersion, CapabilityType } from "./api-types"
+
+export function capabilitySupportsLatest(kind: CapabilityType | undefined): boolean {
+  return kind === "skill" || kind === "plugin" || kind === "bundle" || kind === "knowledge"
+}
 
 export function agentCapabilityFollowsLatest(
   binding: AgentCapability | undefined,
@@ -7,7 +11,7 @@ export function agentCapabilityFollowsLatest(
   const kind = capability?.type ?? binding?.type
   // Match the daemon resolvers: MCP and System Prompt still use stored fields.
   return binding?.pinning_mode === "latest"
-    && (kind === "skill" || kind === "plugin" || kind === "bundle" || kind === "knowledge")
+    && capabilitySupportsLatest(kind)
 }
 
 export function agentCapabilityVersion(

--- a/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
+++ b/apps/web/src/pages/admin/agents/AgentConfigTab.tsx
@@ -36,7 +36,7 @@ import {
 } from "../../../lib/api-capabilities"
 import { useMyCredentials } from "../../../lib/api-credentials"
 import { useSecrets } from "../../../lib/api-secrets"
-import { agentCapabilityFollowsLatest, agentCapabilityVersion } from "../../../lib/agent-capability-version"
+import { agentCapabilityFollowsLatest, agentCapabilityVersion, capabilitySupportsLatest } from "../../../lib/agent-capability-version"
 import { agentExecutionPlacement } from "../../../lib/agent-runtime"
 import { agentEngineLabel, agentEngineOf, agentEngineSupportsCapability, agentEnginesSupportingCapability } from "../../../lib/agent-view-model"
 import { credentialBinding, hasCredentialKind, sharedSecretsForKind } from "../../../lib/credential-bindings"
@@ -292,6 +292,10 @@ function CapabilityCard({
   const versionDeleted = !!binding && !versionsQ.isLoading && !boundVersion && !capability?.latest_version_id
   const fromMarketplace = !!capability?.from_marketplace || (!!capability?.source_workspace_id && capability.source_workspace_id !== workspaceID)
   const deprecated = !!capability?.deprecated_at
+  const canChooseLatest = capabilitySupportsLatest(capability?.type) && !deprecated
+    && (!fromMarketplace || capability?.visibility === "public")
+  const canSwitchVersions = !versionDeleted && (canChooseLatest ? versions.length > 0
+    : !fromMarketplace && (versions.length > 1 || (versions.length === 1 && binding?.pinning_mode === "latest")))
 
   if (!capability && binding) {
     return (
@@ -452,13 +456,14 @@ function CapabilityCard({
             {canEditCredentials && binding.enabled && capability.required_credentials?.some((credential) => credential.required) && (
               <CapabilityCredentialsDialog agent={agent} binding={binding} capability={capability} workspaceID={workspaceID} onToast={onToast} />
             )}
-            {(versions.length > 1 || (versions.length === 1 && binding.pinning_mode === "latest")) && !versionDeleted && !fromMarketplace && (
+            {canSwitchVersions && (
               <CapabilityVersionDialog
                 mode="switch"
                 agent={agent}
                 capability={capability}
                 binding={binding}
                 workspaceID={workspaceID}
+                disabled={!canEditCredentials}
                 onToast={onToast}
               />
             )}

--- a/apps/web/src/pages/admin/agents/CapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/agents/CapabilityVersionDialog.tsx
@@ -10,7 +10,7 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { CredentialBindingSelect } from "../../../components/admin/CredentialBindingSelect"
 import type { ShowToast } from "../../../components/ui/toast"
 import { useEnableAgentCapabilityMutation } from "../../../lib/api-capabilities"
-import { agentCapabilityVersion } from "../../../lib/agent-capability-version"
+import { agentCapabilityVersion, capabilitySupportsLatest } from "../../../lib/agent-capability-version"
 import { catalogIDFromVersion, requiredCredentialKinds, useCapabilityVersions } from "../../../lib/capability-config"
 import { hasCredentialKind, sharedSecretsForKind } from "../../../lib/credential-bindings"
 import type { Agent, AgentCapability, Capability, CapabilityVersion, Secret, UserCredential } from "../../../lib/api-types"
@@ -131,10 +131,14 @@ export function CapabilityVersionDialog({
   const { latest, versions, versionsQ } = useCapabilityVersions(workspaceID, capability, open)
   const currentVersion = agentCapabilityVersion(binding, capability, versions)
   const knowledge = capability.type === "knowledge"
-  const selected = selection || (knowledge && (mode === "enable" || binding?.pinning_mode === "latest") ? "latest" : currentVersion?.id || "")
-  const followsLatest = knowledge && selected === "latest"
+  const allowLatest = knowledge || (mode === "switch" && capabilitySupportsLatest(capability.type) && !capability.deprecated_at
+    && (!capability.from_marketplace || capability.visibility === "public"))
+  const selected = selection || (allowLatest && ((knowledge && mode === "enable") || binding?.pinning_mode === "latest") ? "latest" : currentVersion?.id || "")
+  const followsLatest = allowLatest && selected === "latest"
+  const switchVersions = capability.from_marketplace && currentVersion && !versions.some((version) => version.id === currentVersion.id)
+    ? [...versions, currentVersion] : versions
   const selectedVersion = followsLatest ? latest : selected
-    ? versions.find((version) => version.id === selected) ?? (mode === "enable" ? latest : versions[0])
+    ? switchVersions.find((version) => version.id === selected) ?? (mode === "enable" ? latest : versions[0])
     : mode === "enable" ? latest : versions[0]
   const requiredKinds = useMemo(
     () => mode === "enable" ? requiredCredentialKinds(capability) : [],
@@ -198,7 +202,7 @@ export function CapabilityVersionDialog({
   }
   const isSwitch = mode === "switch"
   const confirmLabel = isSwitch
-    ? followsLatest ? t("capabilities.knowledge.followLatest") : selectedVersion
+    ? followsLatest ? t("agents.detail.capabilities.switchDialog.followLatest") : selectedVersion
       ? t("agents.detail.capabilities.actions.switchConfirm", { version: selectedVersion.version })
       : t("agents.detail.capabilities.actions.switchVersion")
     : t("agents.detail.capabilities.actions.enableConfirm")
@@ -222,17 +226,17 @@ export function CapabilityVersionDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{t(isSwitch ? "agents.detail.capabilities.switchDialog.title" : "agents.detail.capabilities.enableDialog.title", { agent: agent.name, cap: capability.name })}</DialogTitle>
-          <DialogDescription>{t(knowledge ? "capabilities.knowledge.versionHint" : isSwitch ? "agents.detail.capabilities.switchDialog.description" : "agents.detail.capabilities.enableDialog.description")}</DialogDescription>
+          <DialogDescription>{t(knowledge ? "capabilities.knowledge.versionHint" : isSwitch && allowLatest ? "agents.detail.capabilities.switchDialog.followDescription" : isSwitch ? "agents.detail.capabilities.switchDialog.description" : "agents.detail.capabilities.enableDialog.description")}</DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-3">
           {isSwitch ? (
             versionsQ.isLoading ? <Skeleton className="h-28 w-full" /> : (
               <ul className="m-0 list-none p-0">
-                {knowledge && <li><label className="flex h-7 cursor-pointer items-center gap-2 text-sm text-fg">
+                {allowLatest && <li><label className="flex h-7 cursor-pointer items-center gap-2 text-sm text-fg">
                   <input type="radio" name="capability-version" className="h-3.5 w-3.5 accent-accent" checked={selected === "latest"} onChange={() => setSelected("latest")} />
-                  {t("capabilities.knowledge.followLatest")}
+                  {t("agents.detail.capabilities.switchDialog.followLatest")}
                 </label></li>}
-                {versions.map((version, index) => (
+                {switchVersions.map((version, index) => (
                   <li key={version.id}>
                     <label className="flex h-7 cursor-pointer items-center gap-2 text-sm text-fg">
                       <input type="radio" name="capability-version" className="h-3.5 w-3.5 accent-accent" checked={selected === version.id} onChange={() => setSelected(version.id)} />

--- a/tests/e2e/capability-follow-latest.spec.ts
+++ b/tests/e2e/capability-follow-latest.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test, type Page } from "@playwright/test";
+import { json, WORKSPACE_ID as ws, AGENT_ID as aid } from "./helpers/conversation-app";
+const base = `/api/v1/workspaces/${ws}`;
+const configuration = { retained: { note: "Keep this configuration" } };
+
+test("one-version Skill can follow future releases and return to a fixed version", async ({ page }) => {
+  const state = await fixture(page);
+  let dialog = await open(page);
+  await dialog.getByRole("radio", { name: "Follow the latest version", exact: true }).check();
+  await dialog.getByRole("button", { name: "Cancel", exact: true }).click();
+  expect(state.writes).toEqual([]);
+  dialog = await open(page);
+  await expect(dialog.getByRole("radio", { name: /^v1/ })).toBeChecked();
+  await dialog.getByRole("radio", { name: "Follow the latest version", exact: true }).check();
+  await dialog.getByRole("button", { name: "Follow the latest version", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  expect(state.writes).toEqual([{ version: "v1", body: { pinning_mode: "latest", configuration } }]);
+  state.publish();
+  dialog = await open(page);
+  await expect(dialog.getByRole("radio", { name: "Follow the latest version", exact: true })).toBeChecked();
+  await expect(dialog.getByRole("button", { name: "Follow the latest version", exact: true })).toBeDisabled();
+  await dialog.getByRole("radio", { name: /^v2/ }).check();
+  await dialog.getByRole("button", { name: "Switch to 2.0.0", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  expect(state.writes[1]).toEqual({ version: "v2", body: { configuration } });
+});
+
+for (const kind of ["plugin", "bundle", "knowledge"]) {
+  test(`${kind} exposes the existing automatic-follow policy`, async ({ page }) => {
+    const state = await fixture(page, { kind });
+    const dialog = await open(page);
+    await dialog.getByRole("radio", { name: "Follow the latest version", exact: true }).check();
+    await dialog.getByRole("button", { name: "Follow the latest version", exact: true }).click();
+    await expect(dialog).toHaveCount(0);
+    expect(state.writes[0]).toEqual({ version: "v1", body: { pinning_mode: "latest", configuration } });
+  });
+}
+
+for (const kind of ["mcp", "system_prompt"]) {
+  test(`${kind} keeps its fixed-version choices`, async ({ page }) => {
+    const state = await fixture(page, { kind, twoVersions: true });
+    const dialog = await open(page);
+    await expect(dialog.getByRole("radio", { name: "Follow the latest version", exact: true })).toHaveCount(0);
+    await dialog.getByRole("radio", { name: /^v2/ }).check();
+    await dialog.getByRole("button", { name: "Switch to 2.0.0", exact: true }).click();
+    await expect(dialog).toHaveCount(0);
+    expect(state.writes[0]).toEqual({ version: "v2", body: { configuration } });
+  });
+}
+
+test("marketplace policy uses published and bound metadata without reading private version history", async ({ page }) => {
+  const state = await fixture(page, { foreign: true, twoVersions: true });
+  const dialog = await open(page);
+  await expect(dialog.getByRole("radio", { name: /^v1/ })).toBeChecked();
+  await expect(dialog.getByRole("button", { name: "Switch to 1.0.0", exact: true })).toBeDisabled();
+  await dialog.getByRole("radio", { name: "Follow the latest version", exact: true }).check();
+  await dialog.getByRole("button", { name: "Follow the latest version", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  expect(state.writes[0]).toEqual({ version: "v2", body: { pinning_mode: "latest", configuration } });
+  expect(state.versionReads).toBe(0);
+});
+
+test("failed policy change retains the choice for retry", async ({ page }) => {
+  const state = await fixture(page, { saveFailure: true });
+  const dialog = await open(page);
+  await dialog.getByRole("radio", { name: "Follow the latest version", exact: true }).check();
+  await dialog.getByRole("button", { name: "Follow the latest version", exact: true }).click();
+  await expect(dialog.getByText("Synthetic binding failure", { exact: true })).toBeVisible();
+  await expect(dialog.getByRole("radio", { name: "Follow the latest version", exact: true })).toBeChecked();
+  state.saveFailure = false;
+  await dialog.getByRole("button", { name: "Follow the latest version", exact: true }).click();
+  await expect(dialog).toHaveCount(0);
+  expect(state.writes.every(w => w.version === "v1" && w.body.pinning_mode === "latest")).toBe(true);
+});
+
+test("viewer cannot use the policy editing action", async ({ page }) => {
+  const state = await fixture(page, { viewer: true });
+  await page.goto(`/?ws=${ws}&admin=agents&id=${aid}&tab=config`);
+  await expect(page.getByRole("button", { name: "Switch version", exact: true })).toBeDisabled();
+  expect(state.writes).toEqual([]);
+});
+
+async function open(page: Page) {
+  await page.goto(`/?ws=${ws}&admin=agents&id=${aid}&tab=config`);
+  await page.getByRole("button", { name: "Switch version", exact: true }).click();
+  return page.getByRole("dialog", { name: 'Switch "QA Version Capability" version', exact: true });
+}
+
+async function fixture(page: Page, options: { kind?: string; twoVersions?: boolean; foreign?: boolean; saveFailure?: boolean; viewer?: boolean } = {}) {
+  const cap = { id: "cap", workspace_id: options.foreign ? "publisher" : ws, type: options.kind ?? "skill", name: "QA Version Capability", status: "active", visibility: "public",
+    from_marketplace: options.foreign ?? false, latest_version_id: options.twoVersions ? "v2" : "v1", latest_version: options.twoVersions ? "2.0.0" : "1.0.0", pinned_version: "1.0.0", required_credentials: [] };
+  const binding = { id: "binding", capability_id: "cap", capability_version_id: "v1", version: "1.0.0", enabled: true, pinning_mode: "pinned", configuration, capability: cap };
+  const agent = { id: aid, name: "Version Agent", workspace_id: ws, status: "active", visibility: "workspace", connector_type: "agent_daemon", config: { agent_kind: "claude_code", daemon_mode: "local" } };
+  const state = { saveFailure: options.saveFailure ?? false, versionReads: 0, writes: [] as Array<{ version: string; body: { pinning_mode?: string; configuration: typeof configuration } }>,
+    publish: () => { cap.latest_version_id = "v2"; cap.latest_version = "2.0.0"; } };
+  await page.addInitScript(() => { localStorage.setItem("parsar.lang", "en-US"); localStorage.setItem("parsar.theme", "light"); });
+  await page.route("**/api/v1/**", async route => {
+    const path = new URL(route.request().url()).pathname;
+    if (route.request().method() !== "GET") {
+      const version = path.split("/").at(-2)!;
+      const body = route.request().postDataJSON(); state.writes.push({ version, body });
+      if (!path.startsWith(`${base}/agents/${aid}/capabilities/`) || !path.endsWith("/enable")) return json(route, { error: "unexpected_write" }, 400);
+      if (state.saveFailure) return json(route, { error: "invalid_binding", message: "Synthetic binding failure" }, 422);
+      Object.assign(binding, body, { pinning_mode: body.pinning_mode ?? "pinned", capability_version_id: version, version: version === "v2" ? "2.0.0" : "1.0.0" });cap.pinned_version = binding.version;
+      return json(route, binding);
+    }
+    if (path === "/api/v1/me") return json(route, { user_id: "qa", name: "QA", email: "qa@example.test" });
+    if (path === "/api/v1/me/workspaces") return json(route, { workspaces: [{ id: ws, name: "Version QA", role: options.viewer ? "viewer" : "owner" }] });
+    if (path === `${base}/agents`) return json(route, { agents: [agent] });
+    if (path === `${base}/agents/${aid}` || path === `/api/v1/agents/${aid}`) return json(route, agent);
+    if (path === `${base}/agents/${aid}/capabilities`) return json(route, { installed: [binding], available: [] });
+    if (path === `${base}/capabilities`) return json(route, { capabilities: options.foreign ? [] : [cap] });
+    if (path === `${base}/capabilities/cap/versions`) {state.versionReads++; return json(route, { versions: (cap.latest_version_id === "v2" ? [2, 1] : [1]).map(n => ({ id: `v${n}`, capability_id: "cap", version: `${n}.0.0`, required_credentials: [] })) });}
+    if (path.endsWith("/models")) return json(route, { models: [] });
+    if (path.endsWith("/secrets")) return json(route, { secrets: [] });
+    if (path.endsWith("/credentials")) return json(route, { credentials: [] });
+    return json(route, {});
+  });
+  return state;
+}


### PR DESCRIPTION
Agent Config could pin a capability version, but could not enable automatic updates for an existing Skill, Plugin, or Bundle binding. The version dialog now offers automatic follow for runtime-supported types, including a capability with only one version, while retaining the existing per-binding configuration.

Published marketplace capabilities offer their published version and the Agent’s retained version without reading private version history. Viewer controls remain disabled. MCP and System Prompt behavior, capability creation, credentials, runtime resolution, and the old Agent editing wizard are outside this PR. This is a prerequisite for BUG-004, not its final closure.

Validation:
- `make check` passed; local PostgreSQL migration smoke skipped because Docker is unavailable. No database or backend change.
- Scoped ESLint and nine Playwright cases passed, covering supported types, fixed-only types, single-version bindings, marketplace boundaries, viewer access, and save/retry behavior.
- Independent blind review of the entire diff found no actionable in-scope issues.
- Real browser save/reload preserved configuration and other bindings. With Claude Code / MiniMax-M3, publishing V2 moved the following Agent to V2 while a pinned control used V1. After pinning the first Agent to V2, publishing V3 left its execution on V2.
