### PR TITLE
fix(web): synchronize compatible agent model selection

### DIFF
--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -439,9 +439,7 @@ export function CreateAgentDialog({
   // If the user had hand-picked a model and then switched to an engine that
   // can't drive it, clear the pick so it falls back to firstModelID (a
   // compatible default) instead of submitting an incompatible model_id.
-  useEffect(() => {
-    if (modelID && incompatibleModelIDs.has(modelID)) setModelID("")
-  }, [modelID, incompatibleModelIDs])
+  if (modelID && incompatibleModelIDs.has(modelID)) setModelID("")
   const allCapabilitiesPool = useMemo<Capability[]>(() => {
     const data = allCapabilitiesQ.data
     const own = data?.capabilities ?? []


### PR DESCRIPTION
The Agent form synchronizes an incompatible hand-picked model in an effect, failing the React state lint. Apply the same local reset during render when that selection is incompatible, so the next committed form state follows the existing selection rules.

Scope: one local condition, replacing four lines with one. Compatibility rules, create/edit/clone initialization, default-model fallback, permissions and request payloads are unchanged. No unrelated form refactor.

Validation: `make check` and `git diff --check` pass. Full ESLint drops from 23 errors to 22, retaining 1 existing warning. Local Docker remains disabled; the Postgres migration smoke check is skipped. Browser checks cover Claude Code, Codex, Pi and OpenCode switches, compatible manual selections, invalid-selection clearing, automatic defaults, create/edit/clone initialization and preservation of unrelated drafts. No write requests occur.

A fresh independent blind review of the complete diff found no blocking new issues. The reviewer checked initialization, engine switching, defaults and submission context, and independently verified the scoped lint reduction. Browser verification above was completed by the developer.
