### PR TITLE
fix(api): require the import path for Skill versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -356,6 +356,9 @@ description and keep ownership on the side listed here.
 - Markdown Skill imports and new versions must store an engine-neutral ZIP
   containing `SKILL.md`, with its storage reference and SHA-256 persisted before
   reporting success. Existing versions without archives require a new import.
+  Generic capability creation may create Skill metadata, but Skill versions
+  must use the import commit endpoints; generic version writes reject them
+  rather than storing a version the runtime cannot load.
 - Skill ZIP preview and commit must reject duplicate paths, including
   normalized separator/dot-segment and case aliases, so approved file contents
   cannot differ because an extractor chooses a different duplicate entry.

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -6250,9 +6250,10 @@ paths:
     post:
       consumes:
       - application/json
-      description: Creates an MCP or Skill capability in the workspace. Owner/admin
-        only. When body.version is set, an initial capability_version is created in
-        the same call.
+      description: Creates a capability in the workspace. Owner/admin only. When body.version
+        is set, an initial capability_version is created in the same call. Skill versions
+        must use POST /capabilities/import/commit to store their archive; metadata-only
+        Skill creation remains supported.
       operationId: createDevWorkspaceCapability
       parameters:
       - description: Workspace UUID
@@ -6275,7 +6276,8 @@ paths:
             additionalProperties: true
             type: object
         "400":
-          description: Malformed body, missing name/type, or bad canonical_spec
+          description: Malformed body, missing name/type, bad canonical_spec, or Skill
+            version requiring import
           schema:
             additionalProperties:
               type: string
@@ -6813,7 +6815,8 @@ paths:
       consumes:
       - application/json
       description: Adds a new version row to an existing capability. Owner/admin only.
-        Prefer POST .../versions/import/commit for the parsed import path.
+        Skill versions must use POST .../versions/import/commit to store their archive.
+        Prefer that parsed import path for other capability edits as well.
       operationId: createDevWorkspaceCapabilityVersion
       parameters:
       - description: Workspace UUID
@@ -6841,7 +6844,8 @@ paths:
             additionalProperties: true
             type: object
         "400":
-          description: Missing version or bad canonical_spec
+          description: Missing version, bad canonical_spec, or Skill version requiring
+            import
           schema:
             additionalProperties:
               type: string

