### PR TITLE
fix(runtime): install companion CLI with paired devices

### DIFF
--- a/.github/workflows/parsar-daemon-release.yml
+++ b/.github/workflows/parsar-daemon-release.yml
@@ -87,30 +87,20 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          # -trimpath + -buildvcs=false: reproducible builds; no
-          # absolute paths or VCS stamps in the binary.
-          # -ldflags "-s -w": strip symbols + DWARF to halve the binary
-          # size (no impact on debugging since these are released
-          # binaries — local devs build their own with symbols).
-          OUTPUT="parsar-daemon-${VERSION}-${GOOS}-${GOARCH}"
           mkdir -p dist
-          go build \
-            -trimpath \
-            -buildvcs=false \
-            -ldflags "-s -w -X main.version=${VERSION}" \
-            -o "dist/${OUTPUT}" \
-            ./apps/parsar-daemon/cmd/parsar-daemon
-          # Sanity check: confirm the binary actually built and ldd-free.
-          file "dist/${OUTPUT}" || true
-          ls -lh "dist/${OUTPUT}"
+          for BINARY in parsar-daemon parsar; do
+            go build -trimpath -buildvcs=false \
+              -ldflags "-s -w -X github.com/MiniMax-AI-Dev/parsar/apps/${BINARY}/internal/cli.Version=${VERSION}" \
+              -o "dist/${BINARY}-${VERSION}-${GOOS}-${GOARCH}" \
+              "./apps/${BINARY}/cmd/${BINARY}"
+          done
 
-      - name: Compute checksum
-        id: sum
+      - name: Compute checksums
         run: |
           cd dist
