### PR TITLE
fix(web): reset clone credential drafts on source changes

### DIFF
--- a/apps/web/src/pages/admin/agents/useAgentCloneCredentials.ts
+++ b/apps/web/src/pages/admin/agents/useAgentCloneCredentials.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { useQueries } from "@tanstack/react-query"
 import { KEY_CAPABILITY_VERSIONS, listCapabilityVersions } from "../../../lib/api-capabilities"
 import { noUnreachableRetry } from "../../../lib/api-client"
@@ -19,7 +19,11 @@ export function useAgentCloneCredentials(
   secrets: Secret[],
 ) {
   const [choices, setChoices] = useState<Record<string, Record<string, string>>>({})
-  useEffect(() => setChoices({}), [sourceID])
+  const [choiceSourceID, setChoiceSourceID] = useState(sourceID)
+  if (sourceID !== choiceSourceID) {
+    setChoiceSourceID(sourceID)
+    setChoices({})
+  }
   const selected = sourceID ? capabilities.filter((cap) => selectedIDs.includes(cap.id)) : []
   const hasMarketplace = selected.some((cap) => cap.from_marketplace)
   const marketplace = useMarketplaceList(hasMarketplace ? workspaceID : null)


### PR DESCRIPTION
Clone credential choices reset in an effect when the source changes, leaving a React lint error and an extra reset render. Reset the local choice draft on that same source transition before deriving the displayed credential values.

Scope: one hook, 6 additions and 2 deletions. Same-source manual choices are retained. No changes to capability versions, credential visibility or policy, validation, requests, ordinary creation or UI.

Validation:
- `make check`, `git diff --check` and independent code review passed. The new-agent limit required reusing a reviewer who did not participate in this change; only requirements, acceptance, scope and baseline were supplied.
- All 8 existing clone browser tests passed on baseline and candidate, covering version updates, marketplace metadata, load failure/retry, personal/shared model credentials and ordinary creation after clone cancellation.
- An additional controlled browser scenario verifies manual choices across refetch, previous/next steps, cancellation/reopening and another source. All writes are intercepted fixtures.
- Full ESLint drops from 16 to 15 existing errors, with one warning; this hook has no remaining lint errors.
- Local Docker stayed disabled; the standard migration smoke check was skipped accordingly.
