### PR TITLE
feat(agents-api): retain native tool result snapshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,6 +220,13 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   completion text snapshot. A snapshot is not another delta; uncompleted messages
   remain partial when their Turn ends. Keep these observations in the journal
   before projecting public Items. This does not promise daemon event replay.
+- `tool_items` advertises native tool snapshots, enabled per request with
+  `observe_tools`. Codex attaches the original tool item to existing before/after
+  `tool_call` frames, preserving command output, structured MCP results, errors
+  and other engine fields without expanding the legacy product payload. Keep
+  snapshots opaque in the internal journal; the execution service must validate
+  and project supported variants to the pinned public Item schema. Do not expose
+  native snapshots as public Items or synthesize a result for an unfinished call.
 - Execution observations are written to tenant-scoped `turn_events` in ordered,
   idempotent batches before they can back recovery or publication. Keep daemon
   payloads intact; this internal journal is not the public SSE protocol. Flush at

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -57,6 +57,7 @@ func Factory(ctx context.Context, req proto.PromptRequestPayload, out chan<- pro
 //     this by killing the child early.
 type Session struct {
 	observeMessages bool
+	observeTools    bool
 	runID           string
 	cfg             sessionConfig
 	out             chan<- proto.Envelope
@@ -146,6 +147,7 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 	s := &Session{
 		runID:           req.RunID,
 		observeMessages: req.ObserveMessages,
+		observeTools:    req.ObserveTools,
 		cfg:             cfg,
 		out:             out,
 		rpc:             rpc,

--- a/apps/parsar-daemon/internal/agent/codex/session_messages.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_messages.go
@@ -38,9 +38,7 @@ func (s *Session) onItemStarted(raw json.RawMessage) {
 		s.cfg.logger.Warn("codex: dispatch started item failed", "run_id", s.runID, "err", err)
 		return
 	}
-	for _, env := range envs {
-		s.trySend(env)
-	}
+	s.sendItemEvents(envs, raw)
 }
 
 func (s *Session) onItemCompleted(raw json.RawMessage) {
@@ -53,9 +51,7 @@ func (s *Session) onItemCompleted(raw json.RawMessage) {
 		s.cfg.logger.Warn("codex: dispatch completed item failed", "run_id", s.runID, "err", err)
 		return
 	}
-	for _, env := range envs {
-		s.trySend(env)
-	}
+	s.sendItemEvents(envs, raw)
 	messageText := p.Item.Text
 	if messageText == "" {
 		messageText = text

--- a/apps/parsar-daemon/internal/agent/codex/session_tools.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_tools.go
@@ -1,0 +1,33 @@
+package codex
+
+import (
+	"encoding/json"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func (s *Session) sendItemEvents(events []proto.Envelope, notification json.RawMessage) {
+	var native struct {
+		Item json.RawMessage `json:"item"`
+	}
+	if s.observeTools {
+		if err := json.Unmarshal(notification, &native); err != nil {
+			return
+		}
+	}
+	for _, event := range events {
+		if s.observeTools && event.Type == proto.TypeToolCall {
+			var tool proto.ToolCallPayload
+			if err := event.DecodePayload(&tool); err != nil {
+				return
+			}
+			tool.NativeItem = native.Item
+			payload, err := json.Marshal(tool)
+			if err != nil {
+				return
+			}
+			event.Payload = payload
+		}
+		s.trySend(event)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/session_tools_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_tools_test.go
@@ -1,0 +1,70 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestToolSnapshotsPreserveNativeResultsOnlyWhenRequested(t *testing.T) {
+	items := []string{
+		`{"type":"commandExecution","id":"cmd","command":"printf result","cwd":"/tmp","status":"completed","aggregatedOutput":"result\n","exitCode":0,"durationMs":37}`,
+		`{"type":"commandExecution","id":"fail","command":"exit 2","status":"failed","aggregatedOutput":"failure details","exitCode":2,"durationMs":12}`,
+		`{"type":"mcpToolCall","id":"mcp","server":"reference","tool":"lookup","arguments":{"id":"record"},"status":"completed","result":{"content":[{"type":"text","text":"answer"}],"structuredContent":{"version":9007199254740993}},"error":null}`,
+		`{"type":"mcpToolCall","id":"mcp-error","server":"reference","tool":"lookup","arguments":{},"status":"failed","result":null,"error":{"message":"lookup failed"}}`,
+		`{"type":"dynamicToolCall","id":"dynamic","tool":"lookup","namespace":"reference","arguments":["a","b"],"status":"completed","contentItems":[{"type":"inputText","text":"dynamic output"}],"success":true}`,
+		`{"type":"fileChange","id":"edit","status":"completed","changes":[{"path":"/tmp/example","kind":{"type":"update","move_path":null},"diff":"-before\n+after"}]}`,
+		`{"type":"webSearch","id":"search","query":"reference","action":{"type":"search","query":"reference","queries":["reference"]}}`,
+	}
+	for _, item := range items {
+		var identity struct{ ID string }
+		if err := json.Unmarshal([]byte(item), &identity); err != nil {
+			t.Fatal(err)
+		}
+		t.Run(identity.ID, func(t *testing.T) {
+			var legacy []proto.Envelope
+			for _, enabled := range []bool{false, true} {
+				out := make(chan proto.Envelope, 4)
+				s := &Session{runID: "run", observeTools: enabled, out: out, cancelCtx: context.Background(), bufs: NewItemBuffers(), cfg: defaultSessionConfig()}
+				raw := json.RawMessage(`{"threadId":"private-thread","turnId":"private-turn","item":` + item + `}`)
+				s.onItemStarted(raw)
+				s.onItemCompleted(raw)
+				if len(out) != 2 {
+					t.Fatalf("tool event count changed: %d", len(out))
+				}
+				for i, stage := range []string{"before", "after"} {
+					event := <-out
+					var tool proto.ToolCallPayload
+					if err := event.DecodePayload(&tool); err != nil {
+						t.Fatal(err)
+					}
+					if event.Type != proto.TypeToolCall || event.ID != "run" || tool.ID != identity.ID || tool.Stage != stage {
+						t.Fatalf("tool identity/stage changed: %+v %+v", event, tool)
+					}
+					if !enabled {
+						if tool.NativeItem != nil || bytes.Contains(event.Payload, []byte("native_item")) {
+							t.Fatal("legacy request acquired native snapshot")
+						}
+						legacy = append(legacy, event)
+						continue
+					}
+					var expected bytes.Buffer
+					if err := json.Compact(&expected, []byte(item)); err != nil {
+						t.Fatal(err)
+					}
+					if !bytes.Equal(tool.NativeItem, expected.Bytes()) {
+						t.Fatalf("native result lost or coerced: %s", tool.NativeItem)
+					}
+					tool.NativeItem = nil
+					payload, err := json.Marshal(tool)
+					if err != nil || !bytes.Equal(payload, legacy[i].Payload) {
+						t.Fatalf("legacy tool fields changed: %s, %v", payload, err)
+					}
+				}
+			}
+		})
+	}
+}

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -262,6 +262,7 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 				Steering:     true,
 				DurableTurns: true,
 				MessageItems: true,
+				ToolItems:    true,
 			},
 		},
 		Pi: proto.SupportedAgentKind{

--- a/apps/parsar-daemon/internal/cli/connect_test.go
+++ b/apps/parsar-daemon/internal/cli/connect_test.go
@@ -174,7 +174,7 @@ func TestDiscoverAgentCLIsBothAvailable(t *testing.T) {
 	if !got.ClaudeCode.Capabilities.Permissions || !got.ClaudeCode.Capabilities.Resume {
 		t.Fatalf("ClaudeCode capabilities = %#v", got.ClaudeCode.Capabilities)
 	}
-	if !got.Codex.Capabilities.MessageItems || !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
+	if !got.Codex.Capabilities.ToolItems || !got.Codex.Capabilities.MessageItems || !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
 		t.Fatalf("Codex capabilities = %#v (want Streaming+Permissions+Resume)", got.Codex.Capabilities)
 	}
 	if !got.Pi.Available || got.Pi.Version != "pi 0.1.0" {

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -41,7 +41,7 @@ separate future dependency for Team orchestration in Parsar, not the HTTP contra
 | Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, environment `none`, metadata and creation retry keys |
 | Internal Turn/input persistence | Tenant-scoped atomic input batches, steering, request-level retry identity, cancellation targets and terminal outcomes |
 | Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; no public event submission or execution worker yet |
-| Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items`; tenant-scoped paginated Store reads |
+| Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items` and tool snapshots via `tool_items`; tenant-scoped paginated Store reads |
 | Public Turn recovery | Retrieve/list persisted states with scoped pagination; see limitations below |
 | Public Items recovery and SSE | Pending; internal daemon payloads are not upstream wire objects |
 | Pending actions and environment lifecycle | Pending |

--- a/internal/agentdaemon/device/state.go
+++ b/internal/agentdaemon/device/state.go
@@ -66,6 +66,7 @@ type KindCapabilities struct {
 	Resume             bool `json:"resume,omitempty"`
 	Steering           bool `json:"steering,omitempty"`
 	MessageItems       bool `json:"message_items,omitempty"`
+	ToolItems          bool `json:"tool_items,omitempty"`
 	DurableTurns       bool `json:"durable_turns,omitempty"`
 	WorkspaceAuthoring bool `json:"workspace_authoring,omitempty"`
 }

--- a/internal/agentdaemon/gateway/session.go
+++ b/internal/agentdaemon/gateway/session.go
@@ -532,6 +532,7 @@ func deviceKindsFromHeartbeat(p proto.HeartbeatPayload) []device.SupportedAgentK
 				Steering:           info.Capabilities.Steering,
 				DurableTurns:       info.Capabilities.DurableTurns,
 				MessageItems:       info.Capabilities.MessageItems,
+				ToolItems:          info.Capabilities.ToolItems,
 				WorkspaceAuthoring: info.Capabilities.WorkspaceAuthoring,
 			},
 		})

--- a/internal/agentdaemon/gateway/session_test.go
+++ b/internal/agentdaemon/gateway/session_test.go
@@ -405,7 +405,7 @@ func TestSession_HeartbeatPersistsSupportedAgentKinds(t *testing.T) {
 			{
 				Kind:         "codex",
 				Available:    true,
-				Capabilities: proto.AgentKindCapabilities{Steering: true, MessageItems: true},
+				Capabilities: proto.AgentKindCapabilities{Steering: true, MessageItems: true, ToolItems: true},
 			},
 		},
 	})
@@ -431,7 +431,7 @@ func TestSession_HeartbeatPersistsSupportedAgentKinds(t *testing.T) {
 	if opencode.Available || opencode.Version != "missing" || !opencode.Capabilities.Streaming {
 		t.Fatalf("opencode descriptor not converted: %#v", opencode)
 	}
-	if !byKind["codex"].Capabilities.MessageItems || !byKind["codex"].Capabilities.Steering || claude.Capabilities.Steering || opencode.Capabilities.Steering {
+	if !byKind["codex"].Capabilities.ToolItems || claude.Capabilities.ToolItems || opencode.Capabilities.ToolItems || !byKind["codex"].Capabilities.MessageItems || !byKind["codex"].Capabilities.Steering || claude.Capabilities.Steering || opencode.Capabilities.Steering {
 		t.Fatalf("steering capability not preserved: %#v", byKind)
 	}
 	codex, found, known := sess.AgentKindStatus("codex")

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -1,5 +1,7 @@
 package proto
 
+import "encoding/json"
+
 // This package lives at the repo-root module so both the server-side
 // gateway/connector AND apps/parsar-daemon can import it. That rules out
 // importing server/internal/... (Go's internal-package rule), so wire
@@ -91,11 +93,13 @@ type ThinkingPayload struct {
 // when the agent is about to call the tool, "after" when the result
 // is back.
 type ToolCallPayload struct {
-	ID     string         `json:"id"`
-	Name   string         `json:"name"`
-	Stage  string         `json:"stage"`
-	Args   map[string]any `json:"args,omitempty"`
-	Result map[string]any `json:"result,omitempty"`
+	// NativeItem is an opt-in engine snapshot for execution-service projection, not a public Item.
+	NativeItem json.RawMessage `json:"native_item,omitempty"`
+	ID         string          `json:"id"`
+	Name       string          `json:"name"`
+	Stage      string          `json:"stage"`
+	Args       map[string]any  `json:"args,omitempty"`
+	Result     map[string]any  `json:"result,omitempty"`
 }
 
 // PermissionRequestPayload carries an agent's request for human
@@ -242,6 +246,7 @@ type AgentKindCapabilities struct {
 	WorkspaceAuthoring bool `json:"workspace_authoring,omitempty"`
 	Steering           bool `json:"steering,omitempty"`
 	MessageItems       bool `json:"message_items,omitempty"`
+	ToolItems          bool `json:"tool_items,omitempty"`
 	// DurableTurns includes strict resume, completion release and cancellation snapshots.
 	DurableTurns bool `json:"durable_turns,omitempty"`
 }

--- a/internal/agentdaemon/proto/outbound.go
+++ b/internal/agentdaemon/proto/outbound.go
@@ -80,6 +80,7 @@ type PromptRequestPayload struct {
 	ReleaseOnCompletion bool `json:"release_on_completion,omitempty"`
 	StrictResume        bool `json:"strict_resume,omitempty"`
 	ObserveMessages     bool `json:"observe_messages,omitempty"`
+	ObserveTools        bool `json:"observe_tools,omitempty"`
 }
 
 // PromptAttachment is one piece of non-text user input the daemon-side

--- a/services/agents-api/internal/execution/dispatcher.go
+++ b/services/agents-api/internal/execution/dispatcher.go
@@ -93,7 +93,7 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 	if _, err := d.Store.TransitionTurn(ctx, tenantID, sessionID, turnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
 		return store.Turn{}, err
 	}
-	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true, StrictResume: true, ObserveMessages: info.Capabilities.MessageItems}
+	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true, StrictResume: true, ObserveMessages: info.Capabilities.MessageItems, ObserveTools: info.Capabilities.ToolItems}
 	result, status := d.deliver(ctx, tenantID, sessionID, peer, req, inputs[0].Sequence)
 	if result.Done.Usage.Model == "" {
 		result.Done.Usage.Model = snapshot.Agent.Model

--- a/services/agents-api/internal/store/execution_tools_test.go
+++ b/services/agents-api/internal/store/execution_tools_test.go
@@ -1,0 +1,107 @@
+package store_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func TestExecutionNegotiatesAndPersistsToolObservations(t *testing.T) {
+	h := newDispatchHarness(t)
+	ctx := context.Background()
+	first := h.message("legacy", "legacy observation policy")
+	result := h.run(ctx, first.TurnID)
+	var request proto.PromptRequestPayload
+	env := h.read(proto.TypePromptRequest)
+	_ = env.DecodePayload(&request)
+	if request.ObserveTools {
+		t.Fatal("unadvertised observation capability requested")
+	}
+	h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
+	h.finished(result, store.TurnCompleted)
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, ToolItems: true}}}})
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		peer, err := h.registry.LookupDevice(h.device.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, _, _ := peer.AgentKindStatus("codex")
+		if info.Capabilities.ToolItems {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("tool capability lost in gateway")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	input := h.message("observed", "run tools")
+	result = h.run(ctx, input.TurnID)
+	env = h.read(proto.TypePromptRequest)
+	_ = env.DecodePayload(&request)
+	if !request.ObserveTools || request.ObserveMessages {
+		t.Fatal("advertised capability was not requested")
+	}
+	start := json.RawMessage(`{"type":"mcpToolCall","id":"a","server":"reference","tool":"lookup","arguments":{"key":"value"},"status":"inProgress","result":null,"error":null}`)
+	complete := json.RawMessage(`{"type":"mcpToolCall","id":"a","server":"reference","tool":"lookup","arguments":{"key":"value"},"status":"completed","result":{"content":[{"type":"text","text":"answer"}],"structuredContent":{"version":9007199254740993}},"error":null}`)
+	partial := json.RawMessage(`{"type":"commandExecution","id":"b","command":"long-running","status":"inProgress","aggregatedOutput":null,"exitCode":null}`)
+	for i, raw := range []json.RawMessage{start, complete, partial} {
+		id, stage := "a", "before"
+		if i == 1 {
+			stage = "after"
+		}
+		if i == 2 {
+			id = "b"
+		}
+		h.write(input.TurnID, proto.TypeToolCall, proto.ToolCallPayload{ID: id, Stage: stage, NativeItem: raw})
+	}
+	if _, err := h.s.RequestCancel(ctx, h.tenant, h.session.ID, "cancel"); err != nil {
+		t.Fatal(err)
+	}
+	env = h.read(proto.TypePromptCancel)
+	var cancel proto.PromptCancelPayload
+	_ = env.DecodePayload(&cancel)
+	h.write(input.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: cancel.DeliveryID, Applied: true, Outcome: &proto.DonePayload{}})
+	h.finished(result, store.TurnCancelled)
+	reopened, pool := store.NewTestStore(t)
+	defer pool.Close()
+	events, err := reopened.ListTurnEvents(ctx, h.tenant, h.session.ID, input.TurnID, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 5 {
+		t.Fatalf("lost tool observations: %+v", events)
+	}
+	for i, expected := range []json.RawMessage{start, complete, partial} {
+		var tool proto.ToolCallPayload
+		if err = json.Unmarshal(events[i].Payload, &tool); err != nil {
+			t.Fatal(err)
+		}
+		// PostgreSQL canonicalizes object order; compare JSON values without floating-point coercion.
+		var actualValue, expectedValue any
+		decode := func(raw []byte, target *any) {
+			d := json.NewDecoder(bytes.NewReader(raw))
+			d.UseNumber()
+			if e := d.Decode(target); e != nil {
+				t.Fatal(e)
+			}
+		}
+		decode(tool.NativeItem, &actualValue)
+		decode(expected, &expectedValue)
+		if !reflect.DeepEqual(actualValue, expectedValue) {
+			t.Fatalf("tool snapshot changed: %s", tool.NativeItem)
+		}
+		if i == 2 && tool.Stage != "before" {
+			t.Fatal("unfinished call acquired a completion")
+		}
+	}
+	if events[3].Kind != "cancel_receipt" || events[4].Kind != "execution_cancelled" {
+		t.Fatal("terminal ordering changed")
+	}
+}


### PR DESCRIPTION
Codex tool completion currently reaches the execution journal with status and exit code but loses command output, structured MCP results, errors and other native tool fields. Retain the original tool item on the existing before/after observations so the execution service can later project recoverable Items with actual results.

Negotiate native tool observation support independently of message observations. Legacy requests and peers retain their original tool payloads and event counts. The execution journal remains internal; native snapshots are not exposed as public Items.

Validation:
- `make check`, OpenAPI generation and targeted Codex/CLI/gateway/execution race tests passed. Docker remained stopped; Docker migration smoke was skipped.
- Dedicated PostgreSQL Store race suite passed, including negotiated tool snapshots, exact large numeric values and cancellation with an unfinished call after Store reopen.
- Actual daemon + Codex 0.153.4 passed command and MCP execution: a failing shell command retained its output and exit code; a discovered MCP tool retained text and structured content after Store reopen.
- Actual daemon + Codex message/steering/cancellation/native-history regression passed.
- Fresh independent complete-diff blind review passed with no blocking findings; the reviewer independently ran Codex/CLI/gateway/protocol/execution Go tests.

This PR is limited to internal tool-result fidelity. It does not change tool execution, approval rules, product flows, public Items/SSE, or add another model/tool loop. Only existing start/completion observations are retained; intermediate native tool-output deltas and public schema projection remain subsequent work.
