### PR TITLE
feat(daemon): steer active Codex turns with input receipts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -416,6 +416,21 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   Explicit engine approval requests still use the durable interaction lifecycle;
   user-input requests continue to wait for a human answer.
 
+- Active-turn text uses optional daemon `prompt_steer` / `prompt_steer_ack`
+  frames, correlated by run ID and payload `input_id`. Check the engine's
+  advertised `steering` capability first; Codex uses native `turn/steer` with
+  its thread ID and active turn ID precondition. It must never start another
+  turn as a fallback. Only a matching engine receipt confirms acceptance.
+- During an active run, the daemon retains up to 256 steering attempts and
+  replays their receipts. Reusing an input ID with different text is rejected;
+  capacity exhaustion rejects new inputs instead of evicting receipts.
+  `not_ready` means no input was sent and can be retried. An RPC failure yields
+  `outcome_unknown`, cached without automatic redelivery even after an ack-send
+  failure. These receipts are process-local and disappear with the run;
+  durable recovery and interpreting missing receipts remain server-owned.
+  This adapter contract does not expose the public Agents API events endpoint
+  or change the existing product submission path.
+
 - Agent cloning copies enabled capability bindings, version choices, and configuration.
   Pinned clones retain the stored version; latest choices resolve from the current catalog.
   Display, credential checks, and submission use the same version. Shared credentials remain

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -424,9 +424,14 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
 - During an active run, the daemon retains up to 256 steering attempts and
   replays their receipts. Reusing an input ID with different text is rejected;
   capacity exhaustion rejects new inputs instead of evicting receipts.
-  `not_ready` means no input was sent and can be retried. An RPC failure yields
+  `not_ready` / `busy` mean no input was sent and the same input can be
+  retried without changing its identity or text. Native delivery runs outside
+  the shared dispatch loop, with at most one in-flight input per run. An
+  `in_flight` receipt means its result is still pending. A native error response
+  yields `rejected`; a transport failure or invalid receipt yields
   `outcome_unknown`, cached without automatic redelivery even after an ack-send
-  failure. These receipts are process-local and disappear with the run;
+  failure. A steering deadline or cancellation closes a blocked native RPC
+  transport to release stdin writes. These receipts are process-local and disappear with the run;
   durable recovery and interpreting missing receipts remain server-owned.
   This adapter contract does not expose the public Agents API events endpoint
   or change the existing product submission path.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -431,7 +431,9 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   yields `rejected`; a transport failure or invalid receipt yields
   `outcome_unknown`, cached without automatic redelivery even after an ack-send
   failure. A steering deadline or cancellation closes a blocked native RPC
-  transport to release stdin writes. These receipts are process-local and disappear with the run;
+  write; waiting for a receipt after a complete write must preserve the process.
+  Unexpected transport exit ends the run with an error, without duplicating a
+  terminal outcome already received. These receipts disappear with the run;
   durable recovery and interpreting missing receipts remain server-owned.
   This adapter contract does not expose the public Agents API events endpoint
   or change the existing product submission path.

--- a/apps/parsar-daemon/internal/agent/codex/protocol.go
+++ b/apps/parsar-daemon/internal/agent/codex/protocol.go
@@ -16,6 +16,8 @@
 //     with that id to graft the prior turn's context back in.
 package codex
 
+import "fmt"
+
 // JsonRpcVersion is the JSON-RPC 2.0 marker carried on every outbound
 // frame. Inbound frames omit the field per Codex's app-server convention,
 // so the parser does not enforce it on responses.
@@ -52,6 +54,8 @@ type JsonRpcError struct {
 	Message string `json:"message"`
 	Data    any    `json:"data,omitempty"`
 }
+
+func (e *JsonRpcError) Error() string { return fmt.Sprintf("%d %s", e.Code, e.Message) }
 
 // ---------------------------------------------------------------------------
 // initialize handshake

