### PR TITLE
feat(agents-api): persist session configuration snapshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,8 @@ the existing server remains the execution owner until a flow is explicitly moved
 - Establish single-Agent execution, approval, cancellation, idempotent submission,
   event cursor replay and persisted recovery queries before Team orchestration.
   Team definitions, management and orchestration belong to Parsar. Agents API
-  provides single-Agent execution primitives; Team loops are deferred.
+  provides single-Agent execution primitives; Team loops are deferred. Future Team
+  orchestration directly depends on `openai/openai-agents-python` in Parsar.
 - Daemon Skill/SP authoring remains a product operation: forward through a scoped
   product callback with the original requester and workspace checks. A runtime
   credential alone must not grant business write permissions.
@@ -132,13 +133,18 @@ the existing server remains the execution owner until a flow is explicitly moved
 - Tenant scope must come from authenticated service identity before calling the
   execution Store. Product workspace/user references in metadata grant no access.
   Keep credentials and effective execution options out of Session metadata.
+  Store resolved, non-secret Agent/environment configuration in the Session's
+  immutable configuration snapshot, and include it in creation idempotency checks.
+  Public schema validation belongs to the API; the Store validates JSON structure.
 - `make sqlc-generate` and the drift gate cover both services. Run
   `make check-agents-api` with `PARSAR_AGENTS_API_TEST_DATABASE_URL` pointing to a
   dedicated `parsar_agents_api_*_tests` database for Session integration tests.
   CI provides a separate PostgreSQL service. Migration immutability and ordering
   apply independently to each service directory.
