### PR TITLE
fix(web): seed capability metadata on editor transitions

### DIFF
--- a/apps/web/src/pages/admin/capabilities/index.tsx
+++ b/apps/web/src/pages/admin/capabilities/index.tsx
@@ -1146,11 +1146,14 @@ function EditCapabilityDialog({ open, capability, pending, error, onOpenChange, 
   const [name, setName] = useState(capability.name)
   const [description, setDescription] = useState(capability.description ?? "")
 
-  useEffect(() => {
-    if (!open) return
+  const [seededCapability, setSeededCapability] = useState<Capability | null>(null)
+  if (!open) {
+    if (seededCapability) setSeededCapability(null)
+  } else if (capability !== seededCapability) {
+    setSeededCapability(capability)
     setName(capability.name)
     setDescription(capability.description ?? "")
-  }, [open, capability])
+  }
 
   const errMsg = error instanceof ApiError ? error.envelope.message : error instanceof Error ? error.message : null
   const trimmedName = name.trim()


### PR DESCRIPTION
Capability metadata fields were synchronously reset from an effect when the editor opened or its capability changed, leaving a React lint error. Seed the same local fields on those transitions before rendering the editor. Cancel/reopen still restores saved metadata, and failed saves retain the draft for retry.

Scope: only the local name/description initializer. Validation, trimming, requests, permissions, imports and version content are unchanged. Self-reviewed as a small application of the existing reviewed editor initialization pattern (6 additions, 3 deletions).

Validation: `make check` and `git diff --check` passed. Baseline and candidate browser checks passed for reopen, A/B/A switching, missing descriptions, required/length validation and failure/retry; all four PATCH requests were intercepted fixtures. Full ESLint drops from 19 to 18 existing errors, with one existing warning; this file has none. Local Docker remained disabled, so the migration smoke test was skipped by the standard check.
