### PR TITLE
fix(web): show Agent save failures in an error dialog

### DIFF
--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1577,6 +1577,8 @@
         "systemPrompt": "You are a helpful AI assistant for this team. Be concise and accurate."
       },
       "errors": {
+        "createFailed": "Couldn't create Agent",
+        "saveFailed": "Couldn't save Agent",
         "modelRequired": "Pick a model first.",
         "modelUnavailable": "The current model is unavailable. Select an active model.",
         "deviceRequired": "Select a paired machine.",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1577,6 +1577,8 @@
         "systemPrompt": "你是这个团队的 AI 助手。请保持简洁、准确，并优先提供可执行的建议。"
       },
       "errors": {
+        "createFailed": "创建 Agent 失败",
+        "saveFailed": "保存 Agent 失败",
         "modelRequired": "请选择一个模型",
         "modelUnavailable": "当前模型已不可用，请重新选择一个可用模型。",
         "deviceRequired": "请选择一台已接入设备。",

--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -19,6 +19,7 @@ import { Input } from "../../components/ui/input"
 import { Label } from "../../components/ui/label"
 import { Select, SelectOption } from "../../components/ui/select"
 import { AgentInstructionsField } from "./agents/AgentInstructionsField"
+import { AgentSaveErrorDialog } from "./agents/AgentSaveErrorDialog"
 import { AgentVisibilityField } from "./agents/AgentVisibilityField"
 import { AgentCloudPreflight } from "./agents/AgentCloudPreflight"
 import { AgentModelPrerequisite } from "./agents/AgentModelPrerequisite"
@@ -474,6 +475,8 @@ export function CreateAgentDialog({
   const admin = isAdminRole(workspaceRole)
 
   const modelFieldRef = useRef<HTMLDivElement | null>(null)
+  const dialogScopeRef = useRef<HTMLDivElement | null>(null)
+  const submitRef = useRef<HTMLButtonElement | null>(null)
   const modelComboboxRef = useRef<HTMLDivElement | null>(null)
   const fieldID = useId()
   const modelListboxID = useId()
@@ -878,6 +881,7 @@ export function CreateAgentDialog({
       }}
     >
       <DialogContent
+        ref={dialogScopeRef}
         className="flex max-h-[86vh] flex-col overflow-hidden sm:max-w-2xl"
         onEscapeKeyDown={(event) => {
           if (modelDropdownOpenRef.current) {
@@ -1503,12 +1507,6 @@ export function CreateAgentDialog({
             </>
           )}
 
-          {errMsg && (
-            <p className="flex items-start gap-1.5 text-sm text-fg" role="alert">
-              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-failed" strokeWidth={1.5} aria-hidden="true" />
-              <span className="min-w-0 break-words">{errMsg}</span>
-            </p>
-          )}
         </form>
 
         <DialogFooter className="shrink-0">
@@ -1531,6 +1529,7 @@ export function CreateAgentDialog({
             </Button>
           ) : (
             <Button
+              ref={submitRef}
               type="button"
               onClick={() => submit()}
               disabled={!canSubmit}
@@ -1539,6 +1538,13 @@ export function CreateAgentDialog({
             </Button>
           )}
         </DialogFooter>
+        <AgentSaveErrorDialog
+          error={error}
+          message={errMsg}
+          title={t(mode === "edit" ? "agents.form.errors.saveFailed" : "agents.form.errors.createFailed")}
+          submitRef={submitRef}
+          scopeRef={dialogScopeRef}
+        />
         {workspaceID && (
           <PairDaemonDialog
             open={pairDialogOpen}

--- a/apps/web/src/pages/admin/agents/AgentSaveErrorDialog.tsx
+++ b/apps/web/src/pages/admin/agents/AgentSaveErrorDialog.tsx
@@ -1,0 +1,21 @@
+import { useState, type RefObject } from "react"
+import { ErrorDialog } from "../../../components/ui/error-dialog"
+
+export function AgentSaveErrorDialog({ error, message, title, submitRef, scopeRef }: {
+  error: unknown
+  message: string | null
+  title: string
+  submitRef: RefObject<HTMLButtonElement | null>
+  scopeRef: RefObject<HTMLDivElement | null>
+}) {
+  const [dismissedError, setDismissedError] = useState<unknown>(null)
+  if (!message || error === dismissedError) return null
+
+  return <ErrorDialog
+    title={title}
+    message={message}
+    onClose={() => setDismissedError(error)}
+    onRestoreFocus={() => submitRef.current?.focus()}
+    focusScopeRef={scopeRef}
+  />
+}


### PR DESCRIPTION
Failed Agent saves appeared as a bare warning at the bottom of a long form. Managed Agent creation, cloning and editing now use the existing error dialog, with separate create/save titles. Closing it retains the draft and restores focus to the current submit button; repeated failures open it again.

Scope is limited to failure presentation. Existing error extraction, field validation, requests, permissions, credentials, wizard steps and external Agent behavior are unchanged. The local presenter follows the already-reviewed model failure pattern; the shared dialog is unchanged. Self-reviewed as a small UI follow-up.

Validation: `make check` and `git diff --check` passed. Six browser cases cover create/edit/clone in English at 1440px and Chinese dark mode at 768px, each with button/Escape/outside dismissal, focus restoration, preserved drafts, repeated failures and long-message wrapping. All 18 writes used synthetic responses. Agent new/edit/clone/URL draft regression and successful edit retry also passed with intercepted writes. Full ESLint remains at 17 pre-existing errors and one warning; the presenter has none. Local Docker remained disabled, so migration smoke was skipped by the standard check.