-- Pin a concrete reference contract before claiming compatibility with an external
-  Agents API. SDK workflow objects are not themselves a server API contract.
+- The external protocol reference is `openai/openai-python`'s `beta/agents`, pinned
+  in `contracts/agents-api/upstream.json`. Follow its Session/Turn/event semantics
+  and verify supported behavior using the official client. Track current coverage
+  in `contracts/agents-api/README.md`; SDK workflow objects are not this contract.
 
 ### Agent knowledge references
 

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -1,0 +1,54 @@
+# Agents API contract
+
+The external reference is [openai-python beta/agents](https://github.com/openai/openai-python/tree/d7c41efee1b0802b79f3f88a678ef2052b06e9ce/src/openai/resources/beta/agents),
+pinned in `upstream.json`. Its resource methods, corresponding types, pagination
+and streaming helpers define the compatibility target. This directory records
+the boundary; it does not imply that every upstream feature is implemented.
+
+Parsar owns product Agents and Teams. This service owns execution configuration
+snapshots and single-Agent sessions/turns. The OpenAI Agents Python **SDK** is a
+separate future dependency for Team orchestration in Parsar, not the HTTP contract.
+
+## Public semantics
+
+- Use `/agents/sessions` beneath the configured API base URL, bearer authentication
+  and `OpenAI-Beta: agents=v1`. Do not introduce a competing `/sessions` surface.
+- Session creation takes an environment and inline agent configuration or a saved
+  agent reference. A model name is not a daemon engine name.
+- `AgentSession` includes the effective agent/environment, Unix-second timestamps,
+  `object: agent.session`, metadata, required actions, status, usage and vault IDs.
+  A Session remains reusable after its current Turn completes.
+- Input, cancellation and function results are submitted through session events.
+  Turns are queried through `/agents/sessions/{id}/turns`; do not invent turn-create
+  endpoints. Event submissions support the `Idempotency-Key` header.
+- List operations use the upstream `after`, `limit`, `order` and resource-specific
+  filters. Stream events preserve the upstream discriminators and payload shapes.
+- The upstream self-hosted environment includes an exec-server `remote_url`.
+  A Parsar daemon socket is not automatically compatible with that transport.
+  Provider adaptation must be explicit and verified before advertising support.
+
+## Delivery and verification
+
+| Capability | Current state |
+| --- | --- |
+| Shared daemon connection layer | Implemented; existing product protocol retained |
+| Tenant-scoped Session persistence | Implemented; internal Store, not a public API |
+| Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
+| Authenticated Session HTTP API | Pending |
+| Turn execution, events, results and cancellation | Pending |
+| Pending actions and environment lifecycle | Pending |
+| Official-client compatibility and product cutover | Pending |
+| Team orchestration | Deferred; Parsar-owned |
+
+The Store's internal DTO is not the upstream response model. The API layer must
+validate and resolve the upstream schema before persistence, and report only
+supported options. For example, upstream metadata is limited to 16 pairs with
+64-character keys and 512-character values; a storage byte limit is not a
+replacement for that public validation.
+
+Use the pinned official Python client against the actual service, with response
+validation enabled, for supported Session operations, pagination, streaming,
+errors, idempotency and tenant isolation. A client import or permissive parsing
+alone is not evidence of compatibility. Unsupported capabilities must be explicit
+errors, not successful placeholder resources. Add any provider or engine-specific
+extension separately from upstream fields and document it here when implemented.

--- a/contracts/agents-api/upstream.json
+++ b/contracts/agents-api/upstream.json
@@ -1,0 +1,8 @@
+{
+  "repository": "https://github.com/openai/openai-python",
+  "commit": "d7c41efee1b0802b79f3f88a678ef2052b06e9ce",
+  "sdk_version": "3.13.0",
+  "resource_path": "src/openai/resources/beta/agents",
+  "type_path": "src/openai/types/beta",
+  "beta_header": "agents=v1"
+}

--- a/services/agents-api/README.md
+++ b/services/agents-api/README.md
@@ -30,6 +30,15 @@ same key returns a conflict. Read/list operations are tenant-scoped, including
 pagination cursors. Metadata is limited to 16 KiB of JSON string pairs and should
 contain references or labels, not credentials or Agent configuration.
 
+The separate `configuration` field preserves the resolved non-secret Agent and
+environment snapshot as a JSON object, up to 512 KiB. Creation retries include
+that snapshot in their identity; changed configuration conflicts rather than
+mutating an existing Session. Legacy Sessions without configuration keep their
+original retry identity. JSON key order and whitespace do not affect matching.
+The API layer will validate the pinned upstream schema before calling the Store;
+the Store does not invent defaults or claim a daemon environment is connected.
+See [the compatibility boundary](../../contracts/agents-api/README.md).
+
 ## Checks
 
 ```bash

--- a/services/agents-api/internal/db/queries/sessions.sql
+++ b/services/agents-api/internal/db/queries/sessions.sql
@@ -1,6 +1,6 @@
 -- name: CreateSession :one
-INSERT INTO sessions (id, tenant_id, engine, metadata, idempotency_key, request_hash)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO sessions (id, tenant_id, engine, metadata, idempotency_key, request_hash, configuration)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (tenant_id, idempotency_key) DO UPDATE
 SET idempotency_key = EXCLUDED.idempotency_key
 WHERE sessions.request_hash = EXCLUDED.request_hash

--- a/services/agents-api/internal/db/sqlc/models.go
+++ b/services/agents-api/internal/db/sqlc/models.go
@@ -16,4 +16,5 @@ type Session struct {
 	IdempotencyKey string             `json:"idempotency_key"`
 	RequestHash    string             `json:"request_hash"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	Configuration  []byte             `json:"configuration"`
 }

