### PR TITLE
fix(web): seed edit model fields before form commit

### DIFF
--- a/apps/web/src/pages/admin/ModelCrudDialogs.tsx
+++ b/apps/web/src/pages/admin/ModelCrudDialogs.tsx
@@ -750,8 +750,11 @@ export function EditModelDialog({
   const [secretID, setSecretID] = useState<string>("")
   const [credentialKindCode, setCredentialKindCode] = useState<string>("")
 
-  useEffect(() => {
-    if (!open || !model) return
+  const [seededModel, setSeededModel] = useState<Model | null>(null)
+  if (!open || !model) {
+    if (seededModel) setSeededModel(null)
+  } else if (model !== seededModel) {
+    setSeededModel(model)
     setName(model.name)
     setModelKey(model.model_key)
     setBaseURL(model.base_url)
@@ -760,7 +763,7 @@ export function EditModelDialog({
     setNewAPIKey("")
     setSecretID(model.secret_id ?? "")
     setCredentialKindCode(model.credential_kind_code ?? "")
-  }, [open, model, providerTypeMeta])
+  }
 
   if (!model) return null
   const activeSecrets = secrets.filter((s) => s.status === "active" && s.kind === "model_provider")


### PR DESCRIPTION
The edit-model form initializes its fields in an effect, failing the React state lint. Synchronize the same fields before commit when the dialog opens or its model changes, clearing the seed marker when closed or without a model.

Scope: one local initialization guard (6 additions, 3 deletions). All seed values, provider metadata, headers, endpoint mapping, credential references, save requests and error presentation are unchanged. This is a small follow-up to the reviewed model-form initialization work in #491.

Validation: `make check` and `git diff --check` pass. ModelCrudDialogs now passes full ESLint; the app baseline drops from 20 to 19 errors, retaining 1 warning. Local Docker remains disabled, so the Postgres migration smoke test is skipped. The same browser checks pass against baseline and candidate: reopen, switching between shared/personal models and back, fresh-key clearing, headers/endpoints, draft preservation, failure dismissal and retry. All four save requests were intercepted; no models or credentials were modified.

Self-review: the guard converges after one local rerender and tracks the same model identity/open transitions as the old effect. Provider metadata derives only from that model. No shared behavior or new abstraction is introduced.
