### PR TITLE
fix(web): preserve keyboard actions inside list rows

### DIFF
--- a/apps/web/src/pages/admin/AuditPage.tsx
+++ b/apps/web/src/pages/admin/AuditPage.tsx
@@ -349,6 +349,7 @@ function AuditRow({ record, open, onToggle }: { record: ReadableAuditRecord; ope
   const payloadLabel = t("audit.detail.payload")
 
   const onKeyDown = (e: KeyboardEvent<HTMLLIElement>) => {
+    if (e.target !== e.currentTarget) return
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault()
       onToggle()

--- a/apps/web/src/pages/admin/ConversationsPage.tsx
+++ b/apps/web/src/pages/admin/ConversationsPage.tsx
@@ -502,7 +502,7 @@ function ConversationList(p: ListProps) {
               const isActive = c.id === p.selectedConversationId
               const isRenaming = renamingConvId === c.id
               const onKeyDown = (e: KeyboardEvent<HTMLLIElement>) => {
-                if (isRenaming) return
+                if (isRenaming || e.target !== e.currentTarget) return
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault()
                   p.onPickConversation(c.id)


### PR DESCRIPTION
Pressing Enter or Space on a conversation row action opens the conversation instead of activating the button. Audit row actions likewise toggle the row instead of following their links. Limit each row keyboard handler to events originating on the row, matching the existing Agent and capability list behavior.

Scope: two local event guards. No changes to permissions, API calls, persistence, styling, or mouse behavior. Rows without interactive children remain unchanged.

Validation: `make check` and `git diff --check` pass. Local Docker remains disabled, so the Postgres migration smoke check is skipped. Browser verification covers Enter/Space on conversation copy, rename, delete and row activation; audit run/conversation links, payload toggle and row activation; and rename Enter-to-save/Escape-to-cancel. Two renames use intercepted synthetic responses; no real writes occur. Existing Agent, capability and skills rows were checked for the same event boundary.

Developer self-review: the complete two-file diff only prevents descendant key events from triggering parent row actions. This low-impact correction reuses the existing pattern; no independent subagent review was needed.
