### PR TITLE
feat(agents-api): execute durable turns through bound daemons

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,9 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   completion, so the next Turn can resume its durable native ID. Existing product
   requests retain their default idle-process policy. Native history still requires
   the device's persisted engine files; IDs alone cannot restore deleted history.
+  Cancellation receipts carry the stopped engine's continuity snapshot when no
+  Done is emitted. Preserve separately reported usage on failure; do not add the
+  same counters again when Done also includes them.
 - The dispatcher is an internal entry point, not a public event handler or worker.
   Its private `daemon` configuration is neither `environment:none` nor the official
   self-hosted executor protocol. Public environment mapping, durable output events,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   target, including an idle no-op, so retries cannot stop later work. Queued work
   can cancel before dispatch; active work needs an executor outcome. Terminal
   states and outcomes cannot be overwritten. These Store primitives do not yet
-  implement daemon delivery, public event submission or output streams.
+  implement public event submission or output streams.
 - Input requests are ordered batches committed under the same Session lock. A
   retry key identifies the complete ordered batch; changed length/order/content
   conflicts and a failed transaction leaves no partial inputs or cancellation.
@@ -192,6 +192,22 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   connections and binding reads; an existing connection closes on its next
   heartbeat. Connectivity comes from the live registry, not a persisted online
   flag. `last_seen_at` is diagnostic only. Product gateway behavior is unchanged.
+- `services/agents-api/internal/execution` dispatches internally resolved Turns
+  through that gateway. Claim `queued` to `in_progress` before subscribing/sending;
+  never automatically replay a claimed or interrupted Turn. Ordered extra inputs
+  require native steering receipts. Commit terminal outcome and native Session ID
+  together under the admission lock; unapplied messages prevent successful completion.
+  Resolve credentials separately from the immutable non-secret snapshot.
+- Internal execution requires a matching daemon with optional cancellation receipts
+  and `release_on_completion` support. Release the native writer before forwarding
+  completion, so the next Turn can resume its durable native ID. Existing product
+  requests retain their default idle-process policy. Native history still requires
+  the device's persisted engine files; IDs alone cannot restore deleted history.
+- The dispatcher is an internal entry point, not a public event handler or worker.
+  Its private `daemon` configuration is neither `environment:none` nor the official
+  self-hosted executor protocol. Public environment mapping, durable output events,
+  pending interactions, crash reconciliation and provider allocation remain separate
+  slices. Unexpected interaction requests fail explicitly until supported.
 
 ### Agent knowledge references
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,8 +198,10 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   require native steering receipts. Commit terminal outcome and native Session ID
   together under the admission lock; unapplied messages prevent successful completion.
   Resolve credentials separately from the immutable non-secret snapshot.
-- Internal execution requires a matching daemon with optional cancellation receipts
-  and `release_on_completion` support. Release the native writer before forwarding
+- Internal execution requires the advertised `durable_turns` engine capability,
+  strict resume, and optional cancellation receipts
+  and `release_on_completion` support. Reject unadvertised peers before claiming;
+  failed strict resumes must not fall back to a new native thread. Release the native writer before forwarding
   completion, so the next Turn can resume its durable native ID. Existing product
   requests retain their default idle-process policy. Native history still requires
   the device's persisted engine files; IDs alone cannot restore deleted history.

--- a/apps/parsar-daemon/internal/agent/codex/cancellation_outcome.go
+++ b/apps/parsar-daemon/internal/agent/codex/cancellation_outcome.go
@@ -1,0 +1,21 @@
+package codex
+
+import "github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+
+// CancellationOutcome remains readable after Cancel stops the native process.
+func (s *Session) CancellationOutcome() proto.DonePayload {
+	outcome := proto.DonePayload{Metadata: map[string]any{}}
+	if id := s.currentThreadID(); id != "" {
+		outcome.Metadata[proto.DoneMetaAgentSessionID] = id
+		outcome.Metadata[proto.DoneMetaAgentSessionType] = "codex_thread"
+	}
+	s.finalTextMu.Lock()
+	outcome.Content = s.finalText
+	s.finalTextMu.Unlock()
+	s.usageMu.Lock()
+	if usage := s.latestUsage; usage != nil {
+		outcome.Usage = proto.Usage{Provider: "openai", InputTokens: int32(usage.InputTokens), OutputTokens: int32(usage.OutputTokens)}
+	}
+	s.usageMu.Unlock()
+	return outcome
+}

--- a/apps/parsar-daemon/internal/agent/codex/cancellation_outcome.go
+++ b/apps/parsar-daemon/internal/agent/codex/cancellation_outcome.go
@@ -1,9 +1,38 @@
 package codex
 
