### PR TITLE
fix(web): synchronize workspace dialog reset state

### DIFF
--- a/apps/web/src/components/layout/DiscoverWorkspacesDialog.tsx
+++ b/apps/web/src/components/layout/DiscoverWorkspacesDialog.tsx
@@ -47,15 +47,17 @@ export function DiscoverWorkspacesDialog({
   const [searchInput, setSearchInput] = useState("")
   const [debouncedQ, setDebouncedQ] = useState("")
   const [page, setPage] = useState(0)
+  const [previousOpen, setPreviousOpen] = useState(open)
 
   // Reset local state on close so reopen starts clean.
-  useEffect(() => {
+  if (open !== previousOpen) {
+    setPreviousOpen(open)
     if (!open) {
       setSearchInput("")
       setDebouncedQ("")
       setPage(0)
     }
-  }, [open])
+  }
 
   // 300ms debounce + reset page (stale offset is meaningless after query change).
   useEffect(() => {

--- a/apps/web/src/components/layout/WorkspaceCrudDialogs.tsx
+++ b/apps/web/src/components/layout/WorkspaceCrudDialogs.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 import { ApiError } from "../../lib/api-client"
 import type { WorkspaceVisibility } from "../../lib/api-types"
@@ -68,13 +68,20 @@ export function WorkspaceFormDialog({
   const [visibility, setVisibility] =
     useState<WorkspaceVisibility>(initialVisibility)
 
-  // Reset on open so a previous error doesn't leak across opens.
-  useEffect(() => {
+  const [previousInputs, setPreviousInputs] = useState({ open, initialName, initialVisibility })
+
+  // Reseed on open or changed defaults, without clearing drafts on mutation updates.
+  if (
+    open !== previousInputs.open ||
+    initialName !== previousInputs.initialName ||
+    initialVisibility !== previousInputs.initialVisibility
+  ) {
+    setPreviousInputs({ open, initialName, initialVisibility })
     if (open) {
       setName(initialName)
       setVisibility(initialVisibility)
     }
-  }, [open, initialName, initialVisibility])
+  }
 
   const errMsg = extractErrorMessage(error)
   const submitLabel =
@@ -208,11 +215,13 @@ export function JoinRequestDialog({
 }: JoinRequestDialogProps) {
   const { t } = useTranslation("common")
   const [reason, setReason] = useState("")
+  const [previousOpen, setPreviousOpen] = useState(open)
 
   // Reset on open so prior input doesn't leak to a different workspace.
-  useEffect(() => {
+  if (open !== previousOpen) {
+    setPreviousOpen(open)
     if (open) setReason("")
-  }, [open])
+  }
 
   const errMsg = extractErrorMessage(error)
   const trimmed = reason.trim()


### PR DESCRIPTION
Workspace dialogs reset their form state in post-render effects, producing three `react-hooks/set-state-in-effect` diagnostics. Synchronize their existing reset conditions during guarded prop transitions instead, so reopening starts clean while pending and failed submissions retain the user's draft.

Scope is limited to `WorkspaceCrudDialogs` and `DiscoverWorkspacesDialog`. Initial-name and visibility changes, join-reason validation, the 300 ms search debounce, pagination, submission payloads and focus restoration keep their existing behavior. No API, permission, layout or unrelated form changes.

Validation: `make check` passes (local Docker remains disabled, so the Postgres migration smoke check is skipped); both changed files pass ESLint. Full Web ESLint decreases from 32 errors to 29, with two existing warnings unchanged. Browser checks with intercepted writes cover create/rename/join pending and failed submissions, clean reopen, trimmed payloads, join-reason length, search/page reset, pending debounce cancellation and dialog focus. A controlled component browser check covers changed defaults while open and closed.

Independent blind review found no actionable in-scope issues.
