### PR TITLE
fix(web): initialize clone capability drafts before commit

### DIFF
--- a/apps/web/src/pages/admin/agents/useAgentCloneCapabilities.ts
+++ b/apps/web/src/pages/admin/agents/useAgentCloneCapabilities.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, type Dispatch, type SetStateAction } from "react"
+import { useState, type Dispatch, type SetStateAction } from "react"
 import { cloneableAgentCapabilities } from "../../../lib/agent-clone"
 import type { AgentCapability } from "../../../lib/api-types"
 
@@ -12,12 +12,9 @@ export function useAgentCloneCapabilities(
   setVersionChoices: Dispatch<SetStateAction<Record<string, VersionChoice>>>,
 ) {
   const [snapshot, setSnapshot] = useState<{ sourceID: string; bindings: AgentCapability[] } | null>(null)
-  useEffect(() => {
-    if (!open || !sourceID) {
-      setSnapshot(null)
-      return
-    }
-    if (snapshot?.sourceID === sourceID || !bindings) return
+  if (!open || !sourceID) {
+    if (snapshot !== null) setSnapshot(null)
+  } else if (snapshot?.sourceID !== sourceID && bindings) {
     const selected = cloneableAgentCapabilities(bindings)
     setSelectedIDs(selected.map((binding) => binding.capability_id))
     setVersionChoices(Object.fromEntries(selected.map((binding) => [binding.capability_id, {
@@ -26,7 +23,7 @@ export function useAgentCloneCapabilities(
       pinnedVersion: binding.version ?? binding.capability?.pinned_version,
     }])))
     setSnapshot({ sourceID, bindings: selected })
-  }, [open, sourceID, bindings, snapshot, setSelectedIDs, setVersionChoices])
+  }
   return {
     ready: !sourceID || snapshot?.sourceID === sourceID,
     bindings: snapshot?.sourceID === sourceID ? snapshot.bindings : [],


### PR DESCRIPTION
The clone capability initializer synchronously updates local draft state in an effect, failing the full React lint check. Initialize the source snapshot before commit while retaining per-source selection and pinned/latest versions.

Validation: `make check`, eight existing clone browser tests, and baseline/candidate browser checks for manual capability selection, version changes, same-source refresh, wizard navigation, cancel/reopen, source changes, and submitted bindings. Browser requests used synthetic fixtures. Full ESLint drops from 15 to 14 errors, with the existing warning unchanged.

Scope is one local initialization hook. Independent review found no material issues. A reviewer uninvolved in this change was reused because new review sessions reached the tool limit.

Tracks Feishu CHECK-010.
