### PR TITLE
fix(web): memoize inherited knowledge version spec

### DIFF
--- a/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
+++ b/apps/web/src/pages/admin/capabilities/AddCapabilityVersionDialog.tsx
@@ -79,9 +79,9 @@ export function AddCapabilityVersionDialog({
   const [draftSpec, setSpec] = useState<CanonicalSpec | null>(null)
   // Resolve the initial knowledge draft when the version arrives. Once edited,
   // background version refreshes must not replace the user's document changes.
-  const spec = kind === "knowledge" && !draftSpec && latestVersion
+  const spec = useMemo(() => kind === "knowledge" && !draftSpec && latestVersion
     ? { schema_version: 1, kind: "knowledge" as const, knowledge: latestVersion.canonical_spec?.knowledge as CanonicalSpec["knowledge"] }
-    : draftSpec
+    : draftSpec, [kind, draftSpec, latestVersion])
   const waitingForKnowledge = kind === "knowledge" && !!capability.latest_version_id && !latestVersion
   const [inlineSecrets, setInlineSecrets] = useState<ImportInlineSecretInput[]>([])
   const [rawText, setRawText] = useState("")


### PR DESCRIPTION
The add-version dialog recreates its inherited knowledge spec on unrelated renders, producing an exhaustive-deps warning for the inherited-credential memo. Memoize that existing expression using its three inputs: capability kind, local draft and latest version.

Scope: two line replacements in one file. The fallback expression, draft precedence, asynchronous version input, credential checks and submit payload are unchanged. No API or UI changes.

Validation: `make check`, file ESLint and `git diff --check` pass. Full ESLint remains at 23 existing errors and drops from 2 warnings to 1. Local Docker is disabled, so the Postgres migration smoke check is skipped. Developer self-review confirmed all expression inputs are dependencies and the expression itself is unchanged; no additional test or independent review was needed for this local memoization correction.
