### PR TITLE
fix(web): keep ledger row actions clear of content

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -869,13 +869,17 @@ component; page-level empty states retain the default size.
 Structured `Ledger` columns own both header and cell alignment: numbers align
 right; text, identifiers, and dates align left. Keep widths and alignment in
 the shared column model, not separate page-specific header rules. Direct cell
-components must forward `className` to their grid item. Fixed icon/action
+components must forward `className` to their grid item. Fixed icon
 tracks, legacy string templates, and rows spanning multiple columns retain
 their existing layout.
 
 When a list needs a compact presentation beside a detail rail, use container
 queries against the list width. Keep the same data and row actions, with
 explicit field labels when column headings are hidden.
+Declare row actions with `col.actions(count)` so the shared column model reserves
+space for the maximum visible button count. Hover and keyboard focus reveal the
+controls within that space; they must not cover content or shift column widths.
+Headers and rows retain the grid's minimum width when the list viewport is narrower.
 For wrapping row titles, center status icons inside a one-line-height wrapper
 (`h-lh items-center`), aligned to the first line rather than the whole text block.
 The shared Ledger preserves the activated row's viewport position when its

--- a/apps/web/src/components/ui/action-button.tsx
+++ b/apps/web/src/components/ui/action-button.tsx
@@ -76,9 +76,8 @@ export function ActionIconButton({
 
 /**
  * Row action cluster. Inside a `LedgerRow` (a `group`) it floats over the
- * row's right end, invisible until the row is hovered or focused, so the
- * last content column of every ledger ends on the same edge and rows read
- * as content, not as toolbars; pass `always` to keep it visible.
+ * reserved action column, invisible until the row is hovered or focused.
+ * Pass `always` to keep it visible.
  */
 export function RowActions({
   children,

--- a/apps/web/src/components/ui/ledger.tsx
+++ b/apps/web/src/components/ui/ledger.tsx
@@ -70,9 +70,8 @@ function trackFor(c: LedgerColumn): string {
     case "tile":
       return "18px"
     case "actions":
-      // No track: RowActions overlays the row's right end on hover, so
-      // every ledger's last content column ends at the same edge.
-      return "0px"
+      // 28px buttons, 2px gaps, and 2px padding on each side.
+      return `${c.count * 30 + 2}px`
     case "fixed":
       return `${c.width}px`
     default: {
@@ -171,10 +170,8 @@ function alignCells(children: React.ReactNode, columns?: LedgerColumn[]) {
   })
 }
 
-/* Rows and the header share one gutter: 24px each side, the topbar's
-   padding, so the first and last columns of every ledger sit on the same
-   two edges page after page. A trailing (zero-width) actions track still
-   carries the 10px column gap, which the right padding absorbs. */
+/* The trailing action track includes its own padding and column gap;
+   keep its floating controls clear of the last content column. */
 function gutterClass(trailingActions: boolean) {
   return trailingActions ? "pl-6 pr-3.5" : "px-6"
 }
@@ -186,7 +183,7 @@ export function LedgerHeader({ children, className }: { children: React.ReactNod
       aria-hidden="true"
       style={{ gridTemplateColumns: template }}
       className={cn(
-        "sticky top-0 z-[1] grid h-7 items-center gap-x-2.5 border-b border-line bg-surface text-xs text-fg-muted [&>*]:min-w-0 [&>*]:truncate [&>*]:whitespace-nowrap",
+        "sticky top-0 z-[1] grid h-7 min-w-min items-center gap-x-2.5 border-b border-line bg-surface text-xs text-fg-muted [&>*]:min-w-0 [&>*]:truncate [&>*]:whitespace-nowrap",
         gutterClass(trailingActions),
         className,
       )}
@@ -303,7 +300,7 @@ export const LedgerRow = React.forwardRef<
       tabIndex={0}
       style={{ gridTemplateColumns: template }}
       className={cn(
-        "group relative grid h-9 cursor-default items-center gap-x-2.5 border-b border-line text-sm text-fg outline-none transition-colors duration-150 ease-settle hover:app-hover focus-visible:app-hover [&>*]:min-w-0 [&>*]:self-center",
+        "group relative grid h-9 min-w-min cursor-default items-center gap-x-2.5 border-b border-line text-sm text-fg outline-none transition-colors duration-150 ease-settle hover:app-hover focus-visible:app-hover [&>*]:min-w-0 [&>*]:self-center",
         gutterClass(trailingActions),
         selected && "app-selected before:absolute before:bottom-0 before:left-0 before:top-0 before:w-0.5 before:bg-accent before:content-['']",
         className,

--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -63,8 +63,8 @@ const FOLD_KEY = "parsar:conv:sidebarFolded"
 
 /** Reading measure of the thread column; the components below read it. */
 
-/** title · conversation id · age (actions replace the age on hover) */
-const LIST_COLUMNS = [col.title(120, 2), col.id(64, 0.3), col.age(56, 0.3), col.actions(3)]
+/** Conversation summary · actions in the fixed-width sidebar. */
+const LIST_COLUMNS = [col.title(0), col.actions(3)]
 
 import { sandboxSendGuard } from "../../lib/sandbox-send-guard"
 
@@ -517,10 +517,10 @@ function ConversationList(p: ListProps) {
                     if (!isRenaming) p.onPickConversation(c.id)
                   }}
                   onKeyDown={onKeyDown}
-                  className={cn(isRenaming && "h-auto min-h-9 py-1")}
+                  className={cn("h-auto py-2", isRenaming && "min-h-9 py-1")}
                 >
                   {isRenaming ? (
-                    <div className="col-span-4 flex flex-col gap-1" onClick={(e) => e.stopPropagation()}>
+                    <div className="col-span-full flex flex-col gap-1" onClick={(e) => e.stopPropagation()}>
                       <div className="flex items-center gap-1">
                         <Input
                           ref={renameInputRef}
@@ -565,17 +565,21 @@ function ConversationList(p: ListProps) {
                     </div>
                   ) : (
                     <>
-                      <span className="truncate font-medium" title={c.title || undefined}>
-                        {c.title || t("conversations.detail.unnamed")}
-                      </span>
-                      <LedgerId>{tailId(c.id)}</LedgerId>
-                      <span className="truncate text-right text-xs text-fg-muted">
-                        {fmtAgo(c.last_message_at ?? c.updated_at)}
-                      </span>
+                      <div className="min-w-0">
+                        <div className="flex h-7 min-w-0 items-center">
+                          <span className="truncate font-medium" title={c.title || undefined}>
+                            {c.title || t("conversations.detail.unnamed")}
+                          </span>
+                        </div>
+                        <div className="flex min-w-0 items-center gap-2 text-xs text-fg-muted">
+                          <LedgerId>{tailId(c.id)}</LedgerId>
+                          <span className="truncate">{fmtAgo(c.last_message_at ?? c.updated_at)}</span>
+                        </div>
+                      </div>
                       {/* Copying a link needs no write access — a viewer can
                           share what they can already read. Rename and delete
                           keep their own guards (main #283). */}
-                      <RowActions>
+                      <RowActions className="group-[.grid]:top-2 group-[.grid]:translate-y-0">
                         <ActionIconButton
                           icon={Link2}
                           label={copiedId === c.id ? t("conversations.sidebar.copied") : t("conversations.sidebar.copyLinkAria")}

--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -64,7 +64,7 @@ const FOLD_KEY = "parsar:conv:sidebarFolded"
 /** Reading measure of the thread column; the components below read it. */
 
 /** title · conversation id · age (actions replace the age on hover) */
-const LIST_COLUMNS = [col.title(120, 2), col.id(64, 0.3), col.age(56, 0.3), col.actions(2)]
+const LIST_COLUMNS = [col.title(120, 2), col.id(64, 0.3), col.age(56, 0.3), col.actions(3)]
 
 import { sandboxSendGuard } from "../../lib/sandbox-send-guard"
 

--- a/apps/web/src/pages/admin/MembersPage.tsx
+++ b/apps/web/src/pages/admin/MembersPage.tsx
@@ -86,7 +86,7 @@ import { PendingInvitationsList } from "./PendingInvitationsList"
 const ROLES: MemberRole[] = ["owner", "admin", "member", "viewer"]
 
 /** user · email / detail · role · age · actions */
-const LEDGER_COLUMNS = [col.title(), col.id(200, 1), col.meta(104), col.age(80), col.actions(2)]
+const LEDGER_COLUMNS = [col.title(), col.id(200, 1), col.meta(104), col.age(80), col.actions(3)]
 
 /* ------------------------------------------------------------------ */
 /*  Page                                                               */


### PR DESCRIPTION
Hovering a list row can cover its last metadata column with action buttons, leaving partial words visible. Reserve space for the declared action count in the shared Ledger column model, and keep headers and rows as wide as their grid minimum so actions do not cover overflowing content.

The fixed 300px conversation sidebar now shows title and actions above the short ID and time, keeping all fields inside the sidebar. Pending invitations declare their actual maximum of three actions. Button visibility, permissions, handlers, compact Agent/capability positioning and business APIs are preserved. Other wide tables retain horizontal scrolling.

Scope: five files, 30 additions and 26 deletions, including the contributor contract. No API or persistence changes.

Validation: `make check` and scoped component ESLint pass. Local Docker remains disabled, so the Postgres migration smoke check is skipped. Browser checks cover six list types at twenty viewport combinations, hover and keyboard action clearance, header alignment, stable columns, and no horizontal scroll in the conversation sidebar. Separate checks cover dark mode, compact capability rows beside the detail rail, edit dialog access, Inbox icon alignment/scroll anchoring, and conversation rename/delete permissions, validation and failure recovery. Mutations are blocked or fulfilled with synthetic responses; no real data is changed.

A fresh independent blind review of the final full diff found no in-scope actionable issues. Reviewer coverage is static inspection and diff checks; browser verification above was completed by the developer.