--- a/services/agents-api/internal/db/sqlc/sessions.sql.go
+++ b/services/agents-api/internal/db/sqlc/sessions.sql.go
@@ -12,12 +12,12 @@ import (
 )
 
 const createSession = `-- name: CreateSession :one
-INSERT INTO sessions (id, tenant_id, engine, metadata, idempotency_key, request_hash)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO sessions (id, tenant_id, engine, metadata, idempotency_key, request_hash, configuration)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (tenant_id, idempotency_key) DO UPDATE
 SET idempotency_key = EXCLUDED.idempotency_key
 WHERE sessions.request_hash = EXCLUDED.request_hash
-RETURNING id, tenant_id, engine, metadata, idempotency_key, request_hash, created_at
+RETURNING id, tenant_id, engine, metadata, idempotency_key, request_hash, created_at, configuration
 `
 
 type CreateSessionParams struct {
@@ -27,6 +27,7 @@ type CreateSessionParams struct {
 	Metadata       []byte      `json:"metadata"`
 	IdempotencyKey string      `json:"idempotency_key"`
 	RequestHash    string      `json:"request_hash"`
+	Configuration  []byte      `json:"configuration"`
 }
 
 func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (Session, error) {
@@ -37,6 +38,7 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		arg.Metadata,
 		arg.IdempotencyKey,
 		arg.RequestHash,
+		arg.Configuration,
 	)
 	var i Session
 	err := row.Scan(
@@ -47,12 +49,13 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 		&i.IdempotencyKey,
 		&i.RequestHash,
 		&i.CreatedAt,
+		&i.Configuration,
 	)
 	return i, err
 }
 
 const getSession = `-- name: GetSession :one
-SELECT id, tenant_id, engine, metadata, idempotency_key, request_hash, created_at FROM sessions WHERE tenant_id = $1 AND id = $2
+SELECT id, tenant_id, engine, metadata, idempotency_key, request_hash, created_at, configuration FROM sessions WHERE tenant_id = $1 AND id = $2
 `
 
 type GetSessionParams struct {
@@ -71,12 +74,13 @@ func (q *Queries) GetSession(ctx context.Context, arg GetSessionParams) (Session
 		&i.IdempotencyKey,
 		&i.RequestHash,
 		&i.CreatedAt,
+		&i.Configuration,
 	)
 	return i, err
 }
 
 const listSessions = `-- name: ListSessions :many
-SELECT id, tenant_id, engine, metadata, idempotency_key, request_hash, created_at FROM sessions
+SELECT id, tenant_id, engine, metadata, idempotency_key, request_hash, created_at, configuration FROM sessions
 WHERE tenant_id = $1
   AND ($2::timestamptz IS NULL
        OR (created_at, id) < ($2::timestamptz, $3::uuid))
@@ -113,6 +117,7 @@ func (q *Queries) ListSessions(ctx context.Context, arg ListSessionsParams) ([]S
 			&i.IdempotencyKey,
 			&i.RequestHash,
 			&i.CreatedAt,
+			&i.Configuration,
 		); err != nil {
 			return nil, err
 		}

--- a/services/agents-api/internal/store/session_configuration.go
+++ b/services/agents-api/internal/store/session_configuration.go
@@ -11,9 +11,6 @@ func canonicalConfiguration(raw json.RawMessage) (json.RawMessage, error) {
 	if len(raw) == 0 {
 		return json.RawMessage(`{}`), nil
 	}
-	if len(raw) > 512*1024 {
-		return nil, fmt.Errorf("%w: configuration exceeds 512 KiB", ErrInvalidInput)
-	}
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.UseNumber()
 	var fields map[string]any

--- a/services/agents-api/internal/store/session_configuration.go
+++ b/services/agents-api/internal/store/session_configuration.go
@@ -1,0 +1,31 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+func canonicalConfiguration(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return json.RawMessage(`{}`), nil
+	}
+	if len(raw) > 512*1024 {
+		return nil, fmt.Errorf("%w: configuration exceeds 512 KiB", ErrInvalidInput)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var fields map[string]any
+	if err := decoder.Decode(&fields); err != nil || fields == nil {
+		return nil, fmt.Errorf("%w: configuration must be a JSON object", ErrInvalidInput)
+	}
+	if err := decoder.Decode(new(any)); err != io.EOF {
+		return nil, fmt.Errorf("%w: configuration must contain exactly one object", ErrInvalidInput)
+	}
+	canonical, err := json.Marshal(fields)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid configuration", ErrInvalidInput)
+	}
+	return canonical, nil
+}

--- a/services/agents-api/internal/store/session_configuration_test.go
+++ b/services/agents-api/internal/store/session_configuration_test.go
@@ -18,10 +18,35 @@ func TestConfigurationCanonicalization(t *testing.T) {
 	if err != nil || string(got) != want {
 		t.Fatalf("canonical = %s, %v; want %s", got, err, want)
 	}
-	for _, raw := range []string{`null`, `[]`, `"text"`, `{} {}`, `{`, strings.Repeat(" ", 512*1024+1)} {
+	for _, raw := range []string{`null`, `[]`, `"text"`, `{} {}`, `{`} {
 		if _, err := canonicalConfiguration([]byte(raw)); !errors.Is(err, ErrInvalidInput) {
 			t.Fatalf("invalid configuration accepted (length %d): %v", len(raw), err)
 		}
+	}
+}
+
+func TestConfigurationSizeLimitSurvivesJSONBRoundTrip(t *testing.T) {
+	s, _ := testStore(t)
+	ctx := context.Background()
+	tenant := uuid.NewString()
+	empty := `{"agent":{"model":"example","instructions":""},"environment":{"type":"none"}}`
+	raw := strings.Replace(empty, `"instructions":""`, `"instructions":"`+strings.Repeat("x", 512*1024-len(empty))+`"`, 1)
+	input := CreateSessionInput{Engine: "codex", IdempotencyKey: "size-limit", Configuration: []byte(raw)}
+	first, err := s.CreateSession(ctx, tenant, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetSession(ctx, tenant, first.ID)
+	if err != nil || string(got.Configuration) != string(first.Configuration) {
+		t.Fatalf("configuration failed round trip: %v", err)
+	}
+	page, err := s.ListSessions(ctx, tenant, "", 10)
+	if err != nil || len(page.Sessions) != 1 || page.Sessions[0].ID != first.ID {
+		t.Fatalf("configuration broke listing: %v", err)
+	}
+	input.Configuration = append(input.Configuration, ' ')
+	if _, err := s.CreateSession(ctx, tenant, input); !errors.Is(err, ErrInvalidInput) {
+		t.Fatalf("oversized request accepted: %v", err)
 	}
 }
 

--- a/services/agents-api/internal/store/session_configuration_test.go
+++ b/services/agents-api/internal/store/session_configuration_test.go
@@ -1,0 +1,75 @@
+package store
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestConfigurationCanonicalization(t *testing.T) {
+	input := ` {"environment":{"type":"none"},"agent":{"revision":9007199254740993,"model":"example"}} `
+	want := `{"agent":{"model":"example","revision":9007199254740993},"environment":{"type":"none"}}`
+	got, err := canonicalConfiguration([]byte(input))
+	if err != nil || string(got) != want {
+		t.Fatalf("canonical = %s, %v; want %s", got, err, want)
+	}
+	for _, raw := range []string{`null`, `[]`, `"text"`, `{} {}`, `{`, strings.Repeat(" ", 512*1024+1)} {
+		if _, err := canonicalConfiguration([]byte(raw)); !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("invalid configuration accepted (length %d): %v", len(raw), err)
+		}
+	}
+}
+
+func TestConfigurationIsPartOfSessionIdentity(t *testing.T) {
+	s, _ := testStore(t)
+	ctx := context.Background()
+	tenant := uuid.NewString()
+	input := CreateSessionInput{Engine: "codex", IdempotencyKey: "configured",
+		Configuration: []byte(`{"agent":{"model":"example","instructions":"First"},"environment":{"type":"none"}}`)}
+	first, err := s.CreateSession(ctx, tenant, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input.Configuration = []byte(`{"environment": {"type":"none"}, "agent":{"instructions":"First", "model":"example"}}`)
+	replay, err := s.CreateSession(ctx, tenant, input)
+	if err != nil || replay.ID != first.ID || string(replay.Configuration) != string(first.Configuration) {
+		t.Fatalf("equivalent configuration changed identity: %+v, %v", replay, err)
+	}
+	for _, configuration := range []string{
+		`{"agent":{"model":"different","instructions":"First"},"environment":{"type":"none"}}`,
+		`{"agent":{"model":"example","instructions":"Changed"},"environment":{"type":"none"}}`,
+		`{"agent":{"model":"example","instructions":"First"},"environment":{"type":"self_hosted","workspace_directory":"/workspace"}}`,
+	} {
+		input.Configuration = []byte(configuration)
+		if _, err := s.CreateSession(ctx, tenant, input); !errors.Is(err, ErrIdempotencyConflict) {
+			t.Fatalf("changed snapshot was accepted: %v", err)
+		}
+	}
+	stored, err := s.GetSession(ctx, tenant, first.ID)
+	if err != nil || string(stored.Configuration) != string(first.Configuration) {
+		t.Fatalf("retry mutated snapshot: %+v, %v", stored, err)
+	}
+}
+
+func TestLegacySessionIdempotencySurvivesConfigurationMigration(t *testing.T) {
+	s, pool := testStore(t)
+	ctx := context.Background()
+	tenant, id := uuid.NewString(), uuid.NewString()
+	legacyHash := sha256.Sum256([]byte(`{"Engine":"codex","Metadata":{}}`))
+	_, err := pool.Exec(ctx, `INSERT INTO sessions (id, tenant_id, engine, metadata, idempotency_key, request_hash)
+		VALUES ($1, $2, 'codex', '{}', 'legacy', $3)`, id, tenant, hex.EncodeToString(legacyHash[:]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, configuration := range [][]byte{nil, []byte(`{}`), []byte(` { } `)} {
+		got, err := s.CreateSession(ctx, tenant, CreateSessionInput{Engine: "codex", IdempotencyKey: "legacy", Configuration: configuration})
+		if err != nil || got.ID != id || string(got.Configuration) != "{}" {
+			t.Fatalf("legacy retry = %+v, %v", got, err)
+		}
+	}
+}

--- a/services/agents-api/internal/store/sessions.go
+++ b/services/agents-api/internal/store/sessions.go
@@ -30,17 +30,19 @@ var (
 // Session is a durable execution context, separate from product conversations
 // and from live daemon connections. Engine session IDs will be bound at execution.
 type Session struct {
-	ID        string
-	TenantID  string
-	Engine    string
-	Metadata  map[string]string
-	CreatedAt time.Time
+	ID            string
+	TenantID      string
+	Engine        string
+	Metadata      map[string]string
+	CreatedAt     time.Time
+	Configuration json.RawMessage
 }
 
 type CreateSessionInput struct {
 	Engine         string
 	Metadata       map[string]string
 	IdempotencyKey string
+	Configuration  json.RawMessage
 }
 
 type SessionPage struct {
@@ -73,11 +75,21 @@ func (s *Store) CreateSession(ctx context.Context, tenantID string, input Create
 	if len(metadata) > 16*1024 {
 		return Session{}, fmt.Errorf("%w: metadata exceeds 16 KiB", ErrInvalidInput)
 	}
+	configuration, err := canonicalConfiguration(input.Configuration)
+	if err != nil {
+		return Session{}, err
+	}
+	hashConfiguration := configuration
+	// Empty configuration retains the idempotency hashes from the first schema.
+	if string(configuration) == "{}" {
+		hashConfiguration = nil
+	}
 	// JSON map keys are sorted by encoding/json, so key order does not affect retries.
 	canonical, err := json.Marshal(struct {
-		Engine   string
-		Metadata map[string]string
-	}{input.Engine, input.Metadata})
+		Engine        string
+		Metadata      map[string]string
+		Configuration json.RawMessage `json:",omitempty"`
+	}{input.Engine, input.Metadata, hashConfiguration})
 	if err != nil {
 		return Session{}, fmt.Errorf("%w: input: %v", ErrInvalidInput, err)
 	}
@@ -85,6 +97,7 @@ func (s *Store) CreateSession(ctx context.Context, tenantID string, input Create
 	row, err := s.queries.CreateSession(ctx, sqlc.CreateSessionParams{
 		ID: pgtype.UUID{Bytes: uuid.New(), Valid: true}, TenantID: tenant, Engine: input.Engine,
 		Metadata: metadata, IdempotencyKey: input.IdempotencyKey, RequestHash: hex.EncodeToString(hash[:]),
+		Configuration: configuration,
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Session{}, ErrIdempotencyConflict
@@ -163,6 +176,11 @@ func parseID(value string) (pgtype.UUID, error) {
 
 func sessionFromRow(row sqlc.Session) (Session, error) {
 	session := Session{ID: uuid.UUID(row.ID.Bytes).String(), TenantID: uuid.UUID(row.TenantID.Bytes).String(), Engine: row.Engine, CreatedAt: row.CreatedAt.Time}
+	configuration, err := canonicalConfiguration(row.Configuration)
+	if err != nil {
+		return Session{}, fmt.Errorf("decode session configuration: %w", err)
+	}
+	session.Configuration = configuration
 	if err := json.Unmarshal(row.Metadata, &session.Metadata); err != nil {
 		return Session{}, fmt.Errorf("decode session metadata: %w", err)
 	}

--- a/services/agents-api/internal/store/sessions.go
+++ b/services/agents-api/internal/store/sessions.go
@@ -75,6 +75,9 @@ func (s *Store) CreateSession(ctx context.Context, tenantID string, input Create
 	if len(metadata) > 16*1024 {
 		return Session{}, fmt.Errorf("%w: metadata exceeds 16 KiB", ErrInvalidInput)
 	}
+	if len(input.Configuration) > 512*1024 {
+		return Session{}, fmt.Errorf("%w: configuration exceeds 512 KiB", ErrInvalidInput)
+	}
 	configuration, err := canonicalConfiguration(input.Configuration)
 	if err != nil {
 		return Session{}, err

--- a/services/agents-api/internal/store/sessions_test.go
+++ b/services/agents-api/internal/store/sessions_test.go
@@ -76,7 +76,8 @@ func TestSessionsPersistAndStayTenantScoped(t *testing.T) {
 	s, pool := testStore(t)
 	ctx := context.Background()
 	tenantA, tenantB := uuid.NewString(), uuid.NewString()
-	input := CreateSessionInput{Engine: "codex", Metadata: map[string]string{"source": "standalone"}, IdempotencyKey: "first"}
+	input := CreateSessionInput{Engine: "codex", Metadata: map[string]string{"source": "standalone"}, IdempotencyKey: "first",
+		Configuration: []byte(`{"agent":{"model":"test-model","instructions":"Keep the snapshot."},"environment":{"type":"none"}}`)}
 	first, err := s.CreateSession(ctx, tenantA, input)
 	if err != nil {
 		t.Fatal(err)

--- a/services/agents-api/migrations/000002_session_configuration.sql
+++ b/services/agents-api/migrations/000002_session_configuration.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+ALTER TABLE sessions ADD COLUMN configuration jsonb NOT NULL DEFAULT '{}'::jsonb
+    CHECK (jsonb_typeof(configuration) = 'object');
+
+-- +goose Down
+ALTER TABLE sessions DROP COLUMN configuration;


### PR DESCRIPTION
Sessions currently retain an engine and metadata but cannot preserve the Agent/environment configuration needed by the Agents API contract. Store an immutable configuration snapshot and include it in creation retry checks, while preserving existing Session idempotency hashes when configuration is empty.

Add an additive migration and regenerated queries. Pin the official `openai-python` beta/agents reference and document supported boundaries, including Parsar ownership of future Team orchestration through `openai-agents-python`. This change adds no HTTP handlers, execution dispatch or product cutover.

Validation: `make check`, sqlc regeneration, migration order checks, and real PostgreSQL tests under a dedicated execution database/account. Tests cover configuration persistence across pool recreation, equivalent retries, conflicts, legacy rows, concurrent creation and tenant isolation. Local Docker remained stopped; database tests ran remotely.

Independent blind review completed with no outstanding findings. The final database run also verifies a configuration at the 512 KiB request boundary remains readable after PostgreSQL JSONB serialization.