--- a/apps/parsar-daemon/internal/agent/codex/rpc.go
+++ b/apps/parsar-daemon/internal/agent/codex/rpc.go
@@ -275,6 +275,10 @@ func (c *JSONRPCClient) Done() <-chan struct{} {
 // the deadline fires, or the child exits. Returns the raw result JSON
 // so the caller can pick its decode shape.
 func (c *JSONRPCClient) Request(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	return c.request(ctx, method, params, c.writeFrame)
+}
+
+func (c *JSONRPCClient) request(ctx context.Context, method string, params any, write func(any) error) (json.RawMessage, error) {
 	if !c.Alive() {
 		return nil, errors.New("codex rpc: client not alive")
 	}
@@ -291,7 +295,7 @@ func (c *JSONRPCClient) Request(ctx context.Context, method string, params any) 
 	c.pendingMu.Unlock()
 
 	frame := JsonRpcRequest{JsonRpc: JsonRpcVersion, ID: id, Method: method, Params: params}
-	if err := c.writeFrame(frame); err != nil {
+	if err := write(frame); err != nil {
 		c.pendingMu.Lock()
 		delete(c.pending, id)
 		c.pendingMu.Unlock()

--- a/apps/parsar-daemon/internal/agent/codex/rpc.go
+++ b/apps/parsar-daemon/internal/agent/codex/rpc.go
@@ -479,7 +479,7 @@ func (c *JSONRPCClient) handleResponse(rawID, rawResult, rawError json.RawMessag
 			p.resp <- rpcResponse{err: fmt.Errorf("codex rpc: malformed error reply on %s: %w", p.method, err)}
 			return
 		}
-		p.resp <- rpcResponse{err: fmt.Errorf("codex rpc: %s: %d %s", p.method, errBody.Code, errBody.Message)}
+		p.resp <- rpcResponse{err: fmt.Errorf("codex rpc: %s: %w", p.method, &errBody)}
 		return
 	}
 	p.resp <- rpcResponse{result: rawResult}

--- a/apps/parsar-daemon/internal/agent/codex/rpc_write.go
+++ b/apps/parsar-daemon/internal/agent/codex/rpc_write.go
@@ -1,0 +1,26 @@
+package codex
+
+import "context"
+
+func (c *JSONRPCClient) writeFrameContext(ctx context.Context, frame any) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() { done <- c.writeFrame(frame) }()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		select {
+		case err := <-done:
+			return err
+		default:
+		}
+		// A partial frame cannot be retracted. Close only a blocked write;
+		// a response timeout after a complete write leaves the process alive.
+		_ = c.Close()
+		<-done
+		return ctx.Err()
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -73,6 +73,7 @@ type Session struct {
 
 	threadIDMu sync.Mutex
 	threadID   string
+	steering   steeringTurn
 
 	deltaSeq    atomic.Uint64
 	thinkingSeq atomic.Uint64
@@ -180,6 +181,7 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 }
 
 func (s *Session) Cancel(_ context.Context) error {
+	s.stopSteering()
 	s.cancelOnce.Do(func() {
 		s.stopCodexInteractionTimers()
 		// Best-effort turn/interrupt — codex will translate this into
@@ -380,6 +382,7 @@ func (s *Session) onThreadStarted(raw json.RawMessage) {
 }
 
 func (s *Session) onTurnStarted(raw json.RawMessage) {
+	s.startSteering(raw)
 	s.beginUsageTurn(raw)
 	// Reset per-turn buffers. The session is per-prompt so this is
 	// belt-and-suspenders today, but it keeps the buffer semantics
@@ -455,6 +458,7 @@ func (s *Session) onItemCompleted(raw json.RawMessage) {
 }
 
 func (s *Session) onTurnCompleted(raw json.RawMessage) {
+	s.stopSteering()
 	var p TurnCompletedNotification
 	if err := json.Unmarshal(raw, &p); err != nil {
 		s.cfg.logger.Warn("codex: turn/completed decode error",
@@ -608,6 +612,7 @@ func (s *Session) peekLastErrText() string {
 // ---------------------------------------------------------------------------
 
 func (s *Session) emitDone(content string, usage *TurnUsage) {
+	s.stopSteering()
 	doneMeta := map[string]any{}
 	if tid := s.currentThreadID(); tid != "" {
 		doneMeta[proto.DoneMetaAgentSessionID] = tid
@@ -645,6 +650,7 @@ func (s *Session) emitUsage(u TurnUsage) {
 }
 
 func (s *Session) emitTerminal(message string, asError bool) {
+	s.stopSteering()
 	// Always log: this is the only place the daemon decides "the prompt is
 	// over, here's what went wrong (if anything)". Without this, post-
 	// mortem requires correlating server-side TypeError frames against
@@ -696,6 +702,7 @@ func (s *Session) trySend(env proto.Envelope) {
 }
 
 func (s *Session) closeOut() {
+	s.stopSteering()
 	s.closeOutOnce.Do(func() {
 		s.outMu.Lock()
 		s.outClosed = true

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -65,6 +65,8 @@ type Session struct {
 	cancelFn  context.CancelFunc
 
 	cancelOnce   sync.Once
+	cancelled    atomic.Bool
+	terminal     atomic.Bool
 	closeOutOnce sync.Once
 	outMu        sync.RWMutex
 	outClosed    bool
@@ -181,6 +183,7 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 }
 
 func (s *Session) Cancel(_ context.Context) error {
+	s.cancelled.Store(true)
 	s.stopSteering()
 	s.cancelOnce.Do(func() {
 		s.stopCodexInteractionTimers()
@@ -280,6 +283,9 @@ func (s *Session) run(plan SessionPlan, req proto.PromptRequestPayload) {
 	// Block until terminal handlers close the RPC child or cancellation arrives.
 	select {
 	case <-s.rpc.Done():
+		if !s.cancelled.Load() && s.cancelCtx.Err() == nil {
+			s.emitTerminal("codex: connection closed before the run completed", true)
+		}
 	case <-s.cancelCtx.Done():
 		_ = s.rpc.Close()
 	}
@@ -612,6 +618,9 @@ func (s *Session) peekLastErrText() string {
 // ---------------------------------------------------------------------------
 
 func (s *Session) emitDone(content string, usage *TurnUsage) {
+	if !s.terminal.CompareAndSwap(false, true) {
+		return
+	}
 	s.stopSteering()
 	doneMeta := map[string]any{}
 	if tid := s.currentThreadID(); tid != "" {
@@ -650,6 +659,9 @@ func (s *Session) emitUsage(u TurnUsage) {
 }
 
 func (s *Session) emitTerminal(message string, asError bool) {
+	if !s.terminal.CompareAndSwap(false, true) {
+		return
+	}
 	s.stopSteering()
 	// Always log: this is the only place the daemon decides "the prompt is
 	// over, here's what went wrong (if anything)". Without this, post-

--- a/apps/parsar-daemon/internal/agent/codex/session_steering.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_steering.go
@@ -50,11 +50,9 @@ func (s *Session) Steer(ctx context.Context, input proto.PromptSteerPayload) err
 		return agent.ErrSteeringNotReady
 	}
 	params := TurnSteerParams{ThreadID: threadID, ExpectedTurnID: turnID, Input: FirstUserInput(input.Text)}
-	// Closing the transport also releases a blocked stdin write. A context
-	// deadline alone cannot interrupt io.Writer.Write in the native RPC client.
-	stop := context.AfterFunc(ctx, func() { _ = s.rpc.Close() })
-	defer stop()
-	raw, err := s.rpc.Request(ctx, "turn/steer", params)
+	raw, err := s.rpc.request(ctx, "turn/steer", params, func(frame any) error {
+		return s.rpc.writeFrameContext(ctx, frame)
+	})
 	if err != nil {
 		var rejected *JsonRpcError
 		if errors.As(err, &rejected) {

--- a/apps/parsar-daemon/internal/agent/codex/session_steering.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_steering.go
@@ -1,0 +1,73 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+type steeringTurn struct {
+	mu      sync.Mutex
+	id      string
+	stopped bool
+}
+
+// TurnSteerParams mirrors the native Codex app-server turn/steer request.
+type TurnSteerParams struct {
+	ThreadID       string      `json:"threadId"`
+	ExpectedTurnID string      `json:"expectedTurnId"`
+	Input          []UserInput `json:"input"`
+}
+
+var _ agent.Steerer = (*Session)(nil)
+
+// Steer returns success only after Codex accepts input for this native turn.
+func (s *Session) Steer(ctx context.Context, input proto.PromptSteerPayload) error {
+	s.steering.mu.Lock()
+	turnID, stopped := s.steering.id, s.steering.stopped
+	s.steering.mu.Unlock()
+	if stopped || s.cancelCtx.Err() != nil {
+		return agent.ErrSteeringInactive
+	}
+	threadID := s.currentThreadID()
+	if turnID == "" || threadID == "" {
+		return agent.ErrSteeringNotReady
+	}
+	params := TurnSteerParams{ThreadID: threadID, ExpectedTurnID: turnID, Input: FirstUserInput(input.Text)}
+	raw, err := s.rpc.Request(ctx, "turn/steer", params)
+	if err != nil {
+		return err
+	}
+	var result struct {
+		TurnID string `json:"turnId"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return fmt.Errorf("codex: decode steering receipt: %w", err)
+	}
+	if result.TurnID != turnID {
+		return fmt.Errorf("codex: steering receipt does not match the active turn")
+	}
+	return nil
+}
+
+func (s *Session) startSteering(raw json.RawMessage) {
+	var notification TurnStartedNotification
+	if json.Unmarshal(raw, &notification) != nil || notification.ThreadID != s.currentThreadID() {
+		return
+	}
+	s.steering.mu.Lock()
+	defer s.steering.mu.Unlock()
+	if !s.steering.stopped {
+		s.steering.id = notification.Turn.ID
+	}
+}
+
+func (s *Session) stopSteering() {
+	s.steering.mu.Lock()
+	defer s.steering.mu.Unlock()
+	s.steering.stopped = true
+}

--- a/apps/parsar-daemon/internal/agent/codex/session_steering.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_steering.go
@@ -3,6 +3,7 @@ package codex
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -14,6 +15,7 @@ type steeringTurn struct {
 	mu      sync.Mutex
 	id      string
 	stopped bool
+	cancel  context.CancelFunc
 }
 
 // TurnSteerParams mirrors the native Codex app-server turn/steer request.
@@ -27,9 +29,19 @@ var _ agent.Steerer = (*Session)(nil)
 
 // Steer returns success only after Codex accepts input for this native turn.
 func (s *Session) Steer(ctx context.Context, input proto.PromptSteerPayload) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	s.steering.mu.Lock()
 	turnID, stopped := s.steering.id, s.steering.stopped
+	if !stopped {
+		s.steering.cancel = cancel
+	}
 	s.steering.mu.Unlock()
+	defer func() {
+		s.steering.mu.Lock()
+		s.steering.cancel = nil
+		s.steering.mu.Unlock()
+	}()
 	if stopped || s.cancelCtx.Err() != nil {
 		return agent.ErrSteeringInactive
 	}
@@ -38,8 +50,16 @@ func (s *Session) Steer(ctx context.Context, input proto.PromptSteerPayload) err
 		return agent.ErrSteeringNotReady
 	}
 	params := TurnSteerParams{ThreadID: threadID, ExpectedTurnID: turnID, Input: FirstUserInput(input.Text)}
+	// Closing the transport also releases a blocked stdin write. A context
+	// deadline alone cannot interrupt io.Writer.Write in the native RPC client.
+	stop := context.AfterFunc(ctx, func() { _ = s.rpc.Close() })
+	defer stop()
 	raw, err := s.rpc.Request(ctx, "turn/steer", params)
 	if err != nil {
+		var rejected *JsonRpcError
+		if errors.As(err, &rejected) {
+			return fmt.Errorf("%w: %v", agent.ErrSteeringRejected, err)
+		}
 		return err
 	}
 	var result struct {
@@ -70,4 +90,7 @@ func (s *Session) stopSteering() {
 	s.steering.mu.Lock()
 	defer s.steering.mu.Unlock()
 	s.steering.stopped = true
+	if s.steering.cancel != nil {
+		s.steering.cancel()
+	}
 }

--- a/apps/parsar-daemon/internal/agent/codex/session_steering_lifecycle_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_steering_lifecycle_test.go
@@ -1,0 +1,123 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	obslog "github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+)
+
+func TestSteeringReceiptTimeoutAndCompletionKeepProcessAlive(t *testing.T) {
+	for _, complete := range []bool{false, true} {
+		t.Run(map[bool]string{false: "receipt timeout", true: "normal completion"}[complete], func(t *testing.T) {
+			client, server, cleanup := NewTestClient()
+			defer cleanup()
+			out := make(chan proto.Envelope, 4)
+			s := &Session{rpc: client.JSONRPCClient, cancelCtx: context.Background(), out: out, cfg: sessionConfig{logger: obslog.Bg()}}
+			s.setThreadID("thread")
+			s.startSteering(json.RawMessage(`{"threadId":"thread","turn":{"id":"turn"}}`))
+			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			defer cancel()
+			done := make(chan error, 1)
+			go func() { done <- s.Steer(ctx, proto.PromptSteerPayload{InputID: "input", Text: "extra"}) }()
+			var request JsonRpcRequest
+			if err := json.NewDecoder(server.FromClient).Decode(&request); err != nil {
+				t.Fatal(err)
+			}
+			// Withhold the response after reading the entire request frame.
+			if complete {
+				s.onTurnCompleted(json.RawMessage(`{"threadId":"thread","turn":{"id":"turn","status":"completed"}}`))
+			}
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Fatal("missing receipt reported as accepted")
+				}
+			case <-time.After(time.Second):
+				t.Fatal("steering response wait did not stop")
+			}
+			if !client.Alive() {
+				t.Fatal("response wait killed retained process")
+			}
+			if complete {
+				s.emitTerminal("late disconnect", true)
+				var frames []proto.Envelope
+				for env := range out {
+					frames = append(frames, env)
+				}
+				if len(frames) != 1 || frames[0].Type != proto.TypeDone {
+					t.Fatalf("terminal frames: %+v", frames)
+				}
+			}
+		})
+	}
+}
+
+func TestBlockedSteeringWriteEndsRunWithTerminalFrames(t *testing.T) {
+	client, server, cleanup := NewTestClient()
+	defer cleanup()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out := make(chan proto.Envelope, 8)
+	s := &Session{
+		runID: "run", rpc: client.JSONRPCClient, cancelCtx: ctx, out: out,
+		cfg: sessionConfig{logger: obslog.Bg()}, waitDone: make(chan struct{}), cleanup: func() {},
+		bufs: NewItemBuffers(), interactions: newPendingCodexInteractions(),
+	}
+	s.registerHandlers()
+	ready := make(chan error, 1)
+	go func() {
+		decoder := json.NewDecoder(server.FromClient)
+		encoder := json.NewEncoder(server.ToClient)
+		for _, method := range []string{"thread/start", "turn/start"} {
+			var request JsonRpcRequest
+			if err := decoder.Decode(&request); err != nil {
+				ready <- err
+				return
+			}
+			if request.Method != method {
+				t.Errorf("method = %s, expected %s", request.Method, method)
+			}
+			if method == "turn/start" {
+				if err := SendNotification(server, "turn/started", map[string]any{"threadId": "thread", "turn": map[string]any{"id": "turn"}}); err != nil {
+					ready <- err
+					return
+				}
+			}
+			if err := encoder.Encode(map[string]any{"id": request.ID, "result": map[string]any{"thread": map[string]any{"id": "thread"}}}); err != nil {
+				ready <- err
+				return
+			}
+		}
+		ready <- nil
+	}()
+	go s.run(SessionPlan{Model: "synthetic"}, proto.PromptRequestPayload{Prompt: "first"})
+	if err := <-ready; err != nil {
+		t.Fatal(err)
+	}
+	callCtx, callCancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer callCancel()
+	if err := s.Steer(callCtx, proto.PromptSteerPayload{InputID: "blocked", Text: "extra"}); err == nil {
+		t.Fatal("blocked write accepted")
+	}
+	if client.Alive() {
+		t.Fatal("blocked transport still alive")
+	}
+	// TestClient has no child waiter; emulate the process exit after pipe close.
+	close(client.doneCh)
+	select {
+	case <-s.waitDone:
+	case <-ctx.Done():
+		t.Fatal("run did not end after native disconnect")
+	}
+	var frames []proto.Envelope
+	for env := range out {
+		frames = append(frames, env)
+	}
+	if len(frames) != 2 || frames[0].Type != proto.TypeError || frames[1].Type != proto.TypeDone {
+		t.Fatalf("missing honest terminal outcome: %+v", frames)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/session_steering_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_steering_test.go
@@ -57,10 +57,38 @@ func TestSteeringUsesNativeActiveTurnAndReceipt(t *testing.T) {
 			if err := json.NewEncoder(server.ToClient).Encode(map[string]any{"id": request.ID, "result": test.result, "error": test.err}); err != nil {
 				t.Fatal(err)
 			}
-			if err := <-done; (err == nil) != test.wantOK {
+			err := <-done
+			if (err == nil) != test.wantOK {
 				t.Fatalf("want success=%v: %v", test.wantOK, err)
 			}
+			if test.err != nil && !errors.Is(err, agent.ErrSteeringRejected) {
+				t.Fatalf("explicit rejection lost: %v", err)
+			}
 		})
+	}
+}
+
+func TestSteeringDeadlineReleasesBlockedNativeWrite(t *testing.T) {
+	client, _, cleanup := NewTestClient()
+	defer cleanup()
+	s := &Session{rpc: client.JSONRPCClient, cancelCtx: context.Background()}
+	s.setThreadID("native-thread")
+	s.startSteering(json.RawMessage(`{"threadId":"native-thread","turn":{"id":"native-turn"}}`))
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- s.Steer(ctx, proto.PromptSteerPayload{InputID: "blocked", Text: "extra"}) }()
+	// No reader drains the pipe, so the request never reaches its response wait.
+	select {
+	case err := <-done:
+		if err == nil || errors.Is(err, agent.ErrSteeringRejected) {
+			t.Fatalf("blocked delivery has an uncertain outcome: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("deadline did not release native stdin write")
+	}
+	if client.Alive() {
+		t.Fatal("blocked native connection was not closed")
 	}
 }
 

--- a/apps/parsar-daemon/internal/agent/codex/session_steering_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_steering_test.go
@@ -1,0 +1,90 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestSteeringUsesNativeActiveTurnAndReceipt(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		result any
+		err    any
+		wantOK bool
+	}{
+		{name: "accepted", result: map[string]any{"turnId": "native-turn"}, wantOK: true},
+		{name: "wrong turn", result: map[string]any{"turnId": "other-turn"}},
+		{name: "missing turn", result: map[string]any{}},
+		{name: "rejected", err: map[string]any{"code": -32600, "message": "no active turn"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client, server, cleanup := NewTestClient()
+			defer cleanup()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			s := &Session{runID: "daemon-run", rpc: client.JSONRPCClient, cancelCtx: ctx}
+			s.setThreadID("native-thread")
+			s.startSteering(json.RawMessage(`{"threadId":"native-thread","turn":{"id":"native-turn"}}`))
+			done := make(chan error, 1)
+			go func() {
+				done <- s.Steer(ctx, proto.PromptSteerPayload{InputID: "input-1", Text: "追加输入"})
+			}()
+			var request struct {
+				ID     string          `json:"id"`
+				Method string          `json:"method"`
+				Params TurnSteerParams `json:"params"`
+			}
+			if err := json.NewDecoder(server.FromClient).Decode(&request); err != nil {
+				t.Fatal(err)
+			}
+			if request.Method != "turn/steer" || request.Params.ThreadID != "native-thread" || request.Params.ExpectedTurnID != "native-turn" {
+				t.Fatalf("wrong native destination: %+v", request)
+			}
+			if len(request.Params.Input) != 1 || request.Params.Input[0].Text != "追加输入" {
+				t.Fatalf("input lost: %+v", request.Params.Input)
+			}
+			select {
+			case err := <-done:
+				t.Fatalf("returned before native ack: %v", err)
+			default:
+			}
+			if err := json.NewEncoder(server.ToClient).Encode(map[string]any{"id": request.ID, "result": test.result, "error": test.err}); err != nil {
+				t.Fatal(err)
+			}
+			if err := <-done; (err == nil) != test.wantOK {
+				t.Fatalf("want success=%v: %v", test.wantOK, err)
+			}
+		})
+	}
+}
+
+func TestSteeringDoesNotStartOrReviveTurns(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &Session{cancelCtx: ctx}
+	s.setThreadID("native-thread")
+	input := proto.PromptSteerPayload{InputID: "input-1", Text: "extra"}
+	// A nil RPC client proves these states do not issue a request.
+	for _, notification := range []json.RawMessage{nil, json.RawMessage(`{"threadId":"other-thread","turn":{"id":"other-turn"}}`)} {
+		s.startSteering(notification)
+		if err := s.Steer(ctx, input); !errors.Is(err, agent.ErrSteeringNotReady) {
+			t.Fatalf("starting turn: %v", err)
+		}
+	}
+	s.stopSteering()
+	s.startSteering(json.RawMessage(`{"threadId":"native-thread","turn":{"id":"late-turn"}}`))
+	if err := s.Steer(ctx, input); !errors.Is(err, agent.ErrSteeringInactive) {
+		t.Fatalf("terminal turn revived: %v", err)
+	}
+	s = &Session{cancelCtx: ctx}
+	cancel()
+	if err := s.Steer(context.Background(), input); !errors.Is(err, agent.ErrSteeringInactive) {
+		t.Fatalf("cancelled run: %v", err)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/steering.go
+++ b/apps/parsar-daemon/internal/agent/steering.go
@@ -17,3 +17,6 @@ var ErrSteeringNotReady = errors.New("agent: turn is not ready for input")
 
 // ErrSteeringInactive means no input was sent because the run ended or was cancelled.
 var ErrSteeringInactive = errors.New("agent: run is no longer active")
+
+// ErrSteeringRejected means the engine explicitly rejected the input.
+var ErrSteeringRejected = errors.New("agent: input rejected")

--- a/apps/parsar-daemon/internal/agent/steering.go
+++ b/apps/parsar-daemon/internal/agent/steering.go
@@ -1,0 +1,19 @@
+package agent
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+// Steerer optionally delivers additional text to the session's active turn.
+type Steerer interface {
+	Steer(context.Context, proto.PromptSteerPayload) error
+}
+
+// ErrSteeringNotReady means no input was sent because the turn is starting.
+var ErrSteeringNotReady = errors.New("agent: turn is not ready for input")
+
+// ErrSteeringInactive means no input was sent because the run ended or was cancelled.
+var ErrSteeringInactive = errors.New("agent: run is no longer active")

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -259,6 +259,7 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 				Permissions: true,
 				Usage:       true,
 				Resume:      true,
+				Steering:    true,
 			},
 		},
 		Pi: proto.SupportedAgentKind{

--- a/apps/parsar-daemon/internal/dispatch/router.go
+++ b/apps/parsar-daemon/internal/dispatch/router.go
@@ -74,6 +74,7 @@ type sessionState struct {
 	idleLease   uint64
 	retain      bool
 	steering    map[string]steeringReceipt
+	steerBusy   bool
 }
 
 // Config is the constructor input. Registry and Sender are required;

--- a/apps/parsar-daemon/internal/dispatch/router.go
+++ b/apps/parsar-daemon/internal/dispatch/router.go
@@ -73,6 +73,7 @@ type sessionState struct {
 	idleTimer   *time.Timer
 	idleLease   uint64
 	retain      bool
+	steering    map[string]steeringReceipt
 }
 
 // Config is the constructor input. Registry and Sender are required;
@@ -138,6 +139,8 @@ func (r *Router) Handle(ctx context.Context, env proto.Envelope) error {
 		return r.handlePromptRequest(ctx, env)
 	case proto.TypePromptCancel:
 		return r.handlePromptCancel(ctx, env)
+	case proto.TypePromptSteer:
+		return r.handlePromptSteer(ctx, env)
 	case proto.TypePermissionDecision:
 		return r.handlePermissionDecision(ctx, env)
 	case proto.TypePromptForUserChoiceDecision:

--- a/apps/parsar-daemon/internal/dispatch/steering.go
+++ b/apps/parsar-daemon/internal/dispatch/steering.go
@@ -1,0 +1,101 @@
+package dispatch
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+// Retain all attempts for the active run; reject overflow rather than evicting
+// receipts and risking a duplicate native input. Durable recovery is server-owned.
+const maxSteeringInputs = 256
+
+type steeringReceipt struct {
+	fingerprint [32]byte
+	ack         proto.PromptSteerAckPayload
+}
+
+func (r *Router) handlePromptSteer(ctx context.Context, env proto.Envelope) error {
+	var input proto.PromptSteerPayload
+	ack := proto.PromptSteerAckPayload{}
+	if err := env.DecodePayload(&input); err != nil {
+		ack.ErrorCode, ack.Error = "invalid_input", "Invalid steering payload."
+	} else {
+		ack.InputID = input.InputID
+		if env.ID == "" || strings.TrimSpace(input.InputID) == "" || len(input.InputID) > 256 || strings.TrimSpace(input.Text) == "" {
+			ack.ErrorCode, ack.Error = "invalid_input", "Run ID, input ID (up to 256 bytes), and non-empty text are required."
+		} else {
+			ack = r.steer(ctx, env.ID, input)
+		}
+	}
+	reply, err := proto.NewEnvelopeWithTrace(proto.TypePromptSteerAck, env.ID, ack, env.Trace)
+	if err != nil {
+		return err
+	}
+	return r.sender.Send(ctx, reply)
+}
+
+func (r *Router) steer(ctx context.Context, runID string, input proto.PromptSteerPayload) proto.PromptSteerAckPayload {
+	ack := proto.PromptSteerAckPayload{InputID: input.InputID}
+	r.mu.Lock()
+	state := r.sessions[runID]
+	var session agent.Session
+	if state != nil {
+		session = state.session
+	}
+	r.mu.Unlock()
+	if state == nil {
+		ack.ErrorCode, ack.Error = "run_inactive", "The run is no longer active."
+		return ack
+	}
+	if session == nil {
+		ack.ErrorCode, ack.Error = "not_ready", "The run is still starting."
+		return ack
+	}
+	steerer, ok := session.(agent.Steerer)
+	if !ok {
+		ack.ErrorCode, ack.Error = "unsupported", "This engine does not support active-turn input."
+		return ack
+	}
+	// Handle calls are serialized by the transport read loop. The pump can
+	// remove state from the router, but never reads or writes these receipts.
+	fingerprint := sha256.Sum256([]byte(input.Text))
+	if previous, ok := state.steering[input.InputID]; ok {
+		if previous.fingerprint == fingerprint {
+			return previous.ack
+		}
+		ack.ErrorCode, ack.Error = "input_conflict", "This input ID was already used with different text."
+		return ack
+	}
+	if len(state.steering) >= maxSteeringInputs {
+		ack.ErrorCode, ack.Error = "input_limit", "The active run has reached its steering input limit."
+		return ack
+	}
+	callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	err := steerer.Steer(callCtx, input)
+	switch {
+	case errors.Is(err, agent.ErrSteeringNotReady):
+		ack.ErrorCode, ack.Error = "not_ready", err.Error()
+		return ack
+	case errors.Is(err, agent.ErrSteeringInactive):
+		ack.ErrorCode, ack.Error = "run_inactive", err.Error()
+		return ack
+	case err != nil:
+		// A timeout or broken connection may follow native acceptance. Preserve
+		// the uncertainty and never automatically send this input again.
+		ack.ErrorCode, ack.Error = "outcome_unknown", err.Error()
+	default:
+		ack.Accepted = true
+	}
+	if state.steering == nil {
+		state.steering = make(map[string]steeringReceipt)
+	}
+	state.steering[input.InputID] = steeringReceipt{fingerprint: fingerprint, ack: ack}
+	return ack
+}

--- a/apps/parsar-daemon/internal/dispatch/steering.go
+++ b/apps/parsar-daemon/internal/dispatch/steering.go
@@ -30,9 +30,17 @@ func (r *Router) handlePromptSteer(ctx context.Context, env proto.Envelope) erro
 		if env.ID == "" || strings.TrimSpace(input.InputID) == "" || len(input.InputID) > 256 || strings.TrimSpace(input.Text) == "" {
 			ack.ErrorCode, ack.Error = "invalid_input", "Run ID, input ID (up to 256 bytes), and non-empty text are required."
 		} else {
-			ack = r.steer(ctx, env.ID, input)
+			pending := r.queueSteering(ctx, env, input)
+			if pending == nil {
+				return nil
+			}
+			ack = *pending
 		}
 	}
+	return r.sendSteeringAck(ctx, env, ack)
+}
+
+func (r *Router) sendSteeringAck(ctx context.Context, env proto.Envelope, ack proto.PromptSteerAckPayload) error {
 	reply, err := proto.NewEnvelopeWithTrace(proto.TypePromptSteerAck, env.ID, ack, env.Trace)
 	if err != nil {
 		return err
@@ -40,52 +48,79 @@ func (r *Router) handlePromptSteer(ctx context.Context, env proto.Envelope) erro
 	return r.sender.Send(ctx, reply)
 }
 
-func (r *Router) steer(ctx context.Context, runID string, input proto.PromptSteerPayload) proto.PromptSteerAckPayload {
+func (r *Router) queueSteering(ctx context.Context, env proto.Envelope, input proto.PromptSteerPayload) *proto.PromptSteerAckPayload {
 	ack := proto.PromptSteerAckPayload{InputID: input.InputID}
 	r.mu.Lock()
-	state := r.sessions[runID]
-	var session agent.Session
-	if state != nil {
-		session = state.session
-	}
-	r.mu.Unlock()
-	if state == nil {
+	defer r.mu.Unlock()
+	state := r.sessions[env.ID]
+	if state == nil || r.closed {
 		ack.ErrorCode, ack.Error = "run_inactive", "The run is no longer active."
-		return ack
+		return &ack
 	}
-	if session == nil {
-		ack.ErrorCode, ack.Error = "not_ready", "The run is still starting."
-		return ack
-	}
-	steerer, ok := session.(agent.Steerer)
-	if !ok {
-		ack.ErrorCode, ack.Error = "unsupported", "This engine does not support active-turn input."
-		return ack
-	}
-	// Handle calls are serialized by the transport read loop. The pump can
-	// remove state from the router, but never reads or writes these receipts.
 	fingerprint := sha256.Sum256([]byte(input.Text))
 	if previous, ok := state.steering[input.InputID]; ok {
-		if previous.fingerprint == fingerprint {
-			return previous.ack
+		if previous.fingerprint != fingerprint {
+			ack.ErrorCode, ack.Error = "input_conflict", "This input ID was already used with different text."
+			return &ack
 		}
-		ack.ErrorCode, ack.Error = "input_conflict", "This input ID was already used with different text."
-		return ack
-	}
-	if len(state.steering) >= maxSteeringInputs {
+		if previous.ack.ErrorCode != "not_ready" && previous.ack.ErrorCode != "busy" {
+			return &previous.ack
+		}
+	} else if len(state.steering) >= maxSteeringInputs {
 		ack.ErrorCode, ack.Error = "input_limit", "The active run has reached its steering input limit."
-		return ack
+		return &ack
 	}
-	callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	err := steerer.Steer(callCtx, input)
+	if state.steering == nil {
+		state.steering = make(map[string]steeringReceipt)
+	}
+	ack.ErrorCode, ack.Error = "not_ready", "The run is still starting."
+	// Bind input identity before any retryable state so changed text cannot
+	// slip through a startup or in-flight retry.
+	state.steering[input.InputID] = steeringReceipt{fingerprint: fingerprint, ack: ack}
+	if state.session == nil {
+		return &ack
+	}
+	steerer, ok := state.session.(agent.Steerer)
+	if !ok {
+		ack.ErrorCode, ack.Error = "unsupported", "This engine does not support active-turn input."
+		return &ack
+	}
+	if state.steerBusy {
+		ack.ErrorCode, ack.Error = "busy", "Another input is awaiting an engine receipt; retry this input later."
+		state.steering[input.InputID] = steeringReceipt{fingerprint: fingerprint, ack: ack}
+		return &ack
+	}
+	ack.ErrorCode, ack.Error = "in_flight", "This input is awaiting an engine receipt."
+	state.steering[input.InputID] = steeringReceipt{fingerprint: fingerprint, ack: ack}
+	state.steerBusy = true
+	r.shutdownWG.Add(1)
+	go func() {
+		defer r.shutdownWG.Done()
+		callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		result := steeringResult(input.InputID, steerer.Steer(callCtx, input))
+		cancel()
+		r.mu.Lock()
+		state.steering[input.InputID] = steeringReceipt{fingerprint: fingerprint, ack: result}
+		state.steerBusy = false
+		r.mu.Unlock()
+		sendCtx, sendCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer sendCancel()
+		if err := r.sendSteeringAck(sendCtx, env, result); err != nil {
+			r.log.WarnContext(ctx, "steering receipt delivery failed", "run_id", env.ID, "input_id", input.InputID, "err", err)
+		}
+	}()
+	return nil
+}
+
+func steeringResult(inputID string, err error) proto.PromptSteerAckPayload {
+	ack := proto.PromptSteerAckPayload{InputID: inputID}
 	switch {
 	case errors.Is(err, agent.ErrSteeringNotReady):
 		ack.ErrorCode, ack.Error = "not_ready", err.Error()
-		return ack
 	case errors.Is(err, agent.ErrSteeringInactive):
 		ack.ErrorCode, ack.Error = "run_inactive", err.Error()
-		return ack
+	case errors.Is(err, agent.ErrSteeringRejected):
+		ack.ErrorCode, ack.Error = "rejected", err.Error()
 	case err != nil:
 		// A timeout or broken connection may follow native acceptance. Preserve
 		// the uncertainty and never automatically send this input again.
@@ -93,9 +128,5 @@ func (r *Router) steer(ctx context.Context, runID string, input proto.PromptStee
 	default:
 		ack.Accepted = true
 	}
-	if state.steering == nil {
-		state.steering = make(map[string]steeringReceipt)
-	}
-	state.steering[input.InputID] = steeringReceipt{fingerprint: fingerprint, ack: ack}
 	return ack
 }

--- a/apps/parsar-daemon/internal/dispatch/steering_test.go
+++ b/apps/parsar-daemon/internal/dispatch/steering_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
 	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
@@ -56,11 +57,12 @@ func TestSteeringReceiptsAndRetries(t *testing.T) {
 			env := mustEnv(t, proto.TypePromptSteer, "run-1", input)
 			// An ack transport failure must not cause another native invocation.
 			h.sender.failNow = true
-			if err := h.router.Handle(ctx, env); err == nil {
-				t.Fatal("expected ack-send failure")
+			if err := h.router.Handle(ctx, env); err != nil {
+				t.Fatal(err)
 			}
+			waitFor(t, func() bool { h.sender.mu.Lock(); defer h.sender.mu.Unlock(); return !h.sender.failNow }, "failed ack send")
 			for range 2 {
-				if err := h.router.Handle(ctx, env); err != nil {
+				if err := handleSteeringAndWait(t, h, env); err != nil {
 					t.Fatal(err)
 				}
 				ack := lastSteeringAck(t, h.sender, "run-1", "input-1")
@@ -72,7 +74,7 @@ func TestSteeringReceiptsAndRetries(t *testing.T) {
 				}
 			}
 			input.Text = "changed text"
-			if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptSteer, "run-1", input)); err != nil {
+			if err := handleSteeringAndWait(t, h, mustEnv(t, proto.TypePromptSteer, "run-1", input)); err != nil {
 				t.Fatal(err)
 			}
 			if ack := lastSteeringAck(t, h.sender, "run-1", "input-1"); ack.ErrorCode != "input_conflict" {
@@ -108,18 +110,27 @@ func TestSteeringReadinessAndUnsupportedRuns(t *testing.T) {
 	input := proto.PromptSteerPayload{InputID: "input-1", Text: "extra"}
 	env := mustEnv(t, proto.TypePromptSteer, "run-1", input)
 	for _, expected := range []string{"not_ready", ""} {
-		if err := h.router.Handle(ctx, env); err != nil {
+		if err := handleSteeringAndWait(t, h, env); err != nil {
 			t.Fatal(err)
 		}
 		if ack := lastSteeringAck(t, h.sender, "run-1", "input-1"); ack.ErrorCode != expected {
 			t.Fatalf("expected %q: %+v", expected, ack)
+		}
+		if expected == "not_ready" {
+			changed := proto.PromptSteerPayload{InputID: "input-1", Text: "different during startup"}
+			if err := handleSteeringAndWait(t, h, mustEnv(t, proto.TypePromptSteer, "run-1", changed)); err != nil {
+				t.Fatal(err)
+			}
+			if ack := lastSteeringAck(t, h.sender, "run-1", "input-1"); ack.ErrorCode != "input_conflict" {
+				t.Fatalf("startup identity changed: %+v", ack)
+			}
 		}
 	}
 	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptCancel, "run-1", nil)); err != nil {
 		t.Fatal(err)
 	}
 	waitFor(t, func() bool { return h.router.ActiveRuns() == 0 }, "cancel cleanup")
-	if err := h.router.Handle(ctx, env); err != nil {
+	if err := handleSteeringAndWait(t, h, env); err != nil {
 		t.Fatal(err)
 	}
 	if ack := lastSteeringAck(t, h.sender, "run-1", "input-1"); ack.ErrorCode != "run_inactive" {
@@ -130,18 +141,62 @@ func TestSteeringReadinessAndUnsupportedRuns(t *testing.T) {
 	}
 	session := <-h.gotSess
 	defer close(session.out)
-	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptSteer, "run-2", input)); err != nil {
+	if err := handleSteeringAndWait(t, h, mustEnv(t, proto.TypePromptSteer, "run-2", input)); err != nil {
 		t.Fatal(err)
 	}
 	if ack := lastSteeringAck(t, h.sender, "run-2", "input-1"); ack.ErrorCode != "unsupported" {
 		t.Fatalf("unsupported: %+v", ack)
 	}
 	input.Text = " \n "
-	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptSteer, "run-2", input)); err != nil {
+	if err := handleSteeringAndWait(t, h, mustEnv(t, proto.TypePromptSteer, "run-2", input)); err != nil {
 		t.Fatal(err)
 	}
 	if ack := lastSteeringAck(t, h.sender, "run-2", "input-1"); ack.ErrorCode != "invalid_input" {
 		t.Fatalf("invalid: %+v", ack)
+	}
+}
+
+func TestSteeringDoesNotBlockOtherRunCancellation(t *testing.T) {
+	h := newHarness(t)
+	defer h.router.Shutdown(context.Background())
+	entered, release := make(chan struct{}), make(chan struct{})
+	defer close(release)
+	h.reg.Register("codex", func(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+		return &steeringSession{
+			fakeSession: &fakeSession{out: out, closeOutOnCancel: true},
+			steer: func(context.Context, proto.PromptSteerPayload) error {
+				close(entered)
+				<-release
+				return agent.ErrSteeringRejected
+			},
+		}, nil
+	})
+	ctx := context.Background()
+	for _, run := range []struct{ id, engine string }{{"run-1", "codex"}, {"run-2", "claude_code"}} {
+		if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptRequest, run.id, proto.PromptRequestPayload{AgentKind: run.engine})); err != nil {
+			t.Fatal(err)
+		}
+	}
+	other := <-h.gotSess
+	other.closeOutOnCancel = true
+	returned := make(chan error, 1)
+	go func() {
+		returned <- h.router.Handle(ctx, mustEnv(t, proto.TypePromptSteer, "run-1", proto.PromptSteerPayload{InputID: "slow", Text: "extra"}))
+	}()
+	select {
+	case err := <-returned:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("steering blocked dispatch")
+	}
+	<-entered
+	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptCancel, "run-2", nil)); err != nil {
+		t.Fatal(err)
+	}
+	if other.cancels() != 1 {
+		t.Fatal("other run cancellation blocked")
 	}
 }
 
@@ -184,7 +239,7 @@ func TestSteeringCapacityPreservesExistingReceipts(t *testing.T) {
 	}
 	for i := range 257 {
 		input := proto.PromptSteerPayload{InputID: fmt.Sprintf("input-%d", i), Text: "extra"}
-		if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptSteer, "run-1", input)); err != nil {
+		if err := handleSteeringAndWait(t, h, mustEnv(t, proto.TypePromptSteer, "run-1", input)); err != nil {
 			t.Fatal(err)
 		}
 		ack := lastSteeringAck(t, h.sender, "run-1", input.InputID)
@@ -192,10 +247,20 @@ func TestSteeringCapacityPreservesExistingReceipts(t *testing.T) {
 			t.Fatalf("input %d: %+v", i, ack)
 		}
 	}
-	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptSteer, "run-1", proto.PromptSteerPayload{InputID: "input-0", Text: "extra"})); err != nil {
+	if err := handleSteeringAndWait(t, h, mustEnv(t, proto.TypePromptSteer, "run-1", proto.PromptSteerPayload{InputID: "input-0", Text: "extra"})); err != nil {
 		t.Fatal(err)
 	}
 	if ack := lastSteeringAck(t, h.sender, "run-1", "input-0"); !ack.Accepted || calls != 256 {
 		t.Fatalf("receipt evicted or input redelivered: %+v, calls=%d", ack, calls)
 	}
+}
+
+func handleSteeringAndWait(t *testing.T, h *harness, env proto.Envelope) error {
+	t.Helper()
+	before := len(h.sender.snapshot())
+	if err := h.router.Handle(context.Background(), env); err != nil {
+		return err
+	}
+	waitFor(t, func() bool { return len(h.sender.snapshot()) > before }, "steering ack")
+	return nil
 }

--- a/apps/parsar-daemon/internal/dispatch/steering_test.go
+++ b/apps/parsar-daemon/internal/dispatch/steering_test.go
@@ -1,0 +1,201 @@
+package dispatch_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+type steeringSession struct {
+	*fakeSession
+	steer func(context.Context, proto.PromptSteerPayload) error
+}
+
+func (s *steeringSession) Steer(ctx context.Context, input proto.PromptSteerPayload) error {
+	return s.steer(ctx, input)
+}
+
+func TestSteeringReceiptsAndRetries(t *testing.T) {
+	for _, engineError := range []error{nil, errors.New("native connection lost after write")} {
+		name := "accepted"
+		if engineError != nil {
+			name = "uncertain"
+		}
+		t.Run(name, func(t *testing.T) {
+			h := newHarness(t)
+			defer h.router.Shutdown(context.Background())
+			calls, starts := 0, 0
+			h.reg.Register("codex", func(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+				starts++
+				return &steeringSession{
+					fakeSession: &fakeSession{out: out, closeOutOnCancel: true},
+					steer: func(ctx context.Context, input proto.PromptSteerPayload) error {
+						calls++
+						if _, ok := ctx.Deadline(); !ok {
+							t.Error("native request has no deadline")
+						}
+						if input.InputID != "input-1" || input.Text != "additional text" {
+							t.Errorf("input lost: %+v", input)
+						}
+						if len(h.sender.snapshot()) != 0 {
+							t.Error("ack sent before engine accepted input")
+						}
+						return engineError
+					},
+				}, nil
+			})
+			ctx := context.Background()
+			if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptRequest, "run-1", proto.PromptRequestPayload{AgentKind: "codex"})); err != nil {
+				t.Fatal(err)
+			}
+			input := proto.PromptSteerPayload{InputID: "input-1", Text: "additional text"}
+			env := mustEnv(t, proto.TypePromptSteer, "run-1", input)
+			// An ack transport failure must not cause another native invocation.
+			h.sender.failNow = true
+			if err := h.router.Handle(ctx, env); err == nil {
+				t.Fatal("expected ack-send failure")
+			}
+			for range 2 {
+				if err := h.router.Handle(ctx, env); err != nil {
+					t.Fatal(err)
+				}
+				ack := lastSteeringAck(t, h.sender, "run-1", "input-1")
+				if ack.Accepted != (engineError == nil) {
+					t.Fatalf("receipt: %+v", ack)
+				}
+				if engineError != nil && ack.ErrorCode != "outcome_unknown" {
+					t.Fatalf("uncertainty lost: %+v", ack)
+				}
+			}
+			input.Text = "changed text"
+			if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptSteer, "run-1", input)); err != nil {
+				t.Fatal(err)
+			}
+			if ack := lastSteeringAck(t, h.sender, "run-1", "input-1"); ack.ErrorCode != "input_conflict" {
+				t.Fatalf("conflict: %+v", ack)
+			}
+			if calls != 1 || starts != 1 {
+				t.Fatalf("native calls=%d, runs started=%d", calls, starts)
+			}
+		})
+	}
+}
+
+func TestSteeringReadinessAndUnsupportedRuns(t *testing.T) {
+	h := newHarness(t)
+	defer h.router.Shutdown(context.Background())
+	calls := 0
+	h.reg.Register("codex", func(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+		return &steeringSession{
+			fakeSession: &fakeSession{out: out, closeOutOnCancel: true},
+			steer: func(context.Context, proto.PromptSteerPayload) error {
+				calls++
+				if calls == 1 {
+					return agent.ErrSteeringNotReady
+				}
+				return nil
+			},
+		}, nil
+	})
+	ctx := context.Background()
+	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptRequest, "run-1", proto.PromptRequestPayload{AgentKind: "codex"})); err != nil {
+		t.Fatal(err)
+	}
+	input := proto.PromptSteerPayload{InputID: "input-1", Text: "extra"}
+	env := mustEnv(t, proto.TypePromptSteer, "run-1", input)
+	for _, expected := range []string{"not_ready", ""} {
+		if err := h.router.Handle(ctx, env); err != nil {
+			t.Fatal(err)
+		}
+		if ack := lastSteeringAck(t, h.sender, "run-1", "input-1"); ack.ErrorCode != expected {
+			t.Fatalf("expected %q: %+v", expected, ack)
+		}
+	}
+	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptCancel, "run-1", nil)); err != nil {
+		t.Fatal(err)
+	}
+	waitFor(t, func() bool { return h.router.ActiveRuns() == 0 }, "cancel cleanup")
+	if err := h.router.Handle(ctx, env); err != nil {
+		t.Fatal(err)
+	}
+	if ack := lastSteeringAck(t, h.sender, "run-1", "input-1"); ack.ErrorCode != "run_inactive" {
+		t.Fatalf("inactive: %+v", ack)
+	}
+	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptRequest, "run-2", proto.PromptRequestPayload{AgentKind: "claude_code"})); err != nil {
+		t.Fatal(err)
+	}
+	session := <-h.gotSess
+	defer close(session.out)
+	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptSteer, "run-2", input)); err != nil {
+		t.Fatal(err)
+	}
+	if ack := lastSteeringAck(t, h.sender, "run-2", "input-1"); ack.ErrorCode != "unsupported" {
+		t.Fatalf("unsupported: %+v", ack)
+	}
+	input.Text = " \n "
+	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptSteer, "run-2", input)); err != nil {
+		t.Fatal(err)
+	}
+	if ack := lastSteeringAck(t, h.sender, "run-2", "input-1"); ack.ErrorCode != "invalid_input" {
+		t.Fatalf("invalid: %+v", ack)
+	}
+}
+
+func lastSteeringAck(t *testing.T, sender *recSender, runID, inputID string) proto.PromptSteerAckPayload {
+	t.Helper()
+	frames := sender.snapshot()
+	if len(frames) == 0 {
+		t.Fatal("missing ack")
+	}
+	env := frames[len(frames)-1]
+	var ack proto.PromptSteerAckPayload
+	if env.Type != proto.TypePromptSteerAck || env.ID != runID {
+		t.Fatalf("incorrect routing: %+v", env)
+	}
+	if err := env.DecodePayload(&ack); err != nil {
+		t.Fatal(err)
+	}
+	if ack.InputID != inputID {
+		t.Fatalf("incorrect input: %+v", ack)
+	}
+	return ack
+}
+
+func TestSteeringCapacityPreservesExistingReceipts(t *testing.T) {
+	h := newHarness(t)
+	defer h.router.Shutdown(context.Background())
+	calls := 0
+	h.reg.Register("codex", func(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+		return &steeringSession{
+			fakeSession: &fakeSession{out: out, closeOutOnCancel: true},
+			steer: func(context.Context, proto.PromptSteerPayload) error {
+				calls++
+				return nil
+			},
+		}, nil
+	})
+	ctx := context.Background()
+	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptRequest, "run-1", proto.PromptRequestPayload{AgentKind: "codex"})); err != nil {
+		t.Fatal(err)
+	}
+	for i := range 257 {
+		input := proto.PromptSteerPayload{InputID: fmt.Sprintf("input-%d", i), Text: "extra"}
+		if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptSteer, "run-1", input)); err != nil {
+			t.Fatal(err)
+		}
+		ack := lastSteeringAck(t, h.sender, "run-1", input.InputID)
+		if i < 256 && !ack.Accepted || i == 256 && ack.ErrorCode != "input_limit" {
+			t.Fatalf("input %d: %+v", i, ack)
+		}
+	}
+	if err := h.router.Handle(ctx, mustEnv(t, proto.TypePromptSteer, "run-1", proto.PromptSteerPayload{InputID: "input-0", Text: "extra"})); err != nil {
+		t.Fatal(err)
+	}
+	if ack := lastSteeringAck(t, h.sender, "run-1", "input-0"); !ack.Accepted || calls != 256 {
+		t.Fatalf("receipt evicted or input redelivered: %+v, calls=%d", ack, calls)
+	}
+}

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -226,6 +226,7 @@ type AgentKindCapabilities struct {
 	Usage              bool `json:"usage,omitempty"`
 	Resume             bool `json:"resume,omitempty"`
 	WorkspaceAuthoring bool `json:"workspace_authoring,omitempty"`
+	Steering           bool `json:"steering,omitempty"`
 }
 
 // SupportedAgentKind is one daemon-advertised agent engine. Daemons

--- a/internal/agentdaemon/proto/steering.go
+++ b/internal/agentdaemon/proto/steering.go
@@ -1,0 +1,21 @@
+package proto
+
+// TypePromptSteer appends text to an active run; Envelope.ID is the run ID.
+const TypePromptSteer = "prompt_steer"
+
+// TypePromptSteerAck reports engine acceptance on the originating run ID.
+const TypePromptSteerAck = "prompt_steer_ack"
+
+// PromptSteerPayload identifies one text input within an active run.
+type PromptSteerPayload struct {
+	InputID string `json:"input_id"`
+	Text    string `json:"text"`
+}
+
+// PromptSteerAckPayload confirms acceptance, not completion of the input.
+type PromptSteerAckPayload struct {
+	InputID   string `json:"input_id"`
+	Accepted  bool   `json:"accepted"`
+	ErrorCode string `json:"error_code,omitempty"`
+	Error     string `json:"error,omitempty"`
+}


### PR DESCRIPTION
Active runs currently have no daemon operation for receiving another message. Add optional text steering so Codex can accept input in its current native turn and return a run/input-correlated receipt. Other engine adapters retain their existing behavior.

Receipts prevent duplicate native delivery within an active run, including retries after an acknowledgement transport failure. Conflicting input IDs and capacity overflow are rejected. Startup and inactive states are explicit; uncertain RPC outcomes are retained without automatic redelivery. The native turn ID is an enforced precondition, and success requires a matching engine acknowledgement.

Native delivery stays outside the shared dispatch loop. Receipt timeouts preserve the process after a complete write; blocked writes close the transport, and unexpected disconnects emit a single terminal failure.

Scope: daemon protocol, optional engine interface and Codex adapter only. This does not expose the public Agents API events endpoint, switch product execution, or guarantee exactly-once delivery across daemon restarts. CONTRIBUTING documents the contract.

Validation:
- `make check`
- Targeted Codex, dispatcher, CLI and shared gateway tests; race detector for Codex, dispatcher and gateway.
- Real Codex CLI 0.153.4 against an isolated synthetic Responses server: additional input reached the model during one native turn, the run completed, and post-completion steering was rejected.

Independent blind review of the full diff found no actionable issues. Tracked as a partial ATOM-004 milestone in the Feishu board.
