### PR TITLE
feat(agents-api): admit ordered input batches atomically

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,13 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   target, including an idle no-op, so retries cannot stop later work. Queued work
   can cancel before dispatch; active work needs an executor outcome. Terminal
   states and outcomes cannot be overwritten. These Store primitives do not yet
-  implement daemon delivery, public event batches or output streams.
+  implement daemon delivery, public event submission or output streams.
+- Input requests are ordered batches committed under the same Session lock. A
+  retry key identifies the complete ordered batch; changed length/order/content
+  conflicts and a failed transaction leaves no partial inputs or cancellation.
+  Existing single-event requests retain their identities at batch position zero.
+  Internal admission limits are 64 events and 512 KiB of payload per request;
+  the public API must still validate the upstream event schema.
 - The external protocol reference is `openai/openai-python`'s `beta/agents`, pinned
   in `contracts/agents-api/upstream.json`. Follow its Session/Turn/event semantics
   and verify supported behavior using the official client. Track current coverage

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -39,7 +39,7 @@ separate future dependency for Team orchestration in Parsar, not the HTTP contra
 | Tenant-scoped Session persistence | Implemented; internal Store, not a public API |
 | Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
 | Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, environment `none`, metadata and creation retry keys |
-| Internal Turn/input persistence | Tenant-scoped admission, steering, retry identity, cancellation targets and terminal outcomes; no dispatch or public event submission yet |
+| Internal Turn/input persistence | Tenant-scoped atomic input batches, steering, request-level retry identity, cancellation targets and terminal outcomes; no dispatch or public event submission yet |
 | Turn execution, events, results and cancellation | Pending |
 | Pending actions and environment lifecycle | Pending |
 | Official-client compatibility | Strict SDK checks for the supported Session subset, pagination, retries, errors, tenant isolation and restart |

--- a/services/agents-api/internal/db/queries/turns.sql
+++ b/services/agents-api/internal/db/queries/turns.sql
@@ -11,13 +11,20 @@ INSERT INTO turns(id, session_id) VALUES ($1, $2) RETURNING *;
 SELECT t.* FROM turns t JOIN sessions s ON s.id = t.session_id
 WHERE s.tenant_id = $1 AND t.session_id = $2 AND t.id = $3;
 
--- name: FindTurnInput :one
-SELECT sequence, turn_id, (kind = sqlc.arg(kind) AND payload = sqlc.arg(payload)::jsonb)::boolean AS matches
-FROM turn_inputs WHERE session_id = $1 AND idempotency_key = $2;
+-- name: FindInputBatch :many
+WITH previous AS (
+    SELECT sequence, turn_id, kind, payload, batch_position FROM turn_inputs
+    WHERE session_id = $1 AND idempotency_key = $2
+)
+SELECT sequence, turn_id, COALESCE((
+    SELECT jsonb_agg(jsonb_build_object('kind', kind, 'payload', payload) ORDER BY batch_position)
+        = sqlc.arg(batch)::jsonb FROM previous
+), false)::boolean AS matches
+FROM previous ORDER BY batch_position;
 
 -- name: CreateTurnInput :one
-INSERT INTO turn_inputs(session_id, turn_id, idempotency_key, kind, payload)
-VALUES ($1, $2, $3, $4, $5) RETURNING sequence;
+INSERT INTO turn_inputs(session_id, turn_id, idempotency_key, kind, payload, batch_position)
+VALUES ($1, $2, $3, $4, $5, $6) RETURNING sequence;
 
 -- name: RequestTurnCancel :exec
 UPDATE turns SET cancel_requested_at = COALESCE(cancel_requested_at, clock_timestamp()),

--- a/services/agents-api/internal/db/sqlc/models.go
+++ b/services/agents-api/internal/db/sqlc/models.go
@@ -38,4 +38,5 @@ type TurnInput struct {
 	Kind           string             `json:"kind"`
 	Payload        []byte             `json:"payload"`
 	CreatedAt      pgtype.Timestamptz `json:"created_at"`
+	BatchPosition  int32              `json:"batch_position"`
 }