-import "github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+import (
+	"sync"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+type cancellationOutcomeState struct {
+	notificationMu sync.Mutex
+	mu             sync.Mutex
+	terminal       *proto.DonePayload
+}
+
+func (s *Session) rememberOutcome(outcome proto.DonePayload) {
+	s.usageMu.Lock()
+	if outcome.Usage.Provider == "" && s.latestUsage != nil {
+		outcome.Usage = proto.Usage{Provider: "openai", InputTokens: int32(s.latestUsage.InputTokens), OutputTokens: int32(s.latestUsage.OutputTokens)}
+	}
+	s.usageMu.Unlock()
+	s.outcome.mu.Lock()
+	s.outcome.terminal = &outcome
+	s.outcome.mu.Unlock()
+}
 
 // CancellationOutcome remains readable after Cancel stops the native process.
 func (s *Session) CancellationOutcome() proto.DonePayload {
+	s.outcome.notificationMu.Lock()
+	defer s.outcome.notificationMu.Unlock()
+	s.outcome.mu.Lock()
+	terminal := s.outcome.terminal
+	s.outcome.mu.Unlock()
+	if terminal != nil {
+		return *terminal
+	}
 	outcome := proto.DonePayload{Metadata: map[string]any{}}
 	if id := s.currentThreadID(); id != "" {
 		outcome.Metadata[proto.DoneMetaAgentSessionID] = id

--- a/apps/parsar-daemon/internal/agent/codex/resume.go
+++ b/apps/parsar-daemon/internal/agent/codex/resume.go
@@ -1,0 +1,24 @@
+package codex
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func (s *Session) resolveThread(req proto.PromptRequestPayload, plan SessionPlan) error {
+	if strings.TrimSpace(req.AgentSessionID) != "" {
+		if err := s.resumeThread(req.AgentSessionID, plan); err == nil {
+			return nil
+		} else if req.StrictResume {
+			return fmt.Errorf("codex: thread/resume: %w", err)
+		} else {
+			s.cfg.logger.Warn("codex: thread/resume failed; starting fresh", "run_id", s.runID, "thread_id", req.AgentSessionID, "err", err)
+		}
+	}
+	if err := s.startThread(plan); err != nil {
+		return fmt.Errorf("codex: thread/start: %w", err)
+	}
+	return nil
+}

--- a/apps/parsar-daemon/internal/agent/codex/resume_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/resume_test.go
@@ -1,0 +1,73 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/internal/obs/log"
+)
+
+func TestStrictResumeDoesNotStartFresh(t *testing.T) {
+	for _, strict := range []bool{false, true} {
+		t.Run(map[bool]string{false: "legacy", true: "strict"}[strict], func(t *testing.T) {
+			client, server, cleanup := NewTestClient()
+			defer cleanup()
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			s := &Session{rpc: client.JSONRPCClient, cancelCtx: ctx, cfg: sessionConfig{logger: log.With("component", "resume-test")}}
+			result := make(chan error, 1)
+			go func() {
+				result <- s.resolveThread(proto.PromptRequestPayload{AgentSessionID: "existing", StrictResume: strict}, SessionPlan{})
+			}()
+			var req struct {
+				ID     string `json:"id"`
+				Method string `json:"method"`
+			}
+			decoder := json.NewDecoder(server.FromClient)
+			encoder := json.NewEncoder(server.ToClient)
+			if err := decoder.Decode(&req); err != nil {
+				t.Fatal(err)
+			}
+			if req.Method != "thread/resume" {
+				t.Fatal(req.Method)
+			}
+			if err := encoder.Encode(map[string]any{"id": req.ID, "error": map[string]any{"code": -32600, "message": "native history unavailable"}}); err != nil {
+				t.Fatal(err)
+			}
+			if !strict {
+				if err := decoder.Decode(&req); err != nil {
+					t.Fatal(err)
+				}
+				if req.Method != "thread/start" {
+					t.Fatal(req.Method)
+				}
+				if err := encoder.Encode(map[string]any{"id": req.ID, "result": map[string]any{"thread": map[string]string{"id": "fresh"}}}); err != nil {
+					t.Fatal(err)
+				}
+			}
+			select {
+			case err := <-result:
+				if (err != nil) != strict {
+					t.Fatalf("strict=%v err=%v", strict, err)
+				}
+			case <-ctx.Done():
+				t.Fatal("thread resolution did not finish")
+			}
+		})
+	}
+}
+
+func TestCancellationKeepsConsumedTerminalOutputAndUsage(t *testing.T) {
+	out := make(chan proto.Envelope, 8)
+	s := &Session{runID: "run", out: out, cancelCtx: context.Background(), cfg: sessionConfig{logger: log.With("component", "cancel-test")}}
+	s.setThreadID("native")
+	s.appendFinalText("Already produced")
+	s.onTurnCompleted(json.RawMessage(`{"threadId":"native","turn":{"id":"turn","status":"interrupted","usage":{"inputTokens":31,"outputTokens":7}}}`))
+	snapshot := s.CancellationOutcome()
+	if snapshot.Content != "Already produced" || snapshot.Usage.InputTokens != 31 || snapshot.Usage.OutputTokens != 7 || snapshot.Metadata[proto.DoneMetaAgentSessionID] != "native" {
+		t.Fatalf("incomplete terminal snapshot: %+v", snapshot)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -94,6 +94,7 @@ type Session struct {
 	lastErrText string
 
 	interactions *pendingCodexInteractions
+	outcome      cancellationOutcomeState
 }
 
 var _ agent.Session = (*Session)(nil)
@@ -224,21 +225,9 @@ func (s *Session) run(plan SessionPlan, req proto.PromptRequestPayload) {
 	defer s.cleanup()
 	defer s.closeOut()
 
-	// Resolve thread: resume if possible, else start fresh.
-	if strings.TrimSpace(req.AgentSessionID) != "" {
-		if err := s.resumeThread(req.AgentSessionID, plan); err != nil {
-			s.cfg.logger.Warn("codex: thread/resume failed; starting fresh",
-				"run_id", s.runID, "thread_id", req.AgentSessionID, "err", err)
-			if err := s.startThread(plan); err != nil {
-				s.emitTerminal(fmt.Sprintf("codex: thread/start: %v", err), true)
-				return
-			}
-		}
-	} else {
-		if err := s.startThread(plan); err != nil {
-			s.emitTerminal(fmt.Sprintf("codex: thread/start: %v", err), true)
-			return
-		}
+	if err := s.resolveThread(req, plan); err != nil {
+		s.emitTerminal(err.Error(), true)
+		return
 	}
 
 	// turn/start fires the first prompt. The reply ack is fire-and-forget
@@ -464,6 +453,8 @@ func (s *Session) onItemCompleted(raw json.RawMessage) {
 }
 
 func (s *Session) onTurnCompleted(raw json.RawMessage) {
+	s.outcome.notificationMu.Lock()
+	defer s.outcome.notificationMu.Unlock()
 	s.stopSteering()
 	var p TurnCompletedNotification
 	if err := json.Unmarshal(raw, &p); err != nil {
@@ -480,6 +471,9 @@ func (s *Session) onTurnCompleted(raw json.RawMessage) {
 		s.usageMu.Unlock()
 	}
 	if usage != nil {
+		s.usageMu.Lock()
+		s.latestUsage = usage
+		s.usageMu.Unlock()
 		s.emitUsage(*usage)
 	}
 
@@ -636,6 +630,7 @@ func (s *Session) emitDone(content string, usage *TurnUsage) {
 			OutputTokens: int32(usage.OutputTokens),
 		}
 	}
+	s.rememberOutcome(payload)
 	env, err := proto.NewEnvelope(proto.TypeDone, s.runID, payload)
 	if err != nil {
 		return
@@ -689,10 +684,12 @@ func (s *Session) emitTerminal(message string, asError bool) {
 		doneMeta[proto.DoneMetaAgentSessionID] = tid
 		doneMeta[proto.DoneMetaAgentSessionType] = "codex_thread"
 	}
-	env, err := proto.NewEnvelope(proto.TypeDone, s.runID, proto.DonePayload{
+	payload := proto.DonePayload{
 		Content:  message,
 		Metadata: doneMeta,
-	})
+	}
+	s.rememberOutcome(payload)
+	env, err := proto.NewEnvelope(proto.TypeDone, s.runID, payload)
 	if err != nil {
 		return
 	}

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -255,11 +255,12 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 		Codex: proto.SupportedAgentKind{
 			Kind: "codex",
 			Capabilities: proto.AgentKindCapabilities{
-				Streaming:   true,
-				Permissions: true,
-				Usage:       true,
-				Resume:      true,
-				Steering:    true,
+				Streaming:    true,
+				Permissions:  true,
+				Usage:        true,
+				Resume:       true,
+				Steering:     true,
+				DurableTurns: true,
 			},
 		},
 		Pi: proto.SupportedAgentKind{

--- a/apps/parsar-daemon/internal/dispatch/cancellation.go
+++ b/apps/parsar-daemon/internal/dispatch/cancellation.go
@@ -6,6 +6,10 @@ import (
 	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
 )
 
+type cancellationOutcomeProvider interface {
+	CancellationOutcome() proto.DonePayload
+}
+
 func (r *Router) releaseCompletedSession(state *sessionState) error {
 	r.mu.Lock()
 	state.retain = false
@@ -39,6 +43,10 @@ func (r *Router) handlePromptCancel(ctx context.Context, env proto.Envelope) err
 			ack.ErrorCode = "cancel_failed"
 		} else {
 			ack.Applied, ack.ErrorCode = true, ""
+			if provider, ok := state.session.(cancellationOutcomeProvider); ok {
+				outcome := provider.CancellationOutcome()
+				ack.Outcome = &outcome
+			}
 		}
 		state.ctxCancel()
 	}

--- a/apps/parsar-daemon/internal/dispatch/cancellation.go
+++ b/apps/parsar-daemon/internal/dispatch/cancellation.go
@@ -1,0 +1,53 @@
+package dispatch
+
+import (
+	"context"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func (r *Router) releaseCompletedSession(state *sessionState) error {
+	r.mu.Lock()
+	state.retain = false
+	r.mu.Unlock()
+	err := state.session.Cancel(context.Background())
+	state.ctxCancel()
+	return err
+}
+
+func (r *Router) handlePromptCancel(ctx context.Context, env proto.Envelope) error {
+	var request proto.PromptCancelPayload
+	if err := env.DecodePayload(&request); err != nil {
+		return err
+	}
+	r.mu.Lock()
+	state := r.sessions[env.ID]
+	if state != nil {
+		state.retain = false
+	}
+	var cancelSession func(context.Context) error
+	if state != nil && state.session != nil {
+		cancelSession = state.session.Cancel
+	}
+	r.mu.Unlock()
+	ack := proto.InteractionDecisionAckPayload{DeliveryID: request.DeliveryID, ErrorCode: "run_inactive"}
+	if state != nil && cancelSession == nil {
+		ack.ErrorCode = "not_ready"
+	} else if cancelSession != nil {
+		if err := cancelSession(ctx); err != nil {
+			r.log.WarnContext(ctx, "session.Cancel failed", "run_id", env.ID, "err", err)
+			ack.ErrorCode = "cancel_failed"
+		} else {
+			ack.Applied, ack.ErrorCode = true, ""
+		}
+		state.ctxCancel()
+	}
+	if request.DeliveryID == "" {
+		return nil
+	}
+	reply, err := proto.NewEnvelopeWithTrace(proto.TypeInteractionDecisionAck, env.ID, ack, env.Trace)
+	if err != nil {
+		return err
+	}
+	return r.sender.Send(ctx, reply)
+}

--- a/apps/parsar-daemon/internal/dispatch/cancellation_test.go
+++ b/apps/parsar-daemon/internal/dispatch/cancellation_test.go
@@ -16,6 +16,10 @@ type cancelReceiptSession struct {
 	err     error
 }
 
+func (s *cancelReceiptSession) CancellationOutcome() proto.DonePayload {
+	return proto.DonePayload{Metadata: map[string]any{proto.DoneMetaAgentSessionID: "native-cancelled"}}
+}
+
 func TestCompletionWaitsForNativeWriterRelease(t *testing.T) {
 	h := newHarness(t)
 	defer h.router.Shutdown(context.Background())
@@ -88,6 +92,9 @@ func TestCancellationReceiptFollowsAdapterOutcome(t *testing.T) {
 					_ = env.DecodePayload(&ack)
 					if ack.Applied == fails || ack.DeliveryID != "cancel-1" {
 						t.Fatalf("wrong receipt: %+v", ack)
+					}
+					if !fails && (ack.Outcome == nil || ack.Outcome.Metadata[proto.DoneMetaAgentSessionID] != "native-cancelled") {
+						t.Fatal("cancellation receipt lost native identity")
 					}
 				}
 			}

--- a/apps/parsar-daemon/internal/dispatch/cancellation_test.go
+++ b/apps/parsar-daemon/internal/dispatch/cancellation_test.go
@@ -1,0 +1,117 @@
+package dispatch_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+type cancelReceiptSession struct {
+	*fakeSession
+	entered chan struct{}
+	release chan struct{}
+	err     error
+}
+
+func TestCompletionWaitsForNativeWriterRelease(t *testing.T) {
+	h := newHarness(t)
+	defer h.router.Shutdown(context.Background())
+	sess := &cancelReceiptSession{entered: make(chan struct{}), release: make(chan struct{})}
+	h.reg.Register("codex", func(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+		sess.fakeSession = &fakeSession{out: out, closeOutOnCancel: true}
+		return sess, nil
+	})
+	if err := h.router.Handle(context.Background(), mustEnv(t, proto.TypePromptRequest, "release", proto.PromptRequestPayload{AgentKind: "codex", AgentStateKey: "stable", ReleaseOnCompletion: true})); err != nil {
+		t.Fatal(err)
+	}
+	sess.out <- mustEnv(t, proto.TypeDone, "release", proto.DonePayload{Content: "Finished"})
+	<-sess.entered
+	if len(h.sender.snapshot()) != 0 {
+		t.Fatal("completion acknowledged before native writer was released")
+	}
+	close(sess.release)
+	waitFor(t, func() bool { return h.router.ActiveRuns() == 0 }, "release completion")
+	frames := h.sender.snapshot()
+	if len(frames) != 1 || frames[0].Type != proto.TypeDone || sess.cancels() != 1 {
+		t.Fatal("completion or native release missing")
+	}
+}
+
+func (s *cancelReceiptSession) Cancel(ctx context.Context) error {
+	if s.entered != nil {
+		close(s.entered)
+		<-s.release
+		s.entered = nil
+	}
+	_ = s.fakeSession.Cancel(ctx)
+	return s.err
+}
+
+func TestCancellationReceiptFollowsAdapterOutcome(t *testing.T) {
+	for _, fails := range []bool{false, true} {
+		t.Run(map[bool]string{false: "applied", true: "rejected"}[fails], func(t *testing.T) {
+			h := newHarness(t)
+			defer h.router.Shutdown(context.Background())
+			sess := &cancelReceiptSession{entered: make(chan struct{}), release: make(chan struct{})}
+			if fails {
+				sess.err = errors.New("adapter could not cancel")
+			}
+			h.reg.Register("codex", func(ctx context.Context, req proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+				sess.fakeSession = &fakeSession{out: out, closeOutOnCancel: true}
+				return sess, nil
+			})
+			if err := h.router.Handle(context.Background(), mustEnv(t, proto.TypePromptRequest, "run", proto.PromptRequestPayload{AgentKind: "codex"})); err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan error, 1)
+			go func() {
+				done <- h.router.Handle(context.Background(), mustEnv(t, proto.TypePromptCancel, "run", proto.PromptCancelPayload{DeliveryID: "cancel-1"}))
+			}()
+			<-sess.entered
+			for _, env := range h.sender.snapshot() {
+				if env.Type == proto.TypeInteractionDecisionAck {
+					t.Fatal("cancellation acknowledged before adapter returned")
+				}
+			}
+			close(sess.release)
+			if err := <-done; err != nil {
+				t.Fatal(err)
+			}
+			found := false
+			for _, env := range h.sender.snapshot() {
+				if env.Type == proto.TypeInteractionDecisionAck {
+					found = true
+					var ack proto.InteractionDecisionAckPayload
+					_ = env.DecodePayload(&ack)
+					if ack.Applied == fails || ack.DeliveryID != "cancel-1" {
+						t.Fatalf("wrong receipt: %+v", ack)
+					}
+				}
+			}
+			if !found {
+				t.Fatal("missing cancellation receipt")
+			}
+		})
+	}
+}
+
+func TestLegacyCancellationDoesNotEmitNewFrames(t *testing.T) {
+	h := newHarness(t)
+	defer h.router.Shutdown(context.Background())
+	if err := h.router.Handle(context.Background(), mustEnv(t, proto.TypePromptRequest, "legacy", proto.PromptRequestPayload{AgentKind: "claude_code"})); err != nil {
+		t.Fatal(err)
+	}
+	sess := <-h.gotSess
+	sess.closeOutOnCancel = true
+	if err := h.router.Handle(context.Background(), mustEnv(t, proto.TypePromptCancel, "legacy", proto.PromptCancelPayload{})); err != nil {
+		t.Fatal(err)
+	}
+	for _, env := range h.sender.snapshot() {
+		if env.Type == proto.TypeInteractionDecisionAck {
+			t.Fatal("legacy cancellation emitted new receipt")
+		}
+	}
+}

--- a/apps/parsar-daemon/internal/dispatch/router.go
+++ b/apps/parsar-daemon/internal/dispatch/router.go
@@ -62,19 +62,20 @@ type appliedInteractionDecision struct {
 // outbound frame stamps env.Trace with the same value, completing
 // frontend → server → daemon → agent → server attribution.
 type sessionState struct {
-	runID       string
-	stateKey    string
-	session     agent.Session
-	out         chan proto.Envelope
-	ctxCancel   context.CancelFunc
-	pendingIDs  map[string]struct{}
-	pendingAsks map[string]struct{}
-	traceparent string
-	idleTimer   *time.Timer
-	idleLease   uint64
-	retain      bool
-	steering    map[string]steeringReceipt
-	steerBusy   bool
+	runID               string
+	stateKey            string
+	session             agent.Session
+	out                 chan proto.Envelope
+	ctxCancel           context.CancelFunc
+	pendingIDs          map[string]struct{}
+	pendingAsks         map[string]struct{}
+	traceparent         string
+	idleTimer           *time.Timer
+	idleLease           uint64
+	retain              bool
+	releaseOnCompletion bool
+	steering            map[string]steeringReceipt
+	steerBusy           bool
 }
 
 // Config is the constructor input. Registry and Sender are required;
@@ -289,14 +290,15 @@ func (r *Router) handlePromptRequest(callerCtx context.Context, env proto.Envelo
 	}
 	out := make(chan proto.Envelope, 64)
 	state := &sessionState{
-		runID:       runID,
-		stateKey:    stateKey,
-		out:         out,
-		ctxCancel:   sessionCancel,
-		pendingIDs:  make(map[string]struct{}),
-		pendingAsks: make(map[string]struct{}),
-		traceparent: env.Trace,
-		retain:      stateKey != "",
+		runID:               runID,
+		stateKey:            stateKey,
+		out:                 out,
+		ctxCancel:           sessionCancel,
+		pendingIDs:          make(map[string]struct{}),
+		pendingAsks:         make(map[string]struct{}),
+		traceparent:         env.Trace,
+		retain:              stateKey != "",
+		releaseOnCompletion: req.ReleaseOnCompletion,
 	}
 	r.sessions[runID] = state
 	r.mu.Unlock()
@@ -321,25 +323,6 @@ func (r *Router) handlePromptRequest(callerCtx context.Context, env proto.Envelo
 
 	r.shutdownWG.Add(1)
 	go r.pump(state)
-	return nil
-}
-
-func (r *Router) handlePromptCancel(ctx context.Context, env proto.Envelope) error {
-	r.mu.Lock()
-	state, ok := r.sessions[env.ID]
-	if ok {
-		state.retain = false
-	}
-	r.mu.Unlock()
-	if !ok {
-		// Cancelling an unknown / already-finished run is a no-op.
-		r.log.InfoContext(ctx, "prompt_cancel for unknown run (no-op)", "run_id", env.ID)
-		return nil
-	}
-	if err := state.session.Cancel(ctx); err != nil {
-		r.log.WarnContext(ctx, "session.Cancel failed", "run_id", env.ID, "err", err)
-	}
-	state.ctxCancel()
 	return nil
 }
 
@@ -626,6 +609,12 @@ func (r *Router) pump(s *sessionState) {
 				return
 			}
 			r.indexPermissionFrame(s, env)
+			if env.Type == proto.TypeDone && s.releaseOnCompletion {
+				if err := r.releaseCompletedSession(s); err != nil {
+					r.emitTerminalError(pumpCtx, s.runID, "failed to release completed executor")
+					continue
+				}
+			}
 			r.log.InfoContext(pumpCtx, "pump: forwarding envelope", "run_id", s.runID, "type", env.Type, "env_id", env.ID)
 			// Stamp the run's trace onto outbound frames so the
 			// gateway attributes daemon-emitted lines to the same

--- a/internal/agentdaemon/device/state.go
+++ b/internal/agentdaemon/device/state.go
@@ -65,6 +65,7 @@ type KindCapabilities struct {
 	Usage              bool `json:"usage,omitempty"`
 	Resume             bool `json:"resume,omitempty"`
 	Steering           bool `json:"steering,omitempty"`
+	DurableTurns       bool `json:"durable_turns,omitempty"`
 	WorkspaceAuthoring bool `json:"workspace_authoring,omitempty"`
 }
 

--- a/internal/agentdaemon/gateway/session.go
+++ b/internal/agentdaemon/gateway/session.go
@@ -571,6 +571,7 @@ func deviceKindsFromHeartbeat(p proto.HeartbeatPayload) []device.SupportedAgentK
 				Usage:              info.Capabilities.Usage,
 				Resume:             info.Capabilities.Resume,
 				Steering:           info.Capabilities.Steering,
+				DurableTurns:       info.Capabilities.DurableTurns,
 				WorkspaceAuthoring: info.Capabilities.WorkspaceAuthoring,
 			},
 		})

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -229,6 +229,8 @@ type AgentKindCapabilities struct {
 	Resume             bool `json:"resume,omitempty"`
 	WorkspaceAuthoring bool `json:"workspace_authoring,omitempty"`
 	Steering           bool `json:"steering,omitempty"`
+	// DurableTurns includes strict resume, completion release and cancellation snapshots.
+	DurableTurns bool `json:"durable_turns,omitempty"`
 }
 
 // SupportedAgentKind is one daemon-advertised agent engine. Daemons

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -108,6 +108,8 @@ type InteractionDecisionAckPayload struct {
 	Applied    bool   `json:"applied"`
 	ErrorCode  string `json:"error_code,omitempty"`
 	Error      string `json:"error,omitempty"`
+	// Outcome preserves native continuity when cancellation does not emit Done.
+	Outcome *DonePayload `json:"outcome,omitempty"`
 }
 
 // PromptForUserChoiceOption is one button / checkbox the user can

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -42,7 +42,7 @@ const (
 	TypePromptForUserChoice = "prompt_for_user_choice"
 
 	// TypeInteractionDecisionAck confirms that the daemon-side agent
-	// accepted (or definitively rejected) a permission/user-input decision.
+	// accepted (or definitively rejected) a permission/user-input decision or cancellation.
 	// The server must not mark the durable interaction terminal before this
 	// frame arrives.
 	TypeInteractionDecisionAck = "interaction_decision_ack"

--- a/internal/agentdaemon/proto/outbound.go
+++ b/internal/agentdaemon/proto/outbound.go
@@ -78,6 +78,7 @@ type PromptRequestPayload struct {
 	WorkspaceAuthoring bool   `json:"workspace_authoring,omitempty"`
 	// ReleaseOnCompletion closes the native writer before acknowledging Done.
 	ReleaseOnCompletion bool `json:"release_on_completion,omitempty"`
+	StrictResume        bool `json:"strict_resume,omitempty"`
 }
 
 // PromptAttachment is one piece of non-text user input the daemon-side

--- a/internal/agentdaemon/proto/outbound.go
+++ b/internal/agentdaemon/proto/outbound.go
@@ -76,6 +76,8 @@ type PromptRequestPayload struct {
 	// AgentStateKey is the stable daemon-side state directory key.
 	AgentStateKey      string `json:"agent_state_key,omitempty"`
 	WorkspaceAuthoring bool   `json:"workspace_authoring,omitempty"`
+	// ReleaseOnCompletion closes the native writer before acknowledging Done.
+	ReleaseOnCompletion bool `json:"release_on_completion,omitempty"`
 }
 
 // PromptAttachment is one piece of non-text user input the daemon-side
@@ -93,10 +95,10 @@ type PromptAttachment struct {
 	DataBase64 string `json:"data_base64"`
 }
 
-// PromptCancelPayload is intentionally empty; the run identity is on
-// Envelope.ID. Declared so future fields (e.g. Reason) don't require a
-// wire-format bump.
-type PromptCancelPayload struct{}
+// PromptCancelPayload optionally requests an application receipt; identity is on Envelope.ID.
+type PromptCancelPayload struct {
+	DeliveryID string `json:"delivery_id,omitempty"`
+}
 
 // PermissionDecisionPayload carries the human verdict. UpdatedInput
 // lets the approver edit the tool input before letting the call

--- a/services/agents-api/README.md
+++ b/services/agents-api/README.md
@@ -1,13 +1,13 @@
 # Agents API
 
 Execution service under construction. Current slices provide durable Session/Turn
-storage, an authenticated Session HTTP service and an independent migration command. It
-does not run Agents or change Parsar's production dispatch.
+storage, an authenticated Session HTTP service, an internal daemon dispatcher and
+an independent migration command. Public execution is not enabled, and Parsar's
+production dispatch is unchanged.
 
 A Session is an execution context with a stable engine choice. Product
 conversations can map to multiple Sessions. Device connections and bindings are
-internal primitives; native engine IDs, pending interactions and execution
-delivery will be added with their execution flows.
+internal primitives; pending interactions and public execution remain unfinished.
 
 ## Database ownership
 
@@ -60,11 +60,24 @@ once stored, terminal status, timestamps and outcome cannot be overwritten.
 Outcome is a bounded adapter payload, not a second public response schema.
 
 Tenant-scoped Turn and ordered input reads survive process restarts. The Session
-configuration remains immutable and shared by its Turns. These primitives do
-not yet dispatch work, acknowledge input delivery, fence executor ownership,
-resume a native engine session, accept public event batches or emit SSE. Durable
-input acceptance alone is not an exactly-once execution guarantee. Those flows
-must be connected and verified before public execution support is advertised.
+configuration remains immutable and shared by its Turns. The internal dispatcher
+claims a Turn before delivery, confirms additional messages through native steering,
+and commits the outcome and native engine ID together. It requires an internally
+resolved `daemon.work_dir` configuration and a bound device advertising streaming
+and steering. Messages currently use normalized internal `{"text":"..."}` payloads;
+public upstream input mapping is not implemented here.
+
+The dispatcher takes immutable model/instructions from the Session snapshot and
+resolves ephemeral engine credentials separately. Matching daemon versions release
+the native writer before completing a Turn and acknowledge cancellation after the
+engine returns. Subsequent Turns resume the native ID on the same device. Device
+history must still exist. This is not the public self-hosted executor protocol.
+
+Uncertain delivery, disconnected devices and unsupported interactions fail rather
+than report success or automatically replay. A hard process crash can leave claimed
+work in progress until future reconciliation; no background worker is wired yet.
+Public event batches, durable output events, pending interactions and SSE are still
+unsupported. Durable input acceptance is not an exactly-once execution guarantee.
 
 ## Standalone HTTP service
 

--- a/services/agents-api/README.md
+++ b/services/agents-api/README.md
@@ -64,7 +64,8 @@ configuration remains immutable and shared by its Turns. The internal dispatcher
 claims a Turn before delivery, confirms additional messages through native steering,
 and commits the outcome and native engine ID together. It requires an internally
 resolved `daemon.work_dir` configuration and a bound device advertising streaming
-and steering. Messages currently use normalized internal `{"text":"..."}` payloads;
+and steering plus `durable_turns` (strict resume, process release and cancellation
+snapshots). Failed resumes report an error instead of starting a fresh thread. Messages currently use normalized internal `{"text":"..."}` payloads;
 public upstream input mapping is not implemented here.
 
 The dispatcher takes immutable model/instructions from the Session snapshot and

--- a/services/agents-api/internal/db/queries/devices.sql
+++ b/services/agents-api/internal/db/queries/devices.sql
@@ -25,7 +25,10 @@ WHERE session_devices.device_id = EXCLUDED.device_id
 RETURNING device_id;
 
 -- name: GetSessionDevice :one
-SELECT d.id, d.name FROM session_devices b
+SELECT d.id, d.name, b.native_session_id FROM session_devices b
 JOIN sessions s ON s.id = b.session_id
 JOIN devices d ON d.id = b.device_id AND d.tenant_id = s.tenant_id
 WHERE s.tenant_id = $1 AND s.id = $2 AND d.revoked_at IS NULL;
+
+-- name: RememberNativeSession :execrows
+UPDATE session_devices SET native_session_id = $2 WHERE session_id = $1;

--- a/services/agents-api/internal/db/queries/turns.sql
+++ b/services/agents-api/internal/db/queries/turns.sql
@@ -48,3 +48,7 @@ RETURNING *;
 SELECT i.* FROM turn_inputs i JOIN sessions s ON s.id = i.session_id
 WHERE s.tenant_id = $1 AND i.session_id = $2 AND i.turn_id = $3 AND i.sequence > $4
 ORDER BY i.sequence LIMIT $5;
+
+-- name: HasUnappliedMessages :one
+SELECT EXISTS(SELECT 1 FROM turn_inputs
+WHERE session_id = $1 AND turn_id = $2 AND sequence > $3 AND kind = 'message');

--- a/services/agents-api/internal/db/sqlc/devices.sql.go
+++ b/services/agents-api/internal/db/sqlc/devices.sql.go
@@ -96,7 +96,7 @@ func (q *Queries) GetDeviceCredential(ctx context.Context, id pgtype.UUID) (GetD
 }
 
 const getSessionDevice = `-- name: GetSessionDevice :one
-SELECT d.id, d.name FROM session_devices b
+SELECT d.id, d.name, b.native_session_id FROM session_devices b
 JOIN sessions s ON s.id = b.session_id
 JOIN devices d ON d.id = b.device_id AND d.tenant_id = s.tenant_id
 WHERE s.tenant_id = $1 AND s.id = $2 AND d.revoked_at IS NULL
@@ -108,15 +108,33 @@ type GetSessionDeviceParams struct {
 }
 
 type GetSessionDeviceRow struct {
-	ID   pgtype.UUID `json:"id"`
-	Name string      `json:"name"`
+	ID              pgtype.UUID `json:"id"`
+	Name            string      `json:"name"`
+	NativeSessionID string      `json:"native_session_id"`
 }
 
 func (q *Queries) GetSessionDevice(ctx context.Context, arg GetSessionDeviceParams) (GetSessionDeviceRow, error) {
 	row := q.db.QueryRow(ctx, getSessionDevice, arg.TenantID, arg.ID)
 	var i GetSessionDeviceRow
-	err := row.Scan(&i.ID, &i.Name)
+	err := row.Scan(&i.ID, &i.Name, &i.NativeSessionID)
 	return i, err
+}
+
+const rememberNativeSession = `-- name: RememberNativeSession :execrows
+UPDATE session_devices SET native_session_id = $2 WHERE session_id = $1
+`
+
+type RememberNativeSessionParams struct {
+	SessionID       pgtype.UUID `json:"session_id"`
+	NativeSessionID string      `json:"native_session_id"`
+}
+
+func (q *Queries) RememberNativeSession(ctx context.Context, arg RememberNativeSessionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, rememberNativeSession, arg.SessionID, arg.NativeSessionID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const revokeDevice = `-- name: RevokeDevice :execrows

--- a/services/agents-api/internal/db/sqlc/models.go
+++ b/services/agents-api/internal/db/sqlc/models.go
@@ -30,8 +30,9 @@ type Session struct {
 }
 
 type SessionDevice struct {
-	SessionID pgtype.UUID `json:"session_id"`
-	DeviceID  pgtype.UUID `json:"device_id"`
+	SessionID       pgtype.UUID `json:"session_id"`
+	DeviceID        pgtype.UUID `json:"device_id"`
+	NativeSessionID string      `json:"native_session_id"`
 }
 
 type Turn struct {

--- a/services/agents-api/internal/db/sqlc/turns.sql.go
+++ b/services/agents-api/internal/db/sqlc/turns.sql.go
@@ -155,6 +155,24 @@ func (q *Queries) GetTurn(ctx context.Context, arg GetTurnParams) (Turn, error) 
 	return i, err
 }
 
+const hasUnappliedMessages = `-- name: HasUnappliedMessages :one
+SELECT EXISTS(SELECT 1 FROM turn_inputs
+WHERE session_id = $1 AND turn_id = $2 AND sequence > $3 AND kind = 'message')
+`
+
+type HasUnappliedMessagesParams struct {
+	SessionID pgtype.UUID `json:"session_id"`
+	TurnID    pgtype.UUID `json:"turn_id"`
+	Sequence  int64       `json:"sequence"`
+}
+
+func (q *Queries) HasUnappliedMessages(ctx context.Context, arg HasUnappliedMessagesParams) (bool, error) {
+	row := q.db.QueryRow(ctx, hasUnappliedMessages, arg.SessionID, arg.TurnID, arg.Sequence)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
 const listTurnInputs = `-- name: ListTurnInputs :many
 SELECT i.sequence, i.session_id, i.turn_id, i.idempotency_key, i.kind, i.payload, i.created_at, i.batch_position FROM turn_inputs i JOIN sessions s ON s.id = i.session_id
 WHERE s.tenant_id = $1 AND i.session_id = $2 AND i.turn_id = $3 AND i.sequence > $4

--- a/services/agents-api/internal/execution/delivery.go
+++ b/services/agents-api/internal/execution/delivery.go
@@ -1,0 +1,204 @@
+package execution
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/gateway"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+type pendingInput struct {
+	sequence int64
+	text     string
+	started  time.Time
+	waiting  bool
+}
+
+type cancellationResult struct {
+	ack proto.InteractionDecisionAckPayload
+	err error
+}
+
+func requestCancellation(ctx context.Context, peer *gateway.Session, runID string) <-chan cancellationResult {
+	out := make(chan cancellationResult, 1)
+	go func() {
+		id := "cancel:" + runID
+		env, _ := proto.NewEnvelope(proto.TypePromptCancel, runID, proto.PromptCancelPayload{DeliveryID: id})
+		ack, err := peer.SendAndWaitInteractionAck(ctx, env, id)
+		out <- cancellationResult{ack: ack, err: err}
+	}()
+	return out
+}
+
+func send(ctx context.Context, peer *gateway.Session, kind, runID string, payload any) error {
+	env, err := proto.NewEnvelope(kind, runID, payload)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	return peer.Send(ctx, env)
+}
+
+func abort(peer *gateway.Session, runID string) {
+	_ = send(context.Background(), peer, proto.TypePromptCancel, runID, proto.PromptCancelPayload{})
+}
+
+func (d *Dispatcher) deliver(ctx context.Context, tenantID, sessionID string, peer *gateway.Session, request proto.PromptRequestPayload, first int64) (result Result, status string) {
+	status = store.TurnFailed
+	result.AppliedThrough = first
+	upstream, err := peer.Subscribe(request.RunID)
+	if err != nil {
+		result.ErrorCode = "device_disconnected"
+		return
+	}
+	defer peer.Unsubscribe(request.RunID)
+	defer func() {
+		if status == store.TurnFailed {
+			abort(peer, request.RunID)
+		}
+	}()
+	if err := send(ctx, peer, proto.TypePromptRequest, request.RunID, request); err != nil {
+		result.ErrorCode = "delivery_unknown"
+		return
+	}
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	var pending *pendingInput
+	var cancelSent time.Time
+	var cancelReply <-chan cancellationResult
+	cancelCtx, stopCancellation := context.WithCancel(ctx)
+	defer stopCancellation()
+	for {
+		select {
+		case reply := <-cancelReply:
+			if reply.err == nil && reply.ack.Applied {
+				status = store.TurnCancelled
+			} else {
+				result.ErrorCode = "cancel_unconfirmed"
+			}
+			return
+		case <-ctx.Done():
+			result.ErrorCode = "execution_interrupted"
+			return
+		case env, ok := <-upstream:
+			if !ok {
+				result.ErrorCode = "device_disconnected"
+				return
+			}
+			switch env.Type {
+			case proto.TypeError:
+				var failure proto.ErrorPayload
+				if env.DecodePayload(&failure) != nil {
+					result.ErrorCode = "invalid_executor_result"
+					return
+				}
+				result.ErrorCode, result.Error = "engine_failed", failure.Error
+			case proto.TypeDone:
+				if env.DecodePayload(&result.Done) != nil {
+					result.ErrorCode = "invalid_executor_result"
+					return
+				}
+				if cancelReply != nil {
+					select {
+					case reply := <-cancelReply:
+						if reply.err == nil && reply.ack.Applied {
+							status = store.TurnCancelled
+							return
+						}
+						if reply.err != nil || reply.ack.ErrorCode != "run_inactive" {
+							result.ErrorCode = "cancel_unconfirmed"
+							return
+						}
+					case <-ctx.Done():
+						result.ErrorCode = "cancel_unconfirmed"
+						return
+					}
+				}
+				if result.ErrorCode == "" {
+					if pending != nil {
+						result.ErrorCode = "input_outcome_unknown"
+					} else {
+						status = store.TurnCompleted
+					}
+				}
+				return
+			case proto.TypePromptSteerAck:
+				var ack proto.PromptSteerAckPayload
+				if env.DecodePayload(&ack) != nil {
+					result.ErrorCode = "invalid_executor_result"
+					return
+				}
+				if pending == nil || ack.InputID != strconv.FormatInt(pending.sequence, 10) {
+					continue
+				}
+				switch {
+				case ack.Accepted:
+					result.AppliedThrough = pending.sequence
+					pending = nil
+				case ack.ErrorCode == "not_ready" || ack.ErrorCode == "busy":
+					pending.waiting = false
+				case ack.ErrorCode == "in_flight":
+				default:
+					result.ErrorCode, result.Error = "input_"+ack.ErrorCode, ack.Error
+					return
+				}
+			case proto.TypePermissionRequest, proto.TypePromptForUserChoice, proto.TypeAuthoringRequest:
+				result.ErrorCode = "interaction_not_supported"
+				return
+			}
+		case <-ticker.C:
+			if !cancelSent.IsZero() {
+				if time.Since(cancelSent) > 15*time.Second {
+					result.ErrorCode = "cancel_unconfirmed"
+					return
+				}
+				continue
+			}
+			turn, err := d.Store.GetTurn(ctx, tenantID, sessionID, request.RunID)
+			if err != nil {
+				result.ErrorCode = "execution_state_unavailable"
+				return
+			}
+			if turn.Status != store.TurnInProgress {
+				result.ErrorCode = "execution_state_changed"
+				return
+			}
+			if !turn.CancelRequestedAt.IsZero() {
+				cancelReply = requestCancellation(cancelCtx, peer, request.RunID)
+				cancelSent = time.Now()
+				continue
+			}
+			if pending == nil {
+				inputs, err := d.Store.ListTurnInputs(ctx, tenantID, sessionID, request.RunID, result.AppliedThrough, 1)
+				if err != nil {
+					result.ErrorCode = "execution_state_unavailable"
+					return
+				}
+				if len(inputs) == 0 {
+					continue
+				}
+				text, err := messageText(inputs[0].Payload)
+				if err != nil || inputs[0].Kind != "message" {
+					result.ErrorCode = "invalid_input"
+					return
+				}
+				pending = &pendingInput{sequence: inputs[0].Sequence, text: text, started: time.Now()}
+			}
+			if time.Since(pending.started) > 30*time.Second {
+				result.ErrorCode = "input_outcome_unknown"
+				return
+			}
+			if !pending.waiting {
+				if send(ctx, peer, proto.TypePromptSteer, request.RunID, proto.PromptSteerPayload{InputID: strconv.FormatInt(pending.sequence, 10), Text: pending.text}) != nil {
+					result.ErrorCode = "input_outcome_unknown"
+					return
+				}
+				pending.waiting = true
+			}
+		}
+	}
+}

--- a/services/agents-api/internal/execution/delivery.go
+++ b/services/agents-api/internal/execution/delivery.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"time"
 
@@ -76,6 +77,13 @@ func (d *Dispatcher) deliver(ctx context.Context, tenantID, sessionID string, pe
 		select {
 		case reply := <-cancelReply:
 			if reply.err == nil && reply.ack.Applied {
+				if reply.ack.Outcome != nil {
+					raw, _ := json.Marshal(reply.ack.Outcome)
+					_ = result.mergeDone(raw)
+				} else {
+					result.ErrorCode = "cancel_outcome_unavailable"
+					return
+				}
 				status = store.TurnCancelled
 			} else {
 				result.ErrorCode = "cancel_unconfirmed"
@@ -90,6 +98,11 @@ func (d *Dispatcher) deliver(ctx context.Context, tenantID, sessionID string, pe
 				return
 			}
 			switch env.Type {
+			case proto.TypeUsage:
+				if env.DecodePayload(&result.Done.Usage) != nil {
+					result.ErrorCode = "invalid_executor_result"
+					return
+				}
 			case proto.TypeError:
 				var failure proto.ErrorPayload
 				if env.DecodePayload(&failure) != nil {
@@ -98,7 +111,7 @@ func (d *Dispatcher) deliver(ctx context.Context, tenantID, sessionID string, pe
 				}
 				result.ErrorCode, result.Error = "engine_failed", failure.Error
 			case proto.TypeDone:
-				if env.DecodePayload(&result.Done) != nil {
+				if result.mergeDone(env.Payload) != nil {
 					result.ErrorCode = "invalid_executor_result"
 					return
 				}
@@ -106,6 +119,10 @@ func (d *Dispatcher) deliver(ctx context.Context, tenantID, sessionID string, pe
 					select {
 					case reply := <-cancelReply:
 						if reply.err == nil && reply.ack.Applied {
+							if reply.ack.Outcome != nil {
+								raw, _ := json.Marshal(reply.ack.Outcome)
+								_ = result.mergeDone(raw)
+							}
 							status = store.TurnCancelled
 							return
 						}
@@ -201,4 +218,29 @@ func (d *Dispatcher) deliver(ctx context.Context, tenantID, sessionID string, pe
 			}
 		}
 	}
+}
+
+func (r *Result) mergeDone(raw json.RawMessage) error {
+	var done proto.DonePayload
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &done); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return err
+	}
+	if _, present := fields["usage"]; !present {
+		done.Usage = r.Done.Usage
+	}
+	if done.Usage.Model == "" {
+		done.Usage.Model = r.Done.Usage.Model
+	}
+	if done.Content == "" {
+		done.Content = r.Done.Content
+	}
+	if done.Metadata == nil {
+		done.Metadata = r.Done.Metadata
+	}
+	r.Done = done
+	return nil
 }

--- a/services/agents-api/internal/execution/dispatcher.go
+++ b/services/agents-api/internal/execution/dispatcher.go
@@ -95,6 +95,9 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 	}
 	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true}
 	result, status := d.deliver(ctx, tenantID, sessionID, peer, req, inputs[0].Sequence)
+	if result.Done.Usage.Model == "" {
+		result.Done.Usage.Model = snapshot.Agent.Model
+	}
 	nativeID, _ := result.Done.Metadata[proto.DoneMetaAgentSessionID].(string)
 	finishCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/services/agents-api/internal/execution/dispatcher.go
+++ b/services/agents-api/internal/execution/dispatcher.go
@@ -1,0 +1,124 @@
+// Package execution delivers durable Turns through the existing daemon protocol.
+package execution
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"maps"
+	"path/filepath"
+	"strings"
+	"time"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/gateway"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+// Snapshot is resolved internally; Daemon is not a public environment wire type.
+type Snapshot struct {
+	Agent  v1.Agent      `json:"agent"`
+	Daemon *DaemonConfig `json:"daemon"`
+}
+
+type DaemonConfig struct {
+	WorkDir string `json:"work_dir"`
+}
+
+type Dispatcher struct {
+	Store    *store.Store
+	Registry *gateway.Registry
+	// Options resolves transient engine credentials; they are never stored here.
+	Options func(context.Context, store.Session) (map[string]any, error)
+}
+
+type Result struct {
+	Done           proto.DonePayload `json:"done"`
+	ErrorCode      string            `json:"error_code,omitempty"`
+	Error          string            `json:"error,omitempty"`
+	AppliedThrough int64             `json:"applied_through"`
+}
+
+// Run claims once before subscribing or sending. Uncertain deliveries are not replayed.
+func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string) (store.Turn, error) {
+	session, err := d.Store.GetSession(ctx, tenantID, sessionID)
+	if err != nil {
+		return store.Turn{}, err
+	}
+	bound, err := d.Store.GetSessionDevice(ctx, tenantID, sessionID)
+	if err != nil {
+		return store.Turn{}, err
+	}
+	peer, err := d.Registry.LookupDevice(bound.ID)
+	if err != nil {
+		return store.Turn{}, err
+	}
+	info, found, known := peer.AgentKindStatus(session.Engine)
+	if !known || !found || !info.Available || !info.Capabilities.Streaming || !info.Capabilities.Steering {
+		return store.Turn{}, errors.New("device must advertise streaming and steering for this engine")
+	}
+	var snapshot Snapshot
+	if json.Unmarshal(session.Configuration, &snapshot) != nil || snapshot.Daemon == nil || strings.TrimSpace(snapshot.Agent.Model) == "" {
+		return store.Turn{}, store.ErrInvalidInput
+	}
+	workDir := snapshot.Daemon.WorkDir
+	if workDir != "" && !filepath.IsAbs(workDir) && !strings.HasPrefix(workDir, "~/") {
+		return store.Turn{}, store.ErrInvalidInput
+	}
+	inputs, err := d.Store.ListTurnInputs(ctx, tenantID, sessionID, turnID, 0, 1)
+	if err != nil {
+		return store.Turn{}, err
+	}
+	if len(inputs) != 1 || inputs[0].Kind != "message" {
+		return store.Turn{}, store.ErrInvalidInput
+	}
+	text, err := messageText(inputs[0].Payload)
+	if err != nil {
+		return store.Turn{}, err
+	}
+	options := map[string]any{}
+	if d.Options != nil {
+		options, err = d.Options(ctx, session)
+		if err != nil {
+			return store.Turn{}, err
+		}
+		options = maps.Clone(options)
+		if options == nil {
+			options = map[string]any{}
+		}
+	}
+	options["model"], options["system_prompt"] = snapshot.Agent.Model, snapshot.Agent.Instructions
+	delete(options, "override_system_prompt")
+	if _, err := d.Store.TransitionTurn(ctx, tenantID, sessionID, turnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
+		return store.Turn{}, err
+	}
+	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true}
+	result, status := d.deliver(ctx, tenantID, sessionID, peer, req, inputs[0].Sequence)
+	nativeID, _ := result.Done.Metadata[proto.DoneMetaAgentSessionID].(string)
+	finishCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	encoded, err := json.Marshal(result)
+	if err != nil || len(encoded) > 512*1024 || len(nativeID) > 512 {
+		result = Result{ErrorCode: "invalid_executor_result", AppliedThrough: result.AppliedThrough}
+		encoded, _ = json.Marshal(result)
+		status, nativeID = store.TurnFailed, ""
+	}
+	turn, err := d.Store.CompleteExecution(finishCtx, tenantID, sessionID, turnID, status, encoded, nativeID, result.AppliedThrough)
+	if errors.Is(err, store.ErrUnappliedInputs) {
+		result.ErrorCode = "input_not_applied"
+		encoded, _ = json.Marshal(result)
+		return d.Store.CompleteExecution(finishCtx, tenantID, sessionID, turnID, store.TurnFailed, encoded, nativeID, result.AppliedThrough)
+	}
+	return turn, err
+}
+
+func messageText(raw json.RawMessage) (string, error) {
+	var input struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &input) != nil || strings.TrimSpace(input.Text) == "" {
+		return "", store.ErrInvalidInput
+	}
+	return input.Text, nil
+}

--- a/services/agents-api/internal/execution/dispatcher.go
+++ b/services/agents-api/internal/execution/dispatcher.go
@@ -55,8 +55,8 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 		return store.Turn{}, err
 	}
 	info, found, known := peer.AgentKindStatus(session.Engine)
-	if !known || !found || !info.Available || !info.Capabilities.Streaming || !info.Capabilities.Steering {
-		return store.Turn{}, errors.New("device must advertise streaming and steering for this engine")
+	if !known || !found || !info.Available || !info.Capabilities.Streaming || !info.Capabilities.Steering || !info.Capabilities.DurableTurns {
+		return store.Turn{}, errors.New("device must advertise streaming, steering and durable turns for this engine")
 	}
 	var snapshot Snapshot
 	if json.Unmarshal(session.Configuration, &snapshot) != nil || snapshot.Daemon == nil || strings.TrimSpace(snapshot.Agent.Model) == "" {
@@ -93,7 +93,7 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 	if _, err := d.Store.TransitionTurn(ctx, tenantID, sessionID, turnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
 		return store.Turn{}, err
 	}
-	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true}
+	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true, StrictResume: true}
 	result, status := d.deliver(ctx, tenantID, sessionID, peer, req, inputs[0].Sequence)
 	if result.Done.Usage.Model == "" {
 		result.Done.Usage.Model = snapshot.Agent.Model

--- a/services/agents-api/internal/store/devices.go
+++ b/services/agents-api/internal/store/devices.go
@@ -20,8 +20,9 @@ var ErrDeviceBindingConflict = errors.New("session is already bound to a differe
 
 // ExecutionDevice contains safe identity only, never a device credential.
 type ExecutionDevice struct {
-	ID   string
-	Name string
+	ID              string
+	Name            string
+	NativeSessionID string
 }
 
 // CreateDevice is operator provisioning, not a tenant-facing registration API.
@@ -108,7 +109,7 @@ func (s *Store) GetSessionDevice(ctx context.Context, tenantID, sessionID string
 	if err != nil {
 		return ExecutionDevice{}, err
 	}
-	return ExecutionDevice{ID: uuid.UUID(row.ID.Bytes).String(), Name: row.Name}, nil
+	return ExecutionDevice{ID: uuid.UUID(row.ID.Bytes).String(), Name: row.Name, NativeSessionID: row.NativeSessionID}, nil
 }
 
 func deviceLookup(tenantID, id string) (sqlc.GetDeviceParams, error) {

--- a/services/agents-api/internal/store/dispatch_test.go
+++ b/services/agents-api/internal/store/dispatch_test.go
@@ -68,7 +68,7 @@ func newDispatchHarness(t *testing.T) *dispatchHarness {
 		t.Fatal("device connection failed")
 	}
 	t.Cleanup(func() { h.conn.Close() })
-	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true}}}})
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true}}}})
 	deadline := time.Now().Add(3 * time.Second)
 	for {
 		peer, e := h.registry.LookupDevice(h.device.ID)
@@ -332,5 +332,30 @@ func TestExecutionOutcomeAndNativeBindingCommitTogether(t *testing.T) {
 	}
 	if success != 1 {
 		t.Fatal("multiple terminal owners")
+	}
+}
+
+func TestExecutionRejectsLegacyDaemonBeforeClaim(t *testing.T) {
+	h := newDispatchHarness(t)
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true}}}})
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		peer, _ := h.registry.LookupDevice(h.device.ID)
+		info, _, _ := peer.AgentKindStatus("codex")
+		if !info.Capabilities.DurableTurns {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("legacy heartbeat not registered")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	first := h.message("legacy", "Run")
+	if _, err := h.d.Run(context.Background(), h.tenant, h.session.ID, first.TurnID); err == nil {
+		t.Fatal("legacy daemon accepted")
+	}
+	turn, err := h.s.GetTurn(context.Background(), h.tenant, h.session.ID, first.TurnID)
+	if err != nil || turn.Status != store.TurnQueued {
+		t.Fatal("unsupported daemon claimed work")
 	}
 }

--- a/services/agents-api/internal/store/dispatch_test.go
+++ b/services/agents-api/internal/store/dispatch_test.go
@@ -226,8 +226,19 @@ func TestExecutionCancellationRequiresReceiptAndSurvivesContextEnd(t *testing.T)
 			if withDone {
 				h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
 			}
-			h.write(first.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: cancel.DeliveryID, Applied: true})
+			outcome := &proto.DonePayload{Metadata: map[string]any{proto.DoneMetaAgentSessionID: "cancelled-native"}, Usage: proto.Usage{InputTokens: 10}}
+			h.write(first.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: cancel.DeliveryID, Applied: true, Outcome: outcome})
 			h.finished(result, store.TurnCancelled)
+			next := h.message("next", "Continue after cancellation")
+			result = h.run(context.Background(), next.TurnID)
+			env = h.read(proto.TypePromptRequest)
+			var prompt proto.PromptRequestPayload
+			_ = env.DecodePayload(&prompt)
+			if prompt.AgentSessionID != "cancelled-native" {
+				t.Fatal("cancellation lost native continuity")
+			}
+			h.write(next.TurnID, proto.TypeDone, proto.DonePayload{})
+			h.finished(result, store.TurnCompleted)
 		})
 	}
 	h := newDispatchHarness(t)
@@ -255,6 +266,7 @@ func TestExecutionFailureDoesNotBecomeSuccessOrReplay(t *testing.T) {
 			case "disconnect":
 				h.conn.Close()
 			case "engine":
+				h.write(first.TurnID, proto.TypeUsage, proto.UsagePayload{Usage: proto.Usage{InputTokens: 13, OutputTokens: 7}})
 				h.write(first.TurnID, proto.TypeError, proto.ErrorPayload{Error: "Engine failed"})
 				h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
 			case "late-input":
@@ -265,7 +277,14 @@ func TestExecutionFailureDoesNotBecomeSuccessOrReplay(t *testing.T) {
 				h.read(proto.TypePromptSteer)
 				h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
 			}
-			h.finished(result, store.TurnFailed)
+			done := h.finished(result, store.TurnFailed)
+			if kind == "engine" {
+				var outcome execution.Result
+				_ = json.Unmarshal(done.Outcome, &outcome)
+				if outcome.Done.Usage.InputTokens != 13 || outcome.Done.Usage.OutputTokens != 7 {
+					t.Fatal("failed execution lost reported usage")
+				}
+			}
 			if kind != "disconnect" {
 				if _, err := h.d.Run(context.Background(), h.tenant, h.session.ID, first.TurnID); !errors.Is(err, store.ErrTurnConflict) {
 					t.Fatalf("terminal replay: %v", err)

--- a/services/agents-api/internal/store/dispatch_test.go
+++ b/services/agents-api/internal/store/dispatch_test.go
@@ -1,0 +1,317 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/device"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/gateway"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/execution"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/runtime"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+)
+
+type dispatchHarness struct {
+	t          *testing.T
+	s          *store.Store
+	d          *execution.Dispatcher
+	tenant     string
+	session    store.Session
+	device     store.ExecutionDevice
+	conn       *websocket.Conn
+	registry   *gateway.Registry
+	url        string
+	credential string
+}
+
+func newDispatchHarness(t *testing.T) *dispatchHarness {
+	t.Helper()
+	s, _ := store.NewTestStore(t)
+	h := &dispatchHarness{t: t, s: s, tenant: uuid.NewString()}
+	ctx := context.Background()
+	var err error
+	h.session, err = s.CreateSession(ctx, h.tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "session", Configuration: []byte(`{"agent":{"model":"test-model","instructions":"Keep this instruction."},"daemon":{"work_dir":"/tmp"}}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret := uuid.NewString()
+	h.credential = secret
+	h.device, err = s.CreateDevice(ctx, h.tenant, "isolated executor", device.HashCredential(secret))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = s.BindSessionDevice(ctx, h.tenant, h.session.ID, h.device.ID); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewUnstartedServer(nil)
+	wsURL := "ws://" + server.Listener.Addr().String() + "/api/v1/agent-daemon/ws"
+	server.Config.Handler, h.registry, err = runtime.NewGateway(s, wsURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.Start()
+	h.url = server.URL
+	t.Cleanup(func() { server.Close(); runtime.CloseConnections(h.registry) })
+	u, _ := url.Parse(wsURL)
+	u.RawQuery = url.Values{"device_id": {h.device.ID}, "token": {secret}, "version": {proto.Version}}.Encode()
+	h.conn, _, err = websocket.DefaultDialer.Dial(u.String(), nil)
+	if err != nil {
+		t.Fatal("device connection failed")
+	}
+	t.Cleanup(func() { h.conn.Close() })
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true}}}})
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		peer, e := h.registry.LookupDevice(h.device.ID)
+		if e == nil {
+			if _, _, known := peer.AgentKindStatus("codex"); known {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("heartbeat not registered")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	h.d = &execution.Dispatcher{Store: s, Registry: h.registry}
+	return h
+}
+
+func (h *dispatchHarness) message(key, text string) store.InputReceipt {
+	h.t.Helper()
+	body, _ := json.Marshal(map[string]string{"text": text})
+	r, err := h.s.SubmitMessage(context.Background(), h.tenant, h.session.ID, key, body)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	return r
+}
+
+func (h *dispatchHarness) write(run, kind string, payload any) {
+	h.t.Helper()
+	env, err := proto.NewEnvelope(kind, run, payload)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	if err = h.conn.WriteJSON(env); err != nil {
+		h.t.Fatal(err)
+	}
+}
+
+func (h *dispatchHarness) read(kind string) proto.Envelope {
+	h.t.Helper()
+	_ = h.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	for {
+		var env proto.Envelope
+		if err := h.conn.ReadJSON(&env); err != nil {
+			h.t.Fatal(err)
+		}
+		if env.Type == kind {
+			return env
+		}
+	}
+}
+
+type runResult struct {
+	turn store.Turn
+	err  error
+}
+
+func (h *dispatchHarness) run(ctx context.Context, turn string) <-chan runResult {
+	out := make(chan runResult, 1)
+	go func() { result, err := h.d.Run(ctx, h.tenant, h.session.ID, turn); out <- runResult{result, err} }()
+	return out
+}
+
+func (h *dispatchHarness) finished(result <-chan runResult, status string) store.Turn {
+	h.t.Helper()
+	select {
+	case got := <-result:
+		if got.err != nil || got.turn.Status != status {
+			h.t.Fatalf("execution result: status=%s err=%v outcome=%s", got.turn.Status, got.err, got.turn.Outcome)
+		}
+		return got.turn
+	case <-time.After(10 * time.Second):
+		h.t.Fatal("execution did not finish")
+	}
+	return store.Turn{}
+}
+
+func TestExecutionDispatchSteeringAndNativeContinuity(t *testing.T) {
+	h := newDispatchHarness(t)
+	ctx := context.Background()
+	first := h.message("first", "Initial input")
+	result := h.run(ctx, first.TurnID)
+	request := h.read(proto.TypePromptRequest)
+	var prompt proto.PromptRequestPayload
+	_ = request.DecodePayload(&prompt)
+	if prompt.Prompt != "Initial input" || prompt.ConversationID != h.session.ID || prompt.AgentOptions["model"] != "test-model" || prompt.AgentOptions["system_prompt"] != "Keep this instruction." {
+		t.Fatalf("wrong resolved request: %+v", prompt)
+	}
+	if _, err := h.d.Run(ctx, uuid.NewString(), h.session.ID, first.TurnID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("foreign execution: %v", err)
+	}
+	if _, err := h.d.Run(ctx, h.tenant, h.session.ID, first.TurnID); !errors.Is(err, store.ErrTurnConflict) {
+		t.Fatalf("duplicate execution: %v", err)
+	}
+	second := h.message("second", "Follow-up input")
+	steer := h.read(proto.TypePromptSteer)
+	var input proto.PromptSteerPayload
+	_ = steer.DecodePayload(&input)
+	if input.Text != "Follow-up input" {
+		t.Fatal(input.Text)
+	}
+	h.write(first.TurnID, proto.TypePromptSteerAck, proto.PromptSteerAckPayload{InputID: input.InputID, ErrorCode: "not_ready"})
+	retry := h.read(proto.TypePromptSteer)
+	if string(retry.Payload) != string(steer.Payload) {
+		t.Fatal("steering retry changed identity")
+	}
+	h.write(first.TurnID, proto.TypePromptSteerAck, proto.PromptSteerAckPayload{InputID: input.InputID, Accepted: true})
+	h.write(first.TurnID, proto.TypeDone, proto.DonePayload{Content: "Finished", Usage: proto.Usage{InputTokens: 7, OutputTokens: 3}, Metadata: map[string]any{proto.DoneMetaAgentSessionID: "native-thread-1"}})
+	done := h.finished(result, store.TurnCompleted)
+	var outcome execution.Result
+	_ = json.Unmarshal(done.Outcome, &outcome)
+	if outcome.AppliedThrough != second.Sequence || outcome.Done.Usage.InputTokens != 7 {
+		t.Fatalf("missing result: %+v", outcome)
+	}
+	newStore, pool := store.NewTestStore(t)
+	defer pool.Close()
+	h.s = newStore
+	h.d.Store = newStore
+	bound, err := newStore.GetSessionDevice(ctx, h.tenant, h.session.ID)
+	if err != nil || bound.NativeSessionID != "native-thread-1" {
+		t.Fatalf("native binding lost: %+v %v", bound, err)
+	}
+	next := h.message("third", "Continue the session")
+	result = h.run(ctx, next.TurnID)
+	request = h.read(proto.TypePromptRequest)
+	_ = request.DecodePayload(&prompt)
+	if prompt.AgentSessionID != "native-thread-1" || prompt.AgentStateKey != "agents-api-"+h.session.ID {
+		t.Fatal("native continuity lost")
+	}
+	h.write(next.TurnID, proto.TypeDone, proto.DonePayload{Content: "Continued"})
+	h.finished(result, store.TurnCompleted)
+}
+
+func TestExecutionCancellationRequiresReceiptAndSurvivesContextEnd(t *testing.T) {
+	for _, withDone := range []bool{false, true} {
+		t.Run(map[bool]string{false: "receipt", true: "done-before-receipt"}[withDone], func(t *testing.T) {
+			h := newDispatchHarness(t)
+			first := h.message("first", "Run")
+			result := h.run(context.Background(), first.TurnID)
+			h.read(proto.TypePromptRequest)
+			_, err := h.s.RequestCancel(context.Background(), h.tenant, h.session.ID, "cancel")
+			if err != nil {
+				t.Fatal(err)
+			}
+			env := h.read(proto.TypePromptCancel)
+			var cancel proto.PromptCancelPayload
+			_ = env.DecodePayload(&cancel)
+			if cancel.DeliveryID == "" {
+				t.Fatal("cancellation has no receipt identity")
+			}
+			current, err := h.s.GetTurn(context.Background(), h.tenant, h.session.ID, first.TurnID)
+			if err != nil || current.Status != store.TurnInProgress {
+				t.Fatal("cancel finished before receipt")
+			}
+			if withDone {
+				h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
+			}
+			h.write(first.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: cancel.DeliveryID, Applied: true})
+			h.finished(result, store.TurnCancelled)
+		})
+	}
+	h := newDispatchHarness(t)
+	first := h.message("first", "Run")
+	ctx, cancel := context.WithCancel(context.Background())
+	result := h.run(ctx, first.TurnID)
+	h.read(proto.TypePromptRequest)
+	cancel()
+	done := h.finished(result, store.TurnFailed)
+	var outcome execution.Result
+	_ = json.Unmarshal(done.Outcome, &outcome)
+	if outcome.ErrorCode != "execution_interrupted" {
+		t.Fatal(outcome.ErrorCode)
+	}
+}
+
+func TestExecutionFailureDoesNotBecomeSuccessOrReplay(t *testing.T) {
+	for _, kind := range []string{"disconnect", "engine", "late-input", "unconfirmed-input"} {
+		t.Run(kind, func(t *testing.T) {
+			h := newDispatchHarness(t)
+			first := h.message("first", "Run")
+			result := h.run(context.Background(), first.TurnID)
+			h.read(proto.TypePromptRequest)
+			switch kind {
+			case "disconnect":
+				h.conn.Close()
+			case "engine":
+				h.write(first.TurnID, proto.TypeError, proto.ErrorPayload{Error: "Engine failed"})
+				h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
+			case "late-input":
+				h.message("late", "Still unprocessed")
+				h.write(first.TurnID, proto.TypeDone, proto.DonePayload{Content: "Only first input finished"})
+			case "unconfirmed-input":
+				h.message("second", "Steer")
+				h.read(proto.TypePromptSteer)
+				h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
+			}
+			h.finished(result, store.TurnFailed)
+			if kind != "disconnect" {
+				if _, err := h.d.Run(context.Background(), h.tenant, h.session.ID, first.TurnID); !errors.Is(err, store.ErrTurnConflict) {
+					t.Fatalf("terminal replay: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestExecutionOutcomeAndNativeBindingCommitTogether(t *testing.T) {
+	h := newDispatchHarness(t)
+	first := h.message("first", "Run")
+	ctx := context.Background()
+	_, err := h.s.TransitionTurn(ctx, h.tenant, h.session.ID, first.TurnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress})
+	if err != nil {
+		t.Fatal(err)
+	}
+	late := h.message("second", "Late")
+	if _, err := h.s.CompleteExecution(ctx, h.tenant, h.session.ID, first.TurnID, store.TurnCompleted, []byte(`{}`), "native-one", first.Sequence); !errors.Is(err, store.ErrUnappliedInputs) {
+		t.Fatalf("unapplied completion: %v", err)
+	}
+	bound, _ := h.s.GetSessionDevice(ctx, h.tenant, h.session.ID)
+	if bound.NativeSessionID != "" {
+		t.Fatal("native ID committed without outcome")
+	}
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for _, native := range []string{"native-one", "native-two"} {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := h.s.CompleteExecution(ctx, h.tenant, h.session.ID, first.TurnID, store.TurnCompleted, []byte(`{}`), native, late.Sequence)
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	success := 0
+	for err := range errs {
+		if err == nil {
+			success++
+		} else if !errors.Is(err, store.ErrTurnConflict) {
+			t.Fatal(err)
+		}
+	}
+	if success != 1 {
+		t.Fatal("multiple terminal owners")
+	}
+}

--- a/services/agents-api/internal/store/export_test.go
+++ b/services/agents-api/internal/store/export_test.go
@@ -1,0 +1,8 @@
+package store
+
+import (
+	"github.com/jackc/pgx/v5/pgxpool"
+	"testing"
+)
+
+func NewTestStore(t *testing.T) (*Store, *pgxpool.Pool) { return testStore(t) }

--- a/services/agents-api/internal/store/turn_completion.go
+++ b/services/agents-api/internal/store/turn_completion.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/db/sqlc"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+var ErrUnappliedInputs = errors.New("turn has messages without an executor receipt")
+
+// CompleteExecution commits the outcome and native continuity under the admission lock.
+func (s *Store) CompleteExecution(ctx context.Context, tenantID, sessionID, turnID, status string, outcome json.RawMessage, nativeID string, appliedThrough int64) (Turn, error) {
+	p, err := turnLookup(tenantID, sessionID, turnID)
+	if err != nil {
+		return Turn{}, err
+	}
+	if !terminalStatus(status) || len(outcome) > 512*1024 || len(nativeID) > 512 || appliedThrough < 0 {
+		return Turn{}, ErrInvalidInput
+	}
+	outcome, err = canonicalJSONObject(outcome)
+	if err != nil {
+		return Turn{}, err
+	}
+	var row sqlc.Turn
+	err = s.withSession(ctx, tenantID, sessionID, func(q *sqlc.Queries, session pgtype.UUID) error {
+		if _, err := q.GetTurn(ctx, p); errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotFound
+		} else if err != nil {
+			return err
+		}
+		if status == TurnCompleted {
+			pending, err := q.HasUnappliedMessages(ctx, sqlc.HasUnappliedMessagesParams{SessionID: session, TurnID: p.ID, Sequence: appliedThrough})
+			if err != nil {
+				return err
+			}
+			if pending {
+				return ErrUnappliedInputs
+			}
+		}
+		var err error
+		row, err = q.TransitionTurn(ctx, sqlc.TransitionTurnParams{ID: p.ID, SessionID: session, ExpectedStatus: TurnInProgress, NewStatus: status, Outcome: outcome})
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrTurnConflict
+		}
+		if err != nil {
+			return err
+		}
+		if nativeID != "" {
+			n, err := q.RememberNativeSession(ctx, sqlc.RememberNativeSessionParams{SessionID: session, NativeSessionID: nativeID})
+			if err != nil {
+				return err
+			}
+			if n != 1 {
+				return ErrNotFound
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return Turn{}, err
+	}
+	return turnFromRow(row), nil
+}

--- a/services/agents-api/migrations/000006_native_sessions.sql
+++ b/services/agents-api/migrations/000006_native_sessions.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE session_devices ADD COLUMN native_session_id text NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE session_devices DROP COLUMN native_session_id;


### PR DESCRIPTION
Adds an internal execution entry point for durable Turns on tenant-owned daemon devices. It claims work before sending, confirms ordered additional inputs, requires advertised durable-turn semantics and strict native resume, records cancellation only after an executor receipt, and atomically saves terminal results with the native session ID. Opt-in release before completion lets subsequent Codex turns resume without competing native writers; existing product requests keep their idle policy.

This is an internal milestone. Public execution/events/SSE, official environment mapping, background workers/crash reconciliation, durable approvals, provider allocation, Team and Parsar cutover remain out of scope. It does not advertise daemon execution as `environment:none` or the official self-hosted executor protocol.

Validation:
- `make check`, `make openapi`, sqlc generation and daemon race tests passed.
- Dedicated PostgreSQL race tests cover claims, tenant scope, steering confirmation/retries, cancellation, disconnects and atomic completion.
- Actual daemon + Codex with an isolated Responses fixture verified steering, durable output, subsequent-turn history after Store reconstruction, and native request cancellation; no local Docker or paid model requests.
- Three independent whole-diff reviews completed. In-scope execution correctness findings were fixed and revalidated.
- Deferred review finding: cancellation preserves complete terminal output/usage and native identity, but unfinished item deltas are not yet persisted. This belongs to the separately scoped durable-events slice and must be addressed before public execution/streaming rollout; no public traffic is enabled by this PR.
