### PR TITLE
fix(web): synchronize Feishu connector drafts on saved config changes

### DIFF
--- a/apps/web/src/components/admin/FeishuConnectorPanel.tsx
+++ b/apps/web/src/components/admin/FeishuConnectorPanel.tsx
@@ -138,11 +138,13 @@ export function FeishuConnectorPanel({
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const [provision, setProvision] = useState<ProvisionState | null>(null)
 
-  useEffect(() => {
+  const [draftSource, setDraftSource] = useState(current)
+  if (current !== draftSource) {
+    setDraftSource(current)
     setDraft(current ?? EMPTY_CONFIG)
     setSecretInputs(emptySecretInputs())
     setErrorMsg(null)
-  }, [current])
+  }
 
   const dirty = !configEqual(draft, current ?? EMPTY_CONFIG) || secretInputsDirty(secretInputs)
   const saving = mut.isPending || createSecretMut.isPending


### PR DESCRIPTION
The Feishu connector editor synchronizes a changed saved configuration in an effect, causing an extra render and a React lint error. Seed the local draft during the same guarded configuration transition instead.

Scope: one component, 4 additions and 2 deletions. Existing configuration values, temporary-secret clearing and error clearing are preserved. No changes to validation, permissions, Secret storage, connector requests, QR authorization, polling or layout.

Validation:
- `make check` and `git diff --check` passed. Self-reviewed as a small local application of the existing draft synchronization pattern.
- Baseline and candidate browser checks cover initial, unchanged, changed and removed saved configuration; discard; failed Secret creation and successful retry. All write requests use controlled responses; the real Feishu bot binding remains untouched.
- Full ESLint drops from 17 to 16 existing errors, with one existing warning. The separate provisioning timer lint error is outside this PR.
- Local Docker stayed disabled; the standard migration smoke check was skipped accordingly.
