### PR TITLE
fix(web): synchronize credential tab fallback without effect

### DIFF
--- a/apps/web/src/pages/admin/credentials/CredentialsPage.tsx
+++ b/apps/web/src/pages/admin/credentials/CredentialsPage.tsx
@@ -29,9 +29,7 @@ export function CredentialsPage() {
   const [query, setQuery] = useState("")
   const [createRequest, setCreateRequest] = useState(0)
 
-  useEffect(() => {
-    if (tab === "org" && !isAdmin) setTab("personal")
-  }, [tab, isAdmin])
+  if (tab === "org" && !isAdmin) setTab("personal")
 
   // replaceState (not push) — tabs aren't a navigation primitive, the
   // back button shouldn't stair-step through them.


### PR DESCRIPTION
CredentialsPage synchronizes its selected tab after administrator access is lost, producing a `react-hooks/set-state-in-effect` diagnostic. Keep the existing fallback to personal credentials as a local state adjustment.

Only `CredentialsPage.tsx` changes (one addition, three deletions). Permissions, APIs, credential data, layout and URL replacement policy are unchanged.

Validation: `make check` passes; local Docker stays disabled, so the Postgres migration smoke check is skipped. Targeted ESLint is clean; full Web ESLint decreases from 27 to 26 errors with two existing warnings. Six browser scenarios verify owner direct links, access loss and restoration, manual tabs, search retention, switching to a member workspace and member direct-link fallback. Membership and credential reads are controlled; all writes are blocked.

Independent blind review of the full diff and relevant permission, workspace, routing and tab callers found no actionable issues. The reviewer independently passed targeted ESLint, Web TypeScript and diff-format checks.