-          OUTPUT="parsar-daemon-${{ steps.ver.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}"
-          shasum -a 256 "${OUTPUT}" > "${OUTPUT}.sha256"
-          cat "${OUTPUT}.sha256"
+          for OUTPUT in parsar-*; do
+            shasum -a 256 "${OUTPUT}" > "${OUTPUT}.sha256"
+          done
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
@@ -119,6 +109,8 @@ jobs:
           path: |
             dist/parsar-daemon-${{ steps.ver.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
             dist/parsar-daemon-${{ steps.ver.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.sha256
+            dist/parsar-${{ steps.ver.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}
+            dist/parsar-${{ steps.ver.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.sha256
           retention-days: 30
 
   release:
@@ -147,33 +139,12 @@ jobs:
           # Tag name is automatic from refs/tags/<tag>.
           name: parsar-daemon ${{ github.ref_name }}
           body: |
-            parsar-daemon binaries for macOS + Linux (amd64 / arm64).
+            Parsar daemon and companion CLI for macOS and Linux (amd64 / arm64).
+            Use the device pairing command from your Parsar server to install both.
+            For manual installation, download both binaries for your platform,
+            verify their matching SHA256 files, and keep them in the same directory.
 
-            The sandbox image (infra/sandbox/Dockerfile) compiles
-            parsar-daemon from source and doesn't consume this release —
-            these binaries are for the device-pairing "one-line connect
-            command" only.
-
-            ## Install (local laptop)
-            ```sh
-            # macOS arm64 example
-            curl -fsSL -o parsar-daemon \
-              https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/parsar-daemon-${{ github.ref_name }}-darwin-arm64
-            chmod +x parsar-daemon
-            ./parsar-daemon connect --url https://your.parsar.example.com --token <pairing> -b
-            ./parsar-daemon connect -b
-            ```
-
-            Verify the SHA256 against the matching `.sha256` artifact
-            before running.
-          files: |
-            dist/parsar-daemon-*-linux-amd64
-            dist/parsar-daemon-*-linux-amd64.sha256
-            dist/parsar-daemon-*-linux-arm64
-            dist/parsar-daemon-*-linux-arm64.sha256
-            dist/parsar-daemon-*-darwin-amd64
-            dist/parsar-daemon-*-darwin-amd64.sha256
-            dist/parsar-daemon-*-darwin-arm64
-            dist/parsar-daemon-*-darwin-arm64.sha256
+            The sandbox image builds both binaries from source and does not consume this release.
+          files: dist/parsar-*
           fail_on_unmatched_files: true
           generate_release_notes: true

--- a/.github/workflows/parsar-server-release.yml
+++ b/.github/workflows/parsar-server-release.yml
@@ -34,6 +34,7 @@ on:
       # rebuild + republish the server image — else the served binary goes
       # stale against source.
       - "apps/parsar-daemon/**"
+      - "apps/parsar/**"
       - "go.mod"
       - "go.sum"
       - "go.work"
@@ -63,6 +64,7 @@ on:
       - "apps/web/**"
       - "packages/tsconfig/**"
       - "apps/parsar-daemon/**"
+      - "apps/parsar/**"
       - "go.mod"
       - "go.sum"
       - "go.work"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,19 @@ description and keep ownership on the side listed here.
   Show the original SKILL.md entry alongside parsed metadata; do not reconstruct
   its source from canonical fields, which omit unsupported frontmatter.
 
+### Paired-device companion CLI
+
+- Device pairing installs `parsar-daemon` and the `parsar` companion CLI from
+  the same server image or release. Stage both downloads before pairing; a
+  missing CLI must not consume the one-shot pairing token.
+- Pairing defaults to `~/.parsar/bin`; download-only mode retains its existing
+  output-directory and non-executable behavior. Do not modify shell profiles
+  or system directories. Upload-enabled tasks can find the executable `parsar`
+  beside the daemon even after a later reconnect from a different shell.
+- The server image and daemon release workflow ship both binaries for the same
+  four platforms. Companion installation does not grant API authorization;
+  task-scoped uploads keep the current run requester and workspace checks.
+
 ### Runtime and execution concepts
 
 - The daemon resolves loopback Postgres capability-download URLs through its

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,8 +99,9 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # parsar-daemon source (root module, no separate go.mod). Copied after the
 # server build so editing the daemon doesn't invalidate the layer above.
 COPY apps/parsar-daemon ./apps/parsar-daemon
+COPY apps/parsar ./apps/parsar
 
-# Cross-compile the daemon for every platform the install script serves —
+# Cross-compile the daemon and companion CLI for device installation —
 # the allowlist in server/internal/api/parsar_daemon_download.go is
 # {darwin,linux}×{amd64,arm64}. Baking all four into the image lets the
 # minting server hand the host-appropriate binary to the one-line connect
@@ -108,13 +109,17 @@ COPY apps/parsar-daemon ./apps/parsar-daemon
 # stays off so each cross-target links statically.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    mkdir -p /out/daemon \
+    set -e; mkdir -p /out/daemon \
  && for target in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64; do \
       os="${target%/*}"; arch="${target#*/}"; \
       CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" GOFLAGS=-trimpath \
         go build -ldflags="-s -w" \
           -o "/out/daemon/parsar-daemon-${os}-${arch}" \
           ./apps/parsar-daemon/cmd/parsar-daemon; \
+      CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" GOFLAGS=-trimpath \
+        go build -ldflags="-s -w" \
+          -o "/out/daemon/parsar-${os}-${arch}" \
+          ./apps/parsar/cmd/parsar; \
     done
 
 ###############################################################################

--- a/apps/parsar-daemon/internal/cli/companion_path_test.go
+++ b/apps/parsar-daemon/internal/cli/companion_path_test.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCompanionCLIPath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode os.FileMode
+		want bool
+	}{
+		{"executable", 0o700, true},
+		{"download awaiting review", 0o600, false},
+		{"missing", 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tc.mode != 0 {
+				if err := os.WriteFile(filepath.Join(dir, "parsar"), []byte("binary"), tc.mode); err != nil {
+					t.Fatal(err)
+				}
+			}
+			env := map[string]any{"PATH": "/existing/tools", "OTHER": "retained"}
+			addCompanionCLIPath(env, dir)
+			want := "/existing/tools"
+			if tc.want {
+				want = dir + string(os.PathListSeparator) + want
+			}
+			if env["PATH"] != want || env["OTHER"] != "retained" {
+				t.Fatalf("unexpected child environment: %v", env)
+			}
+		})
+	}
+}

--- a/apps/parsar-daemon/internal/cli/skill_upload.go
+++ b/apps/parsar-daemon/internal/cli/skill_upload.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"context"
 	"maps"
+	"os"
+	"path/filepath"
 
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
 	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
@@ -14,9 +16,24 @@ func withSkillUploadServer(factory agent.Factory, serverURL string) agent.Factor
 		if token, _ := env["PARSAR_CAPABILITY_UPLOAD_TOKEN"].(string); token != "" {
 			env = maps.Clone(env)
 			env["PARSAR_SERVER_URL"] = serverURL
+			if executable, err := os.Executable(); err == nil {
+				addCompanionCLIPath(env, filepath.Dir(executable))
+			}
 			req.AgentOptions = maps.Clone(req.AgentOptions)
 			req.AgentOptions["env"] = env
 		}
 		return factory(ctx, req, out)
 	}
+}
+
+func addCompanionCLIPath(env map[string]any, dir string) {
+	info, err := os.Stat(filepath.Join(dir, "parsar"))
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+		return
+	}
+	path, ok := env["PATH"].(string)
+	if !ok {
+		path = os.Getenv("PATH")
+	}
+	env["PATH"] = dir + string(os.PathListSeparator) + path
 }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -4367,8 +4367,8 @@ paths:
       - memories
   /api/v1/parsar-daemon/download:
     get:
-      description: Serves the parsar-daemon binary for the requested os/arch pair
-        from the image's baked-in binary directory. Unauthenticated — the pairing
+      description: Serves the daemon or companion CLI binary for the requested os/arch
+        pair from the image's baked-in binary directory. Unauthenticated — the pairing
         token is what gates the actual connect.
       operationId: downloadParsarDaemon
       parameters:
@@ -4388,11 +4388,18 @@ paths:
         name: arch
         required: true
         type: string
+      - description: binary name (defaults to parsar-daemon)
+        enum:
+        - parsar-daemon
+        - parsar
+        in: query
+        name: binary
+        type: string
       produces:
       - application/octet-stream
       responses:
         "200":
-          description: parsar-daemon binary stream
+          description: device runtime binary stream
           schema:
             type: file
         "400":
@@ -4403,7 +4410,7 @@ paths:
           description: no binary for that os/arch in this image
           schema:
             type: string
-      summary: Download parsar-daemon binary
+      summary: Download device runtime binary
       tags:
       - runtimes
   /api/v1/parsar-daemon/install.sh:

--- a/scripts/install-parsar-daemon.sh
+++ b/scripts/install-parsar-daemon.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 # Parsar — parsar-daemon installer.
 #
-# Downloads the platform-appropriate parsar-daemon binary from the project's
-# GitHub Releases. Does NOT chmod, NOT install onto $PATH, NOT touch
-# system directories — the caller (admin operator on their own laptop)
-# decides where the binary lands. We just put it next to the user's
-# Downloads so a managed laptop policy can intercept it before exec.
+# Pairing installs the daemon and companion CLI together under ~/.parsar/bin.
+# Download-only mode keeps the daemon non-executable for operator review.
+# Neither mode modifies shell profiles or system directories.
 #
 # Resolution order (highest priority first):
 #   1. $PARSAR_DAEMON_VERSION       — exact GitHub Release tag (e.g. v0.1.0)
@@ -41,6 +39,24 @@ esac
 REPO="${PARSAR_DAEMON_REPO:-$DEFAULT_REPO}"
 VERSION="${PARSAR_DAEMON_VERSION:-}"
 OUT_DIR="${PARSAR_DAEMON_OUT_DIR:-${HOME}/Downloads}"
+PAIRING="${PARSAR_DAEMON_CONNECT_TOKEN:-}"
+if [ -n "$PAIRING" ]; then
+  if [ -z "${PARSAR_DAEMON_CONNECT_URL:-}" ]; then
+    echo "parsar-daemon: PARSAR_DAEMON_CONNECT_TOKEN is set but PARSAR_DAEMON_CONNECT_URL is empty" >&2
+    exit 1
+  fi
+  OUT_DIR="${PARSAR_DAEMON_OUT_DIR:-${HOME}/.parsar/bin}"
+fi
+case "$OUT_DIR" in
+  /*) ;;
+  *) echo "parsar-daemon: PARSAR_DAEMON_OUT_DIR must be absolute" >&2; exit 1 ;;
+esac
+mkdir -p "$OUT_DIR"
+DOWNLOAD_DIR="$OUT_DIR"
+if [ -n "$PAIRING" ]; then
+  DOWNLOAD_DIR="$(mktemp -d "${OUT_DIR}/.install.XXXXXX")"
+  trap 'rm -rf "$DOWNLOAD_DIR"' EXIT
+fi
 
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
@@ -67,12 +83,19 @@ SERVED_LOCALLY=""
 SERVER_ORIGIN="${PARSAR_DAEMON_CONNECT_URL:-}"
 if [ -n "$SERVER_ORIGIN" ]; then
   SERVER_ORIGIN="${SERVER_ORIGIN%/}"
-  OUT_FILE="${OUT_DIR}/parsar-daemon-${OS}-${ARCH}"
+  OUT_FILE="${DOWNLOAD_DIR}/parsar-daemon-${OS}-${ARCH}"
   echo "Fetching parsar-daemon for ${OS}/${ARCH} from ${SERVER_ORIGIN}..."
   mkdir -p "$OUT_DIR"
   if curl -fL "${SERVER_ORIGIN}/api/v1/parsar-daemon/download?os=${OS}&arch=${ARCH}" -o "$OUT_FILE"; then
     printf 'Downloaded to %s\n' "$OUT_FILE"
     SERVED_LOCALLY=1
+    if [ -n "$PAIRING" ]; then
+      CLI_FILE="${DOWNLOAD_DIR}/parsar"
+      if ! curl -fL "${SERVER_ORIGIN}/api/v1/parsar-daemon/download?os=${OS}&arch=${ARCH}&binary=parsar" -o "$CLI_FILE"; then
+        echo "parsar-daemon: this server is missing the companion CLI. Upgrade the server and retry; pairing has not started." >&2
+        exit 1
+      fi
+    fi
   else
     echo "Parsar server has no prebuilt binary for ${OS}/${ARCH}; falling back to GitHub Releases." >&2
     rm -f "$OUT_FILE"
@@ -101,7 +124,7 @@ if [ -z "$SERVED_LOCALLY" ]; then
   BARE_VERSION="${VERSION#parsar-daemon-}"
   BINARY="parsar-daemon-${BARE_VERSION}-${OS}-${ARCH}"
   DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}"
-  OUT_FILE="${OUT_DIR}/${BINARY}"
+  OUT_FILE="${DOWNLOAD_DIR}/${BINARY}"
 
   echo "Downloading ${BINARY} from ${DOWNLOAD_URL}..."
   mkdir -p "$OUT_DIR"
@@ -117,35 +140,26 @@ ERR
     exit 1
   fi
 
+  if [ -n "$PAIRING" ]; then
+    CLI_FILE="${DOWNLOAD_DIR}/parsar"
+    CLI_URL="https://github.com/${REPO}/releases/download/${VERSION}/parsar-${BARE_VERSION}-${OS}-${ARCH}"
+    if ! curl -fL "$CLI_URL" -o "$CLI_FILE"; then
+      echo "parsar-daemon: this release is missing the companion CLI. Choose a release containing both binaries; pairing has not started." >&2
+      exit 1
+    fi
+  fi
   printf 'Downloaded to %s\n' "$OUT_FILE"
 fi
 
-# --- One-line connect mode (north star) -------------------------------
-# When the Parsar web "Pair new device / copy one command" button mints a
-# command, it pipes this script with the pairing env vars set:
-#
-#   curl -fsSL .../install.sh \
-#     | PARSAR_DAEMON_CONNECT_URL=<server> \
-#       PARSAR_DAEMON_CONNECT_TOKEN=<one-shot-token> \
-#       PARSAR_DAEMON_CONNECT_DEVICE_NAME=<name> bash
-#
-# In that mode we finish the job: chmod the freshly-downloaded binary and
-# hand off to `connect`, so the operator never touches the binary, its
-# path, or the token. `connect` hydrates URL/token/device-name from these
-# same env vars and scrubs them from child argv, so the one-shot token
-# never appears in any process listing. `exec` replaces this shell; the
-# `-b` flag then re-spawns the daemon detached and returns.
-#
-# Without PARSAR_DAEMON_CONNECT_TOKEN we fall through to the download-only
-# enterprise posture below (no chmod, no $PATH changes) — same script,
-# behaviour gated purely on env. Profile-not-fork applied to the installer.
-if [ -n "${PARSAR_DAEMON_CONNECT_TOKEN:-}" ]; then
-  if [ -z "${PARSAR_DAEMON_CONNECT_URL:-}" ]; then
-    echo "parsar-daemon: PARSAR_DAEMON_CONNECT_TOKEN is set but PARSAR_DAEMON_CONNECT_URL is empty" >&2
-    exit 1
-  fi
+# Pair only after both downloads succeed; the token stays in the environment.
+if [ -n "$PAIRING" ]; then
+  chmod +x "$OUT_FILE" "$CLI_FILE"
+  mv "$CLI_FILE" "${OUT_DIR}/parsar"
+  mv "$OUT_FILE" "${OUT_DIR}/parsar-daemon"
+  rm -rf "$DOWNLOAD_DIR"
+  trap - EXIT
+  OUT_FILE="${OUT_DIR}/parsar-daemon"
   printf 'Pairing this device with %s ...\n' "$PARSAR_DAEMON_CONNECT_URL"
-  chmod +x "$OUT_FILE"
   exec "$OUT_FILE" connect -b
 fi
 

--- a/server/internal/api/install_parsar_daemon.sh
+++ b/server/internal/api/install_parsar_daemon.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 # Parsar — parsar-daemon installer.
 #
-# Downloads the platform-appropriate parsar-daemon binary from the project's
-# GitHub Releases. Does NOT chmod, NOT install onto $PATH, NOT touch
-# system directories — the caller (admin operator on their own laptop)
-# decides where the binary lands. We just put it next to the user's
-# Downloads so a managed laptop policy can intercept it before exec.
+# Pairing installs the daemon and companion CLI together under ~/.parsar/bin.
+# Download-only mode keeps the daemon non-executable for operator review.
+# Neither mode modifies shell profiles or system directories.
 #
 # Resolution order (highest priority first):
 #   1. $PARSAR_DAEMON_VERSION       — exact GitHub Release tag (e.g. v0.1.0)
@@ -41,6 +39,24 @@ esac
 REPO="${PARSAR_DAEMON_REPO:-$DEFAULT_REPO}"
 VERSION="${PARSAR_DAEMON_VERSION:-}"
 OUT_DIR="${PARSAR_DAEMON_OUT_DIR:-${HOME}/Downloads}"
+PAIRING="${PARSAR_DAEMON_CONNECT_TOKEN:-}"
+if [ -n "$PAIRING" ]; then
+  if [ -z "${PARSAR_DAEMON_CONNECT_URL:-}" ]; then
+    echo "parsar-daemon: PARSAR_DAEMON_CONNECT_TOKEN is set but PARSAR_DAEMON_CONNECT_URL is empty" >&2
+    exit 1
+  fi
+  OUT_DIR="${PARSAR_DAEMON_OUT_DIR:-${HOME}/.parsar/bin}"
+fi
+case "$OUT_DIR" in
+  /*) ;;
+  *) echo "parsar-daemon: PARSAR_DAEMON_OUT_DIR must be absolute" >&2; exit 1 ;;
+esac
+mkdir -p "$OUT_DIR"
+DOWNLOAD_DIR="$OUT_DIR"
+if [ -n "$PAIRING" ]; then
+  DOWNLOAD_DIR="$(mktemp -d "${OUT_DIR}/.install.XXXXXX")"
+  trap 'rm -rf "$DOWNLOAD_DIR"' EXIT
+fi
 
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
@@ -67,12 +83,19 @@ SERVED_LOCALLY=""
 SERVER_ORIGIN="${PARSAR_DAEMON_CONNECT_URL:-}"
 if [ -n "$SERVER_ORIGIN" ]; then
   SERVER_ORIGIN="${SERVER_ORIGIN%/}"
-  OUT_FILE="${OUT_DIR}/parsar-daemon-${OS}-${ARCH}"
+  OUT_FILE="${DOWNLOAD_DIR}/parsar-daemon-${OS}-${ARCH}"
   echo "Fetching parsar-daemon for ${OS}/${ARCH} from ${SERVER_ORIGIN}..."
   mkdir -p "$OUT_DIR"
   if curl -fL "${SERVER_ORIGIN}/api/v1/parsar-daemon/download?os=${OS}&arch=${ARCH}" -o "$OUT_FILE"; then
     printf 'Downloaded to %s\n' "$OUT_FILE"
     SERVED_LOCALLY=1
+    if [ -n "$PAIRING" ]; then
+      CLI_FILE="${DOWNLOAD_DIR}/parsar"
+      if ! curl -fL "${SERVER_ORIGIN}/api/v1/parsar-daemon/download?os=${OS}&arch=${ARCH}&binary=parsar" -o "$CLI_FILE"; then
+        echo "parsar-daemon: this server is missing the companion CLI. Upgrade the server and retry; pairing has not started." >&2
+        exit 1
+      fi
+    fi
   else
     echo "Parsar server has no prebuilt binary for ${OS}/${ARCH}; falling back to GitHub Releases." >&2
     rm -f "$OUT_FILE"
@@ -101,7 +124,7 @@ if [ -z "$SERVED_LOCALLY" ]; then
   BARE_VERSION="${VERSION#parsar-daemon-}"
   BINARY="parsar-daemon-${BARE_VERSION}-${OS}-${ARCH}"
   DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY}"
-  OUT_FILE="${OUT_DIR}/${BINARY}"
+  OUT_FILE="${DOWNLOAD_DIR}/${BINARY}"
 
   echo "Downloading ${BINARY} from ${DOWNLOAD_URL}..."
   mkdir -p "$OUT_DIR"
@@ -117,35 +140,26 @@ ERR
     exit 1
   fi
 
+  if [ -n "$PAIRING" ]; then
+    CLI_FILE="${DOWNLOAD_DIR}/parsar"
+    CLI_URL="https://github.com/${REPO}/releases/download/${VERSION}/parsar-${BARE_VERSION}-${OS}-${ARCH}"
+    if ! curl -fL "$CLI_URL" -o "$CLI_FILE"; then
+      echo "parsar-daemon: this release is missing the companion CLI. Choose a release containing both binaries; pairing has not started." >&2
+      exit 1
+    fi
+  fi
   printf 'Downloaded to %s\n' "$OUT_FILE"
 fi
 
-# --- One-line connect mode (north star) -------------------------------
-# When the Parsar web "Pair new device / copy one command" button mints a
-# command, it pipes this script with the pairing env vars set:
-#
-#   curl -fsSL .../install.sh \
-#     | PARSAR_DAEMON_CONNECT_URL=<server> \
-#       PARSAR_DAEMON_CONNECT_TOKEN=<one-shot-token> \
-#       PARSAR_DAEMON_CONNECT_DEVICE_NAME=<name> bash
-#
-# In that mode we finish the job: chmod the freshly-downloaded binary and
-# hand off to `connect`, so the operator never touches the binary, its
-# path, or the token. `connect` hydrates URL/token/device-name from these
-# same env vars and scrubs them from child argv, so the one-shot token
-# never appears in any process listing. `exec` replaces this shell; the
-# `-b` flag then re-spawns the daemon detached and returns.
-#
-# Without PARSAR_DAEMON_CONNECT_TOKEN we fall through to the download-only
-# enterprise posture below (no chmod, no $PATH changes) — same script,
-# behaviour gated purely on env. Profile-not-fork applied to the installer.
-if [ -n "${PARSAR_DAEMON_CONNECT_TOKEN:-}" ]; then
-  if [ -z "${PARSAR_DAEMON_CONNECT_URL:-}" ]; then
-    echo "parsar-daemon: PARSAR_DAEMON_CONNECT_TOKEN is set but PARSAR_DAEMON_CONNECT_URL is empty" >&2
-    exit 1
-  fi
+# Pair only after both downloads succeed; the token stays in the environment.
+if [ -n "$PAIRING" ]; then
+  chmod +x "$OUT_FILE" "$CLI_FILE"
+  mv "$CLI_FILE" "${OUT_DIR}/parsar"
+  mv "$OUT_FILE" "${OUT_DIR}/parsar-daemon"
+  rm -rf "$DOWNLOAD_DIR"
+  trap - EXIT
+  OUT_FILE="${OUT_DIR}/parsar-daemon"
   printf 'Pairing this device with %s ...\n' "$PARSAR_DAEMON_CONNECT_URL"
-  chmod +x "$OUT_FILE"
   exec "$OUT_FILE" connect -b
 fi
 

--- a/server/internal/api/parsar_companion_install_test.go
+++ b/server/internal/api/parsar_companion_install_test.go
@@ -1,0 +1,161 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestDeviceInstallerCompanion(t *testing.T) {
+	for _, tc := range []struct {
+		name, source string
+		pair, cli    bool
+		wantSuccess  bool
+	}{
+		{"server pairing", "server", true, true, true},
+		{"server missing CLI", "server", true, false, false},
+		{"release pairing", "release", true, true, true},
+		{"release missing CLI", "release", true, false, false},
+		{"download only", "server", false, false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			binaries := filepath.Join(root, "binaries")
+			out := filepath.Join(root, "output with spaces")
+			tools := filepath.Join(root, "tools")
+			for _, dir := range []string{binaries, out, tools} {
+				if err := os.Mkdir(dir, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			write := func(path, body string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			}
+			platform := runtime.GOOS + "-" + runtime.GOARCH
+			write(filepath.Join(binaries, "parsar-daemon-"+platform), `#!/bin/sh
+set -eu
+[ "$*" = "connect -b" ]
+[ "$PARSAR_DAEMON_CONNECT_TOKEN" = "synthetic-pairing" ]
+cli="$(dirname "$0")/parsar"
+[ "$("$cli")" = "companion-ok" ]
+printf paired > "$PARSAR_DAEMON_OUT_DIR/paired"
+`)
+			if tc.cli {
+				write(filepath.Join(binaries, "parsar-"+platform), "#!/bin/sh\nprintf companion-ok\n")
+			}
+			r := chi.NewRouter()
+			if tc.source == "server" {
+				RegisterParsarDaemonDownloadRoute(r, ParsarDaemonDownloadConfig{BinaryDir: binaries})
+			}
+			srv := httptest.NewServer(r)
+			defer srv.Close()
+			curl, err := exec.LookPath("curl")
+			if err != nil {
+				t.Skip("curl is required for installer execution")
+			}
+			write(filepath.Join(tools, "curl"), `#!/bin/sh
+set -eu
+url= out=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) out="$2"; shift ;;
+    http*) url="$1" ;;
+  esac
+  shift
+done
+case "$url" in
+  https://github.com/*/releases/download/parsar-daemon-v1.2.3/*)
+    name="${url##*/}"
+    name="$(printf %s "$name" | sed 's/-v1.2.3-/-/')"
+    cp "$TEST_BINARIES/$name" "$out"
+    ;;
+  http://127.0.0.1:*) exec "$TEST_CURL" -fsSL "$url" -o "$out" ;;
+  *) exit 90 ;;
+esac
+`)
+			cmd := exec.Command("bash")
+			cmd.Dir = root
+			cmd.Stdin = strings.NewReader(installParsarDaemonScript)
+			cmd.Env = append(os.Environ(),
+				"PATH="+tools+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"PARSAR_DAEMON_OUT_DIR="+out,
+				"PARSAR_DAEMON_CONNECT_URL="+srv.URL,
+				"PARSAR_DAEMON_VERSION=parsar-daemon-v1.2.3",
+				"TEST_BINARIES="+binaries, "TEST_CURL="+curl,
+				"PARSAR_DAEMON_CONNECT_TOKEN=",
+			)
+			if tc.pair {
+				cmd.Env = append(cmd.Env, "PARSAR_DAEMON_CONNECT_TOKEN=synthetic-pairing")
+				write(filepath.Join(out, "parsar"), "old-cli")
+				write(filepath.Join(out, "parsar-daemon"), "old-daemon")
+			}
+			output, err := cmd.CombinedOutput()
+			if (err == nil) != tc.wantSuccess {
+				t.Fatalf("success=%v, want %v: %s", err == nil, tc.wantSuccess, output)
+			}
+			_, pairedErr := os.Stat(filepath.Join(out, "paired"))
+			if got := pairedErr == nil; got != (tc.pair && tc.wantSuccess) {
+				t.Fatalf("paired=%v", got)
+			}
+			if !tc.wantSuccess {
+				for _, binary := range []string{"parsar", "parsar-daemon"} {
+					body, _ := os.ReadFile(filepath.Join(out, binary))
+					want := "old-cli"
+					if binary == "parsar-daemon" {
+						want = "old-daemon"
+					}
+					if string(body) != want {
+						t.Fatalf("failed download replaced %s", binary)
+					}
+				}
+			}
+			if !tc.pair {
+				info, err := os.Stat(filepath.Join(out, "parsar-daemon-"+platform))
+				if err != nil || info.Mode().Perm()&0o111 != 0 {
+					t.Fatalf("download-only file should not be executable: %v", err)
+				}
+			}
+			staging, _ := filepath.Glob(filepath.Join(out, ".install.*"))
+			if len(staging) != 0 {
+				t.Fatalf("left staging directories: %v", staging)
+			}
+		})
+	}
+}
+
+func TestCompanionBinaryDownload(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "parsar-linux-amd64"), []byte("cli"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := chi.NewRouter()
+	RegisterParsarDaemonDownloadRoute(r, ParsarDaemonDownloadConfig{BinaryDir: dir})
+	for _, tc := range []struct {
+		binary string
+		status int
+	}{
+		{"parsar", http.StatusOK},
+		{"parsar-daemon", http.StatusNotFound},
+		{"..%2F..%2Fetc", http.StatusBadRequest},
+		{"other", http.StatusBadRequest},
+	} {
+		rec := daemonDownloadGet(r, fmt.Sprintf("/api/v1/parsar-daemon/download?os=linux&arch=amd64&binary=%s", tc.binary))
+		if rec.Code != tc.status {
+			t.Fatalf("binary=%s: status=%d", tc.binary, rec.Code)
+		}
+		if tc.status == http.StatusOK && (rec.Body.String() != "cli" || !strings.Contains(rec.Header().Get("Content-Disposition"), "parsar-linux-amd64")) {
+			t.Fatal("companion download returned the wrong binary or filename")
+		}
+	}
+}

--- a/server/internal/api/parsar_daemon_download.go
+++ b/server/internal/api/parsar_daemon_download.go
@@ -23,7 +23,7 @@ var (
 
 type ParsarDaemonDownloadConfig struct {
 	// BinaryDir holds the per-platform parsar-daemon binaries named
-	// parsar-daemon-<os>-<arch>. Empty falls back to defaultDaemonBinaryDir.
+	// parsar-daemon-<os>-<arch> or parsar-<os>-<arch>. Empty uses the default.
 	BinaryDir string
 }
 
@@ -44,14 +44,15 @@ func RegisterParsarDaemonDownloadRoute(r chi.Router, cfg ParsarDaemonDownloadCon
 // caller's os/arch pair. Extracted so swag can attach annotations to a named
 // function.
 //
-//	@Summary	Download parsar-daemon binary
-//	@Description	Serves the parsar-daemon binary for the requested os/arch pair from the image's baked-in binary directory. Unauthenticated — the pairing token is what gates the actual connect.
+//	@Summary	Download device runtime binary
+//	@Description	Serves the daemon or companion CLI binary for the requested os/arch pair from the image's baked-in binary directory. Unauthenticated — the pairing token is what gates the actual connect.
 //	@Tags		runtimes
 //	@ID			downloadParsarDaemon
 //	@Produce	octet-stream
 //	@Param		os query string true "target GOOS" Enums(darwin, linux)
 //	@Param		arch query string true "target GOARCH" Enums(amd64, arm64)
-//	@Success	200 {file} binary "parsar-daemon binary stream"
+//	@Param		binary query string false "binary name (defaults to parsar-daemon)" Enums(parsar-daemon, parsar)
+//	@Success	200 {file} binary "device runtime binary stream"
 //	@Failure	400 {string} string "os/arch not in the accepted allowlist"
 //	@Failure	404 {string} string "no binary for that os/arch in this image"
 //	@Router		/api/v1/parsar-daemon/download [get]
@@ -64,17 +65,25 @@ func parsarDaemonDownloadHandler(dir string) http.HandlerFunc {
 			return
 		}
 
-		name := "parsar-daemon-" + goos + "-" + goarch
+		binary := req.URL.Query().Get("binary")
+		if binary == "" {
+			binary = "parsar-daemon"
+		}
+		if binary != "parsar-daemon" && binary != "parsar" {
+			http.Error(w, "binary must be one of [parsar-daemon parsar]", http.StatusBadRequest)
+			return
+		}
+		name := binary + "-" + goos + "-" + goarch
 		f, err := os.Open(filepath.Join(dir, name))
 		if err != nil {
-			http.Error(w, "no parsar-daemon binary for "+goos+"/"+goarch+" in this image", http.StatusNotFound)
+			http.Error(w, "no "+binary+" binary for "+goos+"/"+goarch+" in this image", http.StatusNotFound)
 			return
 		}
 		defer func() { _ = f.Close() }()
 
 		stat, err := f.Stat()
 		if err != nil || stat.IsDir() {
-			http.Error(w, "no parsar-daemon binary for "+goos+"/"+goarch+" in this image", http.StatusNotFound)
+			http.Error(w, "no "+binary+" binary for "+goos+"/"+goarch+" in this image", http.StatusNotFound)
 			return
 		}
 


### PR DESCRIPTION
Device pairing previously installed only parsar-daemon, leaving Agent-authored Skill uploads without the `parsar` command. Pairing now stages the daemon and companion CLI from the same server or release before starting, and upload-enabled tasks can discover the companion after reconnect.

The default pairing directory is `~/.parsar/bin`. Download-only behavior stays unchanged, existing download callers still receive the daemon, and upload authorization remains scoped to the current run. No shell profiles or system directories are modified.

Validation: `make check`; executable installer tests covering self-hosted/release success and missing companion downloads; daemon tests; all four macOS/Linux amd64/arm64 binary builds; independent blind review with no actionable findings. Fresh-device deployed upload and reconnect verification follows merge.