--- a/server/internal/dev/capability_routes.go
+++ b/server/internal/dev/capability_routes.go
@@ -653,7 +653,7 @@ func listMarketplaceEnabledAgents(runtimeStore RuntimeStore) http.HandlerFunc {
 // version) in the given workspace. Owner/admin only.
 //
 //	@Summary		Create a workspace capability
-//	@Description	Creates an MCP or Skill capability in the workspace. Owner/admin only. When body.version is set, an initial capability_version is created in the same call.
+//	@Description	Creates a capability in the workspace. Owner/admin only. When body.version is set, an initial capability_version is created in the same call. Skill versions must use POST /capabilities/import/commit to store their archive; metadata-only Skill creation remains supported.
 //	@Tags			capabilities
 //	@ID				createDevWorkspaceCapability
 //	@Accept			json
@@ -661,7 +661,7 @@ func listMarketplaceEnabledAgents(runtimeStore RuntimeStore) http.HandlerFunc {
 //	@Param			workspaceID	path	string			true	"Workspace UUID"
 //	@Param			body		body	capabilityBody	true	"Capability create payload"
 //	@Success		201 {object} map[string]interface{} "Created capability"
-//	@Failure		400 {object} map[string]string "Malformed body, missing name/type, or bad canonical_spec"
+//	@Failure		400 {object} map[string]string "Malformed body, missing name/type, bad canonical_spec, or Skill version requiring import"
 //	@Failure		403 {object} map[string]string "Caller is not workspace owner/admin"
 //	@Failure		503 {object} map[string]string "Database-backed capability APIs are disabled"
 //	@Router			/api/v1/workspaces/{workspaceID}/capabilities [post]
@@ -695,6 +695,10 @@ func createWorkspaceCapability(runtimeStore RuntimeStore) http.HandlerFunc {
 		}
 		input := store.CreateCapabilityInput{WorkspaceID: workspaceID, Type: body.Type, Name: body.Name, Description: body.Description, Visibility: capabilityVisibility(body.Visibility, body.Scope), CreatorID: actorID}
 		if strings.TrimSpace(body.Version) != "" {
+			if body.Type == "skill" {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Skill versions require an archive; use POST /capabilities/import/commit"})
+				return
+			}
 			ver := store.CreateCapabilityVersionInput{Version: body.Version, GitRepoURL: body.GitRepoURL, GitRef: body.GitRef, Path: body.Path, Content: body.Content, RequiredCredentials: body.RequiredCredentials, SchemaVersion: body.SchemaVersion, CanonicalSpec: body.CanonicalSpec}
 			if err := validateCanonicalSpecForType(body.Type, body.CanonicalSpec); err != nil {
 				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
@@ -1030,7 +1034,7 @@ func listWorkspaceCapabilityVersions(runtimeStore RuntimeStore) http.HandlerFunc
 // capability. Owner/admin only. Prefer /versions/import/commit for real edits.
 //
 //	@Summary		Create a capability version
-//	@Description	Adds a new version row to an existing capability. Owner/admin only. Prefer POST .../versions/import/commit for the parsed import path.
+//	@Description	Adds a new version row to an existing capability. Owner/admin only. Skill versions must use POST .../versions/import/commit to store their archive. Prefer that parsed import path for other capability edits as well.
 //	@Tags			capabilities
 //	@ID				createDevWorkspaceCapabilityVersion
 //	@Accept			json
@@ -1039,7 +1043,7 @@ func listWorkspaceCapabilityVersions(runtimeStore RuntimeStore) http.HandlerFunc
 //	@Param			capabilityID	path	string					true	"Capability UUID"
 //	@Param			body			body	capabilityVersionBody	true	"Version payload"
 //	@Success		201 {object} map[string]interface{} "Created capability version"
-//	@Failure		400 {object} map[string]string "Missing version or bad canonical_spec"
+//	@Failure		400 {object} map[string]string "Missing version, bad canonical_spec, or Skill version requiring import"
 //	@Failure		403 {object} map[string]string "Caller is not workspace owner/admin"
 //	@Failure		404 {object} map[string]string "Capability not found in this workspace"
 //	@Failure		503 {object} map[string]string "Database-backed capability APIs are disabled"
@@ -1066,6 +1070,10 @@ func createWorkspaceCapabilityVersion(runtimeStore RuntimeStore) http.HandlerFun
 		capability, err := runtimeStore.GetCapability(r.Context(), capabilityID)
 		if err != nil {
 			writeCapabilityError(w, err, "failed to load capability")
+			return
+		}
+		if capability.Type == "skill" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Skill versions require an archive; use POST /capabilities/{capabilityID}/versions/import/commit"})
 			return
 		}
 		expectedType := ""

--- a/server/internal/dev/capability_skill_version_write_test.go
+++ b/server/internal/dev/capability_skill_version_write_test.go
@@ -1,0 +1,66 @@
+package dev
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/capability/canonical"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+)
+
+func TestGenericSkillVersionWritesRequireImport(t *testing.T) {
+	ids := store.DefaultDevFixtureIDs()
+	router, db := capabilityTestRouter(t, map[string]string{ids.UserID: "admin", testUserAID: "member"}, nil)
+	st := store.New(db)
+	base := "/api/v1/workspaces/" + ids.WorkspaceID + "/capabilities"
+	spec := canonical.Spec{SchemaVersion: 1, Kind: canonical.KindSkill, Skill: &canonical.SkillSpec{
+		Slug: "archive-required", Instruction: "Return SKILL-OK.",
+	}}
+
+	for _, canonicalInput := range []bool{false, true} {
+		body := map[string]any{"type": " Skill ", "name": "Unusable Skill", "version": "1.0.0"}
+		if canonicalInput {
+			body["canonical_spec"] = spec
+		} else {
+			body["content"] = map[string]any{"instruction": "Return SKILL-OK."}
+		}
+		res := serveCapabilityRoute(t, router, http.MethodPost, base, mustJSON(t, body), ids.UserID)
+		if res.Code != http.StatusBadRequest || !strings.Contains(res.Body.String(), "/capabilities/import/commit") {
+			t.Fatalf("initial version must direct callers to import: %d %s", res.Code, res.Body.String())
+		}
+	}
+	var count int
+	if err := db.QueryRow(t.Context(), `select count(*) from capability where name = 'Unusable Skill'`).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("rejected creation wrote metadata: count=%d, error=%v", count, err)
+	}
+
+	created := serveCapabilityRoute(t, router, http.MethodPost, base, `{"type":"skill","name":"Skill metadata"}`, ids.UserID)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("metadata creation: %d %s", created.Code, created.Body.String())
+	}
+	var capability store.CapabilityRead
+	if err := json.Unmarshal(created.Body.Bytes(), &capability); err != nil {
+		t.Fatal(err)
+	}
+	endpoint := base + "/" + capability.ID + "/versions"
+	for _, canonicalInput := range []bool{false, true} {
+		body := map[string]any{"version": "1.0.0"}
+		if canonicalInput {
+			body["canonical_spec"] = spec
+		}
+		res := serveCapabilityRoute(t, router, http.MethodPost, endpoint, mustJSON(t, body), ids.UserID)
+		if res.Code != http.StatusBadRequest || !strings.Contains(res.Body.String(), "/versions/import/commit") {
+			t.Fatalf("new version must direct callers to import: %d %s", res.Code, res.Body.String())
+		}
+	}
+	versions, err := st.ListCapabilityVersions(t.Context(), capability.ID)
+	if err != nil || len(versions) != 0 {
+		t.Fatalf("rejected requests wrote versions: count=%d, error=%v", len(versions), err)
+	}
+	denied := serveCapabilityRoute(t, router, http.MethodPost, endpoint, `{"version":"1.0.0"}`, testUserAID)
+	if denied.Code != http.StatusForbidden {
+		t.Fatalf("member authorization changed: %d %s", denied.Code, denied.Body.String())
+	}
+}


### PR DESCRIPTION
Generic capability endpoints could return `201` for a Skill version with no stored archive, then runtime execution failed with `Unknown skill`. Reject those version writes with `400` and direct callers to the existing import commit endpoints, which store the archive. Metadata-only Skill creation remains available.

This change is limited to the two generic write handlers, their API contract, and regression coverage. It does not migrate old versions or change runtime resolution, import packaging, other capability types, or authorization.

Validation: `make check` passed. Five integration tests passed against isolated PostgreSQL, covering rejected writes without persisted records, metadata creation, member permissions, Markdown and ZIP import, MCP versioning, and Knowledge. Local PostgreSQL smoke checks were skipped because local Docker is disabled; the integration cases ran remotely against a dedicated test database.

Independent blind review completed with no actionable findings; the reviewer re-ran all five isolated PostgreSQL regressions.
