### PR TITLE
fix(web): update first-send attempts without object mutation

### DIFF
--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -212,16 +212,19 @@ export function ConversationsPage() {
       attempt = { workspaceId: wsId, agentId: selectedAgentId }
       firstSend.current = attempt
     }
-    if (!attempt.conversationId) {
+    let cid = attempt.conversationId
+    if (!cid) {
       const conv = await createConversation(wsId, {
         title: content.slice(0, 30),
         surface: "web",
         form: "thread",
         agent_id: selectedAgentId,
       })
-      attempt.conversationId = conv.id
+      cid = conv.id
+      const createdAttempt = { ...attempt, conversationId: cid }
+      if (firstSend.current === attempt) firstSend.current = createdAttempt
+      attempt = createdAttempt
     }
-    const cid = attempt.conversationId
     try {
       await sendUserMessage(cid, { content })
     } finally {
@@ -652,4 +655,3 @@ function ConversationList(p: ListProps) {
 /* ============================================================== */
 /*  Main column — header + body (empty or stream) + composer        */
 /* ============================================================== */
-


### PR DESCRIPTION
The empty conversation composer must retain a created conversation when the first message fails, while ignoring stale navigation after the user switches context. Replace the mutation of its cached request object with a new attempt value, and only publish that value if the original request is still current.

Validation: `make check` passes; intercepted browser flows cover failed creation and retry, failed send with conversation reuse, Agent switches during creation and sending, and a workspace switch during creation. No real conversations or messages were created. Full Web ESLint decreases from 33 errors and 2 warnings to 32 errors and 2 warnings. Local Docker remains disabled, so the migration smoke check was skipped.

Scope: one file, 6 additions and 4 deletions. Existing request ordering, error propagation, query invalidation, navigation, permissions, and UI remain unchanged. The unrelated effect diagnostic in this file remains.

A fresh independent blind review found no in-scope issues and independently checked typecheck, diff checks, and the baseline/current lint difference.
