### PR TITLE
feat(agents-api): preserve native message observations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,13 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   self-hosted executor protocol. Public environment mapping, output Items/SSE,
   pending interactions, crash reconciliation and provider allocation remain separate
   slices. Unexpected interaction requests fail explicitly until supported.
+- `message_items` advertises native assistant-message observations. Agents API
+  opts in with `observe_messages` only for advertised peers; ordinary product
+  requests retain their existing frame sequence. Opted-in text deltas carry their
+  native item ID, and `output_message` records start/completion, phase and the
+  completion text snapshot. A snapshot is not another delta; uncompleted messages
+  remain partial when their Turn ends. Keep these observations in the journal
+  before projecting public Items. This does not promise daemon event replay.
 - Execution observations are written to tenant-scoped `turn_events` in ordered,
   idempotent batches before they can back recovery or publication. Keep daemon
   payloads intact; this internal journal is not the public SSE protocol. Flush at

--- a/apps/parsar-daemon/internal/agent/codex/protocol.go
+++ b/apps/parsar-daemon/internal/agent/codex/protocol.go
@@ -295,6 +295,7 @@ type ThreadItem struct {
 	ID   string `json:"id,omitempty"`
 
 	// agentMessage / reasoning
+	Phase       string   `json:"phase,omitempty"`
 	Text        string   `json:"text,omitempty"`
 	Summary     []string `json:"summary,omitempty"`
 	Content     []string `json:"content,omitempty"`

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -56,10 +56,11 @@ func Factory(ctx context.Context, req proto.PromptRequestPayload, out chan<- pro
 //  5. turn/completed emits TypeDone + closes out. Cancel can short-cut
 //     this by killing the child early.
 type Session struct {
-	runID string
-	cfg   sessionConfig
-	out   chan<- proto.Envelope
-	rpc   *JSONRPCClient
+	observeMessages bool
+	runID           string
+	cfg             sessionConfig
+	out             chan<- proto.Envelope
+	rpc             *JSONRPCClient
 
 	cancelCtx context.Context
 	cancelFn  context.CancelFunc
@@ -143,17 +144,18 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 	rpc := NewJSONRPCClient(rpcCfg)
 
 	s := &Session{
-		runID:         req.RunID,
-		cfg:           cfg,
-		out:           out,
-		rpc:           rpc,
-		cancelCtx:     cancelCtx,
-		cancelFn:      cancelFn,
-		waitDone:      make(chan struct{}),
-		cleanup:       plan.Cleanup,
-		bufs:          NewItemBuffers(),
-		resolvedModel: plan.Model,
-		interactions:  newPendingCodexInteractions(),
+		runID:           req.RunID,
+		observeMessages: req.ObserveMessages,
+		cfg:             cfg,
+		out:             out,
+		rpc:             rpc,
+		cancelCtx:       cancelCtx,
+		cancelFn:        cancelFn,
+		waitDone:        make(chan struct{}),
+		cleanup:         plan.Cleanup,
+		bufs:            NewItemBuffers(),
+		resolvedModel:   plan.Model,
+		interactions:    newPendingCodexInteractions(),
 	}
 	s.registerHandlers()
 
@@ -385,23 +387,6 @@ func (s *Session) onTurnStarted(raw json.RawMessage) {
 	s.bufs = NewItemBuffers()
 }
 
-func (s *Session) onAgentDelta(raw json.RawMessage) {
-	var p AgentMessageDeltaNotification
-	if err := json.Unmarshal(raw, &p); err != nil {
-		return
-	}
-	if p.Delta == "" {
-		return
-	}
-	_ = FoldDeltaIntoBuffer(s.bufs, "agent", p.ItemID, p.Delta)
-	seq := s.deltaSeq.Add(1)
-	env, err := proto.NewEnvelope(proto.TypeDelta, s.runID, proto.DeltaPayload{Delta: p.Delta, Sequence: seq})
-	if err != nil {
-		return
-	}
-	s.trySend(env)
-}
-
 func (s *Session) onReasoningDelta(raw json.RawMessage) {
 	var p AgentMessageDeltaNotification
 	if err := json.Unmarshal(raw, &p); err != nil {
@@ -417,39 +402,6 @@ func (s *Session) onReasoningDelta(raw json.RawMessage) {
 		return
 	}
 	s.trySend(env)
-}
-
-func (s *Session) onItemStarted(raw json.RawMessage) {
-	var p ItemStartedNotification
-	if err := json.Unmarshal(raw, &p); err != nil {
-		return
-	}
-	envs, err := DispatchStartedItem(s.runID, p.Item)
-	if err != nil {
-		s.cfg.logger.Warn("codex: dispatch started item failed", "run_id", s.runID, "err", err)
-		return
-	}
-	for _, env := range envs {
-		s.trySend(env)
-	}
-}
-
-func (s *Session) onItemCompleted(raw json.RawMessage) {
-	var p ItemCompletedNotification
-	if err := json.Unmarshal(raw, &p); err != nil {
-		return
-	}
-	envs, text, err := DispatchCompletedItem(s.runID, p.Item, s.bufs)
-	if err != nil {
-		s.cfg.logger.Warn("codex: dispatch completed item failed", "run_id", s.runID, "err", err)
-		return
-	}
-	for _, env := range envs {
-		s.trySend(env)
-	}
-	if text != "" {
-		s.appendFinalText(text)
-	}
 }
 
 func (s *Session) onTurnCompleted(raw json.RawMessage) {

--- a/apps/parsar-daemon/internal/agent/codex/session_messages.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_messages.go
@@ -1,0 +1,77 @@
+package codex
+
+import (
+	"encoding/json"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func (s *Session) onAgentDelta(raw json.RawMessage) {
+	var p AgentMessageDeltaNotification
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return
+	}
+	if p.Delta == "" {
+		return
+	}
+	_ = FoldDeltaIntoBuffer(s.bufs, "agent", p.ItemID, p.Delta)
+	seq := s.deltaSeq.Add(1)
+	payload := proto.DeltaPayload{Delta: p.Delta, Sequence: seq}
+	if s.observeMessages {
+		payload.ItemID = p.ItemID
+	}
+	env, err := proto.NewEnvelope(proto.TypeDelta, s.runID, payload)
+	if err != nil {
+		return
+	}
+	s.trySend(env)
+}
+
+func (s *Session) onItemStarted(raw json.RawMessage) {
+	var p ItemStartedNotification
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return
+	}
+	s.observeMessage(p.Item, "in_progress", nil)
+	envs, err := DispatchStartedItem(s.runID, p.Item)
+	if err != nil {
+		s.cfg.logger.Warn("codex: dispatch started item failed", "run_id", s.runID, "err", err)
+		return
+	}
+	for _, env := range envs {
+		s.trySend(env)
+	}
+}
+
+func (s *Session) onItemCompleted(raw json.RawMessage) {
+	var p ItemCompletedNotification
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return
+	}
+	envs, text, err := DispatchCompletedItem(s.runID, p.Item, s.bufs)
+	if err != nil {
+		s.cfg.logger.Warn("codex: dispatch completed item failed", "run_id", s.runID, "err", err)
+		return
+	}
+	for _, env := range envs {
+		s.trySend(env)
+	}
+	messageText := p.Item.Text
+	if messageText == "" {
+		messageText = text
+	}
+	s.observeMessage(p.Item, "completed", &messageText)
+	if text != "" {
+		s.appendFinalText(text)
+	}
+}
+
+func (s *Session) observeMessage(item ThreadItem, status string, text *string) {
+	if !s.observeMessages || item.Type != "agentMessage" {
+		return
+	}
+	env, err := proto.NewEnvelope(proto.TypeOutputMessage, s.runID, proto.OutputMessagePayload{ID: item.ID, Status: status, Phase: item.Phase, Text: text})
+	if err == nil {
+		s.trySend(env)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/session_messages_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_messages_test.go
@@ -1,0 +1,70 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestMessageObservationIsOptInAndKeepsNativeBoundaries(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "legacy", true: "observed"}[enabled], func(t *testing.T) {
+			out := make(chan proto.Envelope, 16)
+			s := &Session{runID: "run", observeMessages: enabled, out: out, cancelCtx: context.Background(), bufs: NewItemBuffers(), cfg: defaultSessionConfig()}
+			s.onItemStarted(json.RawMessage(`{"item":{"type":"agentMessage","id":"a","phase":"commentary"}}`))
+			s.onAgentDelta(json.RawMessage(`{"itemId":"a","delta":"first"}`))
+			s.onItemStarted(json.RawMessage(`{"item":{"type":"agentMessage","id":"b","phase":"final_answer"}}`))
+			s.onAgentDelta(json.RawMessage(`{"itemId":"b","delta":"second"}`))
+			s.onItemCompleted(json.RawMessage(`{"item":{"type":"agentMessage","id":"a","phase":"commentary","text":"first complete"}}`))
+			// b stays unfinished, as when the native request is cancelled before item/completed.
+			s.onItemCompleted(json.RawMessage(`{"item":{"type":"agentMessage","id":"c","phase":"final_answer","text":"without deltas"}}`))
+			var deltas []proto.DeltaPayload
+			var messages []proto.OutputMessagePayload
+			for len(out) > 0 {
+				env := <-out
+				switch env.Type {
+				case proto.TypeDelta:
+					var p proto.DeltaPayload
+					if err := env.DecodePayload(&p); err != nil {
+						t.Fatal(err)
+					}
+					deltas = append(deltas, p)
+				case proto.TypeOutputMessage:
+					var p proto.OutputMessagePayload
+					if err := env.DecodePayload(&p); err != nil {
+						t.Fatal(err)
+					}
+					messages = append(messages, p)
+				default:
+					t.Fatalf("unexpected frame: %s", env.Type)
+				}
+			}
+			if len(deltas) != 2 || deltas[0].Delta != "first" || deltas[1].Delta != "second" || deltas[1].Sequence != 2 {
+				t.Fatalf("legacy text changed: %+v", deltas)
+			}
+			if !enabled {
+				if len(messages) != 0 || deltas[0].ItemID != "" || deltas[1].ItemID != "" {
+					t.Fatal("legacy request gained observations")
+				}
+				return
+			}
+			if deltas[0].ItemID != "a" || deltas[1].ItemID != "b" || len(messages) != 4 {
+				t.Fatalf("identity lost: %+v %+v", deltas, messages)
+			}
+			if messages[0].ID != "a" || messages[0].Phase != "commentary" || messages[0].Status != "in_progress" || messages[0].Text != nil {
+				t.Fatalf("start: %+v", messages[0])
+			}
+			if messages[1].ID != "b" || messages[1].Phase != "final_answer" || messages[1].Status != "in_progress" {
+				t.Fatalf("second start: %+v", messages[1])
+			}
+			if messages[2].ID != "a" || messages[2].Status != "completed" || messages[2].Text == nil || *messages[2].Text != "first complete" {
+				t.Fatalf("completion: %+v", messages[2])
+			}
+			if messages[3].ID != "c" || messages[3].Text == nil || *messages[3].Text != "without deltas" {
+				t.Fatalf("non-streamed message lost: %+v", messages[3])
+			}
+		})
+	}
+}

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -261,6 +261,7 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 				Resume:       true,
 				Steering:     true,
 				DurableTurns: true,
+				MessageItems: true,
 			},
 		},
 		Pi: proto.SupportedAgentKind{

--- a/apps/parsar-daemon/internal/cli/connect_test.go
+++ b/apps/parsar-daemon/internal/cli/connect_test.go
@@ -174,7 +174,7 @@ func TestDiscoverAgentCLIsBothAvailable(t *testing.T) {
 	if !got.ClaudeCode.Capabilities.Permissions || !got.ClaudeCode.Capabilities.Resume {
 		t.Fatalf("ClaudeCode capabilities = %#v", got.ClaudeCode.Capabilities)
 	}
-	if !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
+	if !got.Codex.Capabilities.MessageItems || !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
 		t.Fatalf("Codex capabilities = %#v (want Streaming+Permissions+Resume)", got.Codex.Capabilities)
 	}
 	if !got.Pi.Available || got.Pi.Version != "pi 0.1.0" {

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -41,7 +41,7 @@ separate future dependency for Team orchestration in Parsar, not the HTTP contra
 | Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, environment `none`, metadata and creation retry keys |
 | Internal Turn/input persistence | Tenant-scoped atomic input batches, steering, request-level retry identity, cancellation targets and terminal outcomes |
 | Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; no public event submission or execution worker yet |
-| Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; tenant-scoped paginated Store reads |
+| Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items`; tenant-scoped paginated Store reads |
 | Public Turn recovery | Retrieve/list persisted states with scoped pagination; see limitations below |
 | Public Items recovery and SSE | Pending; internal daemon payloads are not upstream wire objects |
 | Pending actions and environment lifecycle | Pending |

--- a/internal/agentdaemon/device/state.go
+++ b/internal/agentdaemon/device/state.go
@@ -65,6 +65,7 @@ type KindCapabilities struct {
 	Usage              bool `json:"usage,omitempty"`
 	Resume             bool `json:"resume,omitempty"`
 	Steering           bool `json:"steering,omitempty"`
+	MessageItems       bool `json:"message_items,omitempty"`
 	DurableTurns       bool `json:"durable_turns,omitempty"`
 	WorkspaceAuthoring bool `json:"workspace_authoring,omitempty"`
 }

--- a/internal/agentdaemon/gateway/session.go
+++ b/internal/agentdaemon/gateway/session.go
@@ -531,6 +531,7 @@ func deviceKindsFromHeartbeat(p proto.HeartbeatPayload) []device.SupportedAgentK
 				Resume:             info.Capabilities.Resume,
 				Steering:           info.Capabilities.Steering,
 				DurableTurns:       info.Capabilities.DurableTurns,
+				MessageItems:       info.Capabilities.MessageItems,
 				WorkspaceAuthoring: info.Capabilities.WorkspaceAuthoring,
 			},
 		})

--- a/internal/agentdaemon/gateway/session_test.go
+++ b/internal/agentdaemon/gateway/session_test.go
@@ -405,7 +405,7 @@ func TestSession_HeartbeatPersistsSupportedAgentKinds(t *testing.T) {
 			{
 				Kind:         "codex",
 				Available:    true,
-				Capabilities: proto.AgentKindCapabilities{Steering: true},
+				Capabilities: proto.AgentKindCapabilities{Steering: true, MessageItems: true},
 			},
 		},
 	})
@@ -431,7 +431,7 @@ func TestSession_HeartbeatPersistsSupportedAgentKinds(t *testing.T) {
 	if opencode.Available || opencode.Version != "missing" || !opencode.Capabilities.Streaming {
 		t.Fatalf("opencode descriptor not converted: %#v", opencode)
 	}
-	if !byKind["codex"].Capabilities.Steering || claude.Capabilities.Steering || opencode.Capabilities.Steering {
+	if !byKind["codex"].Capabilities.MessageItems || !byKind["codex"].Capabilities.Steering || claude.Capabilities.Steering || opencode.Capabilities.Steering {
 		t.Fatalf("steering capability not preserved: %#v", byKind)
 	}
 	codex, found, known := sess.AgentKindStatus("codex")

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -16,6 +16,9 @@ const (
 	// full Final.Content.
 	TypeDelta = "delta"
 
+	// TypeOutputMessage carries opt-in native message boundaries and completion snapshots.
+	TypeOutputMessage = "output_message"
+
 	// TypeThinking carries an internal-thinking fragment. Gateway
 	// forwards as a plain EventDelta so existing renderers keep
 	// working.
@@ -65,8 +68,17 @@ const (
 
 // DeltaPayload carries an incremental text fragment from the agent.
 type DeltaPayload struct {
+	ItemID   string `json:"item_id,omitempty"`
 	Delta    string `json:"delta"`
 	Sequence uint64 `json:"sequence"`
+}
+
+// OutputMessagePayload describes a native assistant message; Text is a completion snapshot.
+type OutputMessagePayload struct {
+	ID     string  `json:"id"`
+	Status string  `json:"status"`
+	Phase  string  `json:"phase,omitempty"`
+	Text   *string `json:"text,omitempty"`
 }
 
 // ThinkingPayload carries an internal-thinking fragment.
@@ -229,6 +241,7 @@ type AgentKindCapabilities struct {
 	Resume             bool `json:"resume,omitempty"`
 	WorkspaceAuthoring bool `json:"workspace_authoring,omitempty"`
 	Steering           bool `json:"steering,omitempty"`
+	MessageItems       bool `json:"message_items,omitempty"`
 	// DurableTurns includes strict resume, completion release and cancellation snapshots.
 	DurableTurns bool `json:"durable_turns,omitempty"`
 }

--- a/internal/agentdaemon/proto/outbound.go
+++ b/internal/agentdaemon/proto/outbound.go
@@ -79,6 +79,7 @@ type PromptRequestPayload struct {
 	// ReleaseOnCompletion closes the native writer before acknowledging Done.
 	ReleaseOnCompletion bool `json:"release_on_completion,omitempty"`
 	StrictResume        bool `json:"strict_resume,omitempty"`
+	ObserveMessages     bool `json:"observe_messages,omitempty"`
 }
 
 // PromptAttachment is one piece of non-text user input the daemon-side

--- a/services/agents-api/internal/execution/dispatcher.go
+++ b/services/agents-api/internal/execution/dispatcher.go
@@ -93,7 +93,7 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 	if _, err := d.Store.TransitionTurn(ctx, tenantID, sessionID, turnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
 		return store.Turn{}, err
 	}
-	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true, StrictResume: true}
+	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true, StrictResume: true, ObserveMessages: info.Capabilities.MessageItems}
 	result, status := d.deliver(ctx, tenantID, sessionID, peer, req, inputs[0].Sequence)
 	if result.Done.Usage.Model == "" {
 		result.Done.Usage.Model = snapshot.Agent.Model

--- a/services/agents-api/internal/execution/journal.go
+++ b/services/agents-api/internal/execution/journal.go
@@ -54,7 +54,7 @@ func (j *journal) observe(ctx context.Context, env proto.Envelope) error {
 
 func (j *journal) enqueue(env proto.Envelope) error {
 	switch env.Type {
-	case proto.TypeDelta, proto.TypeThinking, proto.TypeToolCall, proto.TypeUsage,
+	case proto.TypeDelta, proto.TypeOutputMessage, proto.TypeThinking, proto.TypeToolCall, proto.TypeUsage,
 		proto.TypeError, proto.TypeDone, proto.TypePromptSteerAck, "cancel_receipt":
 	default:
 		return nil

--- a/services/agents-api/internal/store/execution_messages_test.go
+++ b/services/agents-api/internal/store/execution_messages_test.go
@@ -1,0 +1,83 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func TestExecutionNegotiatesAndPersistsMessageObservations(t *testing.T) {
+	h := newDispatchHarness(t)
+	ctx := context.Background()
+	first := h.message("legacy", "legacy observation policy")
+	result := h.run(ctx, first.TurnID)
+	var request proto.PromptRequestPayload
+	env := h.read(proto.TypePromptRequest)
+	_ = env.DecodePayload(&request)
+	if request.ObserveMessages {
+		t.Fatal("unadvertised observation capability requested")
+	}
+	h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
+	h.finished(result, store.TurnCompleted)
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, MessageItems: true}}}})
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		peer, err := h.registry.LookupDevice(h.device.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, _, _ := peer.AgentKindStatus("codex")
+		if info.Capabilities.MessageItems {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("message capability lost in gateway")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	input := h.message("observed", "stream separate messages")
+	result = h.run(ctx, input.TurnID)
+	env = h.read(proto.TypePromptRequest)
+	_ = env.DecodePayload(&request)
+	if !request.ObserveMessages {
+		t.Fatal("advertised capability was not requested")
+	}
+	text := "complete"
+	h.write(input.TurnID, proto.TypeOutputMessage, proto.OutputMessagePayload{ID: "a", Status: "in_progress", Phase: "commentary"})
+	h.write(input.TurnID, proto.TypeDelta, proto.DeltaPayload{ItemID: "a", Delta: text, Sequence: 1})
+	h.write(input.TurnID, proto.TypeOutputMessage, proto.OutputMessagePayload{ID: "a", Status: "completed", Phase: "commentary", Text: &text})
+	h.write(input.TurnID, proto.TypeOutputMessage, proto.OutputMessagePayload{ID: "b", Status: "in_progress", Phase: "final_answer"})
+	h.write(input.TurnID, proto.TypeDelta, proto.DeltaPayload{ItemID: "b", Delta: "partial", Sequence: 2})
+	if _, err := h.s.RequestCancel(ctx, h.tenant, h.session.ID, "cancel"); err != nil {
+		t.Fatal(err)
+	}
+	env = h.read(proto.TypePromptCancel)
+	var cancel proto.PromptCancelPayload
+	_ = env.DecodePayload(&cancel)
+	h.write(input.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: cancel.DeliveryID, Applied: true, Outcome: &proto.DonePayload{}})
+	h.finished(result, store.TurnCancelled)
+	reopened, pool := store.NewTestStore(t)
+	defer pool.Close()
+	events, err := reopened.ListTurnEvents(ctx, h.tenant, h.session.ID, input.TurnID, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 7 {
+		t.Fatalf("lost message observations: %+v", events)
+	}
+	var complete proto.OutputMessagePayload
+	if err = json.Unmarshal(events[2].Payload, &complete); err != nil || complete.ID != "a" || complete.Text == nil || *complete.Text != "complete" || complete.Phase != "commentary" {
+		t.Fatalf("completed snapshot: %+v %v", complete, err)
+	}
+	var delta proto.DeltaPayload
+	if err = json.Unmarshal(events[4].Payload, &delta); err != nil || delta.ItemID != "b" || delta.Delta != "partial" {
+		t.Fatalf("cancelled partial identity lost: %+v %v", delta, err)
+	}
+	if events[5].Kind != "cancel_receipt" || events[6].Kind != "execution_cancelled" {
+		t.Fatal("terminal ordering changed")
+	}
+}


### PR DESCRIPTION
The execution journal receives anonymous text deltas, so it cannot distinguish native assistant messages or their completion boundaries. Preserve Codex message IDs on deltas and record separate start/completion observations with phase and completion text.

Negotiate `message_items` through the existing daemon capability heartbeat and enable observations per request. Existing product requests and older peers keep their original frame behavior. Agents API journals the new observations without treating completion snapshots as additional text deltas. The touched message handlers move out of the oversized Codex session file.

Validation:
- `make check` and OpenAPI generation passed; local Docker remained stopped, so Docker migration smoke was skipped.
- Codex, CLI discovery, shared gateway and execution race tests passed, including opt-in/legacy message behavior.
- Dedicated PostgreSQL race suite passed, including capability negotiation and persisted completed/partial message identity through cancellation.
- Actual daemon + Codex 0.153.4 with an isolated Responses fixture passed: two distinct native messages with final_answer phase and completion snapshots, unfinished output cancellation, steering and native session continuation.
- Fresh independent complete-diff blind review passed with no blocking findings; reviewer independently reran targeted Go tests.

Scope is internal native message fidelity only: public Items/SSE, tool-result projection and other engine support remain subsequent work. This does not add daemon event replay or change the native model/tool loop.
