### PR TITLE
fix(web): synchronize capability pagination without effect

### DIFF
--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -127,10 +127,11 @@ export function CapabilitiesPage() {
   const [directoryFilters, setDirectoryFilters] = useState<DirectoryFilterState>({ category: "", verifiedOnly: false, sort: "featured" })
   const [page, setPage] = useState(1)
   const debouncedQuery = useDebouncedValue(query, 250)
-  // Reset to page 1 whenever the user changes filters.
-  useEffect(() => {
+  const [pageFilters, setPageFilters] = useState({ query: debouncedQuery, type: typeFilter })
+  if (pageFilters.query !== debouncedQuery || pageFilters.type !== typeFilter) {
+    setPageFilters({ query: debouncedQuery, type: typeFilter })
     setPage(1)
-  }, [debouncedQuery, typeFilter])
+  }
   const capsQ = useCapabilitiesQuery(wid, debouncedQuery, typeFilter, page, PAGE_SIZE)
   const agentsQ = useAgents(wid)
   const workspacesQ = useMyWorkspaces()


### PR DESCRIPTION
The capability list resets pagination in a post-render effect when its debounced search or type filter changes, producing a `react-hooks/set-state-in-effect` diagnostic. Track the filters associated with the current page and reset when they change.

Only pagination/filter synchronization in `CapabilitiesPage` changes (four additions, three deletions). Query policy, debounce timing, APIs, row data, permissions, import/install/edit flows and layout are unchanged.

Validation: `make check` passes; local Docker remains disabled, so the Postgres migration smoke check is skipped. Full Web ESLint decreases from 25 to 24 errors with two existing warnings; the pagination diagnostic is gone, while the separate edit-dialog diagnostic in the same file remains. Six browser groups cover ordinary paging, canceled input before debounce, settled/cleared search, type changes and revisits, repeated filters, tab switching and empty-filter reset. All capability data is synthetic, and all API writes are blocked.

Independent blind review of the complete diff found no actionable issues. The reviewer received requirements, acceptance criteria and scope only, and independently ran web typecheck and diff checks.
