### PR TITLE
feat(agents-api): expose authenticated session HTTP resources

### DIFF
--- a/.github/workflows/agents-api.yml
+++ b/.github/workflows/agents-api.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'services/agents-api/**'
+      - 'contracts/agents-api/**'
       - 'internal/**'
       - 'go.mod'
       - 'go.sum'
@@ -13,6 +14,7 @@ on:
   pull_request:
     paths:
       - 'services/agents-api/**'
+      - 'contracts/agents-api/**'
       - 'internal/**'
       - 'go.mod'
       - 'go.sum'
@@ -54,3 +56,21 @@ jobs:
         env:
           PARSAR_AGENTS_API_TEST_DATABASE_URL: postgres://agents_api:agents_api_test_only@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/parsar_agents_api_ci_tests?sslmode=disable
         run: make check-agents-api
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install pinned official client
+        run: |
+          python - <<'PY'
+          import json, subprocess, sys
+          pin = json.load(open('contracts/agents-api/upstream.json'))
+          subprocess.run([sys.executable, '-m', 'pip', 'install',
+                          'openai @ git+https://github.com/openai/openai-python@' + pin['commit']], check=True)
+          PY
+      - name: Build standalone service
+        run: go build -o "$RUNNER_TEMP/agents-api" ./services/agents-api/cmd/server
+      - name: Verify official-client HTTP compatibility
+        env:
+          PARSAR_AGENTS_API_TEST_DATABASE_URL: postgres://agents_api:agents_api_test_only@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/parsar_agents_api_ci_tests?sslmode=disable
+          AGENTS_API_SERVER_BIN: ${{ runner.temp }}/agents-api
+        run: python services/agents-api/tests/official_client.py

--- a/.github/workflows/agents-api.yml
+++ b/.github/workflows/agents-api.yml
@@ -64,7 +64,7 @@ jobs:
           python - <<'PY'
           import json, subprocess, sys
           pin = json.load(open('contracts/agents-api/upstream.json'))
