### PR TITLE
fix(web): bind workspace focus refs explicitly

### DIFF
--- a/apps/web/src/components/layout/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/layout/WorkspaceSwitcher.tsx
@@ -80,7 +80,7 @@ export function WorkspaceSwitcher() {
   const [joinTarget, setJoinTarget] = useState<DiscoverableWorkspace | null>(
     null
   )
-  const dialogFocus = useWorkspaceDialogFocus(
+  const { triggerRef, menuRef, rememberFocus, restoreFocus } = useWorkspaceDialogFocus(
     createWsOpen || !!renameWs || !!archiveWs || !!joinTarget || discoverDialogOpen
   )
   // Toast rendered next to the trigger (not page-top) since the switcher
@@ -113,7 +113,7 @@ export function WorkspaceSwitcher() {
       >
         <DropdownMenu.Trigger asChild>
           <button
-            ref={dialogFocus.triggerRef}
+            ref={triggerRef}
             type="button"
             aria-label={t("workspaceSwitcher.triggerAriaLabel")}
             title={triggerLabel}
@@ -137,8 +137,8 @@ export function WorkspaceSwitcher() {
 
         <DropdownMenu.Portal>
           <DropdownMenu.Content
-            ref={dialogFocus.menuRef}
-            onFocusCapture={dialogFocus.rememberFocus}
+            ref={menuRef}
+            onFocusCapture={rememberFocus}
             align="start"
             sideOffset={6}
             className="app-shadow-floating z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] w-96 max-w-[calc(100vw-1rem)] overflow-x-hidden overflow-y-auto rounded-lg border border-line bg-surface p-1 text-sm text-fg-muted animate-pop-in data-[state=closed]:animate-pop-out"
@@ -288,7 +288,7 @@ export function WorkspaceSwitcher() {
 
       <WorkspaceFormDialog
         open={createWsOpen}
-        onCloseAutoFocus={dialogFocus.restoreFocus}
+        onCloseAutoFocus={restoreFocus}
         onOpenChange={(open) => {
           if (!open) createWorkspaceMut.reset()
           setCreateWsOpen(open)
@@ -311,7 +311,7 @@ export function WorkspaceSwitcher() {
 
       <WorkspaceFormDialog
         open={renameWs !== null}
-        onCloseAutoFocus={dialogFocus.restoreFocus}
+        onCloseAutoFocus={restoreFocus}
         onOpenChange={(open) => {
           if (!open) {
             updateWorkspaceMut.reset()
@@ -346,7 +346,7 @@ export function WorkspaceSwitcher() {
 
       <ConfirmArchiveDialog
         open={archiveWs !== null}
-        onCloseAutoFocus={dialogFocus.restoreFocus}
+        onCloseAutoFocus={restoreFocus}
         onOpenChange={(open) => {
           if (!open) {
             archiveWorkspaceMut.reset()
@@ -375,7 +375,7 @@ export function WorkspaceSwitcher() {
 
       <JoinRequestDialog
         open={joinTarget !== null}
-        onCloseAutoFocus={dialogFocus.restoreFocus}
+        onCloseAutoFocus={restoreFocus}
         onOpenChange={(open) => {
           if (!open) {
             requestJoinMut.reset()
@@ -404,7 +404,7 @@ export function WorkspaceSwitcher() {
 
       <DiscoverWorkspacesDialog
         open={discoverDialogOpen}
-        onCloseAutoFocus={dialogFocus.restoreFocus}
+        onCloseAutoFocus={restoreFocus}
         onOpenChange={setDiscoverDialogOpen}
         onSelectToJoin={(ws) => {
           setDiscoverDialogOpen(false)


### PR DESCRIPTION
WorkspaceSwitcher triggers seven React Hooks ref diagnostics when reading refs and focus callbacks through a single returned object. Bind those values explicitly so the analyzer can distinguish them.

This changes no focus behavior, permissions, menu layout, form lifecycle, or lint configuration. The diff is limited to WorkspaceSwitcher and follows CHECK-010.

Validation: `make check` passed with local Docker disabled (PostgreSQL smoke skipped). A Chromium check against the real QA API verified create, rename, and archive cancellation returns focus to the original menu action, Escape restores the trigger, and keyboard reopening works, with zero API writes. Full ESLint falls from 41 errors / 2 warnings to 34 errors / 2 warnings; remaining findings are preexisting. Independent review covers the full diff.
