### PR TITLE
fix(web): keep capability summaries current

### DIFF
--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -219,11 +219,7 @@ export function CapabilitiesPage() {
   const latestVersions = versionSummary.latest
   const selectedLatestVersion = addVersionCapability ? latestVersions.get(addVersionCapability.id) : undefined
   const uninstallAgents = uninstallAgentsQ.data ?? uninstallTarget?.enabled_agents ?? []
-  const enabledCounts = useMemo(
-    () => countCapabilityInstalls(agentCapabilityQueries.map((q) => q.data?.installed ?? [])),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [agentCapabilityQueries.map((q) => q.dataUpdatedAt).join(":")],
-  )
+  const enabledCounts = countCapabilityInstalls(agentCapabilityQueries.map((q) => q.data?.installed ?? []))
 
   const countsUnavailable = agentsQ.isLoading || !!agentsQ.error || agentCapabilityQueries.some((q) => q.isLoading || q.error)
 
@@ -1321,18 +1317,15 @@ function useCapabilityVersionSummary(workspaceID: string | null, capabilities: C
       staleTime: 30_000,
     })),
   })
-  return useMemo(() => {
-    const latest = new Map<string, CapabilityVersion>()
-    const byCapability = new Map<string, CapabilityVersion[]>()
-    queries.forEach((q, idx) => {
-      const capabilityID = capabilities[idx].id
-      const versions = q.data?.versions ?? []
-      byCapability.set(capabilityID, versions)
-      if (versions[0]) latest.set(capabilityID, versions[0])
-    })
-    return { latest, byCapability }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [capabilities, queries.map((q) => q.dataUpdatedAt).join(":")])
+  const latest = new Map<string, CapabilityVersion>()
+  const byCapability = new Map<string, CapabilityVersion[]>()
+  queries.forEach((q, idx) => {
+    const capabilityID = capabilities[idx].id
+    const versions = q.data?.versions ?? []
+    byCapability.set(capabilityID, versions)
+    if (versions[0]) latest.set(capabilityID, versions[0])
+  })
+  return { latest, byCapability }
 }
 
 


### PR DESCRIPTION
Capabilities summaries cache Agent counts and version lists using joined query timestamps. This violates the React Hooks memo rules and can keep the display stale when query data changes without a different timestamp.

Compute these two small summaries from the current query results. Enabled-binding filtering, version ordering, APIs, query invalidation, and layout remain unchanged. This is a local follow-up to CHECK-010; other existing ESLint findings are outside this PR.

Validation: `make check` passed with local Docker disabled (PostgreSQL migration smoke skipped). A Chromium regression verified count 1→0 and version 1.0.0→2.0.0 after same-timestamp query-data changes. Full ESLint improved from 43 errors / 2 warnings to 41 errors / 2 warnings; the remaining findings are preexisting. Independent review covered the complete diff.