-          subprocess.run([sys.executable, '-m', 'pip', 'install',
+          subprocess.run([sys.executable, '-m', 'pip', 'install', '-r', 'services/agents-api/tests/requirements.txt',
                           'openai @ git+https://github.com/openai/openai-python@' + pin['commit']], check=True)
           PY
       - name: Build standalone service

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "server/**"
       - "services/agents-api/**"
+      - "contracts/agents-api/**"
       - "internal/**"
       - "apps/web/**"
       - "packages/cli/**"
@@ -30,6 +31,7 @@ on:
     paths:
       - "server/**"
       - "services/agents-api/**"
+      - "contracts/agents-api/**"
       - "internal/**"
       - "apps/web/**"
       - "packages/cli/**"
@@ -102,7 +104,7 @@ jobs:
                 go=true
                 store=true
                 ;;
-              server/*|internal/*|services/agents-api/*)
+              server/*|internal/*|services/agents-api/*|contracts/agents-api/*)
                 go=true
                 ;;
               apps/web/*)

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -23,6 +23,8 @@ on:
       - 'redocly.yaml'
       - 'server/**/*.go'
       - 'internal/agentdaemon/gateway/**/*.go'
+      - 'services/agents-api/**/*.go'
+      - 'contracts/agents-api/**'
       - '.github/workflows/openapi.yml'
       - 'Makefile'
   pull_request:
@@ -31,6 +33,8 @@ on:
       - 'redocly.yaml'
       - 'server/**/*.go'
       - 'internal/agentdaemon/gateway/**/*.go'
+      - 'services/agents-api/**/*.go'
+      - 'contracts/agents-api/**'
       - '.github/workflows/openapi.yml'
       - 'Makefile'
 
@@ -59,9 +63,9 @@ jobs:
         run: make openapi
       - name: Fail on drift
         run: |
-          if ! git diff --exit-code -- docs/openapi/openapi.yaml; then
+          if ! git diff --exit-code -- docs/openapi/openapi.yaml contracts/agents-api/openapi.yaml; then
             echo ""
-            echo "::error::docs/openapi/openapi.yaml is out of sync with the swaggo annotations."
+            echo "::error::Generated OpenAPI contracts are out of sync with the swaggo annotations."
             echo "Run 'make openapi' locally, commit the regenerated file, and push."
             exit 1
           fi
@@ -75,4 +79,4 @@ jobs:
         with:
           node-version: '22'
       - name: Lint OpenAPI spec
-        run: npx --yes @redocly/cli@2.35.1 lint docs/openapi/openapi.yaml
+        run: npx --yes @redocly/cli@2.35.1 lint docs/openapi/openapi.yaml contracts/agents-api/openapi.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,18 @@ the existing server remains the execution owner until a flow is explicitly moved
   in `contracts/agents-api/upstream.json`. Follow its Session/Turn/event semantics
   and verify supported behavior using the official client. Track current coverage
   in `contracts/agents-api/README.md`; SDK workflow objects are not this contract.
+- Shared supported wire types live in `contracts/agents-api/v1`. `make openapi`
+  separately generates the product spec and `contracts/agents-api/openapi.yaml`;
+  never mix their routes or authentication schemes. CI checks both for drift.
+- The standalone service uses `AGENTS_API_DATABASE_URL` and operator-provisioned
+  SHA-256 API key bindings from `AGENTS_API_KEYS_FILE`. Tenant identity comes only
+  from that binding; metadata and product session cookies grant no access. The
+  operator-selected `AGENTS_API_ENGINE` is separate from the requested model.
+  Until execution is connected, support only documented idle Session operations
+  and reject unsupported input/environment/agent options explicitly.
+- `services/agents-api/tests/official_client.py` verifies the actual server with
+  the pinned SDK and strict response validation. It requires a dedicated test DB
+  prepared by the Store tests and `AGENTS_API_SERVER_BIN`; it never starts Docker.
 
 ### Agent knowledge references
 

--- a/Makefile
+++ b/Makefile
@@ -266,11 +266,20 @@ openapi:
 	    --outputTypes yaml \
 	    --parseInternal \
 	    --parseDepth 100 \
-	    --exclude ./apps,./packages,./services,./node_modules,./tests,./infra
+	    --exclude ./apps,./packages,./services,./contracts,./node_modules,./tests,./infra
 	@mv docs/openapi/gen/swagger.yaml docs/openapi/openapi.yaml
 	@rmdir docs/openapi/gen 2>/dev/null || true
 	@echo "openapi: wrote docs/openapi/openapi.yaml"
 	@echo "openapi: paths=$$(grep -c '^  /' docs/openapi/openapi.yaml)"
+	$(SWAG) init \
+	    -g cmd/server/main.go \
+	    --dir ./services/agents-api,./contracts/agents-api/v1 \
+	    --output contracts/agents-api/gen \
+	    --outputTypes yaml \
+	    --parseInternal
+	@mv contracts/agents-api/gen/swagger.yaml contracts/agents-api/openapi.yaml
+	@rmdir contracts/agents-api/gen
+	@echo "openapi: wrote contracts/agents-api/openapi.yaml"
 
 # --- E2B sandbox template ----------------------------------------------
 #

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -34,10 +34,11 @@ separate future dependency for Team orchestration in Parsar, not the HTTP contra
 | Shared daemon connection layer | Implemented; existing product protocol retained |
 | Tenant-scoped Session persistence | Implemented; internal Store, not a public API |
 | Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
-| Authenticated Session HTTP API | Pending |
+| Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, environment `none`, metadata and creation retry keys |
 | Turn execution, events, results and cancellation | Pending |
 | Pending actions and environment lifecycle | Pending |
-| Official-client compatibility and product cutover | Pending |
+| Official-client compatibility | Strict SDK checks for the supported Session subset, pagination, retries, errors, tenant isolation and restart |
+| Product cutover | Pending |
 | Team orchestration | Deferred; Parsar-owned |
 
 The Store's internal DTO is not the upstream response model. The API layer must
@@ -52,3 +53,10 @@ errors, idempotency and tenant isolation. A client import or permissive parsing
 alone is not evidence of compatibility. Unsupported capabilities must be explicit
 errors, not successful placeholder resources. Add any provider or engine-specific
 extension separately from upstream fields and document it here when implemented.
+
+`openapi.yaml` is our generated supported surface; it is not the full upstream
+specification. The shared Go wire types are in `v1`. Session update/delete, saved
+Agent references/filtering, other agent options, vaults, initial input, streaming
+and execution/provider resources are not supported by this slice. Reject them
+explicitly. `AGENTS_API_ENGINE` selects the service's engine independently of the
+requested model; it does not add a competing field to the upstream request.

--- a/contracts/agents-api/openapi.yaml
+++ b/contracts/agents-api/openapi.yaml
@@ -8,6 +8,7 @@ definitions:
         type: string
       param:
         type: string
+        x-nullable: true
       type:
         type: string
     required:
@@ -21,12 +22,14 @@ definitions:
         type: string
       instructions:
         type: string
+        x-nullable: true
       model:
         type: string
       multi_agent:
         $ref: '#/definitions/v1.MultiAgentConfig'
       name:
         type: string
+        x-nullable: true
       reasoning:
         $ref: '#/definitions/v1.Reasoning'
       service_tier:
@@ -54,14 +57,17 @@ definitions:
         $ref: '#/definitions/v1.InlineAgent'
       agent_id:
         type: string
+        x-nullable: true
       environment:
         $ref: '#/definitions/v1.Environment'
       input:
         type: object
+        x-nullable: true
       metadata:
         additionalProperties:
           type: string
         type: object
+        x-nullable: true
       stream:
         type: boolean
       vault_ids:
@@ -92,6 +98,7 @@ definitions:
     properties:
       instructions:
         type: string
+        x-nullable: true
       model:
         type: string
     required:
@@ -103,6 +110,7 @@ definitions:
         type: boolean
       max_concurrent_subagents:
         type: integer
+        x-nullable: true
     required:
     - enabled
     type: object
@@ -110,8 +118,10 @@ definitions:
     properties:
       effort:
         type: string
+        x-nullable: true
       summary:
         type: string
+        x-nullable: true
     type: object
   v1.Session:
     properties:
@@ -123,6 +133,7 @@ definitions:
         $ref: '#/definitions/v1.Environment'
       error:
         type: string
+        x-nullable: true
       id:
         type: string
       last_active_at:
@@ -145,6 +156,7 @@ definitions:
         type: string
       usage:
         type: object
+        x-nullable: true
       vault_ids:
         items:
           type: string

--- a/contracts/agents-api/openapi.yaml
+++ b/contracts/agents-api/openapi.yaml
@@ -1,0 +1,366 @@
+basePath: /v1
+definitions:
+  v1.APIError:
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+      param:
+        type: string
+      type:
+        type: string
+    required:
+    - code
+    - message
+    - type
+    type: object
+  v1.Agent:
+    properties:
+      id:
+        type: string
+      instructions:
+        type: string
+      model:
+        type: string
+      multi_agent:
+        $ref: '#/definitions/v1.MultiAgentConfig'
+      name:
+        type: string
+      reasoning:
+        $ref: '#/definitions/v1.Reasoning'
+      service_tier:
+        enum:
+        - auto
+        type: string
+      text:
+        $ref: '#/definitions/v1.TextConfig'
+      tools:
+        items:
+          type: object
+        type: array
+    required:
+    - id
+    - model
+    - multi_agent
+    - reasoning
+    - service_tier
+    - text
+    - tools
+    type: object
+  v1.CreateSessionRequest:
+    properties:
+      agent:
+        $ref: '#/definitions/v1.InlineAgent'
+      agent_id:
+        type: string
+      environment:
+        $ref: '#/definitions/v1.Environment'
+      input:
+        type: object
+      metadata:
+        additionalProperties:
+          type: string
+        type: object
+      stream:
+        type: boolean
+      vault_ids:
+        items:
+          type: string
+        type: array
+    required:
+    - agent
+    - environment
+    type: object
+  v1.Environment:
+    properties:
+      type:
+        enum:
+        - none
+        type: string
+    required:
+    - type
+    type: object
+  v1.ErrorResponse:
+    properties:
+      error:
+        $ref: '#/definitions/v1.APIError'
+    required:
+    - error
+    type: object
+  v1.InlineAgent:
+    properties:
+      instructions:
+        type: string
+      model:
+        type: string
+    required:
+    - model
+    type: object
+  v1.MultiAgentConfig:
+    properties:
+      enabled:
+        type: boolean
+      max_concurrent_subagents:
+        type: integer
+    required:
+    - enabled
+    type: object
+  v1.Reasoning:
+    properties:
+      effort:
+        type: string
+      summary:
+        type: string
+    type: object
+  v1.Session:
+    properties:
+      agent:
+        $ref: '#/definitions/v1.Agent'
+      created_at:
+        type: integer
+      environment:
+        $ref: '#/definitions/v1.Environment'
+      error:
+        type: string
+      id:
+        type: string
+      last_active_at:
+        type: integer
+      metadata:
+        additionalProperties:
+          type: string
+        type: object
+      object:
+        enum:
+        - agent.session
+        type: string
+      required_actions:
+        items:
+          type: object
+        type: array
+      status:
+        enum:
+        - idle
+        type: string
+      usage:
+        type: object
+      vault_ids:
+        items:
+          type: string
+        type: array
+    required:
+    - agent
+    - created_at
+    - environment
+    - id
+    - last_active_at
+    - metadata
+    - object
+    - required_actions
+    - status
+    - vault_ids
+    type: object
+  v1.SessionList:
+    properties:
+      data:
+        items:
+          $ref: '#/definitions/v1.Session'
+        type: array
+      has_more:
+        type: boolean
+    required:
+    - data
+    - has_more
+    type: object
+  v1.TextConfig:
+    properties:
+      format:
+        $ref: '#/definitions/v1.TextFormat'
+      verbosity:
+        enum:
+        - medium
+        type: string
+    required:
+    - format
+    - verbosity
+    type: object
+  v1.TextFormat:
+    properties:
+      type:
+        enum:
+        - text
+        type: string
+    required:
+    - type
+    type: object
+info:
+  contact: {}
+  description: Supported single-Agent execution resources from the pinned openai-python
+    beta/agents contract.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  title: Agents API
+  version: "1"
+paths:
+  /agents/sessions:
+    get:
+      description: Cursor and results are scoped to the authenticated execution tenant.
+        Saved agent filtering is not supported yet.
+      parameters:
+      - description: agents=v1
+        in: header
+        name: OpenAI-Beta
+        required: true
+        type: string
+      - description: Last Session ID from the previous page
+        in: query
+        name: after
+        type: string
+      - default: 20
+        description: Page size
+        in: query
+        maximum: 100
+        minimum: 1
+        name: limit
+        type: integer
+      - default: desc
+        description: Creation order
+        enum:
+        - asc
+        - desc
+        in: query
+        name: order
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1.SessionList'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: List execution Sessions
+      tags:
+      - Sessions
+    post:
+      consumes:
+      - application/json
+      description: Supports inline model/instructions and environment type none. Execution
+        input and other options are explicitly unsupported in this slice.
+      parameters:
+      - description: agents=v1
+        in: header
+        name: OpenAI-Beta
+        required: true
+        type: string
+      - description: Creation retry key, up to 128 bytes
+        in: header
+        name: Idempotency-Key
+        type: string
+      - description: Session configuration
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/v1.CreateSessionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1.Session'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "413":
+          description: Request Entity Too Large
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Create an execution Session
+      tags:
+      - Sessions
+  /agents/sessions/{session_id}:
+    get:
+      parameters:
+      - description: agents=v1
+        in: header
+        name: OpenAI-Beta
+        required: true
+        type: string
+      - description: Session ID
+        in: path
+        name: session_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1.Session'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Retrieve an execution Session
+      tags:
+      - Sessions
+schemes:
+- http
+- https
+securityDefinitions:
+  BearerAuth:
+    in: header
+    name: Authorization
+    type: apiKey
+swagger: "2.0"

--- a/contracts/agents-api/v1/sessions.go
+++ b/contracts/agents-api/v1/sessions.go
@@ -6,17 +6,17 @@ import "encoding/json"
 // CreateSessionRequest currently supports inline agents without initial input.
 type CreateSessionRequest struct {
 	Agent       *InlineAgent      `json:"agent" binding:"required"`
-	AgentID     *string           `json:"agent_id,omitempty"`
+	AgentID     *string           `json:"agent_id,omitempty" extensions:"x-nullable"`
 	Environment *Environment      `json:"environment" binding:"required"`
-	Input       json.RawMessage   `json:"input,omitempty" swaggertype:"object"`
-	Metadata    map[string]string `json:"metadata,omitempty"`
+	Input       json.RawMessage   `json:"input,omitempty" swaggertype:"object" extensions:"x-nullable"`
+	Metadata    map[string]string `json:"metadata,omitempty" extensions:"x-nullable"`
 	Stream      bool              `json:"stream,omitempty"`
 	VaultIDs    []string          `json:"vault_ids,omitempty"`
 }
 
 type InlineAgent struct {
 	Model        string  `json:"model" binding:"required"`
-	Instructions *string `json:"instructions,omitempty"`
+	Instructions *string `json:"instructions,omitempty" extensions:"x-nullable"`
 }
 
 // Environment currently supports the upstream environment-free configuration.
@@ -26,10 +26,10 @@ type Environment struct {
 
 type Agent struct {
 	ID           string            `json:"id" binding:"required"`
-	Instructions *string           `json:"instructions"`
+	Instructions *string           `json:"instructions" extensions:"x-nullable"`
 	Model        string            `json:"model" binding:"required"`
 	MultiAgent   MultiAgentConfig  `json:"multi_agent" binding:"required"`
-	Name         *string           `json:"name"`
+	Name         *string           `json:"name" extensions:"x-nullable"`
 	Reasoning    Reasoning         `json:"reasoning" binding:"required"`
 	ServiceTier  string            `json:"service_tier" enums:"auto" binding:"required"`
 	Text         TextConfig        `json:"text" binding:"required"`
@@ -38,12 +38,12 @@ type Agent struct {
 
 type MultiAgentConfig struct {
 	Enabled                bool `json:"enabled" binding:"required"`
-	MaxConcurrentSubagents *int `json:"max_concurrent_subagents"`
+	MaxConcurrentSubagents *int `json:"max_concurrent_subagents" extensions:"x-nullable"`
 }
 
 type Reasoning struct {
-	Effort  *string `json:"effort,omitempty"`
-	Summary *string `json:"summary,omitempty"`
+	Effort  *string `json:"effort,omitempty" extensions:"x-nullable"`
+	Summary *string `json:"summary,omitempty" extensions:"x-nullable"`
 }
 
 type TextConfig struct {
@@ -60,13 +60,13 @@ type Session struct {
 	Agent           Agent             `json:"agent" binding:"required"`
 	CreatedAt       int64             `json:"created_at" binding:"required"`
 	Environment     Environment       `json:"environment" binding:"required"`
-	Error           *string           `json:"error"`
+	Error           *string           `json:"error" extensions:"x-nullable"`
 	LastActiveAt    int64             `json:"last_active_at" binding:"required"`
 	Metadata        map[string]string `json:"metadata" binding:"required"`
 	Object          string            `json:"object" enums:"agent.session" binding:"required"`
 	RequiredActions []json.RawMessage `json:"required_actions" swaggertype:"array,object" binding:"required"`
 	Status          string            `json:"status" enums:"idle" binding:"required"`
-	Usage           json.RawMessage   `json:"usage" swaggertype:"object"`
+	Usage           json.RawMessage   `json:"usage" swaggertype:"object" extensions:"x-nullable"`
 	VaultIDs        []string          `json:"vault_ids" binding:"required"`
 }
 
@@ -83,5 +83,5 @@ type APIError struct {
 	Message string  `json:"message" binding:"required"`
 	Type    string  `json:"type" binding:"required"`
 	Code    string  `json:"code" binding:"required"`
-	Param   *string `json:"param"`
+	Param   *string `json:"param" extensions:"x-nullable"`
 }

--- a/contracts/agents-api/v1/sessions.go
+++ b/contracts/agents-api/v1/sessions.go
@@ -1,0 +1,87 @@
+// Package v1 contains the supported wire types from the pinned Agents API.
+package v1
+
+import "encoding/json"
+
+// CreateSessionRequest currently supports inline agents without initial input.
+type CreateSessionRequest struct {
+	Agent       *InlineAgent      `json:"agent" binding:"required"`
+	AgentID     *string           `json:"agent_id,omitempty"`
+	Environment *Environment      `json:"environment" binding:"required"`
+	Input       json.RawMessage   `json:"input,omitempty" swaggertype:"object"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	Stream      bool              `json:"stream,omitempty"`
+	VaultIDs    []string          `json:"vault_ids,omitempty"`
+}
+
+type InlineAgent struct {
+	Model        string  `json:"model" binding:"required"`
+	Instructions *string `json:"instructions,omitempty"`
+}
+
+// Environment currently supports the upstream environment-free configuration.
+type Environment struct {
+	Type string `json:"type" enums:"none" binding:"required"`
+}
+
+type Agent struct {
+	ID           string            `json:"id" binding:"required"`
+	Instructions *string           `json:"instructions"`
+	Model        string            `json:"model" binding:"required"`
+	MultiAgent   MultiAgentConfig  `json:"multi_agent" binding:"required"`
+	Name         *string           `json:"name"`
+	Reasoning    Reasoning         `json:"reasoning" binding:"required"`
+	ServiceTier  string            `json:"service_tier" enums:"auto" binding:"required"`
+	Text         TextConfig        `json:"text" binding:"required"`
+	Tools        []json.RawMessage `json:"tools" swaggertype:"array,object" binding:"required"`
+}
+
+type MultiAgentConfig struct {
+	Enabled                bool `json:"enabled" binding:"required"`
+	MaxConcurrentSubagents *int `json:"max_concurrent_subagents"`
+}
+
+type Reasoning struct {
+	Effort  *string `json:"effort,omitempty"`
+	Summary *string `json:"summary,omitempty"`
+}
+
+type TextConfig struct {
+	Format    TextFormat `json:"format" binding:"required"`
+	Verbosity string     `json:"verbosity" enums:"medium" binding:"required"`
+}
+
+type TextFormat struct {
+	Type string `json:"type" enums:"text" binding:"required"`
+}
+
+type Session struct {
+	ID              string            `json:"id" binding:"required"`
+	Agent           Agent             `json:"agent" binding:"required"`
+	CreatedAt       int64             `json:"created_at" binding:"required"`
+	Environment     Environment       `json:"environment" binding:"required"`
+	Error           *string           `json:"error"`
+	LastActiveAt    int64             `json:"last_active_at" binding:"required"`
+	Metadata        map[string]string `json:"metadata" binding:"required"`
+	Object          string            `json:"object" enums:"agent.session" binding:"required"`
+	RequiredActions []json.RawMessage `json:"required_actions" swaggertype:"array,object" binding:"required"`
+	Status          string            `json:"status" enums:"idle" binding:"required"`
+	Usage           json.RawMessage   `json:"usage" swaggertype:"object"`
+	VaultIDs        []string          `json:"vault_ids" binding:"required"`
+}
+
+type SessionList struct {
+	Data    []Session `json:"data" binding:"required"`
+	HasMore bool      `json:"has_more" binding:"required"`
+}
+
+type ErrorResponse struct {
+	Error APIError `json:"error" binding:"required"`
+}
+
+type APIError struct {
+	Message string  `json:"message" binding:"required"`
+	Type    string  `json:"type" binding:"required"`
+	Code    string  `json:"code" binding:"required"`
+	Param   *string `json:"param"`
+}

--- a/services/agents-api/README.md
+++ b/services/agents-api/README.md
@@ -72,12 +72,13 @@ After preparing a dedicated test database, build the server and verify it with
 the official client installed from the commit in `contracts/agents-api/upstream.json`:
 
 ```bash
+python -m pip install -r services/agents-api/tests/requirements.txt
 go build -o /tmp/agents-api ./services/agents-api/cmd/server
 AGENTS_API_SERVER_BIN=/tmp/agents-api python services/agents-api/tests/official_client.py
 ```
 
 The test uses `PARSAR_AGENTS_API_TEST_DATABASE_URL`, temporary service keys and
-fresh tenant IDs. It checks strict response schemas, retries, ordering, tenant
+fresh tenant IDs. It checks upstream and generated response schemas, retries, ordering, tenant
 isolation, unsupported options and reads after a process restart.
 
 ## Checks

--- a/services/agents-api/README.md
+++ b/services/agents-api/README.md
@@ -27,7 +27,7 @@ claimed in a request body. Store methods alone do not authenticate callers.
 Session creation requires an idempotency key scoped to the tenant. Repeating the
 same engine and metadata returns the existing Session; different input with the
 same key returns a conflict. Read/list operations are tenant-scoped, including
-pagination cursors. Metadata is limited to 16 KiB of JSON string pairs and should
+pagination cursors. Metadata is limited to 64 KiB of JSON string pairs and should
 contain references or labels, not credentials or Agent configuration.
 
 The separate `configuration` field preserves the resolved non-secret Agent and
@@ -35,9 +35,50 @@ environment snapshot as a JSON object, up to 512 KiB. Creation retries include
 that snapshot in their identity; changed configuration conflicts rather than
 mutating an existing Session. Legacy Sessions without configuration keep their
 original retry identity. JSON key order and whitespace do not affect matching.
-The API layer will validate the pinned upstream schema before calling the Store;
+The API layer validates the supported upstream schema before calling the Store;
 the Store does not invent defaults or claim a daemon environment is connected.
 See [the compatibility boundary](../../contracts/agents-api/README.md).
+
+## Standalone HTTP service
+
+Run migrations first, then `go run ./services/agents-api/cmd/server`. The service
+requires `AGENTS_API_DATABASE_URL` and `AGENTS_API_KEYS_FILE`; it does not read the
+product database or accept product login cookies. The key file is a JSON array of
+`{"tenant_id":"<nonzero UUID>","token_sha256":"<SHA-256 hex digest>"}` bindings.
+Provision a random bearer key per execution tenant and give clients the plaintext
+key securely; keep only its digest in the server file. Rotate by replacing the
+bindings and restarting. These service identities do not grant product-user rights.
+
+`AGENTS_API_ADDR` defaults to `127.0.0.1:8091`; use a TLS reverse proxy for remote
+access. `AGENTS_API_ENGINE` defaults to `codex` and is stored independently from
+the client's requested model. This slice stores configuration; it does not run
+that engine or connect an environment yet.
+
+The SDK base URL is `http://127.0.0.1:8091/v1`. Supported operations are Session
+create, retrieve and list, with `OpenAI-Beta: agents=v1` (set by the official SDK).
+Creation supports inline `agent.model`, optional `agent.instructions`,
+`environment: {"type":"none"}`, and metadata. Metadata allows at most 16 pairs,
+64-character keys and 512-character values, including Unicode. Requests have a
+1 MiB body limit and resolved configuration retains the 512 KiB Store limit.
+`Idempotency-Key` makes creation retries safe; omission creates a new Session.
+Inline Agent IDs identify the Session's immutable execution configuration, not a
+reusable Parsar Agent. List supports `after`, `limit` (1–100) and `order` (asc/desc).
+
+Unsupported fields, saved Agent references, vaults, initial input and streaming
+return explicit errors. Session update/delete, event submission and other
+resources remain unsupported. `/healthz` reports process liveness only.
+
+After preparing a dedicated test database, build the server and verify it with
+the official client installed from the commit in `contracts/agents-api/upstream.json`:
+
+```bash
+go build -o /tmp/agents-api ./services/agents-api/cmd/server
+AGENTS_API_SERVER_BIN=/tmp/agents-api python services/agents-api/tests/official_client.py
+```
+
+The test uses `PARSAR_AGENTS_API_TEST_DATABASE_URL`, temporary service keys and
+fresh tenant IDs. It checks strict response schemas, retries, ordering, tenant
+isolation, unsupported options and reads after a process restart.
 
 ## Checks
 

--- a/services/agents-api/cmd/server/main.go
+++ b/services/agents-api/cmd/server/main.go
@@ -1,0 +1,90 @@
+// Package main runs the standalone Agents API service.
+//
+// @title Agents API
+// @version 1
+// @description Supported single-Agent execution resources from the pinned openai-python beta/agents contract.
+// @license.name Apache 2.0
+// @license.url https://www.apache.org/licenses/LICENSE-2.0.html
+// @BasePath /v1
+// @schemes http https
+// @securityDefinitions.apikey BearerAuth
+// @in header
+// @name Authorization
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/api"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Bg().Error("agents-api startup failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	databaseURL, keysFile := os.Getenv("AGENTS_API_DATABASE_URL"), os.Getenv("AGENTS_API_KEYS_FILE")
+	if databaseURL == "" || keysFile == "" {
+		return errors.New("AGENTS_API_DATABASE_URL and AGENTS_API_KEYS_FILE are required")
+	}
+	content, err := os.ReadFile(keysFile)
+	if err != nil {
+		return errors.New("cannot read AGENTS_API_KEYS_FILE")
+	}
+	var keys []api.APIKey
+	if err := json.Unmarshal(content, &keys); err != nil {
+		return errors.New("AGENTS_API_KEYS_FILE must contain an array of API key bindings")
+	}
+	auth, err := api.NewAuthenticator(keys)
+	if err != nil {
+		return err
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		return errors.New("invalid Agents API database configuration")
+	}
+	defer pool.Close()
+	ready, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if err := pool.Ping(ready); err != nil {
+		return errors.New("Agents API database connection failed")
+	}
+	engine := os.Getenv("AGENTS_API_ENGINE")
+	if engine == "" {
+		engine = "codex"
+	}
+	handler, err := api.NewHandler(store.New(pool), auth, engine)
+	if err != nil {
+		return err
+	}
+	addr := os.Getenv("AGENTS_API_ADDR")
+	if addr == "" {
+		addr = "127.0.0.1:8091"
+	}
+	server := &http.Server{Addr: addr, Handler: handler, ReadHeaderTimeout: 10 * time.Second, ReadTimeout: 30 * time.Second, WriteTimeout: 30 * time.Second, IdleTimeout: 60 * time.Second}
+	done := make(chan error, 1)
+	go func() { done <- server.ListenAndServe() }()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		shutdown, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		return server.Shutdown(shutdown)
+	}
+}

--- a/services/agents-api/internal/api/auth.go
+++ b/services/agents-api/internal/api/auth.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// APIKey binds a service credential to an execution tenant, not a product user.
+// Configuration stores the SHA-256 hex digest, never the plaintext key.
+type APIKey struct {
+	TokenSHA256 string `json:"token_sha256"`
+	TenantID    string `json:"tenant_id"`
+}
+
+type Authenticator struct{ tenants map[[32]byte]string }
+
+func NewAuthenticator(keys []APIKey) (*Authenticator, error) {
+	if len(keys) == 0 {
+		return nil, errors.New("at least one Agents API key is required")
+	}
+	a := &Authenticator{tenants: make(map[[32]byte]string, len(keys))}
+	for _, key := range keys {
+		tenant, err := uuid.Parse(key.TenantID)
+		if err != nil || tenant == uuid.Nil {
+			return nil, errors.New("API key tenant_id must be a nonzero UUID")
+		}
+		digest, err := hex.DecodeString(key.TokenSHA256)
+		if err != nil || len(digest) != sha256.Size {
+			return nil, errors.New("API key token_sha256 must be a SHA-256 hex digest")
+		}
+		hash := [32]byte(digest)
+		if _, exists := a.tenants[hash]; exists {
+			return nil, errors.New("duplicate API key digest")
+		}
+		a.tenants[hash] = tenant.String()
+	}
+	return a, nil
+}
+
+func (a *Authenticator) tenant(r *http.Request) (string, bool) {
+	parts := strings.Fields(r.Header.Get("Authorization"))
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return "", false
+	}
+	tenant, ok := a.tenants[sha256.Sum256([]byte(parts[1]))]
+	return tenant, ok
+}

--- a/services/agents-api/internal/api/configuration.go
+++ b/services/agents-api/internal/api/configuration.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"unicode/utf8"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+	"github.com/google/uuid"
+)
+
+type configuration struct {
+	Agent       v1.Agent       `json:"agent"`
+	Environment v1.Environment `json:"environment"`
+}
+
+func resolve(input v1.CreateSessionRequest, tenant, key string) (json.RawMessage, error) {
+	if input.AgentID != nil || input.Stream || len(input.VaultIDs) > 0 || (len(input.Input) > 0 && !bytes.Equal(bytes.TrimSpace(input.Input), []byte("null"))) {
+		return nil, errors.New("Saved agents, initial input, streaming and vaults are not supported by this service yet.")
+	}
+	if input.Agent == nil || strings.TrimSpace(input.Agent.Model) == "" {
+		return nil, errors.New("agent.model is required for an inline agent.")
+	}
+	if input.Environment == nil || input.Environment.Type != "none" {
+		return nil, errors.New("This service currently requires environment.type=none.")
+	}
+	if len(input.Metadata) > 16 {
+		return nil, errors.New("metadata supports at most 16 pairs.")
+	}
+	for k, value := range input.Metadata {
+		if utf8.RuneCountInString(k) > 64 || utf8.RuneCountInString(value) > 512 {
+			return nil, errors.New("metadata keys must be at most 64 characters and values at most 512 characters.")
+		}
+	}
+	// Inline execution configuration has its own stable identity for creation retries.
+	id := "agent_" + uuid.NewSHA1(uuid.NameSpaceOID, []byte(tenant+"\x00"+key)).String()
+	return json.Marshal(configuration{Agent: v1.Agent{
+		ID: id, Model: input.Agent.Model, Instructions: input.Agent.Instructions,
+		ServiceTier: "auto", Text: v1.TextConfig{Format: v1.TextFormat{Type: "text"}, Verbosity: "medium"},
+		Tools: []json.RawMessage{},
+	}, Environment: *input.Environment})
+}
+
+func sessionResponse(session store.Session) (v1.Session, error) {
+	var cfg configuration
+	if err := json.Unmarshal(session.Configuration, &cfg); err != nil || cfg.Agent.ID == "" || cfg.Agent.Model == "" || cfg.Environment.Type != "none" {
+		return v1.Session{}, errors.New("unsupported stored session configuration")
+	}
+	return v1.Session{
+		ID: session.ID, Agent: cfg.Agent, Environment: cfg.Environment,
+		CreatedAt: session.CreatedAt.Unix(), LastActiveAt: session.CreatedAt.Unix(),
+		Metadata: session.Metadata, Object: "agent.session", Status: "idle",
+		RequiredActions: []json.RawMessage{}, VaultIDs: []string{},
+	}, nil
+}

--- a/services/agents-api/internal/api/errors.go
+++ b/services/agents-api/internal/api/errors.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(value)
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	kind := "invalid_request_error"
+	if status >= 500 {
+		kind = "server_error"
+	} else if status == http.StatusUnauthorized {
+		kind = "authentication_error"
+	}
+	writeJSON(w, status, v1.ErrorResponse{Error: v1.APIError{Message: message, Type: kind, Code: code}})
+}
+
+func writeStoreError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		writeError(w, http.StatusNotFound, "not_found", "Session not found.")
+	case errors.Is(err, store.ErrIdempotencyConflict):
+		writeError(w, http.StatusConflict, "idempotency_conflict", "This idempotency key was used with different input.")
+	case errors.Is(err, store.ErrInvalidInput):
+		writeError(w, http.StatusBadRequest, "invalid_request", "Invalid Session identifier or request limits.")
+	default:
+		// Driver errors can include submitted values; do not log the raw error.
+		log.Ctx(r.Context()).Error("agents-api persistence operation failed")
+		writeError(w, http.StatusInternalServerError, "internal_error", "The Session operation could not be completed.")
+	}
+}

