### PR TITLE
fix(runtime): authorize inline Skill uploads from sandbox runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -365,6 +365,22 @@ description and keep ownership on the side listed here.
   Reject filenames outside Unicode stream-safe normalization rather than
   adding a separate unbounded normalizer.
 
+### Runtime Skill uploads
+
+- `parsar plugin add` may upload inline Skill bundles using a per-run
+  `PARSAR_CAPABILITY_UPLOAD_TOKEN`. The daemon supplies its paired server URL
+  per request; never export the device's runner credential to an Agent shell.
+  The default sandbox includes the CLI; custom runtimes must install it separately.
+- The upload endpoint derives workspace and actor from the persisted run's
+  requesting user, checking current owner/admin membership and running status
+  on every request. Tokens expire after one hour and are unusable once the run
+  ends. They do not authenticate workspace management or other runtime APIs.
+- This path creates workspace-only bundles of inline Markdown Skills. It cannot
+  publish publicly, bind Agents, upload supporting files, or install server/client
+  plugin code, hooks, tools or credentials. Existing FDE APIs remain independent.
+- Shared/cloud runtimes remain Agent-owned; uploading does not assign a fixed
+  user to the device or change spec/memory identity rules.
+
 ### Plugin Bundle (KindBundle) architecture
 
 - A Plugin Bundle is a `KindBundle` capability that packages server tools,

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -335,10 +335,10 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 }
 
 func registerAgentKinds(registry *agent.Registry, agentCLIs agentCLIDiscovery, serverURL string) {
-	registry.RegisterKind(agentCLIs.ClaudeCode, withCapabilityDownloads(claudecode.Factory, serverURL))
-	registry.RegisterKind(agentCLIs.OpenCode, withCapabilityDownloads(opencodeagent.Factory, serverURL))
-	registry.RegisterKind(agentCLIs.Codex, withCapabilityDownloads(codex.Factory, serverURL))
-	registry.RegisterKind(agentCLIs.Pi, withCapabilityDownloads(pi.Factory, serverURL))
+	registry.RegisterKind(agentCLIs.ClaudeCode, withSkillUploadServer(withCapabilityDownloads(claudecode.Factory, serverURL), serverURL))
+	registry.RegisterKind(agentCLIs.OpenCode, withSkillUploadServer(withCapabilityDownloads(opencodeagent.Factory, serverURL), serverURL))
+	registry.RegisterKind(agentCLIs.Codex, withSkillUploadServer(withCapabilityDownloads(codex.Factory, serverURL), serverURL))
+	registry.RegisterKind(agentCLIs.Pi, withSkillUploadServer(withCapabilityDownloads(pi.Factory, serverURL), serverURL))
 }
 
 // spawnBackground forks the daemon into the background. Parent

--- a/apps/parsar-daemon/internal/cli/skill_upload.go
+++ b/apps/parsar-daemon/internal/cli/skill_upload.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"context"
+	"maps"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func withSkillUploadServer(factory agent.Factory, serverURL string) agent.Factory {
+	return func(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+		env, _ := req.AgentOptions["env"].(map[string]any)
+		if token, _ := env["PARSAR_CAPABILITY_UPLOAD_TOKEN"].(string); token != "" {
+			env = maps.Clone(env)
+			env["PARSAR_SERVER_URL"] = serverURL
+			req.AgentOptions = maps.Clone(req.AgentOptions)
+			req.AgentOptions["env"] = env
+		}
+		return factory(ctx, req, out)
+	}
+}

