### PR TITLE
fix(web): render agent status errors from state

### DIFF
--- a/apps/web/src/pages/admin/agents/AgentStatusControl.tsx
+++ b/apps/web/src/pages/admin/agents/AgentStatusControl.tsx
@@ -1,4 +1,4 @@
-import { useRef, type ReactNode } from "react"
+import { useRef, useState, type ReactNode } from "react"
 import { Loader2, Pause, Play } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
@@ -13,7 +13,7 @@ export function AgentStatusControl({ workspaceID, children }: { workspaceID: str
   const mutation = useSetAgentStatus(workspaceID)
   const toast = useToast()
   const scope = useRef<HTMLElement | null>(null)
-  const requestedAgent = useRef<Agent | null>(null)
+  const [requestedAgent, setRequestedAgent] = useState<Agent | null>(null)
 
   const renderAction = (agent: Agent) => {
     const enable = agent.status === "disabled"
@@ -22,7 +22,7 @@ export function AgentStatusControl({ workspaceID, children }: { workspaceID: str
     return (
       <Button data-agent-status-action={agent.id} variant="outline" disabled={mutation.isPending} onClick={() => {
         if (mutation.isPending) return
-        requestedAgent.current = agent
+        setRequestedAgent(agent)
         mutation.mutate({ agentID: agent.id, enabled: enable }, {
           onSuccess: () => toast.show(t(enable ? "agents.statusAction.enabled" : "agents.statusAction.disabled", { name: agent.name })),
         })
@@ -38,11 +38,11 @@ export function AgentStatusControl({ workspaceID, children }: { workspaceID: str
       {children(renderAction)}
       {mutation.isError && <ErrorDialog
         title={t("agents.statusAction.failed")}
-        message={`${requestedAgent.current?.name ?? ""}: ${t("common:errors.submitRetryHint")}`}
+        message={`${requestedAgent?.name ?? ""}: ${t("common:errors.submitRetryHint")}`}
         detail={mutation.error.message}
         onClose={() => mutation.reset()}
         onRestoreFocus={() => {
-          const buttons = document.querySelectorAll<HTMLButtonElement>(`[data-agent-status-action="${CSS.escape(requestedAgent.current?.id ?? "")}"]`)
+          const buttons = document.querySelectorAll<HTMLButtonElement>(`[data-agent-status-action="${CSS.escape(requestedAgent?.id ?? "")}"]`)
           const target = buttons[buttons.length - 1]
             ?? document.querySelector<HTMLElement>("[data-agent-status-action], input[type=search]")
           scope.current = target?.parentElement ?? null


### PR DESCRIPTION
Agent status errors rendered the last requested Agent from a ref, triggering three React Hooks lint errors. Store that request snapshot in React state so error copy renders from state, retaining the existing pending guard, success feedback and focus fallback.

Validation: `make check`, scoped ESLint, and a browser check for pending detail switching, original error identity, dismissal focus, retry and enable/disable. This is a five-line replacement in one component, self-reviewed. Full ESLint remains at 43 errors and 2 warnings; no lint rule or API changed.