--- a/services/agents-api/internal/api/handler.go
+++ b/services/agents-api/internal/api/handler.go
@@ -1,0 +1,208 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+type SessionStore interface {
+	CreateSession(context.Context, string, store.CreateSessionInput) (store.Session, error)
+	GetSession(context.Context, string, string) (store.Session, error)
+	ListSessions(context.Context, string, string, int, bool) (store.SessionPage, error)
+}
+
+type Handler struct {
+	store  SessionStore
+	auth   *Authenticator
+	engine string
+}
+
+func NewHandler(s SessionStore, auth *Authenticator, engine string) (http.Handler, error) {
+	if s == nil || auth == nil || !store.ValidEngine(engine) {
+		return nil, errors.New("session store, authentication and a valid execution engine are required")
+	}
+	h := &Handler{store: s, auth: auth, engine: engine}
+	router := chi.NewRouter()
+	router.Use(log.HTTPMiddleware)
+	router.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+	router.Route("/v1", func(r chi.Router) {
+		r.Use(h.authenticate)
+		r.Post("/agents/sessions", h.createSession)
+		r.Get("/agents/sessions", h.listSessions)
+		r.Get("/agents/sessions/{session_id}", h.getSession)
+		r.NotFound(func(w http.ResponseWriter, _ *http.Request) {
+			writeError(w, http.StatusNotFound, "unsupported_operation", "This API operation is not supported.")
+		})
+		r.MethodNotAllowed(func(w http.ResponseWriter, _ *http.Request) {
+			writeError(w, http.StatusMethodNotAllowed, "unsupported_operation", "This API method is not supported.")
+		})
+	})
+	return router, nil
+}
+
+type tenantContextKey struct{}
+
+func (h *Handler) authenticate(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tenant, ok := h.auth.tenant(r)
+		if !ok {
+			w.Header().Set("WWW-Authenticate", "Bearer")
+			writeError(w, http.StatusUnauthorized, "invalid_api_key", "A valid Agents API bearer key is required.")
+			return
+		}
+		if r.Header.Get("OpenAI-Beta") != "agents=v1" {
+			writeError(w, http.StatusBadRequest, "invalid_beta_header", "OpenAI-Beta: agents=v1 is required.")
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), tenantContextKey{}, tenant)))
+	})
+}
+
+func tenantID(r *http.Request) string { return r.Context().Value(tenantContextKey{}).(string) }
+
+// createSession creates an idle execution Session without submitting a Turn.
+// @Summary Create an execution Session
+// @Description Supports inline model/instructions and environment type none. Execution input and other options are explicitly unsupported in this slice.
+// @Tags Sessions
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param OpenAI-Beta header string true "agents=v1"
+// @Param Idempotency-Key header string false "Creation retry key, up to 128 bytes"
+// @Param body body v1.CreateSessionRequest true "Session configuration"
+// @Success 200 {object} v1.Session
+// @Failure 400,401,409,413,500 {object} v1.ErrorResponse
+// @Router /agents/sessions [post]
+func (h *Handler) createSession(w http.ResponseWriter, r *http.Request) {
+	if len(r.URL.Query()) > 0 {
+		writeError(w, http.StatusBadRequest, "unsupported_parameter", "Session creation does not accept query parameters.")
+		return
+	}
+	var input v1.CreateSessionRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1024*1024))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&input); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Request exceeds 1 MiB.")
+		} else {
+			writeError(w, http.StatusBadRequest, "invalid_request", "Request must be a JSON object containing supported fields.")
+		}
+		return
+	}
+	if err := decoder.Decode(new(any)); err != io.EOF {
+		writeError(w, http.StatusBadRequest, "invalid_request", "Request must contain exactly one JSON object.")
+		return
+	}
+	key := r.Header.Get("Idempotency-Key")
+	if key == "" {
+		key = uuid.NewString()
+	}
+	configuration, err := resolve(input, tenantID(r), key)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "unsupported_or_invalid_configuration", err.Error())
+		return
+	}
+	session, err := h.store.CreateSession(r.Context(), tenantID(r), store.CreateSessionInput{
+		Engine: h.engine, IdempotencyKey: key, Metadata: input.Metadata, Configuration: configuration,
+	})
+	if err != nil {
+		writeStoreError(w, r, err)
+		return
+	}
+	h.respondSession(w, r, session)
+}
+
+// @Summary Retrieve an execution Session
+// @Tags Sessions
+// @Produce json
+// @Security BearerAuth
+// @Param OpenAI-Beta header string true "agents=v1"
+// @Param session_id path string true "Session ID"
+// @Success 200 {object} v1.Session
+// @Failure 400,401,404,500 {object} v1.ErrorResponse
+// @Router /agents/sessions/{session_id} [get]
+func (h *Handler) getSession(w http.ResponseWriter, r *http.Request) {
+	if len(r.URL.Query()) > 0 {
+		writeError(w, http.StatusBadRequest, "unsupported_parameter", "Session retrieval does not accept query parameters.")
+		return
+	}
+	session, err := h.store.GetSession(r.Context(), tenantID(r), chi.URLParam(r, "session_id"))
+	if err != nil {
+		writeStoreError(w, r, err)
+		return
+	}
+	h.respondSession(w, r, session)
+}
+
+func (h *Handler) respondSession(w http.ResponseWriter, r *http.Request, session store.Session) {
+	response, err := sessionResponse(session)
+	if err != nil {
+		writeStoreError(w, r, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+// @Summary List execution Sessions
+// @Description Cursor and results are scoped to the authenticated execution tenant. Saved agent filtering is not supported yet.
+// @Tags Sessions
+// @Produce json
+// @Security BearerAuth
+// @Param OpenAI-Beta header string true "agents=v1"
+// @Param after query string false "Last Session ID from the previous page"
+// @Param limit query int false "Page size" minimum(1) maximum(100) default(20)
+// @Param order query string false "Creation order" Enums(asc,desc) default(desc)
+// @Success 200 {object} v1.SessionList
+// @Failure 400,401,404,500 {object} v1.ErrorResponse
+// @Router /agents/sessions [get]
+func (h *Handler) listSessions(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	for key, values := range q {
+		if (key != "after" && key != "limit" && key != "order") || len(values) != 1 {
+			writeError(w, http.StatusBadRequest, "unsupported_parameter", "Supported list parameters are after, limit and order, each supplied once.")
+			return
+		}
+	}
+	limit, order := 20, q.Get("order")
+	if raw, ok := q["limit"]; ok {
+		var err error
+		limit, err = strconv.Atoi(raw[0])
+		if err != nil || limit < 1 || limit > 100 {
+			writeError(w, http.StatusBadRequest, "invalid_request", "limit must be between 1 and 100.")
+			return
+		}
+	}
+	if order != "" && order != "asc" && order != "desc" {
+		writeError(w, http.StatusBadRequest, "invalid_request", "order must be asc or desc.")
+		return
+	}
+	page, err := h.store.ListSessions(r.Context(), tenantID(r), strings.TrimSpace(q.Get("after")), limit, order == "asc")
+	if err != nil {
+		writeStoreError(w, r, err)
+		return
+	}
+	response := v1.SessionList{Data: make([]v1.Session, 0, len(page.Sessions)), HasMore: page.NextCursor != ""}
+	for _, session := range page.Sessions {
+		item, err := sessionResponse(session)
+		if err != nil {
+			writeStoreError(w, r, err)
+			return
+		}
+		response.Data = append(response.Data, item)
+	}
+	writeJSON(w, http.StatusOK, response)
+}

--- a/services/agents-api/internal/api/handler_test.go
+++ b/services/agents-api/internal/api/handler_test.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+	"github.com/google/uuid"
+)
+
+type recordingStore struct {
+	SessionStore
+	tenant string
+	input  store.CreateSessionInput
+}
+
+func (s *recordingStore) CreateSession(_ context.Context, tenant string, input store.CreateSessionInput) (store.Session, error) {
+	s.tenant, s.input = tenant, input
+	return store.Session{ID: uuid.NewString(), TenantID: tenant, Metadata: input.Metadata, Configuration: input.Configuration, CreatedAt: time.Unix(1700000000, 0)}, nil
+}
+
+func testHandler(t *testing.T) (http.Handler, *recordingStore, string) {
+	t.Helper()
+	tenant := uuid.NewString()
+	hash := sha256.Sum256([]byte("test-api-key"))
+	auth, err := NewAuthenticator([]APIKey{{TokenSHA256: hex.EncodeToString(hash[:]), TenantID: tenant}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &recordingStore{}
+	h, err := NewHandler(s, auth, "claude_code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h, s, tenant
+}
+
+func TestHTTPConfigurationAndTenantIdentity(t *testing.T) {
+	h, s, tenant := testHandler(t)
+	body := `{"agent":{"model":"requested-model","instructions":"Keep this."},"environment":{"type":"none"},"metadata":{"tenant_id":"untrusted-tenant"}}`
+	request := httptest.NewRequest(http.MethodPost, "/v1/agents/sessions", strings.NewReader(body))
+	request.Header.Set("Authorization", "Bearer test-api-key")
+	request.Header.Set("OpenAI-Beta", "agents=v1")
+	request.Header.Set("Idempotency-Key", "retry-key")
+	request.Header.Set("X-Tenant-ID", "untrusted-tenant")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, request)
+	if w.Code != http.StatusOK || s.tenant != tenant || s.input.Engine != "claude_code" || s.input.IdempotencyKey != "retry-key" {
+		t.Fatalf("request = %d %s; tenant=%s, engine=%s", w.Code, w.Body, s.tenant, s.input.Engine)
+	}
+	var response v1.Session
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil || response.Agent.Model != "requested-model" || response.Object != "agent.session" || response.Status != "idle" || response.CreatedAt != 1700000000 {
+		t.Fatalf("invalid response: %s, %v", w.Body, err)
+	}
+	if response.RequiredActions == nil || response.VaultIDs == nil || response.Agent.Tools == nil {
+		t.Fatal("upstream list fields must be empty arrays, not null")
+	}
+}
+
+func TestHTTPRejectsUntrustedOrUnsupportedRequests(t *testing.T) {
+	valid := `{"agent":{"model":"example"},"environment":{"type":"none"}}`
+	for _, test := range []struct {
+		name, auth, beta, path, body string
+		status                       int
+	}{
+		{"missing auth", "", "agents=v1", "/v1/agents/sessions", valid, 401},
+		{"invalid auth", "Bearer wrong", "agents=v1", "/v1/agents/sessions", valid, 401},
+		{"missing beta", "Bearer test-api-key", "", "/v1/agents/sessions", valid, 400},
+		{"tenant query", "Bearer test-api-key", "agents=v1", "/v1/agents/sessions?tenant_id=other", valid, 400},
+		{"tenant body", "Bearer test-api-key", "agents=v1", "/v1/agents/sessions", strings.Replace(valid, `"agent":`, `"tenant_id":"other","agent":`, 1), 400},
+		{"hosted environment", "Bearer test-api-key", "agents=v1", "/v1/agents/sessions", strings.Replace(valid, `"none"`, `"openai_hosted"`, 1), 400},
+		{"initial input", "Bearer test-api-key", "agents=v1", "/v1/agents/sessions", strings.Replace(valid, `"agent":`, `"input":"run it","agent":`, 1), 400},
+		{"stream", "Bearer test-api-key", "agents=v1", "/v1/agents/sessions", strings.Replace(valid, `"agent":`, `"stream":true,"agent":`, 1), 400},
+		{"saved agent", "Bearer test-api-key", "agents=v1", "/v1/agents/sessions", strings.Replace(valid, `"agent":`, `"agent_id":"saved","agent":`, 1), 400},
+		{"unknown agent option", "Bearer test-api-key", "agents=v1", "/v1/agents/sessions", strings.Replace(valid, `"model":`, `"tools":[{}],"model":`, 1), 400},
+		{"multiple objects", "Bearer test-api-key", "agents=v1", "/v1/agents/sessions", valid + `{}`, 400},
+		{"no object", "Bearer test-api-key", "agents=v1", "/v1/agents/sessions", `null`, 400},
+		{"large body", "Bearer test-api-key", "agents=v1", "/v1/agents/sessions", `{"agent":{"model":"` + strings.Repeat("x", 1024*1024) + `"}}`, 413},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			h, s, _ := testHandler(t)
+			r := httptest.NewRequest(http.MethodPost, test.path, strings.NewReader(test.body))
+			r.Header.Set("Authorization", test.auth)
+			r.Header.Set("OpenAI-Beta", test.beta)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			var response v1.ErrorResponse
+			if w.Code != test.status || json.Unmarshal(w.Body.Bytes(), &response) != nil || response.Error.Code == "" || s.tenant != "" {
+				t.Fatalf("response = %d %s, stored tenant = %s", w.Code, w.Body, s.tenant)
+			}
+		})
+	}
+}
+
+func TestAuthenticatorRejectsInvalidBindings(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	tenant := uuid.NewString()
+	for _, keys := range [][]APIKey{nil, {{TenantID: tenant, TokenSHA256: "bad"}}, {{TenantID: "not-a-tenant", TokenSHA256: digest}}, {{TenantID: tenant, TokenSHA256: digest}, {TenantID: uuid.NewString(), TokenSHA256: digest}}} {
+		if _, err := NewAuthenticator(keys); err == nil {
+			t.Fatal("invalid authentication bindings accepted")
+		}
+	}
+}

--- a/services/agents-api/internal/db/queries/sessions.sql
+++ b/services/agents-api/internal/db/queries/sessions.sql
@@ -13,6 +13,11 @@ SELECT * FROM sessions WHERE tenant_id = $1 AND id = $2;
 SELECT * FROM sessions
 WHERE tenant_id = sqlc.arg(tenant_id)
   AND (sqlc.narg(after_created)::timestamptz IS NULL
-       OR (created_at, id) < (sqlc.narg(after_created)::timestamptz, sqlc.arg(after_id)::uuid))
-ORDER BY created_at DESC, id DESC
+       OR (NOT sqlc.arg(ascending)::boolean AND (created_at, id) < (sqlc.narg(after_created)::timestamptz, sqlc.arg(after_id)::uuid))
+       OR (sqlc.arg(ascending)::boolean AND (created_at, id) > (sqlc.narg(after_created)::timestamptz, sqlc.arg(after_id)::uuid)))
+ORDER BY
+    CASE WHEN sqlc.arg(ascending)::boolean THEN created_at END ASC,
+    CASE WHEN sqlc.arg(ascending)::boolean THEN id END ASC,
+    CASE WHEN NOT sqlc.arg(ascending)::boolean THEN created_at END DESC,
+    CASE WHEN NOT sqlc.arg(ascending)::boolean THEN id END DESC
 LIMIT sqlc.arg(page_limit);

--- a/services/agents-api/internal/db/sqlc/sessions.sql.go
+++ b/services/agents-api/internal/db/sqlc/sessions.sql.go
@@ -83,14 +83,20 @@ const listSessions = `-- name: ListSessions :many
 SELECT id, tenant_id, engine, metadata, idempotency_key, request_hash, created_at, configuration FROM sessions
 WHERE tenant_id = $1
   AND ($2::timestamptz IS NULL
-       OR (created_at, id) < ($2::timestamptz, $3::uuid))
-ORDER BY created_at DESC, id DESC
-LIMIT $4
+       OR (NOT $3::boolean AND (created_at, id) < ($2::timestamptz, $4::uuid))
+       OR ($3::boolean AND (created_at, id) > ($2::timestamptz, $4::uuid)))
+ORDER BY
+    CASE WHEN $3::boolean THEN created_at END ASC,
+    CASE WHEN $3::boolean THEN id END ASC,
+    CASE WHEN NOT $3::boolean THEN created_at END DESC,
+    CASE WHEN NOT $3::boolean THEN id END DESC
+LIMIT $5
 `
 
 type ListSessionsParams struct {
 	TenantID     pgtype.UUID        `json:"tenant_id"`
 	AfterCreated pgtype.Timestamptz `json:"after_created"`
+	Ascending    bool               `json:"ascending"`
 	AfterID      pgtype.UUID        `json:"after_id"`
 	PageLimit    int32              `json:"page_limit"`
 }
@@ -99,6 +105,7 @@ func (q *Queries) ListSessions(ctx context.Context, arg ListSessionsParams) ([]S
 	rows, err := q.db.Query(ctx, listSessions,
 		arg.TenantID,
 		arg.AfterCreated,
+		arg.Ascending,
 		arg.AfterID,
 		arg.PageLimit,
 	)

--- a/services/agents-api/internal/store/session_configuration_test.go
+++ b/services/agents-api/internal/store/session_configuration_test.go
@@ -40,7 +40,7 @@ func TestConfigurationSizeLimitSurvivesJSONBRoundTrip(t *testing.T) {
 	if err != nil || string(got.Configuration) != string(first.Configuration) {
 		t.Fatalf("configuration failed round trip: %v", err)
 	}
-	page, err := s.ListSessions(ctx, tenant, "", 10)
+	page, err := s.ListSessions(ctx, tenant, "", 10, false)
 	if err != nil || len(page.Sessions) != 1 || page.Sessions[0].ID != first.ID {
 		t.Fatalf("configuration broke listing: %v", err)
 	}

--- a/services/agents-api/internal/store/sessions.go
+++ b/services/agents-api/internal/store/sessions.go
@@ -54,6 +54,8 @@ type Store struct{ queries *sqlc.Queries }
 
 func New(pool *pgxpool.Pool) *Store { return &Store{queries: sqlc.New(pool)} }
 
+func ValidEngine(engine string) bool { return enginePattern.MatchString(engine) }
+
 // CreateSession uses a caller-scoped key to make retries safe, including
 // concurrent submissions. Different input with the same key is a conflict.
 func (s *Store) CreateSession(ctx context.Context, tenantID string, input CreateSessionInput) (Session, error) {
@@ -62,7 +64,7 @@ func (s *Store) CreateSession(ctx context.Context, tenantID string, input Create
 		return Session{}, err
 	}
 	input.Engine = strings.TrimSpace(input.Engine)
-	if !enginePattern.MatchString(input.Engine) || strings.TrimSpace(input.IdempotencyKey) == "" || len(input.IdempotencyKey) > 128 {
+	if !ValidEngine(input.Engine) || strings.TrimSpace(input.IdempotencyKey) == "" || len(input.IdempotencyKey) > 128 {
 		return Session{}, fmt.Errorf("%w: engine and idempotency key are required", ErrInvalidInput)
 	}
 	if input.Metadata == nil {
@@ -72,8 +74,8 @@ func (s *Store) CreateSession(ctx context.Context, tenantID string, input Create
 	if err != nil {
 		return Session{}, fmt.Errorf("%w: metadata: %v", ErrInvalidInput, err)
 	}
-	if len(metadata) > 16*1024 {
-		return Session{}, fmt.Errorf("%w: metadata exceeds 16 KiB", ErrInvalidInput)
+	if len(metadata) > 64*1024 {
+		return Session{}, fmt.Errorf("%w: metadata exceeds 64 KiB", ErrInvalidInput)
 	}
 	if len(input.Configuration) > 512*1024 {
 		return Session{}, fmt.Errorf("%w: configuration exceeds 512 KiB", ErrInvalidInput)
@@ -131,9 +133,9 @@ func (s *Store) GetSession(ctx context.Context, tenantID, sessionID string) (Ses
 	return sessionFromRow(row)
 }
 
-// ListSessions returns newest sessions first. The cursor is the last returned
+// ListSessions orders by creation time and ID. The cursor is the last returned
 // session ID and must belong to the same tenant; it grants no additional access.
-func (s *Store) ListSessions(ctx context.Context, tenantID, cursor string, limit int) (SessionPage, error) {
+func (s *Store) ListSessions(ctx context.Context, tenantID, cursor string, limit int, ascending bool) (SessionPage, error) {
 	tenant, err := parseID(tenantID)
 	if err != nil {
 		return SessionPage{}, err
@@ -141,7 +143,7 @@ func (s *Store) ListSessions(ctx context.Context, tenantID, cursor string, limit
 	if limit < 1 || limit > 100 {
 		return SessionPage{}, fmt.Errorf("%w: page size must be 1..100", ErrInvalidInput)
 	}
-	params := sqlc.ListSessionsParams{TenantID: tenant, PageLimit: int32(limit + 1), AfterID: pgtype.UUID{Valid: true}}
+	params := sqlc.ListSessionsParams{TenantID: tenant, PageLimit: int32(limit + 1), AfterID: pgtype.UUID{Valid: true}, Ascending: ascending}
 	if cursor != "" {
 		after, err := s.GetSession(ctx, tenantID, cursor)
 		if err != nil {

--- a/services/agents-api/internal/store/sessions_test.go
+++ b/services/agents-api/internal/store/sessions_test.go
@@ -92,7 +92,7 @@ func TestSessionsPersistAndStayTenantScoped(t *testing.T) {
 	if _, err := s.GetSession(ctx, tenantB, first.ID); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("cross-tenant read: %v", err)
 	}
-	if _, err := s.ListSessions(ctx, tenantB, first.ID, 10); !errors.Is(err, ErrNotFound) {
+	if _, err := s.ListSessions(ctx, tenantB, first.ID, 10, false); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("cross-tenant cursor: %v", err)
 	}
 	for _, key := range []string{"second", "third"} {
@@ -111,7 +111,7 @@ func TestSessionsPersistAndStayTenantScoped(t *testing.T) {
 	seen := map[string]bool{}
 	cursor := ""
 	for {
-		page, err := recovered.ListSessions(ctx, tenantA, cursor, 2)
+		page, err := recovered.ListSessions(ctx, tenantA, cursor, 2, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -132,7 +132,7 @@ func TestSessionsPersistAndStayTenantScoped(t *testing.T) {
 	if len(seen) != 3 || !seen[first.ID] || seen[other.ID] {
 		t.Fatalf("pagination lost or leaked sessions: %+v", seen)
 	}
-	empty, err := recovered.ListSessions(ctx, uuid.NewString(), "", 10)
+	empty, err := recovered.ListSessions(ctx, uuid.NewString(), "", 10, false)
 	if err != nil || empty.Sessions == nil || len(empty.Sessions) != 0 {
 		t.Fatalf("empty tenant = %+v, %v", empty, err)
 	}
@@ -183,7 +183,7 @@ func TestConcurrentSessionCreationIsIdempotent(t *testing.T) {
 			t.Fatalf("changed request = %v", err)
 		}
 	}
-	page, err := s.ListSessions(ctx, tenant, "", 10)
+	page, err := s.ListSessions(ctx, tenant, "", 10, false)
 	if err != nil || len(page.Sessions) != 1 || !reflect.DeepEqual(page.Sessions[0], replay) {
 		t.Fatalf("retry changed stored session: %+v, %v", page, err)
 	}

--- a/services/agents-api/tests/official_client.py
+++ b/services/agents-api/tests/official_client.py
@@ -1,0 +1,129 @@
+"""Exercise the real service and PostgreSQL with the pinned official Python SDK."""
+
+import hashlib
+import importlib.metadata
+import json
+import os
+from pathlib import Path
+import secrets
+import socket
+import subprocess
+import tempfile
+import time
+from urllib.parse import parse_qs, urlsplit
+import uuid
+
+import httpx2
+from openai import AuthenticationError, BadRequestError, ConflictError, NotFoundError, OpenAI
+
+
+def main():
+    root = Path(__file__).resolve().parents[3]
+    pin = json.loads((root / "contracts/agents-api/upstream.json").read_text())
+    distribution = importlib.metadata.distribution("openai")
+    source = json.loads(distribution.read_text("direct_url.json") or "{}")
+    assert source.get("vcs_info", {}).get("commit_id") == pin["commit"], "Install the pinned SDK commit first"
+    dsn = os.environ["PARSAR_AGENTS_API_TEST_DATABASE_URL"]
+    parts = urlsplit(dsn)
+    database = parse_qs(parts.query).get("dbname", [parts.path.lstrip("/")])[0]
+    assert parts.scheme in ("postgres", "postgresql") and database.startswith("parsar_agents_api_") and database.endswith("_tests"), "A dedicated execution test database is required"
+    binary = os.environ["AGENTS_API_SERVER_BIN"]
+    with socket.socket() as address:
+        address.bind(("127.0.0.1", 0))
+        port = address.getsockname()[1]
+    base = f"http://127.0.0.1:{port}"
+    tokens = [secrets.token_hex(32), secrets.token_hex(32)]
+    bindings = [{"tenant_id": str(uuid.uuid4()), "token_sha256": hashlib.sha256(token.encode()).hexdigest()} for token in tokens]
+    process = None
+    with tempfile.TemporaryDirectory(prefix="agents-api-test-") as directory:
+        keys = Path(directory) / "keys.json"
+        keys.write_text(json.dumps(bindings))
+        keys.chmod(0o600)
+        env = dict(os.environ, AGENTS_API_DATABASE_URL=dsn, AGENTS_API_KEYS_FILE=str(keys), AGENTS_API_ADDR=f"127.0.0.1:{port}", AGENTS_API_ENGINE="codex")
+        with (Path(directory) / "server.log").open("w+") as log:
+            def start():
+                child = subprocess.Popen([binary], env=env, stdout=log, stderr=log)
+                try:
+                    deadline = time.monotonic() + 20
+                    with httpx2.Client(trust_env=False, timeout=1) as probe:
+                        while time.monotonic() < deadline:
+                            if child.poll() is not None:
+                                raise AssertionError("Agents API exited during startup")
+                            try:
+                                if probe.get(base + "/healthz").status_code == 200:
+                                    return child
+                            except httpx2.TransportError:
+                                pass
+                            time.sleep(0.1)
+                    raise AssertionError("Agents API did not become healthy")
+                except BaseException:
+                    child.terminate()
+                    child.wait(timeout=15)
+                    raise
+
+            def client(token):
+                return OpenAI(api_key=token, base_url=base + "/v1", max_retries=0, _strict_response_validation=True, http_client=httpx2.Client(trust_env=False, timeout=10))
+
+            def expect_error(error, operation):
+                try:
+                    operation()
+                except error as result:
+                    assert isinstance(result.body, dict) and result.body.get("code")
+                else:
+                    raise AssertionError(f"Expected {error.__name__}")
+
+            try:
+                process = start()
+                with client(tokens[0]) as a, client(tokens[1]) as b, client("invalid-key") as invalid:
+                    sessions = a.beta.agents.sessions
+                    spec = {"agent": {"model": "requested-test-model", "instructions": "Keep the configuration."}, "environment": {"type": "none"}}
+                    headers = {"Idempotency-Key": "same-key"}
+                    first = sessions.create(**spec, metadata={"workspace": "untrusted-reference"}, extra_headers=headers)
+                    assert first.object == "agent.session" and first.status == "idle"
+                    assert first.agent.model == spec["agent"]["model"] and first.agent.instructions == spec["agent"]["instructions"]
+                    assert first.environment.type == "none" and first.required_actions == [] and first.vault_ids == []
+                    assert first.agent.tools == [] and first.agent.multi_agent.enabled is False
+                    assert first.created_at == first.last_active_at and isinstance(first.created_at, int)
+                    replay = sessions.create(**spec, metadata={"workspace": "untrusted-reference"}, extra_headers=headers)
+                    assert replay == first
+                    assert sessions.retrieve(first.id) == first
+                    changed = {**spec, "agent": {**spec["agent"], "instructions": "Changed"}}
+                    expect_error(ConflictError, lambda: sessions.create(**changed, metadata={"workspace": "untrusted-reference"}, extra_headers=headers))
+                    others = [sessions.create(**spec) for _ in range(2)]
+                    expected = {first.id, *(item.id for item in others)}
+                    asc = list(sessions.list(limit=1, order="asc"))
+                    desc = list(sessions.list(limit=2, order="desc"))
+                    assert {item.id for item in asc} == expected
+                    assert [item.id for item in asc] == list(reversed([item.id for item in desc]))
+                    assert list(sessions.list(after=asc[-1].id, order="asc")) == []
+                    other = b.beta.agents.sessions.create(**spec, extra_headers=headers)
+                    assert other.id != first.id
+                    assert [item.id for item in b.beta.agents.sessions.list()] == [other.id]
+                    expect_error(NotFoundError, lambda: b.beta.agents.sessions.retrieve(first.id))
+                    expect_error(NotFoundError, lambda: b.beta.agents.sessions.list(after=first.id))
+                    expect_error(AuthenticationError, lambda: invalid.beta.agents.sessions.retrieve(first.id))
+                    expect_error(BadRequestError, lambda: sessions.retrieve(first.id, extra_headers={"OpenAI-Beta": ""}))
+                    expect_error(BadRequestError, lambda: sessions.create(**spec, input="Do work"))
+                    expect_error(BadRequestError, lambda: sessions.create(**spec, stream=True))
+                    expect_error(BadRequestError, lambda: sessions.create(agent=spec["agent"], environment={"type": "self_hosted", "workspace_directory": "/workspace"}))
+                    expect_error(BadRequestError, lambda: sessions.create(**spec, extra_body={"tenant_id": bindings[1]["tenant_id"]}))
+                    expect_error(BadRequestError, lambda: sessions.list(agent_id="unsupported-saved-agent"))
+                    expect_error(BadRequestError, lambda: sessions.list(limit=0))
+                    assert {item.id for item in sessions.list()} == expected
+                    metadata = {str(i): "🧪" * 512 for i in range(16)}
+                    large = sessions.create(**spec, metadata=metadata)
+                    assert sessions.retrieve(large.id).metadata == metadata
+                    process.terminate()
+                    process.wait(timeout=15)
+                    process = start()
+                    assert sessions.retrieve(first.id) == first
+                    assert sessions.create(**spec, metadata={"workspace": "untrusted-reference"}, extra_headers=headers) == first
+                print("Official client: strict schemas, persistence/restart, retries, pagination, tenant isolation and explicit unsupported options passed.")
+            finally:
+                if process and process.poll() is None:
+                    process.terminate()
+                    process.wait(timeout=15)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/agents-api/tests/official_client.py
+++ b/services/agents-api/tests/official_client.py
@@ -14,11 +14,32 @@ from urllib.parse import parse_qs, urlsplit
 import uuid
 
 import httpx2
+from jsonschema import Draft4Validator
 from openai import AuthenticationError, BadRequestError, ConflictError, NotFoundError, OpenAI
+import yaml
+
+
+def nullable_schema(value):
+    """Translate Swagger 2's nullable extension for JSON Schema validation."""
+    if isinstance(value, list):
+        return [nullable_schema(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    converted = {key: nullable_schema(item) for key, item in value.items() if key != "x-nullable"}
+    return {"anyOf": [{"type": "null"}, converted]} if value.get("x-nullable") else converted
 
 
 def main():
     root = Path(__file__).resolve().parents[3]
+    contract = nullable_schema(yaml.safe_load((root / "contracts/agents-api/openapi.yaml").read_text()))
+
+    def validate_response(response):
+        response.read()
+        path = response.request.url.path.removeprefix("/v1")
+        if path.startswith("/agents/sessions/"):
+            path = "/agents/sessions/{session_id}"
+        schema = contract["paths"][path][response.request.method.lower()]["responses"][str(response.status_code)]["schema"]
+        Draft4Validator({"definitions": contract["definitions"], **schema}).validate(response.json())
     pin = json.loads((root / "contracts/agents-api/upstream.json").read_text())
     distribution = importlib.metadata.distribution("openai")
     source = json.loads(distribution.read_text("direct_url.json") or "{}")
@@ -62,7 +83,7 @@ def main():
                     raise
 
             def client(token):
-                return OpenAI(api_key=token, base_url=base + "/v1", max_retries=0, _strict_response_validation=True, http_client=httpx2.Client(trust_env=False, timeout=10))
+                return OpenAI(api_key=token, base_url=base + "/v1", max_retries=0, _strict_response_validation=True, http_client=httpx2.Client(trust_env=False, timeout=10, event_hooks={"response": [validate_response]}))
 
             def expect_error(error, operation):
                 try:
@@ -118,7 +139,7 @@ def main():
                     process = start()
                     assert sessions.retrieve(first.id) == first
                     assert sessions.create(**spec, metadata={"workspace": "untrusted-reference"}, extra_headers=headers) == first
-                print("Official client: strict schemas, persistence/restart, retries, pagination, tenant isolation and explicit unsupported options passed.")
+                print("Official client: upstream and generated response schemas, persistence/restart, retries, pagination, tenant isolation and explicit unsupported options passed.")
             finally:
                 if process and process.poll() is None:
                     process.terminate()

--- a/services/agents-api/tests/requirements.txt
+++ b/services/agents-api/tests/requirements.txt
@@ -1,0 +1,2 @@
+jsonschema==4.25.1
+PyYAML==6.0.2


### PR DESCRIPTION
Agents API now runs independently and exposes the supported `openai-python` beta/agents Session create, retrieve and list operations. Bearer key digests bind callers to execution tenants; inline Agent configuration and creation retry identity persist in the dedicated database.

This slice supports model/instructions, environment `none`, metadata, ascending/descending cursor pagination and safe errors. It explicitly rejects initial input, streaming, saved Agent references, other environments and unsupported options. It does not execute Turns, switch product traffic or add Team orchestration.

Generate the service contract separately from the unchanged product API contract, and run the pinned official client with strict response validation in CI. Runtime code remains within the new service and its supported contract types; existing migrations are unchanged.

Validation: `make check`, `make sqlc-generate`, `make openapi`, structural OpenAPI lint, and a real standalone process against remote isolated PostgreSQL. The pinned official SDK verifies schemas, configuration/restart persistence, retry conflicts, both pagination orders, tenant isolation, Unicode metadata and explicit unsupported behavior. Local Docker remains stopped.

Independent blind review completed. Its generated-schema nullability finding was corrected in the wire annotations; the real HTTP proof now validates every response against both the generated Swagger contract and the pinned official client types. The annotation/test correction was locally reviewed; runtime behavior did not change.
