### PR TITLE
fix(web): initialize pending shared model credentials before commit

### DIFF
--- a/apps/web/src/pages/admin/CreateAgentDialog.tsx
+++ b/apps/web/src/pages/admin/CreateAgentDialog.tsx
@@ -658,14 +658,13 @@ export function CreateAgentDialog({
   // still be loading; once they land, resolve to the first existing one. Gated
   // on the credential_ref UI so no-credential models stay untouched; with zero
   // secrets it stays pending and the inline new-secret form takes over.
-  useEffect(() => {
-    if (mode !== "create" || cloneSourceID) return
-    if (!requiresModel || selectedModel?.credential_mode !== "credential_ref") return
-    if (modelBindingChoice.source !== "shared") return
-    if ("existing_secret_id" in modelBindingChoice || "new_secret" in modelBindingChoice) return
-    if (modelNewSecretExpanded || sharedSecrets.length === 0) return
+  if (mode === "create" && !cloneSourceID && requiresModel
+    && selectedModel?.credential_mode === "credential_ref"
+    && modelBindingChoice.source === "shared"
+    && !("existing_secret_id" in modelBindingChoice) && !("new_secret" in modelBindingChoice)
+    && !modelNewSecretExpanded && sharedSecrets.length > 0) {
     setModelBindingChoice({ source: "shared", existing_secret_id: sharedSecrets[0].id })
-  }, [mode, cloneSourceID, requiresModel, selectedModel, modelBindingChoice, modelNewSecretExpanded, sharedSecrets])
+  }
   const modelSharedSecrets = cloneSourceID
     ? sharedSecretsForKind(sharedSecrets, selectedModel?.credential_kind_code || "model_api_key")
     : sharedSecrets


### PR DESCRIPTION
A pending shared model credential is synchronously initialized in an effect during Agent creation, which fails the full React lint check. Initialize the local choice before commit using the same eligibility conditions and existing first-secret ordering.

Validation: `make check`, eight existing clone E2E tests, and baseline/candidate browser checks for delayed shared-secret arrival, manual shared and personal choices, draft preservation, cancel/reopen, and submitted references. All browser requests used synthetic fixtures. Full ESLint drops from 14 to 13 errors, with the existing warning unchanged.

Scope is the local default-choice condition in the Agent form; credential filtering, authorization, API and creation payload logic are unchanged. Independent review found no material issues. An uninvolved reviewer was reused because new review sessions reached the tool limit; only requirements, acceptance criteria, scope and baseline were supplied.

Tracks Feishu CHECK-010.