--- a/apps/parsar-daemon/internal/cli/skill_upload_test.go
+++ b/apps/parsar-daemon/internal/cli/skill_upload_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestSkillUploadUsesPairedAddressPerRequest(t *testing.T) {
+	t.Setenv("PARSAR_SERVER_URL", "unchanged-process-env")
+	env := map[string]any{"PARSAR_CAPABILITY_UPLOAD_TOKEN": "run-a", "PARSAR_SERVER_URL": "http://localhost:1234", "MODEL_KEY": "preserve"}
+	opts := map[string]any{"env": env, "model": "preserve"}
+	calls := 0
+	factory := withSkillUploadServer(func(_ context.Context, req proto.PromptRequestPayload, _ chan<- proto.Envelope) (agent.Session, error) {
+		calls++
+		if calls == 1 {
+			got := req.AgentOptions["env"].(map[string]any)
+			if got["PARSAR_SERVER_URL"] != "http://parsar-server:8080" || got["PARSAR_CAPABILITY_UPLOAD_TOKEN"] != "run-a" || got["MODEL_KEY"] != "preserve" || req.AgentOptions["model"] != "preserve" {
+				t.Fatal("per-run context incorrect")
+			}
+			if _, exists := got["PARSAR_RUNNER_TOKEN"]; exists {
+				t.Fatal("exported device credential")
+			}
+		} else if len(req.AgentOptions) != 0 {
+			t.Fatal("previous run's context leaked")
+		}
+		return nil, nil
+	}, "http://parsar-server:8080")
+	if _, err := factory(t.Context(), proto.PromptRequestPayload{AgentOptions: opts}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := factory(t.Context(), proto.PromptRequestPayload{}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if env["PARSAR_SERVER_URL"] != "http://localhost:1234" || os.Getenv("PARSAR_SERVER_URL") != "unchanged-process-env" {
+		t.Fatal("mutated caller or process environment")
+	}
+}

--- a/apps/parsar/internal/cli/client.go
+++ b/apps/parsar/internal/cli/client.go
@@ -93,6 +93,13 @@ func (e *apiError) Error() string {
 // do dispatches a JSON request and unmarshals the response. body and
 // out are both optional.
 func (c *client) do(ctx context.Context, method, path string, query url.Values, body, out any) error {
+	token := c.cfg.RunnerToken
+	if method == http.MethodPost && path == "/api/v1/agent-authoring/skill-bundles" {
+		token = c.cfg.CapabilityUploadToken
+	}
+	if token == "" {
+		return fmt.Errorf("this command requires PARSAR_RUNNER_TOKEN; a Skill upload credential only permits plugin add")
+	}
 	endpoint, err := c.endpointURL(path, query)
 	if err != nil {
 		return err
@@ -109,7 +116,7 @@ func (c *client) do(ctx context.Context, method, path string, query url.Values, 
 	if err != nil {
 		return fmt.Errorf("build request: %w", err)
 	}
-	req.Header.Set("Authorization", "Bearer "+c.cfg.RunnerToken)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/json")
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")

--- a/apps/parsar/internal/cli/config.go
+++ b/apps/parsar/internal/cli/config.go
@@ -8,29 +8,30 @@ import (
 )
 
 // Config is the resolved environment the CLI uses to talk to Parsar.
-// Only ServerURL + RunnerToken are required; the rest are informational
-// and surface via `parsar version` / `parsar sync`.
+// Upload credentials authorize plugin add only; other commands use RunnerToken.
 type Config struct {
-	ServerURL      string // PARSAR_SERVER_URL — must be parseable absolute URL
-	RunnerToken    string // PARSAR_RUNNER_TOKEN — bearer credential
-	RuntimeID      string // PARSAR_RUNTIME_ID
-	WorkspaceID    string // PARSAR_WORKSPACE_ID
-	UserID         string // PARSAR_USER_ID
-	Connector      string // PARSAR_CONNECTOR — "claude" | "opencode" | "codex"
-	AgentID        string // PARSAR_AGENT_ID
-	ConversationID string // PARSAR_CONVERSATION_ID
+	CapabilityUploadToken string // PARSAR_CAPABILITY_UPLOAD_TOKEN
+	ServerURL             string // PARSAR_SERVER_URL — must be parseable absolute URL
+	RunnerToken           string // PARSAR_RUNNER_TOKEN — bearer credential
+	RuntimeID             string // PARSAR_RUNTIME_ID
+	WorkspaceID           string // PARSAR_WORKSPACE_ID
+	UserID                string // PARSAR_USER_ID
+	Connector             string // PARSAR_CONNECTOR — "claude" | "opencode" | "codex"
+	AgentID               string // PARSAR_AGENT_ID
+	ConversationID        string // PARSAR_CONVERSATION_ID
 }
 
 func loadConfigFromEnv() (Config, error) {
 	cfg := Config{
-		ServerURL:      strings.TrimSpace(os.Getenv("PARSAR_SERVER_URL")),
-		RunnerToken:    strings.TrimSpace(os.Getenv("PARSAR_RUNNER_TOKEN")),
-		RuntimeID:      strings.TrimSpace(os.Getenv("PARSAR_RUNTIME_ID")),
-		WorkspaceID:    strings.TrimSpace(os.Getenv("PARSAR_WORKSPACE_ID")),
-		UserID:         strings.TrimSpace(os.Getenv("PARSAR_USER_ID")),
-		Connector:      strings.TrimSpace(os.Getenv("PARSAR_CONNECTOR")),
-		AgentID:        strings.TrimSpace(os.Getenv("PARSAR_AGENT_ID")),
-		ConversationID: strings.TrimSpace(os.Getenv("PARSAR_CONVERSATION_ID")),
+		CapabilityUploadToken: strings.TrimSpace(os.Getenv("PARSAR_CAPABILITY_UPLOAD_TOKEN")),
+		ServerURL:             strings.TrimSpace(os.Getenv("PARSAR_SERVER_URL")),
+		RunnerToken:           strings.TrimSpace(os.Getenv("PARSAR_RUNNER_TOKEN")),
+		RuntimeID:             strings.TrimSpace(os.Getenv("PARSAR_RUNTIME_ID")),
+		WorkspaceID:           strings.TrimSpace(os.Getenv("PARSAR_WORKSPACE_ID")),
+		UserID:                strings.TrimSpace(os.Getenv("PARSAR_USER_ID")),
+		Connector:             strings.TrimSpace(os.Getenv("PARSAR_CONNECTOR")),
+		AgentID:               strings.TrimSpace(os.Getenv("PARSAR_AGENT_ID")),
+		ConversationID:        strings.TrimSpace(os.Getenv("PARSAR_CONVERSATION_ID")),
 	}
 	if err := cfg.validate(); err != nil {
 		return Config{}, err
@@ -42,8 +43,8 @@ func (c Config) validate() error {
 	if c.ServerURL == "" {
 		return fmt.Errorf("PARSAR_SERVER_URL is required")
 	}
-	if c.RunnerToken == "" {
-		return fmt.Errorf("PARSAR_RUNNER_TOKEN is required")
+	if c.RunnerToken == "" && c.CapabilityUploadToken == "" {
+		return fmt.Errorf("PARSAR_RUNNER_TOKEN is required (plugin add may use PARSAR_CAPABILITY_UPLOAD_TOKEN)")
 	}
 	u, err := url.Parse(c.ServerURL)
 	if err != nil {

--- a/apps/parsar/internal/cli/plugin.go
+++ b/apps/parsar/internal/cli/plugin.go
@@ -101,6 +101,14 @@ func runPluginAdd(ctx *runContext, args []string) error {
 		return fmt.Errorf("plugin add: manifest.version is required")
 	}
 
+	cfg, err := ctx.resolveConfig()
+	if err != nil {
+		return fmt.Errorf("plugin add: %w", err)
+	}
+	if cfg.CapabilityUploadToken != "" && (manifest.Server != nil || manifest.Client != nil || len(manifest.Tools)+len(manifest.Hooks)+len(manifest.Credentials) > 0) {
+		return fmt.Errorf("plugin add: this run can upload inline Skills only; server/client code, tools, hooks and credentials are not supported")
+	}
+
 	// Read skill files and embed content
 	skills, err := readPluginSkills(pluginDir, manifest.Skills)
 	if err != nil {
@@ -150,11 +158,11 @@ func runPluginAdd(ctx *runContext, args []string) error {
 
 	// Build the API request
 	reqBody := map[string]any{
-		"type":        "bundle",
-		"name":        manifest.Name,
-		"description": manifest.Description,
-		"visibility":  "workspace",
-		"version":     manifest.Version,
+		"type":           "bundle",
+		"name":           manifest.Name,
+		"description":    manifest.Description,
+		"visibility":     "workspace",
+		"version":        manifest.Version,
 		"canonical_spec": canonicalSpec,
 	}
 
@@ -176,15 +184,15 @@ func runPluginAdd(ctx *runContext, args []string) error {
 		}
 	}
 
-	cfg, err := ctx.resolveConfig()
-	if err != nil {
-		return fmt.Errorf("plugin add: %w", err)
-	}
-	if strings.TrimSpace(cfg.WorkspaceID) == "" {
-		return fmt.Errorf("plugin add: PARSAR_WORKSPACE_ID is required")
+	endpoint := "/api/v1/agent-authoring/skill-bundles"
+	if cfg.CapabilityUploadToken == "" {
+		if strings.TrimSpace(cfg.WorkspaceID) == "" {
+			return fmt.Errorf("plugin add: PARSAR_WORKSPACE_ID is required")
+		}
+		endpoint = "/api/v1/workspaces/" + cfg.WorkspaceID + "/capabilities/plugins/install"
 	}
 	var result map[string]any
-	if err := newClient(cfg).do(context.Background(), "POST", "/api/v1/workspaces/"+cfg.WorkspaceID+"/capabilities/plugins/install", nil, reqBody, &result); err != nil {
+	if err := newClient(cfg).do(context.Background(), "POST", endpoint, nil, reqBody, &result); err != nil {
 		return fmt.Errorf("plugin add: %w", err)
 	}
 

--- a/apps/parsar/internal/cli/root.go
+++ b/apps/parsar/internal/cli/root.go
@@ -82,7 +82,7 @@ func printRootHelp(w io.Writer) {
 	}
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Run `parsar <subcommand> --help` for subcommand-specific flags.")
-	fmt.Fprintln(w, "Environment: PARSAR_SERVER_URL and PARSAR_RUNNER_TOKEN are required.")
+	fmt.Fprintln(w, "Environment: PARSAR_SERVER_URL and PARSAR_RUNNER_TOKEN are required; plugin add also accepts PARSAR_CAPABILITY_UPLOAD_TOKEN.")
 }
 
 // newFlagSet returns a FlagSet that suppresses its own stderr output;

--- a/apps/parsar/internal/cli/skill_upload_test.go
+++ b/apps/parsar/internal/cli/skill_upload_test.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPluginAddUsesUploadCredentialWithoutWorkspaceOrRunner(t *testing.T) {
+	dir := t.TempDir()
+	for file, content := range map[string]string{"manifest.json": `{"name":"guide","version":"1.0.0","skills":["guide.md"]}`, "guide.md": "Return GUIDE-OK."} {
+		if err := os.WriteFile(filepath.Join(dir, file), []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path != "/api/v1/agent-authoring/skill-bundles" || r.Header.Get("Authorization") != "Bearer upload-test" {
+			t.Errorf("wrong upload endpoint or credential")
+		}
+		var payload struct {
+			CanonicalSpec struct {
+				Bundle struct{ Skills []bundleSkillPayload } `json:"bundle"`
+			} `json:"canonical_spec"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Error(err)
+		}
+		if len(payload.CanonicalSpec.Bundle.Skills) != 1 || payload.CanonicalSpec.Bundle.Skills[0].Instruction != "Return GUIDE-OK." {
+			t.Error("Skill file was not embedded")
+		}
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"created"}`))
+	}))
+	defer server.Close()
+	t.Setenv("PARSAR_SERVER_URL", server.URL)
+	t.Setenv("PARSAR_CAPABILITY_UPLOAD_TOKEN", "upload-test")
+	t.Setenv("PARSAR_RUNNER_TOKEN", "")
+	t.Setenv("PARSAR_WORKSPACE_ID", "")
+	ctx, stdout, _ := newCapturedCtx(nil)
+	if err := execute(ctx, []string{"plugin", "add", "--json", dir}); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "created") || calls != 1 {
+		t.Fatal("upload did not complete")
+	}
+	if err := execute(ctx, []string{"spec", "list"}); err == nil || !strings.Contains(err.Error(), "PARSAR_RUNNER_TOKEN") {
+		t.Fatalf("upload credential escaped to another API: %v", err)
+	}
+	if calls != 1 {
+		t.Fatal("sent an upload credential to another endpoint")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(`{"name":"guide","version":"1.0.0","server":{"entry":"missing.js"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := execute(ctx, []string{"plugin", "add", dir}); err == nil || !strings.Contains(err.Error(), "inline Skills only") {
+		t.Fatalf("code plugin was not rejected before local installation: %v", err)
+	}
+	if calls != 1 {
+		t.Fatal("unsupported plugin was sent")
+	}
+}
+
+func TestPluginAddRetainsLegacyEndpoint(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(`{"name":"guide","version":"1.0.0","skills":["guide.md"]}`), 0600)
+	_ = os.WriteFile(filepath.Join(dir, "guide.md"), []byte("GUIDE-OK"), 0600)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/workspaces/workspace/capabilities/plugins/install" || r.Header.Get("Authorization") != "Bearer legacy" {
+			t.Error("legacy upload changed")
+		}
+		_, _ = w.Write([]byte(`{"id":"created"}`))
+	}))
+	defer server.Close()
+	ctx, _, _ := newCapturedCtx(&Config{ServerURL: server.URL, RunnerToken: "legacy", WorkspaceID: "workspace"})
+	if err := execute(ctx, []string{"plugin", "add", dir}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1935,6 +1935,72 @@ paths:
       summary: Agent-daemon WebSocket upgrade
       tags:
       - agent-daemon
+  /api/v1/agent-authoring/skill-bundles:
+    post:
+      consumes:
+      - application/json
+      description: Accepts a run-scoped upload bearer credential. The running task's
+        requesting user must currently be an owner/admin. Creates a workspace-only
+        bundle of inline Skills; no server/client code or credential references.
+      parameters:
+      - description: Bearer run-scoped Skill upload credential
+        in: header
+        name: Authorization
+        required: true
+        type: string
+      - description: Inline Skill bundle
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/dev.installPluginBody'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created capability and version
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Invalid or unsupported bundle
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Invalid or expired credential
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Run inactive or requester is not owner/admin
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Requester no longer belongs to the workspace
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Capability name already exists
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Permission or storage read failed
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Upload a Skill bundle from a running Agent
+      tags:
+      - capabilities
   /api/v1/agent-runs/{runID}:
     get:
       description: Returns a run, including retained history and agent_deleted state

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -383,6 +383,7 @@ func main() {
 		interactionService = interaction.NewService(dbStore, interaction.RegistryDelivery{Runs: dbStore, Registry: connectorReg}, log.Bg())
 		opts = append(opts, dev.WithInteractionService(interactionService))
 	}
+	skillUploadSigner := auth.NewSkillUploadSigner(cfg.Secret.MasterKey)
 	// Shared signer for the auto-mounted fetch_chat_history tool. Hoisted to
 	// function scope so both the agent_daemon connector (mints per-conversation
 	// tokens) and the internal history endpoint (verifies them) share one
@@ -456,6 +457,12 @@ func main() {
 			// sandbox calls back into, plus the per-conversation token signer.
 			// Nil signer (empty master key) disables the injection.
 			IMHistoryEndpoint: cfg.BuildPublicURL("/internal/im/history"),
+			SkillUploadTokenSigner: func() func(string) (string, error) {
+				if skillUploadSigner == nil {
+					return nil
+				}
+				return skillUploadSigner.Token
+			}(),
 			IMHistoryTokenSigner: func() func(string) string {
 				if imHistorySigner == nil {
 					return nil
@@ -710,6 +717,9 @@ func main() {
 		log.Bg().Info("invite-link system enabled")
 	}
 	dev.RegisterRoutesWithStore(r, runtimeStore, opts...)
+	if dbStore != nil {
+		dev.RegisterSkillUploadRoute(r, dbStore, skillUploadSigner)
+	}
 
 	// imHistoryResolver is bound to the outbound worker once it is built
 	// (later in boot than routes are registered); until then the internal

--- a/server/internal/auth/skill_upload.go
+++ b/server/internal/auth/skill_upload.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+const skillUploadAudience = "parsar/skill-upload/v1"
+
+// SkillUploadSigner issues upload-only credentials for one running task.
+type SkillUploadSigner struct {
+	key []byte
+}
+
+func NewSkillUploadSigner(masterKey string) *SkillUploadSigner {
+	if strings.TrimSpace(masterKey) == "" {
+		return nil
+	}
+	mac := hmac.New(sha256.New, []byte(masterKey))
+	mac.Write([]byte(skillUploadAudience))
+	return &SkillUploadSigner{key: mac.Sum(nil)}
+}
+
+func (s *SkillUploadSigner) Token(runID string) (string, error) {
+	if s == nil || len(s.key) == 0 {
+		return "", errors.New("skill upload is unavailable")
+	}
+	if _, err := uuid.Parse(runID); err != nil {
+		return "", errors.New("skill upload requires a run UUID")
+	}
+	return jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
+		Subject:   runID,
+		Audience:  jwt.ClaimStrings{skillUploadAudience},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+	}).SignedString(s.key)
+}
+
+func (s *SkillUploadSigner) Verify(token string) (string, error) {
+	if s == nil || len(s.key) == 0 {
+		return "", errors.New("skill upload is unavailable")
+	}
+	claims := &jwt.RegisteredClaims{}
+	_, err := jwt.ParseWithClaims(token, claims, func(_ *jwt.Token) (any, error) {
+		return s.key, nil
+	}, jwt.WithValidMethods([]string{"HS256"}), jwt.WithAudience(skillUploadAudience), jwt.WithExpirationRequired())
+	if err != nil {
+		return "", errors.New("invalid or expired skill upload credential")
+	}
+	if _, err := uuid.Parse(claims.Subject); err != nil {
+		return "", errors.New("invalid skill upload run")
+	}
+	return claims.Subject, nil
+}

--- a/server/internal/auth/skill_upload_test.go
+++ b/server/internal/auth/skill_upload_test.go
@@ -1,0 +1,47 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestSkillUploadCredentialScopeAndExpiry(t *testing.T) {
+	s := NewSkillUploadSigner("test-master-key")
+	const runID = "00000000-0000-0000-0000-000000001234"
+	token, err := s.Token(runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, err := s.Verify(token); err != nil || got != runID {
+		t.Fatalf("verify: run=%q, error=%v", got, err)
+	}
+	if _, err := NewSkillUploadSigner("other-key").Verify(token); err == nil {
+		t.Fatal("accepted a different signing key")
+	}
+	for _, tc := range []struct {
+		name     string
+		audience string
+		expires  *jwt.NumericDate
+		method   jwt.SigningMethod
+	}{
+		{"expired", skillUploadAudience, jwt.NewNumericDate(time.Now().Add(-time.Second)), jwt.SigningMethodHS256},
+		{"no expiry", skillUploadAudience, nil, jwt.SigningMethodHS256},
+		{"wrong audience", "runtime", jwt.NewNumericDate(time.Now().Add(time.Hour)), jwt.SigningMethodHS256},
+		{"wrong algorithm", skillUploadAudience, jwt.NewNumericDate(time.Now().Add(time.Hour)), jwt.SigningMethodHS384},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bad, err := jwt.NewWithClaims(tc.method, jwt.RegisteredClaims{Subject: runID, Audience: jwt.ClaimStrings{tc.audience}, ExpiresAt: tc.expires}).SignedString(s.key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := s.Verify(bad); err == nil {
+				t.Fatal("accepted invalid credential")
+			}
+		})
+	}
+	if NewSkillUploadSigner(" ") != nil {
+		t.Fatal("empty master key enabled signing")
+	}
+}

--- a/server/internal/connector/agentdaemon/connector.go
+++ b/server/internal/connector/agentdaemon/connector.go
@@ -109,7 +109,8 @@ type Config struct {
 	// auto-mounted fetch_chat_history tool presents to IMHistoryEndpoint. It
 	// MUST sign with the same secret the endpoint verifies (both derive from
 	// the master key). Nil disables the tool injection.
-	IMHistoryTokenSigner func(conversationID string) string
+	IMHistoryTokenSigner   func(conversationID string) string
+	SkillUploadTokenSigner func(runID string) (string, error)
 
 	// ExecutionRecorder persists the per-run execution snapshot. Nil
 	// keeps tests on the pre-snapshot behavior.
@@ -192,6 +193,7 @@ type Connector struct {
 	pluginsDir        string
 	imHistoryEndpoint string
 	imHistoryToken    func(conversationID string) string
+	skillUploadToken  func(runID string) (string, error)
 	log               *slog.Logger
 }
 
@@ -277,6 +279,7 @@ func New(cfg Config) *Connector {
 		pluginsDir:        cfg.PluginsDir,
 		imHistoryEndpoint: cfg.IMHistoryEndpoint,
 		imHistoryToken:    cfg.IMHistoryTokenSigner,
+		skillUploadToken:  cfg.SkillUploadTokenSigner,
 		log:               cfg.Log,
 	}
 }
@@ -518,6 +521,10 @@ func (c *Connector) streamPrompt(ctx context.Context, in connector.PromptInput, 
 	}
 	kindInfo, _, _ := sess.AgentKindStatus(agentKind)
 	c.recordExecutionSnapshot(ctx, in, bind, agentKind, kindInfo)
+
+	if err := c.applySkillUpload(agentOptions, in.RunID); err != nil {
+		return errorChannel(in.RunID, "Skill upload context could not be prepared"), nil
+	}
 
 	upstream, err := sess.Subscribe(in.RunID)
 	if err != nil {

--- a/server/internal/connector/agentdaemon/skill_upload.go
+++ b/server/internal/connector/agentdaemon/skill_upload.go
@@ -1,0 +1,39 @@
+package agentdaemon
+
+const skillUploadInstruction = `## Uploading Skills to Parsar
+
+When asked to upload a generated Skill, use: parsar plugin add --json /absolute/path/to/bundle
+The default Parsar sandbox includes this CLI. If it is unavailable on a custom
+runtime, report the missing CLI prerequisite; do not ask for account credentials.
+The directory must contain manifest.json with name, version, and skills (an array
+of Markdown file paths relative to that directory). Example:
+{"name":"team-guide","version":"1.0.0","skills":["skills/team-guide.md"]}
+This uploads inline Skill instructions to this run's workspace. It does not
+upload supporting files, execute plugin code, publish publicly, or bind an Agent.
+The requesting user must be a workspace owner/admin. The upload credential is
+provided through PARSAR_CAPABILITY_UPLOAD_TOKEN and expires after this run or one
+hour. Never print credentials or ask the user to paste them. Other Parsar CLI
+commands have separate authorization requirements.`
+
+func (c *Connector) applySkillUpload(opts map[string]any, runID string) error {
+	if c.skillUploadToken == nil {
+		return nil
+	}
+	token, err := c.skillUploadToken(runID)
+	if err != nil {
+		return err
+	}
+	env := copyStringAnyMap(opts["env"])
+	env["PARSAR_CAPABILITY_UPLOAD_TOKEN"] = token
+	opts["env"] = env
+	key := "system_prompt"
+	if stringFromMap(opts, "override_system_prompt") != "" {
+		key = "override_system_prompt"
+	}
+	base := stringFromMap(opts, key)
+	if base != "" {
+		base += "\n\n"
+	}
+	opts[key] = base + skillUploadInstruction
+	return nil
+}

--- a/server/internal/connector/agentdaemon/skill_upload_test.go
+++ b/server/internal/connector/agentdaemon/skill_upload_test.go
@@ -1,0 +1,32 @@
+package agentdaemon
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSkillUploadContextIsRunScopedAndSecretFreePrompt(t *testing.T) {
+	for _, key := range []string{"system_prompt", "override_system_prompt"} {
+		t.Run(key, func(t *testing.T) {
+			c := &Connector{skillUploadToken: func(runID string) (string, error) { return "secret-" + runID, nil }}
+			env := map[string]any{"MODEL_KEY": "preserved"}
+			for _, runID := range []string{"run-a", "run-b"} {
+				opts := map[string]any{key: "existing instructions", "env": env}
+				if err := c.applySkillUpload(opts, runID); err != nil {
+					t.Fatal(err)
+				}
+				got := opts["env"].(map[string]any)
+				if got["PARSAR_CAPABILITY_UPLOAD_TOKEN"] != "secret-"+runID || got["MODEL_KEY"] != "preserved" {
+					t.Fatal("wrong request environment")
+				}
+				prompt := opts[key].(string)
+				if !strings.HasPrefix(prompt, "existing instructions") || !strings.Contains(prompt, "parsar plugin add") || strings.Contains(prompt, "secret-") {
+					t.Fatal("prompt lost instructions or exposed token")
+				}
+			}
+			if len(env) != 1 {
+				t.Fatal("mutated input environment")
+			}
+		})
+	}
+}

--- a/server/internal/dev/plugin_install_routes.go
+++ b/server/internal/dev/plugin_install_routes.go
@@ -47,70 +47,86 @@ func installPlugin(runtimeStore RuntimeStore) http.HandlerFunc {
 		if !ok {
 			return
 		}
-		var body installPluginBody
-		if err := decodeBody(r, &body); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
-			return
-		}
-		if strings.TrimSpace(body.Name) == "" {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
-			return
-		}
-		if strings.TrimSpace(body.Version) == "" {
-			body.Version = "1.0.0"
-		}
-
-		// Decode and validate the canonical_spec.
-		if len(body.CanonicalSpec) == 0 {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "canonical_spec is required"})
-			return
-		}
-		var spec canonical.Spec
-		if err := json.Unmarshal(body.CanonicalSpec, &spec); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("canonical_spec decode: %s", err)})
-			return
-		}
-		if spec.Kind != canonical.KindBundle {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("canonical_spec.kind must be \"bundle\", got %q", spec.Kind)})
-			return
-		}
-		if err := spec.Validate(); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("canonical_spec validation: %s", err)})
-			return
-		}
-
-		visibility := strings.TrimSpace(body.Visibility)
-		if visibility == "" {
-			visibility = "workspace"
-		}
-
-		sourcePayload := json.RawMessage(`{}`)
-
-		result, err := runtimeStore.ImportCapability(r.Context(), store.ImportCapabilityInput{
-			WorkspaceID:   workspaceID,
-			Name:          strings.TrimSpace(body.Name),
-			Description:   strings.TrimSpace(body.Description),
-			Visibility:    visibility,
-			Type:          "bundle",
-			CreatorID:     actorID,
-			Version:       strings.TrimSpace(body.Version),
-			SourcePayload: sourcePayload,
-			Spec:          spec,
-		})
-		if err != nil {
-			if errors.Is(err, store.ErrCapabilityNameTaken) {
-				writeJSON(w, http.StatusConflict, map[string]string{"error": "a plugin with this name already exists in the workspace"})
-				return
-			}
-			writeCapabilityError(w, err, "failed to install plugin")
-			return
-		}
-		writeJSON(w, http.StatusCreated, map[string]any{
-			"id":                  result.Capability.ID,
-			"name":                result.Capability.Name,
-			"type":                result.Capability.Type,
-			"capability_version":  result.CapabilityVersion.ID,
-			"version":             result.CapabilityVersion.Version,
-		})
+		installPluginForActor(w, r, runtimeStore, workspaceID, actorID, false)
 	}
+}
+
+func installPluginForActor(w http.ResponseWriter, r *http.Request, runtimeStore RuntimeStore, workspaceID, actorID string, skillsOnly bool) {
+	var body installPluginBody
+	if err := decodeBody(r, &body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	if strings.TrimSpace(body.Name) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "name is required"})
+		return
+	}
+	if strings.TrimSpace(body.Version) == "" {
+		body.Version = "1.0.0"
+	}
+
+	// Decode and validate the canonical_spec.
+	if len(body.CanonicalSpec) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "canonical_spec is required"})
+		return
+	}
+	var spec canonical.Spec
+	if err := json.Unmarshal(body.CanonicalSpec, &spec); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("canonical_spec decode: %s", err)})
+		return
+	}
+	if spec.Kind != canonical.KindBundle {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("canonical_spec.kind must be \"bundle\", got %q", spec.Kind)})
+		return
+	}
+	if err := spec.Validate(); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("canonical_spec validation: %s", err)})
+		return
+	}
+
+	if skillsOnly {
+		b := spec.Bundle
+		if len(b.Skills) == 0 || b.ServerEntry != "" || b.ClientEntry != "" || len(b.Tools)+len(b.Hooks)+len(b.Credentials) > 0 {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "this upload accepts inline Skills only; server/client code, tools, hooks and credentials are not supported"})
+			return
+		}
+		if body.Visibility != "" && body.Visibility != "workspace" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "Skill uploads must remain workspace-only"})
+			return
+		}
+	}
+
+	visibility := strings.TrimSpace(body.Visibility)
+	if visibility == "" {
+		visibility = "workspace"
+	}
+
+	sourcePayload := json.RawMessage(`{}`)
+
+	result, err := runtimeStore.ImportCapability(r.Context(), store.ImportCapabilityInput{
+		WorkspaceID:   workspaceID,
+		Name:          strings.TrimSpace(body.Name),
+		Description:   strings.TrimSpace(body.Description),
+		Visibility:    visibility,
+		Type:          "bundle",
+		CreatorID:     actorID,
+		Version:       strings.TrimSpace(body.Version),
+		SourcePayload: sourcePayload,
+		Spec:          spec,
+	})
+	if err != nil {
+		if errors.Is(err, store.ErrCapabilityNameTaken) {
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "a plugin with this name already exists in the workspace"})
+			return
+		}
+		writeCapabilityError(w, err, "failed to install plugin")
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"id":                 result.Capability.ID,
+		"name":               result.Capability.Name,
+		"type":               result.Capability.Type,
+		"capability_version": result.CapabilityVersion.ID,
+		"version":            result.CapabilityVersion.Version,
+	})
 }

--- a/server/internal/dev/skill_upload_routes.go
+++ b/server/internal/dev/skill_upload_routes.go
@@ -1,0 +1,64 @@
+package dev
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+type skillUploadStore interface {
+	RuntimeStore
+	GetAgentRunInvocation(context.Context, string) (store.AgentRunInvocation, error)
+}
+
+func RegisterSkillUploadRoute(r chi.Router, runtimeStore skillUploadStore, signer *auth.SkillUploadSigner) {
+	if runtimeStore != nil && signer != nil {
+		r.Post("/api/v1/agent-authoring/skill-bundles", uploadSkillBundle(runtimeStore, signer))
+	}
+}
+
+// @Summary Upload a Skill bundle from a running Agent
+// @Description Accepts a run-scoped upload bearer credential. The running task's requesting user must currently be an owner/admin. Creates a workspace-only bundle of inline Skills; no server/client code or credential references.
+// @Tags capabilities
+// @Accept json
+// @Produce json
+// @Param Authorization header string true "Bearer run-scoped Skill upload credential"
+// @Param body body installPluginBody true "Inline Skill bundle"
+// @Success 201 {object} map[string]interface{} "Created capability and version"
+// @Failure 400 {object} map[string]string "Invalid or unsupported bundle"
+// @Failure 401 {object} map[string]string "Invalid or expired credential"
+// @Failure 403 {object} map[string]string "Run inactive or requester is not owner/admin"
+// @Failure 404 {object} map[string]string "Requester no longer belongs to the workspace"
+// @Failure 500 {object} map[string]string "Permission or storage read failed"
+// @Failure 409 {object} map[string]string "Capability name already exists"
+// @Router /api/v1/agent-authoring/skill-bundles [post]
+func uploadSkillBundle(runtimeStore skillUploadStore, signer *auth.SkillUploadSigner) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		header := strings.Fields(r.Header.Get("Authorization"))
+		if len(header) != 2 || !strings.EqualFold(header[0], "Bearer") {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "skill upload credential required"})
+			return
+		}
+		runID, err := signer.Verify(header[1])
+		if err != nil {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid or expired skill upload credential"})
+			return
+		}
+		run, err := runtimeStore.GetAgentRunInvocation(r.Context(), runID)
+		if err != nil || run.Status != "running" || run.RequestedByType != "user" || run.RequestedByID == "" {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": "skill upload requires an active user-requested run"})
+			return
+		}
+		r = r.WithContext(auth.WithUserID(r.Context(), run.RequestedByID))
+		if err := auth.RequireWorkspaceRole(r.Context(), runtimeStore, run.WorkspaceID, "owner", "admin"); err != nil {
+			writeRBACError(w, err)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		installPluginForActor(w, r, runtimeStore, run.WorkspaceID, run.RequestedByID, true)
+	}
+}

--- a/server/internal/dev/skill_upload_routes_test.go
+++ b/server/internal/dev/skill_upload_routes_test.go
@@ -1,0 +1,185 @@
+package dev
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/auth"
+	"github.com/MiniMax-AI-Dev/parsar/server/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+const uploadTestRun = "00000000-0000-0000-0000-000000009999"
+const uploadTestBody = `{"name":"generated-guide","canonical_spec":{"schema_version":1,"kind":"bundle","bundle":{"name":"generated-guide","version":"1.0.0","skills":[{"slug":"guide","instruction":"Answer GUIDE-OK."}]}}}`
+
+type skillUploadTestStore struct {
+	RuntimeStore
+	run                            store.AgentRunInvocation
+	role                           string
+	roleErr                        error
+	imports                        []store.ImportCapabilityInput
+	checkedWorkspace, checkedActor string
+}
+
+func (s *skillUploadTestStore) GetAgentRunInvocation(_ context.Context, id string) (store.AgentRunInvocation, error) {
+	if id != s.run.RunID {
+		return store.AgentRunInvocation{}, store.ErrUnknownAgentRun
+	}
+	return s.run, nil
+}
+func (s *skillUploadTestStore) GetWorkspaceMemberRole(_ context.Context, ws, actor string) (string, error) {
+	s.checkedWorkspace, s.checkedActor = ws, actor
+	return s.role, s.roleErr
+}
+func (s *skillUploadTestStore) ImportCapability(_ context.Context, in store.ImportCapabilityInput) (store.ImportCapabilityResult, error) {
+	s.imports = append(s.imports, in)
+	return store.ImportCapabilityResult{}, nil
+}
+
+func skillUploadRequest(handler http.Handler, token, body string) *httptest.ResponseRecorder {
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/agent-authoring/skill-bundles?workspace_id=foreign", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer "+token)
+	r.Header.Set("X-Parsar-Dev-User-ID", "spoofed-owner")
+	r = r.WithContext(auth.WithUserID(r.Context(), "spoofed-owner"))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	return w
+}
+
+func TestSkillUploadRequiresCurrentRunRequesterPermission(t *testing.T) {
+	signer := auth.NewSkillUploadSigner("test-master-key")
+	token, err := signer.Token(uploadTestRun)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, status, actorType, role string
+		roleErr                       error
+		code                          int
+	}{
+		{"owner", "running", "user", "owner", nil, 201},
+		{"admin", "running", "user", "admin", nil, 201},
+		{"member", "running", "user", "member", nil, 403},
+		{"viewer", "running", "user", "viewer", nil, 403},
+		{"removed", "running", "user", "", store.ErrNotMember, 404},
+		{"membership failure", "running", "user", "", errors.New("database unavailable"), 500},
+		{"queued", "queued", "user", "owner", nil, 403},
+		{"completed", "completed", "user", "owner", nil, 403},
+		{"failed", "failed", "user", "owner", nil, 403},
+		{"cancelled", "cancelled", "user", "owner", nil, 403},
+		{"system", "running", "system", "owner", nil, 403},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &skillUploadTestStore{run: store.AgentRunInvocation{RunID: uploadTestRun, WorkspaceID: "run-workspace", RequestedByID: "real-requester", RequestedByType: tc.actorType, Status: tc.status}, role: tc.role, roleErr: tc.roleErr}
+			w := skillUploadRequest(uploadSkillBundle(s, signer), token, uploadTestBody)
+			if w.Code != tc.code {
+				t.Fatalf("status %d: %s", w.Code, w.Body)
+			}
+			if tc.code != 201 {
+				if len(s.imports) != 0 {
+					t.Fatal("denied request wrote a capability")
+				}
+				return
+			}
+			if s.checkedActor != "real-requester" || s.checkedWorkspace != "run-workspace" {
+				t.Fatal("checked supplied identity instead of run requester")
+			}
+			if len(s.imports) != 1 || s.imports[0].WorkspaceID != "run-workspace" || s.imports[0].CreatorID != "real-requester" || s.imports[0].Visibility != "workspace" {
+				t.Fatalf("wrong import scope: %+v", s.imports)
+			}
+		})
+	}
+}
+
+func TestSkillUploadRejectsUnsupportedPayloadsAndCredentials(t *testing.T) {
+	signer := auth.NewSkillUploadSigner("test-master-key")
+	token, _ := signer.Token(uploadTestRun)
+	s := &skillUploadTestStore{run: store.AgentRunInvocation{RunID: uploadTestRun, WorkspaceID: "ws", RequestedByID: "user", RequestedByType: "user", Status: "running"}, role: "owner"}
+	handler := uploadSkillBundle(s, signer)
+	for _, field := range []string{`"server_entry":"index.js"`, `"client_entry":"index.js"`, `"tools":["tool"]`, `"hooks":["hook"]`, `"credentials":["secret"]`} {
+		body := strings.Replace(uploadTestBody, `"skills":`, field+`,"skills":`, 1)
+		if w := skillUploadRequest(handler, token, body); w.Code != 400 {
+			t.Fatalf("accepted %s: %d %s", field, w.Code, w.Body)
+		}
+	}
+	for _, body := range []string{`{`, strings.Replace(uploadTestBody, `"name":"generated-guide",`, `"visibility":"public","name":"generated-guide",`, 1), strings.Repeat(" ", 1<<20) + uploadTestBody} {
+		if w := skillUploadRequest(handler, token, body); w.Code != 400 {
+			t.Fatalf("accepted invalid payload: %d", w.Code)
+		}
+	}
+	for _, bad := range []string{"", "runner-credential", token + "x"} {
+		if w := skillUploadRequest(handler, bad, uploadTestBody); w.Code != 401 {
+			t.Fatalf("accepted invalid bearer: %d", w.Code)
+		}
+	}
+	unknown, _ := signer.Token("00000000-0000-0000-0000-000000008888")
+	if w := skillUploadRequest(handler, unknown, uploadTestBody); w.Code != 403 {
+		t.Fatal("accepted unknown run")
+	}
+	if len(s.imports) != 0 {
+		t.Fatal("rejected payload wrote data")
+	}
+}
+
+func TestSkillUploadRealStoreRevokesAndRetainsActor(t *testing.T) {
+	db := openDevRouteTestDB(t)
+	s := store.New(db)
+	ids := store.DefaultDevFixtureIDs()
+	_, err := s.SeedDevFixture(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	insertCapabilityExtraUser(t, db, testUserAID, "uploader@example.com")
+	insertWorkspaceMember(t, db, testUserAID, "admin")
+	insertQueuedRun(t, db, ids, ids.BackendAgentID)
+	if _, err := db.Exec(t.Context(), `update agent_runs set status='running', requested_by_id=$1 where id=$2`, testUserAID, uploadTestRun); err != nil {
+		t.Fatal(err)
+	}
+	signer := auth.NewSkillUploadSigner("test-master-key")
+	token, _ := signer.Token(uploadTestRun)
+	r := chi.NewRouter()
+	RegisterSkillUploadRoute(r, s, signer)
+	w := skillUploadRequest(r, token, uploadTestBody)
+	if w.Code != 201 {
+		t.Fatalf("upload %d: %s", w.Code, w.Body)
+	}
+	var result map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	var actor, ws, visibility string
+	if err := db.QueryRow(t.Context(), `select creator_id::text, workspace_id::text, visibility from capability where id=$1`, result["id"]).Scan(&actor, &ws, &visibility); err != nil {
+		t.Fatal(err)
+	}
+	if actor != testUserAID || ws != ids.WorkspaceID || visibility != "workspace" {
+		t.Fatalf("persisted scope: %s %s %s", actor, ws, visibility)
+	}
+	if w := skillUploadRequest(r, token, uploadTestBody); w.Code != 409 {
+		t.Fatalf("duplicate: %d %s", w.Code, w.Body)
+	}
+	newBody := strings.ReplaceAll(uploadTestBody, "generated-guide", "denied-guide")
+	if _, err := db.Exec(t.Context(), `update workspace_members set role='member' where workspace_id=$1 and user_id=$2`, ids.WorkspaceID, testUserAID); err != nil {
+		t.Fatal(err)
+	}
+	if w := skillUploadRequest(r, token, newBody); w.Code != 403 {
+		t.Fatalf("removed permission: %d %s", w.Code, w.Body)
+	}
+	if _, err := db.Exec(t.Context(), `update workspace_members set role='admin' where workspace_id=$1 and user_id=$2`, ids.WorkspaceID, testUserAID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(t.Context(), `update agent_runs set status='completed' where id=$1`, uploadTestRun); err != nil {
+		t.Fatal(err)
+	}
+	if w := skillUploadRequest(r, token, newBody); w.Code != 403 {
+		t.Fatalf("finished run: %d %s", w.Code, w.Body)
+	}
+	var count int
+	if err := db.QueryRow(t.Context(), `select count(*) from capability where name='denied-guide'`).Scan(&count); err != nil || count != 0 {
+		t.Fatalf("denied writes: %d %v", count, err)
+	}
+}


### PR DESCRIPTION
Default sandbox Agents could generate Skill files but could not upload them: their child processes lacked the service URL and the workspace plugin endpoint requires a Web session. Allow `parsar plugin add` to upload inline Markdown Skill bundles through an upload-only credential for the current run.

The server derives actor and workspace from the persisted run requester and checks current owner/admin permission and running status on each request. Credentials expire after one hour and cannot authenticate general workspace or runtime APIs. The daemon supplies its paired service address per request without exporting the device credential. Uploads stay workspace-only and cannot contain server/client code, hooks, tools or credential references.

Scope excludes supporting files, bare-device CLI distribution, shared-device ownership and memory APIs. The default sandbox already includes both CLI and daemon; bare-device installation is tracked separately as CHECK-013.

Validation: `make check`; scoped auth, connector, daemon and CLI tests; isolated PostgreSQL tests for real requester attribution, permission removal, run completion, invalid payloads and existing capability creation. The baseline CLI `TestTruncate` failure is independently fixed by #469; all other CLI tests passed. Final independent blind review passed with no actionable findings. Deployed end-to-end verification will follow the merge.
