### PR TITLE
fix(web): synchronize model picker highlight before commit

### DIFF
--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -580,14 +580,13 @@ export function CreateAgentDialog({
     )
   }
 
-  useEffect(() => {
-    if (!modelDropdownOpen) return
+  if (modelDropdownOpen) {
     const firstSelectable = filteredModels.find((m) => !incompatibleModelIDs.has(m.id))
     const nextHighlighted = filteredModels.some((m) => m.id === highlightedModelID)
       ? highlightedModelID
       : (filteredModels.find((m) => m.id === selectedModelID)?.id ?? firstSelectable?.id ?? null)
     if (nextHighlighted !== highlightedModelID) setHighlightedModelID(nextHighlighted)
-  }, [filteredModels, highlightedModelID, incompatibleModelIDs, modelDropdownOpen, selectedModelID])
+  }
 
   useEffect(() => {
     if (!modelDropdownOpen) return


### PR DESCRIPTION
The Agent model picker updates its highlighted option in an effect, failing the React state lint and requiring an extra committed render when search results change. Synchronize that local highlight before commit using the existing calculation and equality guard.

Scope: only highlight synchronization in CreateAgentDialog (2 additions, 3 deletions). Model compatibility, selection rules, keyboard handlers, form initialization, layout and API payloads remain unchanged.

Validation: `make check` and `git diff --check` pass. Full ESLint drops from 22 errors to 21, retaining 1 existing warning. Local Docker stays disabled, so the Postgres migration smoke test is skipped. Browser checks cover arrow navigation, filtering, empty and disabled-only results, Enter/Escape, four engine switches, and create/edit/clone draft preservation. API writes were blocked and none occurred.

Self-review: the unchanged calculation converges after one guarded local rerender. This is a small follow-up to the independently reviewed local state synchronization in #489; no new shared behavior or abstraction is introduced.
