### PR TITLE
feat(agents-api): use official Go SDK for product client

### DIFF
--- a/.github/workflows/agents-api.yml
+++ b/.github/workflows/agents-api.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'services/agents-api/**'
       - 'contracts/agents-api/**'
+      - 'packages/agents-client/**'
       - 'internal/**'
       - 'go.mod'
       - 'go.sum'
@@ -15,6 +16,7 @@ on:
     paths:
       - 'services/agents-api/**'
       - 'contracts/agents-api/**'
+      - 'packages/agents-client/**'
       - 'internal/**'
       - 'go.mod'
       - 'go.sum'

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,7 @@ on:
       - "server/**"
       - "services/agents-api/**"
       - "contracts/agents-api/**"
+      - "packages/agents-client/**"
       - "internal/**"
       - "apps/web/**"
       - "packages/cli/**"
@@ -32,6 +33,7 @@ on:
       - "server/**"
       - "services/agents-api/**"
       - "contracts/agents-api/**"
+      - "packages/agents-client/**"
       - "internal/**"
       - "apps/web/**"
       - "packages/cli/**"
@@ -104,7 +106,7 @@ jobs:
                 go=true
                 store=true
                 ;;
-              server/*|internal/*|services/agents-api/*|contracts/agents-api/*)
+              server/*|internal/*|services/agents-api/*|contracts/agents-api/*|packages/agents-client/*)
                 go=true
                 ;;
               apps/web/*)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,9 +154,16 @@ the existing server remains the execution owner until a flow is explicitly moved
   operator-selected `AGENTS_API_ENGINE` is separate from the requested model.
   Until execution is connected, support only documented idle Session operations
   and reject unsupported input/environment/agent options explicitly.
+- `packages/agents-client/v1` configures the pinned official `openai-go` Session
+  service. Use SDK request/response types, pagination and errors directly rather
+  than reimplementing transport or copying wire types. Supply an explicit service
+  base URL/key and creation retry key; SDK retries are disabled by default. Product
+  integration is a later cutover, not a side effect of constructing this client.
 - `services/agents-api/tests/official_client.py` verifies the actual server with
   the pinned SDK and strict response validation. It requires a dedicated test DB
   prepared by the Store tests and `AGENTS_API_SERVER_BIN`; it never starts Docker.
+  The same harness runs the official Go client with fresh execution tenants and
+  checks its created Sessions through the Python SDK.
 
 ### Agent knowledge references
 
@@ -761,6 +768,11 @@ the existing server remains the execution owner until a flow is explicitly moved
   or SQL first, then regenerate.
 
 ## Code quality & architecture
+
+Prefer existing code, official SDKs and maintained third-party components before
+adding custom infrastructure. Keep adapters limited to product-specific behavior;
+pin dependencies and verify compatibility at the service boundary. Record the
+chosen dependency and any necessary custom implementation in the linked task.
 
 Parsar favors small, single-purpose files and reused helpers over growing
 files and copy-pasted logic. These rules are forward-looking: they do not

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-GO_TEST_PACKAGE ?= $(shell cd server && go list ./... ../internal/agentdaemon/gateway ../internal/agentdaemon/device ../services/agents-api/... | grep -Ev '/server/internal/(store|seed)$$')
+GO_TEST_PACKAGE ?= $(shell cd server && go list ./... ../internal/agentdaemon/gateway ../internal/agentdaemon/device ../services/agents-api/... ../packages/agents-client/... | grep -Ev '/server/internal/(store|seed)$$')
 GO_TEST_RUN ?=
 GO_TEST_ARGS ?=
 SQLC_VERSION ?= v1.29.0
@@ -341,4 +341,4 @@ e2b-template-binaries:
 # Dedicated execution-store tests require their own PostgreSQL database.
 .PHONY: check-agents-api
 check-agents-api:
-	go test ./services/agents-api/... -count=1
+	go test ./services/agents-api/... ./packages/agents-client/... -count=1

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -38,6 +38,7 @@ separate future dependency for Team orchestration in Parsar, not the HTTP contra
 | Turn execution, events, results and cancellation | Pending |
 | Pending actions and environment lifecycle | Pending |
 | Official-client compatibility | Strict SDK checks for the supported Session subset, pagination, retries, errors, tenant isolation and restart |
+| Go product client | Official `openai-go` v3.61.0 with a thin service configuration; real HTTP integration tests |
 | Product cutover | Pending |
 | Team orchestration | Deferred; Parsar-owned |
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/larksuite/oapi-sdk-go/v3 v3.10.0
+	github.com/openai/openai-go/v3 v3.61.0
 	github.com/pressly/goose/v3 v3.27.3
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/slack-go/slack v0.29.0
@@ -20,6 +21,13 @@ require (
 	golang.org/x/crypto v0.55.0
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/tidwall/gjson v1.19.0 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.1 // indirect
+	github.com/tidwall/sjson v1.2.5 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6
 github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/openai/openai-go/v3 v3.61.0 h1:nMLuGFdKBF0sB3qFVNwE8kpBpenVN1ucYRoKcx7E1u0=
+github.com/openai/openai-go/v3 v3.61.0/go.mod h1:ufI1+K+t0ijRB3gk8eztiw1crcDpsBuxRQL4sbLIrts=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pressly/goose/v3 v3.27.3 h1:pIglVHjw99r4e/hDHHwbl9vfOsDMqUokfkXo6+n/RxA=
@@ -89,6 +91,16 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.19.0 h1:xwxm7n691Uf3u5OFjzngavjGTh55KX5q/9w9xHW88JU=
+github.com/tidwall/gjson v1.19.0/go.mod h1:V37/opeE/JbLUOfH0QTXiNez2l0RUjYUhpT4szFQAfc=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
+github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/packages/agents-client/README.md
+++ b/packages/agents-client/README.md
@@ -1,0 +1,56 @@
+# Agents API Go client
+
+`v1` configures the [official openai-go SDK](https://github.com/openai/openai-go/tree/v3.61.0),
+pinned in the root `go.mod`. It returns the SDK's Session service directly. Request
+types, response parsing, cursor pagination, events and errors remain SDK-owned.
+The external protocol baseline remains the pinned Python SDK in
+[`contracts/agents-api/upstream.json`](../../contracts/agents-api/upstream.json).
+
+```go
+import (
+    agentsclient "github.com/MiniMax-AI-Dev/parsar/packages/agents-client/v1"
+    "github.com/openai/openai-go/v3"
+    "github.com/openai/openai-go/v3/option"
+)
+
+sessions, err := agentsclient.New(agentsclient.Config{
+    BaseURL: serviceBaseURL, // Includes /v1; use TLS for remote connections.
+    APIKey: serviceKey,     // Execution tenant identity, not a product login token.
+})
+if err != nil {
+    return err
+}
+session, err := sessions.New(ctx, openai.BetaAgentSessionNewParams{
+    Agent: openai.BetaAgentSessionNewParamsAgent{
+        Model: openai.String("requested-model"),
+        Instructions: openai.String("Follow the supplied instructions."),
+    },
+    Environment: openai.EnvironmentParamUnion{
+        OfParamNone: &openai.EnvironmentParamNone{},
+    },
+}, option.WithHeader("Idempotency-Key", operationID))
+```
+
+Use a stable, non-secret operation ID for a creation retry, with the same request.
+Omitting the key creates a new Session on each call. SDK retries are disabled by
+default. Requests honor the caller's context; the default HTTP timeout is 30 seconds.
+An optional trusted HTTP client can configure the transport/timeout. Its cookie jar
+is ignored and redirects are rejected. No OpenAI environment credentials or product
+session cookies are inherited. Per-request SDK options are trusted application code;
+do not accept them from end users.
+
+Use `sessions.Get`, `sessions.List` and the returned page's `GetNextPage` directly.
+Errors can be inspected using `errors.As(err, &apiErr)` with `*openai.Error`.
+SDK errors retain the request and response: log selected status/code fields, not
+raw errors, request dumps or credentials. Constructing this client does not switch
+Parsar's current execution flow or grant workspace/user permissions.
+
+The SDK includes more methods than the server currently supports. Only the
+[documented Session subset](../../contracts/agents-api/README.md) is implemented;
+other methods receive explicit service errors. Team orchestration belongs in Parsar
+and depends on `openai-agents-python`, not this client package.
+
+`make check-go` includes configuration tests. The real-service harness in
+`services/agents-api/tests/official_client.py` runs `TestService` with fresh tenants
+and a dedicated PostgreSQL database. It validates Go-created Sessions through the
+official Python SDK as well. No product database or model calls are involved.

--- a/packages/agents-client/v1/client.go
+++ b/packages/agents-client/v1/client.go
@@ -1,0 +1,49 @@
+// Package v1 configures the official Go SDK for Parsar's independent Agents API.
+package v1
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+type Config struct {
+	// BaseURL includes the API prefix, for example https://agents.example/v1.
+	BaseURL string
+	APIKey  string
+	// HTTPClient optionally supplies a trusted transport and timeout. The client
+	// is copied; its cookie jar and redirect policy are not used.
+	HTTPClient *http.Client
+}
+
+// New returns the official Session service. It does not load OpenAI environment
+// credentials or switch Parsar's execution path. Callers use SDK types, pagination
+// and *openai.Error directly, and supply Idempotency-Key for creation retries.
+// SDK retries are disabled; an uncertain write can be retried with the same key.
+func New(cfg Config) (openai.BetaAgentSessionService, error) {
+	u, err := url.Parse(cfg.BaseURL)
+	if err != nil || u == nil || (u.Scheme != "http" && u.Scheme != "https") || u.Hostname() == "" || u.User != nil || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return openai.BetaAgentSessionService{}, errors.New("agents API base URL must be an absolute HTTP(S) URL without credentials, query or fragment")
+	}
+	if strings.TrimSpace(cfg.APIKey) == "" || strings.ContainsAny(cfg.APIKey, " \t\r\n") {
+		return openai.BetaAgentSessionService{}, errors.New("an explicit agents API key without whitespace is required")
+	}
+	h := http.Client{Timeout: 30 * time.Second}
+	if cfg.HTTPClient != nil {
+		h = *cfg.HTTPClient
+	}
+	// Product cookies and redirected credentials must not cross this boundary.
+	h.Jar = nil
+	h.CheckRedirect = func(*http.Request, []*http.Request) error { return errors.New("agents API redirects are disabled") }
+	return openai.NewBetaAgentSessionService(
+		option.WithBaseURL(strings.TrimRight(u.String(), "/")+"/"),
+		option.WithAPIKey(cfg.APIKey),
+		option.WithHTTPClient(&h),
+		option.WithMaxRetries(0),
+	), nil
+}

--- a/packages/agents-client/v1/client_test.go
+++ b/packages/agents-client/v1/client_test.go
@@ -1,0 +1,85 @@
+package v1_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	client "github.com/MiniMax-AI-Dev/parsar/packages/agents-client/v1"
+	"github.com/openai/openai-go/v3"
+)
+
+func TestExplicitServiceIdentityAndNoSDKRetries(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "unrelated-key")
+	t.Setenv("OPENAI_BASE_URL", "http://unrelated.invalid")
+	t.Setenv("OPENAI_ORG_ID", "unrelated-org")
+	calls := 0
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path != "/prefix/v1/agents/sessions/session-1" || r.Header.Get("Authorization") != "Bearer service-key" || r.Header.Get("OpenAI-Beta") != "agents=v1" || r.Header.Get("OpenAI-Organization") != "" {
+			t.Error("incorrect service address or identity")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"code":"unavailable","message":"try later","type":"server_error"}}`))
+	}))
+	defer s.Close()
+	c, err := client.New(client.Config{BaseURL: s.URL + "/prefix/v1", APIKey: "service-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.Get(context.Background(), "session-1")
+	var apiErr *openai.Error
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 503 || apiErr.Code != "unavailable" || calls != 1 {
+		t.Fatalf("expected one request and the SDK error: %v", err)
+	}
+}
+
+func TestRedirectsAndProductCookies(t *testing.T) {
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/unexpected" || r.Header.Get("Cookie") != "" {
+			t.Error("followed redirect or sent product cookies")
+		}
+		w.Header().Set("Location", "/unexpected")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer s.Close()
+	jar, _ := cookiejar.New(nil)
+	u, _ := url.Parse(s.URL)
+	jar.SetCookies(u, []*http.Cookie{{Name: "product-session", Value: "private"}})
+	h := &http.Client{Jar: jar, Timeout: time.Second}
+	c, err := client.New(client.Config{BaseURL: s.URL + "/v1/", APIKey: "service-key", HTTPClient: h})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = c.Get(context.Background(), "session-1")
+	if err == nil || !strings.Contains(err.Error(), "redirects are disabled") || h.Jar != jar || h.CheckRedirect != nil {
+		t.Fatal("redirect policy failed or modified the caller's client")
+	}
+}
+
+func TestConfigurationAndContext(t *testing.T) {
+	for _, base := range []string{"relative", "ftp://host/v1", "http://user:secret@host/v1", "http://host/v1?key=secret"} {
+		if _, err := client.New(client.Config{BaseURL: base, APIKey: "key"}); err == nil || strings.Contains(err.Error(), "secret") {
+			t.Fatal("invalid base URL accepted or exposed")
+		}
+	}
+	if _, err := client.New(client.Config{BaseURL: "http://localhost/v1"}); err == nil {
+		t.Fatal("accepted missing service key")
+	}
+	c, err := client.New(client.Config{BaseURL: "http://localhost/v1", APIKey: "key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.Get(ctx, "session-1"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("lost context cancellation: %v", err)
+	}
+}

--- a/packages/agents-client/v1/service_test.go
+++ b/packages/agents-client/v1/service_test.go
@@ -1,0 +1,107 @@
+package v1_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"slices"
+	"testing"
+	"time"
+
+	client "github.com/MiniMax-AI-Dev/parsar/packages/agents-client/v1"
+	"github.com/openai/openai-go/v3"
+	"github.com/openai/openai-go/v3/option"
+)
+
+// The official-client harness starts the actual service with a dedicated test
+// database and fresh tenant keys, then supplies these explicit test variables.
+func TestService(t *testing.T) {
+	base, key, otherKey := os.Getenv("AGENTS_API_CLIENT_TEST_BASE_URL"), os.Getenv("AGENTS_API_CLIENT_TEST_KEY"), os.Getenv("AGENTS_API_CLIENT_TEST_OTHER_KEY")
+	if base == "" && key == "" && otherKey == "" {
+		t.Skip("real service test is run by services/agents-api/tests/official_client.py")
+	}
+	if base == "" || key == "" || otherKey == "" {
+		t.Fatal("all real service test settings are required")
+	}
+	newClient := func(token string) openai.BetaAgentSessionService {
+		t.Helper()
+		c, err := client.New(client.Config{BaseURL: base, APIKey: token})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return c
+	}
+	a, b, invalid := newClient(key), newClient(otherKey), newClient("invalid-key")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	input := openai.BetaAgentSessionNewParams{
+		Agent:       openai.BetaAgentSessionNewParamsAgent{Model: openai.String("go-client-test-model"), Instructions: openai.String("Keep this configuration.")},
+		Environment: openai.EnvironmentParamUnion{OfParamNone: &openai.EnvironmentParamNone{}},
+		Metadata:    map[string]string{"workspace": "not-an-identity"},
+	}
+	retry := option.WithHeader("Idempotency-Key", "go-client-first")
+	first, err := a.New(ctx, input, retry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ID == "" || first.Object != "agent.session" || first.Status != "idle" || first.Agent.Model != "go-client-test-model" || first.Agent.Instructions != "Keep this configuration." || first.Environment.Type != "none" {
+		t.Fatal("incorrect resolved Session")
+	}
+	read, err := a.Get(ctx, first.ID)
+	if err != nil || read.RawJSON() != first.RawJSON() {
+		t.Fatalf("retrieve: %v", err)
+	}
+	replay, err := a.New(ctx, input, retry)
+	if err != nil || replay.ID != first.ID {
+		t.Fatalf("retry: %v", err)
+	}
+	expectStatus := func(err error, status int) {
+		t.Helper()
+		var apiErr *openai.Error
+		if !errors.As(err, &apiErr) || apiErr.StatusCode != status || apiErr.Code == "" {
+			t.Fatalf("expected SDK HTTP %d error: %v", status, err)
+		}
+	}
+	changed := input
+	changed.Agent.Instructions = openai.String("Changed")
+	_, err = a.New(ctx, changed, retry)
+	expectStatus(err, 409)
+	for _, key := range []string{"go-client-second", "go-client-third"} {
+		if _, err := a.New(ctx, input, option.WithHeader("Idempotency-Key", key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	list := func(order openai.BetaAgentSessionListParamsOrder) []string {
+		t.Helper()
+		page, err := a.List(ctx, openai.BetaAgentSessionListParams{Limit: openai.Int(1), Order: order})
+		var ids []string
+		for err == nil && page != nil {
+			for _, session := range page.Data {
+				ids = append(ids, session.ID)
+			}
+			if len(ids) > 3 {
+				t.Fatal("unexpected or repeating page")
+			}
+			page, err = page.GetNextPage()
+		}
+		if err != nil || len(ids) != 3 {
+			t.Fatalf("pagination: %v", err)
+		}
+		return ids
+	}
+	asc, desc := list(openai.BetaAgentSessionListParamsOrderAsc), list(openai.BetaAgentSessionListParamsOrderDesc)
+	slices.Reverse(desc)
+	if !slices.Equal(asc, desc) || !slices.Contains(asc, first.ID) {
+		t.Fatal("incorrect creation ordering")
+	}
+	other, err := b.New(ctx, input, retry)
+	if err != nil || other.ID == first.ID {
+		t.Fatalf("tenant-scoped creation: %v", err)
+	}
+	_, err = b.Get(ctx, first.ID)
+	expectStatus(err, 404)
+	_, err = b.List(ctx, openai.BetaAgentSessionListParams{After: openai.String(first.ID)})
+	expectStatus(err, 404)
+	_, err = invalid.Get(ctx, first.ID)
+	expectStatus(err, 401)
+}

--- a/services/agents-api/README.md
+++ b/services/agents-api/README.md
@@ -1,8 +1,8 @@
 # Agents API
 
 Execution service under construction. This first slice provides durable Session
-storage and an independent migration command. It does not expose HTTP endpoints,
-run Agents, or change Parsar's production dispatch.
+storage, an authenticated HTTP service and an independent migration command. It
+does not run Agents or change Parsar's production dispatch.
 
 A Session is an execution context with a stable engine choice. Product
 conversations can map to multiple Sessions. Native engine IDs, device bindings,
@@ -20,12 +20,12 @@ AGENTS_API_DATABASE_URL='postgres://.../agents_api' \
 make sqlc-generate
 ```
 
-The Store requires a tenant on every operation. The future API authentication
-layer must derive that tenant from the caller's credential, never trust a tenant
+The Store requires a tenant on every operation. The API authentication
+layer derives that tenant from the caller's credential, never a tenant
 claimed in a request body. Store methods alone do not authenticate callers.
 
 Session creation requires an idempotency key scoped to the tenant. Repeating the
-same engine and metadata returns the existing Session; different input with the
+same engine, metadata and configuration returns the existing Session; different input with the
 same key returns a conflict. Read/list operations are tenant-scoped, including
 pagination cursors. Metadata is limited to 64 KiB of JSON string pairs and should
 contain references or labels, not credentials or Agent configuration.
@@ -79,7 +79,9 @@ AGENTS_API_SERVER_BIN=/tmp/agents-api python services/agents-api/tests/official_
 
 The test uses `PARSAR_AGENTS_API_TEST_DATABASE_URL`, temporary service keys and
 fresh tenant IDs. It checks upstream and generated response schemas, retries, ordering, tenant
-isolation, unsupported options and reads after a process restart.
+isolation, unsupported options and reads after a process restart. It also runs the
+[official Go client integration](../../packages/agents-client/README.md), using two
+fresh tenants, and validates its created Sessions through the Python SDK.
 
 ## Checks
 
@@ -93,4 +95,4 @@ workspace tables. Tests apply only this service's migrations and use new tenant
 IDs without truncating tables. Missing test configuration skips DB tests locally;
 the `agents-api` CI workflow always supplies its own PostgreSQL service. Run the
 full `make check` before review as well. Product OpenAPI generation excludes this
-service; its future HTTP contract will have a separate generated artifact.
+service; its supported HTTP contract is generated separately.

--- a/services/agents-api/tests/official_client.py
+++ b/services/agents-api/tests/official_client.py
@@ -53,7 +53,7 @@ def main():
         address.bind(("127.0.0.1", 0))
         port = address.getsockname()[1]
     base = f"http://127.0.0.1:{port}"
-    tokens = [secrets.token_hex(32), secrets.token_hex(32)]
+    tokens = [secrets.token_hex(32) for _ in range(4)]
     bindings = [{"tenant_id": str(uuid.uuid4()), "token_sha256": hashlib.sha256(token.encode()).hexdigest()} for token in tokens]
     process = None
     with tempfile.TemporaryDirectory(prefix="agents-api-test-") as directory:
@@ -139,6 +139,14 @@ def main():
                     process = start()
                     assert sessions.retrieve(first.id) == first
                     assert sessions.create(**spec, metadata={"workspace": "untrusted-reference"}, extra_headers=headers) == first
+                go_env = dict(os.environ, AGENTS_API_CLIENT_TEST_BASE_URL=base + "/v1",
+                              AGENTS_API_CLIENT_TEST_KEY=tokens[2], AGENTS_API_CLIENT_TEST_OTHER_KEY=tokens[3])
+                subprocess.run(["go", "test", "./packages/agents-client/v1", "-run", "^TestService$", "-count=1"],
+                               cwd=root, env=go_env, check=True, timeout=120)
+                with client(tokens[2]) as go_tenant:
+                    go_sessions = list(go_tenant.beta.agents.sessions.list())
+                    assert len(go_sessions) == 3 and all(item.agent.model == "go-client-test-model" for item in go_sessions)
+                print("Official Go client: creation/retries, retrieval, bidirectional pagination and tenant isolation passed.")
                 print("Official client: upstream and generated response schemas, persistence/restart, retries, pagination, tenant isolation and explicit unsupported options passed.")
             finally:
                 if process and process.poll() is None:


### PR DESCRIPTION
Provide a product-side entry point to the independent Agents API using the official `openai-go` v3.61.0 Session service. Keep request/response types, pagination and errors in the SDK; Parsar configures the explicit service URL/key, timeout, redirect/cookie boundary and disabled SDK retries. Product execution stays on its current path.

Add real HTTP coverage using the Go SDK and the pinned Python SDK against the same isolated execution database, and include the client in the existing Make/CI checks. Document the supported Session subset and the preference for maintained SDKs over custom infrastructure.

Validation: `make check` passed (local Docker remains disabled); real service + remote dedicated PostgreSQL passed for creation/retries, conflicts, retrieval, asc/desc pagination, tenant isolation, and Python validation of Go-created Sessions. Client race tests and actionlint passed. Independent blind review passed with no actionable findings; it covered the complete diff, service identity boundary, SDK reuse, checks and scope.

Scope: ATOM-003 client portion only. No product cutover, service API/schema changes, Turn execution, or Team orchestration.
