### PR TITLE
fix(web): present Feishu setup failures in an error dialog

### DIFF
--- a/apps/web/src/components/admin/FeishuConnectorPanel.tsx
+++ b/apps/web/src/components/admin/FeishuConnectorPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState, type MouseEvent } from "react"
 import { useTranslation } from "react-i18next"
 import QRCode from "qrcode"
 import { ExternalLink, Loader2, QrCode } from "lucide-react"
@@ -16,6 +16,7 @@ import type { CreateSecretRequest } from "../../lib/api-types"
 import { randomHex } from "../../lib/random"
 import { Badge } from "../ui/badge"
 import { Button } from "../ui/button"
+import { ErrorDialog } from "../ui/error-dialog"
 import { Field } from "../ui/label"
 import { Input } from "../ui/input"
 import { PropertyList, Property } from "../ui/property-list"
@@ -137,6 +138,8 @@ export function FeishuConnectorPanel({
   const [secretInputs, setSecretInputs] = useState<SecretInputs>(emptySecretInputs())
   const [errorMsg, setErrorMsg] = useState<string | null>(null)
   const [provision, setProvision] = useState<ProvisionState | null>(null)
+  const panelRef = useRef<HTMLElement>(null)
+  const errorTriggerRef = useRef<HTMLButtonElement | null>(null)
 
   const [draftSource, setDraftSource] = useState(current)
   if (current !== draftSource) {
@@ -227,7 +230,8 @@ export function FeishuConnectorPanel({
     return () => window.clearTimeout(timer)
   }, [agentID, agentName, onToast, pollProvision, pollProvisionPending, provision, t])
 
-  const onSave = async () => {
+  const onSave = async (event: MouseEvent<HTMLButtonElement>) => {
+    errorTriggerRef.current = event.currentTarget
     setErrorMsg(null)
     try {
       const config = await buildConfigWithSecretRefs(draft, secretInputs, async (body) => {
@@ -263,7 +267,8 @@ export function FeishuConnectorPanel({
     setErrorMsg(null)
   }
 
-  const onBeginProvision = () => {
+  const onBeginProvision = (event: MouseEvent<HTMLButtonElement>) => {
+    errorTriggerRef.current = event.currentTarget
     setErrorMsg(null)
     beginProvisionMut.mutate(agentID, {
       onSuccess: async (res) => {
@@ -300,7 +305,7 @@ export function FeishuConnectorPanel({
   const disabled = !canEdit || saving
 
   return (
-    <section className="mt-6 max-w-2xl">
+    <section ref={panelRef} className="mt-6 max-w-2xl">
       <div className="mb-2 flex h-7 items-center justify-between gap-2">
         <h2 className="text-sm font-medium text-fg">{t("agents.feishuConnector.title")}</h2>
       </div>
@@ -466,7 +471,17 @@ export function FeishuConnectorPanel({
         )}
 
         {errorMsg && (
-          <InlineError role="alert" data-testid="feishu-error">{errorMsg}</InlineError>
+          <ErrorDialog
+            title={t("agents.feishuConnector.errors.title")}
+            message={errorMsg}
+            onClose={() => setErrorMsg(null)}
+            onRestoreFocus={() => {
+              const trigger = errorTriggerRef.current
+              if (trigger?.isConnected && !trigger.disabled) trigger.focus()
+              else panelRef.current?.querySelector<HTMLInputElement>("input:not(:disabled)")?.focus()
+            }}
+            focusScopeRef={panelRef}
+          />
         )}
       </div>
 

--- a/apps/web/src/i18n/locales/en-US/admin.json
+++ b/apps/web/src/i18n/locales/en-US/admin.json
@@ -1270,7 +1270,8 @@
       "errors": {
         "appIdInUse": "This App ID is already bound to another active Agent in this instance. Pick a different App ID, or disable the other Agent's Feishu binding first.",
         "incomplete": "When enabled, App ID / App Secret / Verification Token are all required.",
-        "generic": "Save failed"
+        "generic": "Save failed",
+        "title": "Couldn't configure Feishu"
       },
       "actions": {
         "save": "Save",

--- a/apps/web/src/i18n/locales/zh-CN/admin.json
+++ b/apps/web/src/i18n/locales/zh-CN/admin.json
@@ -1270,7 +1270,8 @@
       "errors": {
         "appIdInUse": "这个 App ID 已经被本实例的另一个启用 Agent 占用了. 请换一个 App ID, 或先把那个 Agent 的飞书绑定关掉.",
         "incomplete": "启用时, App ID / App Secret / Verification Token 都必须填.",
-        "generic": "保存失败"
+        "generic": "保存失败",
+        "title": "飞书配置失败"
       },
       "actions": {
         "save": "保存",


### PR DESCRIPTION
Feishu setup failures appear as a bare line near the bottom of a long connector form. Show save and QR-start failures in the existing error dialog, retaining the draft and returning focus safely when it closes. Repeated failures open a new prompt; saved configuration changes preserve the correct bot entry mode.

Scope: localized presentation and focus restoration in the Feishu editor only. No changes to validation, Secret creation, permissions, connector requests, QR polling or shared dialog behavior.

Validation:
- Independent code review passed. The new-agent limit required reusing a reviewer who did not participate in this change; only requirements, acceptance, scope and baseline were supplied.
- `make check` and `git diff --check` passed. Full ESLint remains at 16 existing errors and one warning.
- Browser checks passed for save and QR-start failures in English side rail and Chinese narrow expanded view: button/Escape/outside dismissal, repeated errors, retained drafts and restored focus. All 12 failure requests were intercepted.
- Baseline and candidate configuration lifecycle checks passed, including changed/removed saved config, discarded temporary secrets, failed Secret creation and successful retry. All four writes were intercepted; the real bot binding was untouched.
- Local Docker stayed disabled; the standard migration smoke check was skipped accordingly.
