### PR TITLE
fix(web): update runtime error cache without effect

### DIFF
--- a/apps/web/src/pages/admin/RuntimePage.tsx
+++ b/apps/web/src/pages/admin/RuntimePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react"
+import React, { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { AlertTriangle, Loader2, Skull, Zap } from "lucide-react"
 
@@ -288,9 +288,12 @@ function CloudInstancesPanel({
   const fmtAgo = useRelativeTime()
   const checkLabelFor = useConnectivityCheckLabel()
   const [settledError, setSettledError] = useState<{ workspaceID: string | null; error: unknown } | null>(null)
-  useEffect(() => {
-    if (!loading) setSettledError(error ? { workspaceID, error } : null)
-  }, [workspaceID, loading, error])
+  if (!loading) {
+    const nextError = error ? { workspaceID, error } : null
+    if (settledError?.workspaceID !== nextError?.workspaceID || settledError?.error !== nextError?.error) {
+      setSettledError(nextError)
+    }
+  }
   const displayedError = error || (loading && settledError?.workspaceID === workspaceID ? settledError.error : null)
   const [testingId, setTestingId] = useState<string | null>(null)
   const [testResult, setTestResult] = useState<{ bindingId: string; result: ConnectivityResult } | null>(null)


### PR DESCRIPTION
The Runtime Instances panel caches its last settled loading error in a post-render effect, producing a `react-hooks/set-state-in-effect` diagnostic. Update that cache when the settled error changes while preserving its workspace boundary and retry feedback.

Only the error cache in `RuntimePage.tsx` changes. Query behavior, retry strategy, instance operations, permissions and layout are unchanged.

Validation: `make check` passes; local Docker remains disabled, so the Postgres migration smoke check is skipped. The changed file passes ESLint; full Web ESLint decreases from 28 to 27 errors, with two existing warnings. Browser checks cover first and subsequent failure, retained feedback throughout a pending retry, workspace switching, reopening the panel and successful recovery. All instance responses are controlled and API writes are blocked.

Independent blind review of the complete diff and relevant callers found no actionable issues; the reviewer independently ran targeted ESLint, Web TypeScript and diff-format checks.
