### PR TITLE
fix(web): declare chat state before run callback

### DIFF
--- a/apps/web/src/components/conversation/ConversationThread.tsx
+++ b/apps/web/src/components/conversation/ConversationThread.tsx
@@ -379,16 +379,16 @@ function ChatStream({
   // Wall clock of the moment the composer handed us a run id: the trace's
   // clock until the timeline carries the run's own started_at.
   const [liveStartedAt, setLiveStartedAt] = useState<number | null>(null)
-  const startRun = useCallback((runId: string) => {
-    setChatToast(null)
-    setLiveStartedAt(Date.now())
-    setActiveRunId(runId)
-  }, [])
   // Surface fire-and-forget /start failures (e.g. daemon offline,
   // network error). Server now auto-starts agent_daemon runs, so a
   // /start that returns 200 `already running` is fine; only true
   // network/5xx errors land here.
   const [chatToast, setChatToast] = useState<{ text: string; detail?: string; runID?: string } | null>(null)
+  const startRun = useCallback((runId: string) => {
+    setChatToast(null)
+    setLiveStartedAt(Date.now())
+    setActiveRunId(runId)
+  }, [])
   const stream = useAgentRunStream(conversationId, activeRunId, { enabled: !!activeRunId })
   const hasActiveStream = !!activeRunId && stream.status !== "error" && stream.status !== "done"
   // Our sentence and the server's string, kept apart. They used to be one


### PR DESCRIPTION
ConversationThread's run-start callback referenced the chat toast setter before its declaration, causing the React Hooks immutability lint rule to reject the component. Move the unchanged callback below the state declaration.

Validation: the unchanged baseline produces one scoped ESLint error; this version produces none. `make check` passes. The full web ESLint baseline still has 46 errors and 2 warnings outside this change. Self-reviewed as a declaration-order-only change; no chat behavior or lint rules changed.
