### PR TITLE
fix(web): clear import feedback when source input is emptied

### DIFF
--- a/apps/web/src/pages/admin/capabilities/ImportMCPForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportMCPForm.tsx
@@ -78,8 +78,6 @@ export function ImportMCPForm({
     if (debounceRef.current) window.clearTimeout(debounceRef.current)
     if (raw.trim() === "") {
       onChange(null)
-      setWarnings([])
-      setErrorMessage(null)
       previewMut.reset()
       return
     }
@@ -156,7 +154,13 @@ export function ImportMCPForm({
           id="import-mcp-source"
           aria-label={t("capabilities.import.tab.mcp", "MCP")}
           value={raw}
-          onChange={(e) => setRaw(e.target.value)}
+          onChange={(e) => {
+            setRaw(e.target.value)
+            if (!e.target.value.trim()) {
+              setWarnings([])
+              setErrorMessage(null)
+            }
+          }}
           rows={20}
           placeholder={
             format === "toml"

--- a/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
+++ b/apps/web/src/pages/admin/capabilities/ImportSkillForm.tsx
@@ -93,8 +93,6 @@ export function ImportSkillForm({
     if (debounceRef.current) window.clearTimeout(debounceRef.current)
     if (raw.trim() === "") {
       onChange(null)
-      setPasteWarnings([])
-      setPasteError(null)
       previewMut.reset()
       return
     }
@@ -265,7 +263,13 @@ export function ImportSkillForm({
               <Textarea
                 id="import-skill-markdown"
                 value={raw}
-                onChange={(e) => setRaw(e.target.value)}
+                onChange={(e) => {
+                  setRaw(e.target.value)
+                  if (!e.target.value.trim()) {
+                    setPasteWarnings([])
+                    setPasteError(null)
+                  }
+                }}
                 rows={12}
                 placeholder={t(
                   "capabilities.import.skill.placeholder",


### PR DESCRIPTION
Clearing MCP or Skill source text synchronously resets local warning/error state in preview effects, failing the full React lint check. Clear that feedback in each textarea's change handler while retaining the existing empty-input spec reset and preview mutation reset.

Validation: `make check`; baseline/candidate browser flows for errors, warnings, empty/whitespace input, resumed parsing, MCP JSON/TOML, Skill paste/ZIP switching, import payloads, and new-version prefill. All requests were synthetic. Full ESLint drops from 13 to 11 errors, with the existing warning unchanged.

Self-reviewed as a small local event-handler correction. Initial feedback starts empty, text changes use these handlers, and Skill mode changes retain their existing explicit resets. Parsing, debounce, upload, credentials, API and layout are unchanged.

Tracks Feishu CHECK-010.