--- a/services/agents-api/internal/db/sqlc/turns.sql.go
+++ b/services/agents-api/internal/db/sqlc/turns.sql.go
@@ -37,8 +37,8 @@ func (q *Queries) CreateTurn(ctx context.Context, arg CreateTurnParams) (Turn, e
 }
 
 const createTurnInput = `-- name: CreateTurnInput :one
-INSERT INTO turn_inputs(session_id, turn_id, idempotency_key, kind, payload)
-VALUES ($1, $2, $3, $4, $5) RETURNING sequence
+INSERT INTO turn_inputs(session_id, turn_id, idempotency_key, kind, payload, batch_position)
+VALUES ($1, $2, $3, $4, $5, $6) RETURNING sequence
 `
 
 type CreateTurnInputParams struct {
@@ -47,6 +47,7 @@ type CreateTurnInputParams struct {
 	IdempotencyKey string      `json:"idempotency_key"`
 	Kind           string      `json:"kind"`
 	Payload        []byte      `json:"payload"`
+	BatchPosition  int32       `json:"batch_position"`
 }
 
 func (q *Queries) CreateTurnInput(ctx context.Context, arg CreateTurnInputParams) (int64, error) {
@@ -56,40 +57,55 @@ func (q *Queries) CreateTurnInput(ctx context.Context, arg CreateTurnInputParams
 		arg.IdempotencyKey,
 		arg.Kind,
 		arg.Payload,
+		arg.BatchPosition,
 	)
 	var sequence int64
 	err := row.Scan(&sequence)
 	return sequence, err
 }
 
-const findTurnInput = `-- name: FindTurnInput :one
-SELECT sequence, turn_id, (kind = $3 AND payload = $4::jsonb)::boolean AS matches
-FROM turn_inputs WHERE session_id = $1 AND idempotency_key = $2
+const findInputBatch = `-- name: FindInputBatch :many
+WITH previous AS (
+    SELECT sequence, turn_id, kind, payload, batch_position FROM turn_inputs
+    WHERE session_id = $1 AND idempotency_key = $2
+)
+SELECT sequence, turn_id, COALESCE((
+    SELECT jsonb_agg(jsonb_build_object('kind', kind, 'payload', payload) ORDER BY batch_position)
+        = $3::jsonb FROM previous
+), false)::boolean AS matches
+FROM previous ORDER BY batch_position
 `
 
-type FindTurnInputParams struct {
+type FindInputBatchParams struct {
 	SessionID      pgtype.UUID `json:"session_id"`
 	IdempotencyKey string      `json:"idempotency_key"`
-	Kind           string      `json:"kind"`
-	Payload        []byte      `json:"payload"`
+	Batch          []byte      `json:"batch"`
 }
 
-type FindTurnInputRow struct {
+type FindInputBatchRow struct {
 	Sequence int64       `json:"sequence"`
 	TurnID   pgtype.UUID `json:"turn_id"`
 	Matches  bool        `json:"matches"`
 }
 
-func (q *Queries) FindTurnInput(ctx context.Context, arg FindTurnInputParams) (FindTurnInputRow, error) {
-	row := q.db.QueryRow(ctx, findTurnInput,
-		arg.SessionID,
-		arg.IdempotencyKey,
-		arg.Kind,
-		arg.Payload,
-	)
-	var i FindTurnInputRow
-	err := row.Scan(&i.Sequence, &i.TurnID, &i.Matches)
-	return i, err
+func (q *Queries) FindInputBatch(ctx context.Context, arg FindInputBatchParams) ([]FindInputBatchRow, error) {
+	rows, err := q.db.Query(ctx, findInputBatch, arg.SessionID, arg.IdempotencyKey, arg.Batch)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FindInputBatchRow{}
+	for rows.Next() {
+		var i FindInputBatchRow
+		if err := rows.Scan(&i.Sequence, &i.TurnID, &i.Matches); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getActiveTurn = `-- name: GetActiveTurn :one
@@ -140,7 +156,7 @@ func (q *Queries) GetTurn(ctx context.Context, arg GetTurnParams) (Turn, error) 
 }
 
 const listTurnInputs = `-- name: ListTurnInputs :many
-SELECT i.sequence, i.session_id, i.turn_id, i.idempotency_key, i.kind, i.payload, i.created_at FROM turn_inputs i JOIN sessions s ON s.id = i.session_id
+SELECT i.sequence, i.session_id, i.turn_id, i.idempotency_key, i.kind, i.payload, i.created_at, i.batch_position FROM turn_inputs i JOIN sessions s ON s.id = i.session_id
 WHERE s.tenant_id = $1 AND i.session_id = $2 AND i.turn_id = $3 AND i.sequence > $4
 ORDER BY i.sequence LIMIT $5
 `
