### PR TITLE
test(cli): count the ellipsis in truncation width

### DIFF
--- a/apps/parsar/internal/cli/helpers_test.go
+++ b/apps/parsar/internal/cli/helpers_test.go
@@ -35,7 +35,8 @@ func TestTruncate(t *testing.T) {
 		{"hello", 5, "hello"},
 		{"hello world", 5, "hell…"},
 		// truncate is rune-aware, not byte-aware.
-		{"engineer", 2, "en…"},
+		{"engineer", 2, "e…"},
+		{"工程师", 2, "工…"},
 		{"abc", 1, "a"},
 		{"abc", 0, "abc"},
 	}


### PR DESCRIPTION
The truncation test expected three characters for a width of two, so the Parsar CLI test package failed even though the helper followed its existing width contract. Correct that expectation and add a multibyte example. Production behavior is unchanged.

Validation: `make check` and `go test ./apps/parsar/internal/cli -count=1` passed. Self-reviewed as a test-only correction (CHECK-012).
