### PR TITLE
fix(web): initialize Agent forms on open transitions

### DIFF
--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -478,15 +478,10 @@ export function CreateAgentDialog({
   const fieldID = useId()
   const modelListboxID = useId()
   const modelSecretID = useId()
-  const wasOpenRef = useRef(false)
+  const [previousOpen, setPreviousOpen] = useState(false)
+  if (open !== previousOpen) setPreviousOpen(open)
 
-  useEffect(() => {
-    if (!open) {
-      wasOpenRef.current = false
-      return
-    }
-    if (wasOpenRef.current) return
-    wasOpenRef.current = true
+  if (open && !previousOpen) {
     const params = new URLSearchParams(window.location.search.replace(/^\?+/, "?"))
     if (mode === "create") {
       // Clone path: an `agent` prop in create mode means prefill from that
@@ -557,7 +552,7 @@ export function CreateAgentDialog({
     setPairDialogOpen(false)
     setStep(1)
     setCapabilityTypeFilter("all")
-  }, [open, mode, agent, agent?.id, defaultAgentDescription, defaultAgentName, defaultSystemPrompt, firstModelID, initialDraft])
+  }
 
   const clone = useAgentCloneCapabilities(open, cloneSourceID,
     existingBindingsQ.isFetching || existingBindingsQ.isError ? undefined : existingBindingsQ.data?.installed,


### PR DESCRIPTION
Agent forms reset their fields in an effect on first open, leaving a React lint error and an extra initialization commit. Initialize on the same open transition before rendering the form. Existing defaults, clone configuration, URL/return drafts and edit values remain unchanged; subsequent data updates do not overwrite the open draft.

Scope: only the opening initializer (4 additions, 9 deletions). No change to credential selection, clone loading, field validation, permissions, requests or layout.

Validation:
- `make check`, `git diff --check` and independent review passed. The new-agent limit required reusing a reviewer who had not participated in this change; only requirements, acceptance, scope and baseline were provided.
- Baseline and candidate browser checks passed for new/edit/clone/URL drafts, cancellation and reopening, and failed edit/retry. Write responses were controlled fixtures; no actual resource was changed.
- CC/Codex/Pi/OpenCode model selection regression passed. Full ESLint drops from 18 to 17 existing errors, with one existing warning.
- Local Docker stayed disabled; the standard migration smoke check was skipped accordingly.
