### PR TITLE
fix(web): reset delete confirmation on agent identity changes

### DIFF
--- a/apps/web/src/pages/admin/agents/DeleteAgentDialog.tsx
+++ b/apps/web/src/pages/admin/agents/DeleteAgentDialog.tsx
@@ -1,5 +1,5 @@
 import { Check, Copy, Loader2 } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -41,14 +41,16 @@ export function DeleteAgentDialog({
   const { t } = useTranslation("admin")
   const [confirmation, setConfirmation] = useState("")
   const [copied, setCopied] = useState(false)
+  const [previousAgentID, setPreviousAgentID] = useState(agent?.id)
   const expected = agent?.name ?? ""
   const canDelete = Boolean(agent) && confirmation === expected && !pending
   const msg = errorMessage(error)
 
-  useEffect(() => {
+  if (previousAgentID !== agent?.id) {
+    setPreviousAgentID(agent?.id)
     setConfirmation("")
     setCopied(false)
-  }, [agent?.id])
+  }
 
   async function copyAgentName() {
     if (!expected || pending) return


### PR DESCRIPTION
The Agent deletion dialog resets confirmation text and copy feedback in a post-render effect, producing a `react-hooks/set-state-in-effect` diagnostic. Reset them when the Agent ID changes while preserving the existing exact-name confirmation and pending/error behavior.

Only `DeleteAgentDialog.tsx` changes (5 additions, 3 deletions). Deletion APIs, permissions, history retention, clipboard timeout behavior, layout and callers are unchanged.

Validation: `make check` passes; local Docker stays disabled, so the Postgres migration smoke check is skipped. The changed file passes ESLint; full Web ESLint decreases from 29 to 28 errors, with two existing warnings. Browser checks cover both list and detail entry points, exact-name matching, intercepted failed deletion and retry, pending-state controls, copy feedback and cancel/reopen. A controlled component browser check verifies different IDs with identical names, same-ID refresh/rename, and reopening the same Agent. All deletion requests and clipboard writes are intercepted.

Independent blind review found no actionable in-scope issues.
