### PR TITLE
fix(web): synchronize conversation action targets without effect

### DIFF
--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -352,10 +352,8 @@ function ConversationList(p: ListProps) {
   const [deleteBusy, setDeleteBusy] = useState(false)
   const [deleteError, setDeleteError] = useState<string>("")
   const renameInputRef = useRef<HTMLInputElement>(null)
-  useEffect(() => {
-    if (!p.canWrite) setRenamingConvId(null)
-    if (!p.canDelete) setDeleteConvId(null)
-  }, [p.canWrite, p.canDelete])
+  if (!p.canWrite && renamingConvId !== null) setRenamingConvId(null)
+  if (!p.canDelete && deleteConvId !== null) setDeleteConvId(null)
   useEffect(() => {
     if (renamingConvId && renameInputRef.current) {
       renameInputRef.current.focus()


### PR DESCRIPTION
The conversation list clears its active rename/delete targets after access changes in a post-render effect, producing a `react-hooks/set-state-in-effect` diagnostic. Synchronize those targets locally when their corresponding permission is lost.

Only the two action-target resets in `ConversationList` change (two additions, four deletions). Permission rules, APIs, message/history behavior, layout and submission logic are unchanged.

Validation: `make check` passes; local Docker remains disabled, so the Postgres migration smoke check is skipped. The changed file passes ESLint; full Web ESLint decreases from 26 to 25 errors with two existing warnings. Browser checks cover permission loss/restoration, retained member rename access, autofocus/selection, validation, Escape cancellation, pending controls, failed submissions and successful retries. Membership and conversations use controlled responses; rename/delete requests are intercepted and no real data is changed.

Independent blind review of the complete diff, permission derivation and rename/delete callers found no actionable issues. The reviewer independently passed targeted ESLint and diff-format checks.
