### PR TITLE
fix(web): show model save failures in error dialogs

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -127,6 +127,7 @@
     },
     "createModel": {
       "title": "Add shared model",
+      "errorTitle": "Couldn't create model",
       "fields": {
         "name": "Display name",
         "namePlaceholder": "e.g. Claude Opus 4.5",
@@ -162,6 +163,7 @@
     },
     "editModel": {
       "title": "Edit \"{{name}}\"",
+      "errorTitle": "Couldn't save model",
       "submit": "Save",
       "locked": {
         "providerType": "Provider type",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -127,6 +127,7 @@
     },
     "createModel": {
       "title": "新建共享模型",
+      "errorTitle": "创建模型失败",
       "fields": {
         "name": "模型名称",
         "namePlaceholder": "例：Claude Opus 4.5",
@@ -162,6 +163,7 @@
     },
     "editModel": {
       "title": "编辑「{{name}}」",
+      "errorTitle": "保存模型失败",
       "submit": "保存修改",
       "locked": {
         "providerType": "供应商类型",

--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -11,7 +11,6 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { Plus, X } from "lucide-react"
-import { ApiError } from "../../lib/api-client"
 import type { Model, ModelCredentialMode, Secret } from "../../lib/api-types"
 import {
   useDetectModelEndpoints,
@@ -36,6 +35,7 @@ import { CredentialKindCombobox } from "./capabilities/CredentialKindCombobox"
 import { ModelKeyCombobox } from "./ModelKeyCombobox"
 import { ProviderTypeCombobox } from "./ProviderTypeCombobox"
 import { ModelEndpointBaseURLsEditor } from "./ModelEndpointBaseURLsEditor"
+import { ModelSaveErrorDialog } from "./ModelSaveErrorDialog"
 import {
   getProviderCatalogSnapshot,
   loadProviderCatalog,
@@ -56,15 +56,6 @@ import {
   shouldReplaceModelName,
   shouldReplaceProviderModelKey,
 } from "../../lib/model-provider-options"
-
-function extractErrorMessage(err: unknown): string | null {
-  if (!err) return null
-  if (err instanceof ApiError) {
-    return err.envelope.message || err.message
-  }
-  if (err instanceof Error) return err.message
-  return String(err)
-}
 
 /* --- HeadersEditor ------------------------------------------------------
  *
@@ -286,6 +277,7 @@ export function CreateModelDialog({
 }: CreateModelDialogProps) {
   const { t } = useTranslation("admin")
   const { t: tc } = useTranslation("common")
+  const formRef = useRef<HTMLFormElement>(null)
 
   const [providerCatalog, setProviderCatalog] = useState(getProviderCatalogSnapshot)
   useEffect(() => {
@@ -404,7 +396,6 @@ export function CreateModelDialog({
   const showHeadersEditor = true
   const showAuthSchemeSelector = !!cfg?.authSchemeSelector
   const providerModels = cfg?.models ?? []
-  const errMsg = extractErrorMessage(error)
 
   // Resolve each provider option's display label once (literal brand name, or
   // translated key for the generic gateways) for the searchable picker.
@@ -551,7 +542,7 @@ export function CreateModelDialog({
         <DialogHeader>
           <DialogTitle>{t("models.createModel.title")}</DialogTitle>
         </DialogHeader>
-        <form className="flex flex-col" onSubmit={handleSubmit}>
+        <form ref={formRef} className="flex flex-col" onSubmit={handleSubmit}>
           <div className="grid gap-3">
             <TextField
               id="model-name"
@@ -694,8 +685,6 @@ export function CreateModelDialog({
             )}
           </RailSection>
 
-          {errMsg && <ErrorState title={errMsg} className="pb-0" />}
-
           <DialogFooter className="mt-4">
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
               {tc("actions.cancel")}
@@ -705,6 +694,7 @@ export function CreateModelDialog({
             </Button>
           </DialogFooter>
         </form>
+        <ModelSaveErrorDialog error={error} title={t("models.createModel.errorTitle")} formRef={formRef} />
       </DialogContent>
     </Dialog>
   )
@@ -743,6 +733,7 @@ export function EditModelDialog({
 }: EditModelDialogProps) {
   const { t } = useTranslation("admin")
   const { t: tc } = useTranslation("common")
+  const formRef = useRef<HTMLFormElement>(null)
 
   const providerTypeMeta = useMemo(() => {
     if (!model) return undefined
@@ -772,7 +763,6 @@ export function EditModelDialog({
   }, [open, model, providerTypeMeta])
 
   if (!model) return null
-  const errMsg = extractErrorMessage(error)
   const activeSecrets = secrets.filter((s) => s.status === "active" && s.kind === "model_provider")
   const isInline = model.credential_mode === "inline_secret"
   const isCredentialRef = model.credential_mode === "credential_ref"
@@ -839,7 +829,7 @@ export function EditModelDialog({
         <DialogHeader>
           <DialogTitle>{t("models.editModel.title", { name: model.name })}</DialogTitle>
         </DialogHeader>
-        <form className="flex flex-col" onSubmit={handleSubmit}>
+        <form ref={formRef} className="flex flex-col" onSubmit={handleSubmit}>
           {/* --- Locked identity --- */}
           <PropertyList className="mb-3">
             <Property label={t("models.editModel.locked.providerType")}>{model.provider_type}</Property>
@@ -942,8 +932,6 @@ export function EditModelDialog({
             </RailSection>
           )}
 
-          {errMsg && <ErrorState title={errMsg} className="pb-0" />}
-
           <DialogFooter className="mt-4">
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={pending}>
               {tc("actions.cancel")}
@@ -953,6 +941,7 @@ export function EditModelDialog({
             </Button>
           </DialogFooter>
         </form>
+        <ModelSaveErrorDialog error={error} title={t("models.editModel.errorTitle")} formRef={formRef} />
       </DialogContent>
     </Dialog>
   )

--- a/apps/web/src/pages/admin/ModelSaveErrorDialog.tsx
+++ b/apps/web/src/pages/admin/ModelSaveErrorDialog.tsx
@@ -1,0 +1,28 @@
+import { useState, type RefObject } from "react"
+import { ErrorDialog } from "../../components/ui/error-dialog"
+import { ApiError } from "../../lib/api-client"
+
+function extractErrorMessage(err: unknown): string | null {
+  if (!err) return null
+  if (err instanceof ApiError) return err.envelope.message || err.message
+  if (err instanceof Error) return err.message
+  return String(err)
+}
+
+export function ModelSaveErrorDialog({ error, title, formRef }: {
+  error: unknown
+  title: string
+  formRef: RefObject<HTMLFormElement | null>
+}) {
+  const [dismissedError, setDismissedError] = useState<unknown>(null)
+  const message = extractErrorMessage(error)
+  if (!message || error === dismissedError) return null
+
+  return <ErrorDialog
+    title={title}
+    message={message}
+    onClose={() => setDismissedError(error)}
+    onRestoreFocus={() => formRef.current?.querySelector<HTMLButtonElement>('button[type="submit"]')?.focus()}
+    focusScopeRef={formRef}
+  />
+}


### PR DESCRIPTION
Model creation and editing currently leave submission failures as a bare line at the bottom of the form. Show them in the existing ErrorDialog with localized create/save failure titles, retaining the form and returning focus to its submit action when dismissed.

Scope: model create/duplicate and edit feedback only. A small model-specific presenter reuses ErrorDialog and the existing error-message extraction. Requests, credentials, field validation and inaccessible-secret guidance are unchanged. No shared dialog or backend changes.

Validation: `make check` and `git diff --check` pass; full ESLint remains at the existing 20 errors and 1 warning, with no new presenter errors. Local Docker remains disabled, so the Postgres migration smoke check is skipped. Browser checks cover both forms across English/Chinese, light/dark and 768/1080/1440px widths: repeated failure, Close/Escape/outside dismissal, preserved fields and focus, and successful retry. The create/duplicate initialization regression also passes. All write responses were synthetic; no workspace models or credentials were modified.

A fresh independent blind review found no actionable regressions in the complete four-file diff. The reviewer checked the stated interaction and localization scope, ran TypeScript and the diff whitespace check, and confirmed the remaining scoped lint error belongs to the baseline. Browser checks and the full `make check` above were completed by the developer.
