### PR TITLE
fix(web): initialize credential kind form before effects

### DIFF
--- a/apps/web/src/pages/admin/capabilities/NewCredentialKindInlineDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/NewCredentialKindInlineDialog.tsx
@@ -46,16 +46,23 @@ export function NewCredentialKindInlineDialog({
   const { t } = useTranslation("admin")
   const mut = useCreateCredentialKindMutation(workspaceID)
 
-  const [code, setCode] = useState("")
+  const [code, setCode] = useState(initialCode?.toLowerCase() ?? "")
   const [displayName, setDisplayName] = useState("")
   const [description, setDescription] = useState("")
+  const [previousOpen, setPreviousOpen] = useState(open)
 
   // Seed only on the open transition — subsequent edits stay user-driven.
+  if (open !== previousOpen) {
+    setPreviousOpen(open)
+    if (open) {
+      setCode(initialCode?.toLowerCase() ?? "")
+      setDisplayName("")
+      setDescription("")
+    }
+  }
+
   useEffect(() => {
     if (!open) return
-    setCode(initialCode?.toLowerCase() ?? "")
-    setDisplayName("")
-    setDescription("")
     mut.reset()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])


### PR DESCRIPTION
The inline credential-kind dialog resets three local form fields synchronously in an effect, failing the full React state lint. Initialize the code from its seed and reset local fields only when the dialog opens, using the existing guarded render-time state pattern. Keep mutation reset in its effect.

Scope: one file, 11 additions and 4 deletions. Preserve create requests, validation, error recovery, permissions, nested dialog behavior, and the parent MCP import. No dependency or API changes.

Validation: `make check`, file ESLint and `git diff --check` pass. The full ESLint baseline drops from 24 errors to 23, with 2 existing warnings. Local Docker remains disabled; the Postgres migration smoke check is skipped. Browser checks cover search-code prefill, cancel/reopen, validation, draft preservation during refresh/failure, clearing an old mutation error, and successful retry selecting the new kind without losing the MCP configuration. All writes use intercepted synthetic responses.

Developer self-review confirmed the open-transition condition preserves edits while open and resets fields only for a new opening. Mutation lifecycle and request handlers are unchanged; this local state correction did not require an independent subagent review.
