### PR TITLE
fix(web): seed new model fields before form commit

### DIFF
--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -322,13 +322,10 @@ export function CreateModelDialog({
   const [baseConfig, setBaseConfig] = useState<Record<string, unknown>>({})
   const detectEndpointsMut = useDetectModelEndpoints(workspaceID)
 
-  const wasOpenRef = useRef(false)
-  useEffect(() => {
-    if (open && !wasOpenRef.current) {
-      // Seed every field. If `initialValues` was provided (duplicate
-      // flow), pull from it; otherwise reset to the same empty defaults
-      // we shipped before. Both branches bump headersSeed in the same
-      // effect tick so HeadersEditor reseeds atomically with the parent.
+  const [previousOpen, setPreviousOpen] = useState(false)
+  if (previousOpen !== open) {
+    setPreviousOpen(open)
+    if (open) {
       const seed = initialValues
       if (seed) {
         const providerCfg = providerTypes.find((p) => p.key === seed.provider_type)
@@ -378,8 +375,7 @@ export function CreateModelDialog({
       }
       setHeadersSeed((n) => n + 1)
     }
-    wasOpenRef.current = open
-  }, [open, initialValues, providerTypes, defaultProviderType])
+  }
 
   function handleProviderTypeChange(next: string) {
     const cfg = providerTypes.find((p) => p.key === next)


### PR DESCRIPTION
The new-model form seeds its local fields in an effect on opening, failing the React state lint. Keep the same open-only initialization and seed values, but synchronize them before committing the form.

Scope: CreateModelDialog initialization only (5 additions, 9 deletions). Provider selection, credential policy, headers and extra configuration, request payloads, and EditModelDialog remain unchanged.

Validation: `make check` and `git diff --check` pass. Full ESLint decreases from 21 to 20 errors, with 1 existing warning. Docker stays disabled, so the Postgres migration smoke test is skipped. The same browser checks pass on baseline and candidate: create/cancel/reopen, draft preservation during catalog refresh, shared and personal model duplication, headers and extra configuration, failed submission and retry. Every write request was fulfilled synthetically; no model or credential was created in the test workspace.

A fresh independent blind review found no blocking new issues. The reviewer inspected the entire diff and ran the web typecheck, diff whitespace check and scoped lint comparison. The remaining EditModelDialog lint error belongs to the baseline. Browser verification and the full `make check` above were completed by the developer.
