### PR TITLE
fix(web): expire Feishu provisioning before the next poll

### DIFF
--- a/apps/web/src/components/admin/FeishuConnectorPanel.tsx
+++ b/apps/web/src/components/admin/FeishuConnectorPanel.tsx
@@ -173,11 +173,12 @@ export function FeishuConnectorPanel({
 
   useEffect(() => {
     if (!provision || provision.status !== "pending" || pollProvisionPending) return
-    if (Date.now() >= provision.expiresAt) {
-      setProvision({ ...provision, status: "expired", message: t("agents.feishuConnector.provision.expired") })
-      return
-    }
+    const delay = Math.min(Math.max(1, provision.intervalSec) * 1000, Math.max(0, provision.expiresAt - Date.now()))
     const timer = window.setTimeout(() => {
+      if (Date.now() >= provision.expiresAt) {
+        setProvision({ ...provision, status: "expired", message: t("agents.feishuConnector.provision.expired") })
+        return
+      }
       pollProvision(
         {
           agentID,
@@ -226,7 +227,7 @@ export function FeishuConnectorPanel({
           },
         },
       )
-    }, Math.max(1, provision.intervalSec) * 1000)
+    }, delay)
     return () => window.clearTimeout(timer)
   }, [agentID, agentName, onToast, pollProvision, pollProvisionPending, provision, t])
 


### PR DESCRIPTION
A Feishu provisioning code could wait past its local expiry when the next polling interval was longer than the remaining validity. Schedule the next check for the earlier of the poll interval and expiry deadline, then stop expired provisioning before sending another request.

Scope is limited to QR timer scheduling in `FeishuConnectorPanel`. Authorization, identities, request payloads, saved connector configuration, credentials, and layout are unchanged.

Validation: `make check`, `git diff --check`, and six baseline/candidate browser scenarios passed: successful configuration with an updated poll interval and no overlapping requests, local expiry and regeneration, server expiry, server error, request failure, and cancellation. All browser writes were mocked. Full ESLint now reports eight errors and one warning in other files. Independent review found no material in-scope issues. An uninvolved reviewer was reused because new reviewer creation reached the tool limit; only requirements, acceptance criteria, scope, repository, and comparison baseline were supplied.