@@ -176,6 +192,7 @@ func (q *Queries) ListTurnInputs(ctx context.Context, arg ListTurnInputsParams) 
 			&i.Kind,
 			&i.Payload,
 			&i.CreatedAt,
+			&i.BatchPosition,
 		); err != nil {
 			return nil, err
 		}

--- a/services/agents-api/internal/store/input_batches_test.go
+++ b/services/agents-api/internal/store/input_batches_test.go
@@ -1,0 +1,188 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func messageInput(text string) Input {
+	payload, _ := json.Marshal(map[string]string{"text": text})
+	return Input{Kind: "message", Payload: payload}
+}
+
+func TestInputBatchesAreOrderedAndIdempotentAcrossConnections(t *testing.T) {
+	s, _ := testStore(t)
+	other, _ := testStore(t)
+	tenant, session := newTurnSession(t, s)
+	ctx := context.Background()
+	const count = 8
+	batch := []Input{messageInput("first"), messageInput("second")}
+	for _, repeated := range []bool{true, false} {
+		var wg sync.WaitGroup
+		receipts := make(chan []InputReceipt, count)
+		errs := make(chan error, count)
+		for i := range count {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				st := s
+				if i%2 == 0 {
+					st = other
+				}
+				key := "same-batch"
+				if !repeated {
+					key = fmt.Sprintf("batch-%d", i)
+				}
+				got, err := st.SubmitInputs(ctx, tenant, session.ID, key, batch)
+				receipts <- got
+				errs <- err
+			}()
+		}
+		wg.Wait()
+		close(receipts)
+		close(errs)
+		for err := range errs {
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		newBatches := 0
+		for got := range receipts {
+			if len(got) != 2 || got[0].TurnID == "" || got[0].TurnID != got[1].TurnID || got[0].Sequence >= got[1].Sequence || got[0].Replayed != got[1].Replayed {
+				t.Fatalf("invalid batch receipt: %+v", got)
+			}
+			if !got[0].Replayed {
+				newBatches++
+			}
+		}
+		want := count
+		if repeated {
+			want = 1
+		}
+		if newBatches != want {
+			t.Fatalf("accepted %d batches, want %d", newBatches, want)
+		}
+	}
+	got, err := s.SubmitInputs(ctx, tenant, session.ID, "same-batch", batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputs, err := s.ListTurnInputs(ctx, tenant, session.ID, got[0].TurnID, 0, 100)
+	if err != nil || len(inputs) != 2*(count+1) {
+		t.Fatalf("inputs=%d err=%v", len(inputs), err)
+	}
+	for i, input := range inputs {
+		var payload map[string]string
+		if err := json.Unmarshal(input.Payload, &payload); err != nil {
+			t.Fatal(err)
+		}
+		want := "first"
+		if i%2 == 1 {
+			want = "second"
+		}
+		if payload["text"] != want {
+			t.Fatalf("batch interleaved at %d: %v", i, payload)
+		}
+	}
+}
+
+func TestBatchRetriesCompareTheWholeRequestAndRetainTargets(t *testing.T) {
+	s, pool := testStore(t)
+	tenant, session := newTurnSession(t, s)
+	ctx := context.Background()
+	cancel := Input{Kind: "cancel", Payload: json.RawMessage(`{}`)}
+	batch := []Input{cancel, messageInput("one"), cancel, messageInput("two")}
+	first, err := s.SubmitInputs(ctx, tenant, session.ID, "mixed", batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first[0].TurnID != "" || first[1].TurnID == "" || first[1].TurnID != first[2].TurnID || first[1].TurnID == first[3].TurnID {
+		t.Fatalf("cancellation targets: %+v", first)
+	}
+	cancelled, err := s.GetTurn(ctx, tenant, session.ID, first[1].TurnID)
+	if err != nil || cancelled.Status != TurnCancelled {
+		t.Fatalf("cancelled turn=%+v err=%v", cancelled, err)
+	}
+	transition(t, s, tenant, session.ID, first[3].TurnID, TurnQueued, TurnInProgress)
+	transition(t, s, tenant, session.ID, first[3].TurnID, TurnInProgress, TurnCompleted)
+	next := submitMessage(t, s, tenant, session.ID, "next")
+	for _, changed := range [][]Input{batch[:3], append(append([]Input{}, batch...), cancel), {batch[0], batch[3], batch[2], batch[1]}} {
+		if _, err := s.SubmitInputs(ctx, tenant, session.ID, "mixed", changed); !errors.Is(err, ErrIdempotencyConflict) {
+			t.Fatalf("changed batch accepted: %v", err)
+		}
+	}
+	batch[1].Payload = json.RawMessage(`{ "text" : "one" }`)
+	pool.Close()
+	restarted, _ := testStore(t)
+	retry, err := restarted.SubmitInputs(ctx, tenant, session.ID, "mixed", batch)
+	for i := range first {
+		first[i].Replayed = true
+	}
+	if err != nil || !reflect.DeepEqual(retry, first) {
+		t.Fatalf("restart changed receipts: %+v, %v", retry, err)
+	}
+	current, err := restarted.GetTurn(ctx, tenant, session.ID, next.TurnID)
+	if err != nil || current.Status != TurnQueued || !current.CancelRequestedAt.IsZero() {
+		t.Fatalf("retry cancelled later work: %+v, %v", current, err)
+	}
+	otherTenant, _ := newTurnSession(t, restarted)
+	if _, err := restarted.SubmitInputs(ctx, otherTenant, session.ID, "mixed", batch); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("batch retry escaped tenant: %v", err)
+	}
+}
+
+func TestFailedBatchRollsBackEarlierCancellationAndInputs(t *testing.T) {
+	s, pool := testStore(t)
+	tenant, session := newTurnSession(t, s)
+	ctx := context.Background()
+	initial := submitMessage(t, s, tenant, session.ID, "initial")
+	transition(t, s, tenant, session.ID, initial.TurnID, TurnQueued, TurnInProgress)
+	key := uuid.NewString()
+	constraint := "batch_failure_" + strings.ReplaceAll(key, "-", "")
+	// Inject a storage error on the second insert, after cancellation has run.
+	_, err := pool.Exec(ctx, "ALTER TABLE turn_inputs ADD CONSTRAINT "+constraint+" CHECK (idempotency_key <> '"+key+"' OR batch_position = 0)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _, _ = pool.Exec(ctx, "ALTER TABLE turn_inputs DROP CONSTRAINT IF EXISTS "+constraint) })
+	batch := []Input{{Kind: "cancel", Payload: json.RawMessage(`{}`)}, messageInput("after cancel")}
+	if got, err := s.SubmitInputs(ctx, tenant, session.ID, key, batch); err == nil || got != nil {
+		t.Fatalf("partial batch succeeded: %+v %v", got, err)
+	}
+	turn, err := s.GetTurn(ctx, tenant, session.ID, initial.TurnID)
+	if err != nil || turn.Status != TurnInProgress || !turn.CancelRequestedAt.IsZero() {
+		t.Fatalf("cancellation escaped rollback: %+v %v", turn, err)
+	}
+	inputs, err := s.ListTurnInputs(ctx, tenant, session.ID, initial.TurnID, 0, 100)
+	if err != nil || len(inputs) != 1 {
+		t.Fatalf("partial inputs survived: %v %v", inputs, err)
+	}
+	if _, err := pool.Exec(ctx, "ALTER TABLE turn_inputs DROP CONSTRAINT "+constraint); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.SubmitInputs(ctx, tenant, session.ID, key, batch)
+	if err != nil || len(got) != 2 || got[0].Replayed || got[1].Replayed {
+		t.Fatalf("retry after rollback: %+v %v", got, err)
+	}
+}
+
+func TestInputBatchValidation(t *testing.T) {
+	for _, input := range [][]Input{
+		nil, make([]Input, 65), {messageInput("ok"), {Kind: "unsupported", Payload: json.RawMessage(`{}`)}},
+		{{Kind: "message"}}, {{Kind: "message", Payload: json.RawMessage(`[]`)}},
+		{{Kind: "cancel", Payload: json.RawMessage(`{"target":"other"}`)}},
+		{messageInput(strings.Repeat("x", 300*1024)), messageInput(strings.Repeat("y", 300*1024))},
+	} {
+		if _, _, err := validateInputs(input); !errors.Is(err, ErrInvalidInput) {
+			t.Fatalf("invalid batch accepted: %v", err)
+		}
+	}
+}

--- a/services/agents-api/internal/store/turn_inputs.go
+++ b/services/agents-api/internal/store/turn_inputs.go
@@ -28,73 +28,119 @@ type TurnInput struct {
 	CreatedAt time.Time
 }
 
-// SubmitMessage persists one validated input. An idle Session gets a new Turn;
-// active Sessions receive steering input on the current Turn. API-level event
-// validation and batch submission are separate from this internal primitive.
+// Input is a validated execution command, not an upstream wire type.
+// The API validates event fields before constructing this storage input.
+type Input struct {
+	Kind    string          `json:"kind"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+// SubmitMessage and RequestCancel use the same request-level admission as batches.
 func (s *Store) SubmitMessage(ctx context.Context, tenantID, sessionID, key string, payload json.RawMessage) (InputReceipt, error) {
-	if len(payload) == 0 || len(payload) > 512*1024 {
-		return InputReceipt{}, fmt.Errorf("%w: message payload must be nonempty and at most 512 KiB", ErrInvalidInput)
-	}
-	canonical, err := canonicalJSONObject(payload)
+	return s.submitOne(ctx, tenantID, sessionID, key, Input{Kind: "message", Payload: payload})
+}
+
+func (s *Store) RequestCancel(ctx context.Context, tenantID, sessionID, key string) (InputReceipt, error) {
+	return s.submitOne(ctx, tenantID, sessionID, key, Input{Kind: "cancel", Payload: json.RawMessage(`{}`)})
+}
+
+func (s *Store) submitOne(ctx context.Context, tenantID, sessionID, key string, input Input) (InputReceipt, error) {
+	receipts, err := s.SubmitInputs(ctx, tenantID, sessionID, key, []Input{input})
 	if err != nil {
 		return InputReceipt{}, err
 	}
-	return s.submitInput(ctx, tenantID, sessionID, key, "message", canonical)
+	return receipts[0], nil
 }
 
-// RequestCancel fixes the cancellation target at first acceptance. A retry must
-// not cancel a later Turn. Queued work stops immediately; running work remains
-// active until the executor acknowledges cancellation or reports another outcome.
-func (s *Store) RequestCancel(ctx context.Context, tenantID, sessionID, key string) (InputReceipt, error) {
-	return s.submitInput(ctx, tenantID, sessionID, key, "cancel", json.RawMessage(`{}`))
-}
-
-func (s *Store) submitInput(ctx context.Context, tenantID, sessionID, key, kind string, payload json.RawMessage) (InputReceipt, error) {
+// SubmitInputs commits a request in order under one Session lock. The entire
+// batch is the retry identity; replay never re-evaluates a cancellation target.
+// Internal receipts are not the response body of the public events endpoint.
+func (s *Store) SubmitInputs(ctx context.Context, tenantID, sessionID, key string, inputs []Input) ([]InputReceipt, error) {
 	if strings.TrimSpace(key) == "" || len(key) > 128 {
-		return InputReceipt{}, fmt.Errorf("%w: idempotency key is required and limited to 128 bytes", ErrInvalidInput)
+		return nil, fmt.Errorf("%w: idempotency key is required and limited to 128 bytes", ErrInvalidInput)
 	}
-	var receipt InputReceipt
-	err := s.withSession(ctx, tenantID, sessionID, func(q *sqlc.Queries, session pgtype.UUID) error {
-		previous, err := q.FindTurnInput(ctx, sqlc.FindTurnInputParams{SessionID: session, IdempotencyKey: key, Kind: kind, Payload: payload})
-		if err == nil {
-			if !previous.Matches {
+	batch, encoded, err := validateInputs(inputs)
+	if err != nil {
+		return nil, err
+	}
+	receipts := make([]InputReceipt, 0, len(batch))
+	err = s.withSession(ctx, tenantID, sessionID, func(q *sqlc.Queries, session pgtype.UUID) error {
+		previous, err := q.FindInputBatch(ctx, sqlc.FindInputBatchParams{SessionID: session, IdempotencyKey: key, Batch: encoded})
+		if err != nil {
+			return err
+		}
+		if len(previous) > 0 {
+			if !previous[0].Matches {
 				return ErrIdempotencyConflict
 			}
-			receipt = inputReceipt(previous.Sequence, previous.TurnID, true)
+			for _, row := range previous {
+				receipts = append(receipts, inputReceipt(row.Sequence, row.TurnID, true))
+			}
 			return nil
 		}
-		if !errors.Is(err, pgx.ErrNoRows) {
-			return err
-		}
-		turn, err := q.GetActiveTurn(ctx, session)
-		if errors.Is(err, pgx.ErrNoRows) {
-			if kind == "message" {
-				turn, err = q.CreateTurn(ctx, sqlc.CreateTurnParams{ID: pgtype.UUID{Bytes: uuid.New(), Valid: true}, SessionID: session})
-			} else {
-				err = nil // Retain even an idle cancellation's retry identity.
-			}
-		}
-		if err != nil {
-			return err
-		}
-		sequence, err := q.CreateTurnInput(ctx, sqlc.CreateTurnInputParams{
-			SessionID: session, TurnID: turn.ID, IdempotencyKey: key, Kind: kind, Payload: payload,
-		})
-		if err != nil {
-			return err
-		}
-		if kind == "cancel" && turn.ID.Valid {
-			if err := q.RequestTurnCancel(ctx, sqlc.RequestTurnCancelParams{ID: turn.ID, SessionID: session}); err != nil {
+		for position, input := range batch {
+			receipt, err := admitInput(ctx, q, session, key, int32(position), input)
+			if err != nil {
 				return err
 			}
+			receipts = append(receipts, receipt)
 		}
-		receipt = inputReceipt(sequence, turn.ID, false)
 		return nil
 	})
 	if err != nil {
-		return InputReceipt{}, fmt.Errorf("submit turn input: %w", err)
+		return nil, fmt.Errorf("submit turn inputs: %w", err)
 	}
-	return receipt, nil
+	return receipts, nil
+}
+
+func validateInputs(inputs []Input) ([]Input, json.RawMessage, error) {
+	if len(inputs) == 0 || len(inputs) > 64 {
+		return nil, nil, fmt.Errorf("%w: input batch must contain 1..64 events", ErrInvalidInput)
+	}
+	batch := make([]Input, len(inputs))
+	size := 0
+	for i, input := range inputs {
+		size += len(input.Payload)
+		if size > 512*1024 || len(input.Payload) == 0 || (input.Kind != "message" && input.Kind != "cancel") {
+			return nil, nil, fmt.Errorf("%w: message/cancel payloads must be nonempty and total at most 512 KiB", ErrInvalidInput)
+		}
+		payload, err := canonicalJSONObject(input.Payload)
+		if err != nil {
+			return nil, nil, err
+		}
+		if input.Kind == "cancel" && string(payload) != "{}" {
+			return nil, nil, fmt.Errorf("%w: cancel payload must be empty", ErrInvalidInput)
+		}
+		batch[i] = Input{Kind: input.Kind, Payload: payload}
+	}
+	encoded, err := json.Marshal(batch)
+	return batch, encoded, err
+}
+
+func admitInput(ctx context.Context, q *sqlc.Queries, session pgtype.UUID, key string, position int32, input Input) (InputReceipt, error) {
+	turn, err := q.GetActiveTurn(ctx, session)
+	if errors.Is(err, pgx.ErrNoRows) {
+		if input.Kind == "message" {
+			turn, err = q.CreateTurn(ctx, sqlc.CreateTurnParams{ID: pgtype.UUID{Bytes: uuid.New(), Valid: true}, SessionID: session})
+		} else {
+			err = nil // Retain even an idle cancellation's retry identity.
+		}
+	}
+	if err != nil {
+		return InputReceipt{}, err
+	}
+	sequence, err := q.CreateTurnInput(ctx, sqlc.CreateTurnInputParams{
+		SessionID: session, TurnID: turn.ID, IdempotencyKey: key, Kind: input.Kind, Payload: input.Payload, BatchPosition: position,
+	})
+	if err != nil {
+		return InputReceipt{}, err
+	}
+	if input.Kind == "cancel" && turn.ID.Valid {
+		if err := q.RequestTurnCancel(ctx, sqlc.RequestTurnCancelParams{ID: turn.ID, SessionID: session}); err != nil {
+			return InputReceipt{}, err
+		}
+	}
+	return inputReceipt(sequence, turn.ID, false), nil
 }
 
 // ListTurnInputs is an internal ordered recovery query, not the public SSE stream.

--- a/services/agents-api/migrations/000004_input_batches.sql
+++ b/services/agents-api/migrations/000004_input_batches.sql
@@ -1,0 +1,12 @@
+-- +goose Up
+-- Existing single-event requests retain their retry identity at position zero.
+ALTER TABLE turn_inputs ADD COLUMN batch_position integer NOT NULL DEFAULT 0
+    CHECK (batch_position >= 0);
+ALTER TABLE turn_inputs DROP CONSTRAINT turn_inputs_session_id_idempotency_key_key;
+ALTER TABLE turn_inputs ADD UNIQUE (session_id, idempotency_key, batch_position);
+
+-- +goose Down
+-- A multi-event request cannot be represented by the previous schema without
+-- losing inputs or retry identities. Let the uniqueness check stop such a downgrade.
+ALTER TABLE turn_inputs ADD UNIQUE (session_id, idempotency_key);
+ALTER TABLE turn_inputs DROP COLUMN batch_position;


### PR DESCRIPTION
## What & why

Input admission previously assigned one retry key to one event. Accept ordered message/cancel batches under a single request identity so a failed request leaves no partial input, turn creation, or cancellation, and retrying it retains the original receipts and targets.

## How

Reuse the Session transaction and existing input table. Single-event calls use the same admission path; existing rows keep position zero. A retry must match the entire ordered batch. Limit internal batches to 64 events and 512 KiB of payload. Downgrading after multi-event requests safely fails instead of deleting accepted inputs.

This change is limited to internal Agents API storage. Public event submission, dispatch, SSE, and Parsar integration remain separate work.

## Verification

- `make check` and `make sqlc-generate` passed.
- All Store tests passed against a dedicated PostgreSQL database with `-race`, including concurrent requests across connections, retry targets after reconnecting, tenant isolation, and an injected failure after cancellation to verify rollback.
- Independent blind review found no issues and independently passed all Store tests with `-race` on the dedicated PostgreSQL database.

Tracked in Feishu: ATOM-004 under REQ-006; this PR completes only the batch admission subtask.
