### PR TITLE
feat(agents-api): honor explicit no-environment execution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,16 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   self-hosted executor protocol. Public environment mapping, output Items/SSE,
   pending interactions, crash reconciliation and provider allocation remain separate
   slices. Unexpected interaction requests fail explicitly until supported.
+- `environment_none` advertises the Codex adapter's explicit environment-disable
+  path. Execution snapshots with public `environment.type=none` require that
+  capability and set `disable_execution_environment` on the internal prompt.
+  The daemon forces `CODEX_EXEC_SERVER_URL=none` after caller environment options
+  and confirms native `local` and `remote` environments are unknown before starting
+  or resuming a thread. Unsupported binaries fail closed. The bound device hosts
+  the engine process; it is not a user execution environment. This is not an OS
+  isolation guarantee, and engine state still lives on that host. Ordinary product
+  requests retain their existing environment. Public event admission and worker
+  scheduling remain separate from this internal dispatch capability.
 - `message_items` advertises native assistant-message observations. Agents API
   opts in with `observe_messages` only for advertised peers; ordinary product
   requests retain their existing frame sequence. Opted-in text deltas carry their

--- a/apps/parsar-daemon/internal/agent/codex/environment.go
+++ b/apps/parsar-daemon/internal/agent/codex/environment.go
@@ -1,0 +1,24 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// Check the native provider instead of assuming an older binary honors the flag.
+func verifyNoExecutionEnvironment(ctx context.Context, rpc *JSONRPCClient) error {
+	for _, id := range []string{"local", "remote"} {
+		raw, err := rpc.Request(ctx, "environment/status", map[string]string{"environmentId": id})
+		if err != nil {
+			return fmt.Errorf("codex: cannot confirm disabled execution environment: %w", err)
+		}
+		var result struct {
+			Status string `json:"status"`
+		}
+		if json.Unmarshal(raw, &result) != nil || result.Status != "unknown" {
+			return fmt.Errorf("codex: execution environment %s was not disabled", id)
+		}
+	}
+	return nil
+}

--- a/apps/parsar-daemon/internal/agent/codex/environment_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/environment_test.go
@@ -1,0 +1,43 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestNoEnvironmentRequiresNativeConfirmation(t *testing.T) {
+	for _, status := range []string{"unknown", "ready", "pending", "disconnected", ""} {
+		t.Run(status, func(t *testing.T) {
+			client, server, cleanup := NewTestClient()
+			defer cleanup()
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			done := make(chan error, 1)
+			go func() { done <- verifyNoExecutionEnvironment(ctx, client.JSONRPCClient) }()
+			for _, id := range []string{"local", "remote"} {
+				var req struct {
+					ID     string            `json:"id"`
+					Method string            `json:"method"`
+					Params map[string]string `json:"params"`
+				}
+				if err := json.NewDecoder(server.FromClient).Decode(&req); err != nil {
+					t.Fatal(err)
+				}
+				if req.Method != "environment/status" || req.Params["environmentId"] != id {
+					t.Fatal(req)
+				}
+				if err := json.NewEncoder(server.ToClient).Encode(map[string]any{"id": req.ID, "result": map[string]string{"status": status}}); err != nil {
+					t.Fatal(err)
+				}
+				if status != "unknown" {
+					break
+				}
+			}
+			if err := <-done; (err == nil) != (status == "unknown") {
+				t.Fatalf("status %q: %v", status, err)
+			}
+		})
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -121,7 +121,13 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		return nil, fmt.Errorf("codex: build session plan: %w", err)
 	}
 
-	skillRoot, err := prepareManagedSkills(parent, cfg.logger, req)
+	if req.DisableExecutionEnvironment {
+		plan.Env = append(plan.Env, "CODEX_EXEC_SERVER_URL=none")
+	}
+	skillRoot := ""
+	if !req.DisableExecutionEnvironment {
+		skillRoot, err = prepareManagedSkills(parent, cfg.logger, req)
+	}
 	if err != nil {
 		plan.Cleanup()
 		return nil, err
@@ -169,6 +175,14 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		cancelFn()
 		plan.Cleanup()
 		return nil, fmt.Errorf("codex: rpc start: %w", err)
+	}
+	if req.DisableExecutionEnvironment {
+		if err := verifyNoExecutionEnvironment(cancelCtx, rpc); err != nil {
+			cancelFn()
+			_ = rpc.Close()
+			plan.Cleanup()
+			return nil, err
+		}
 	}
 	if skillRoot != "" {
 		if err := setSkillExtraRoots(cancelCtx, rpc, []string{skillRoot}); err != nil {

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -255,14 +255,15 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 		Codex: proto.SupportedAgentKind{
 			Kind: "codex",
 			Capabilities: proto.AgentKindCapabilities{
-				Streaming:    true,
-				Permissions:  true,
-				Usage:        true,
-				Resume:       true,
-				Steering:     true,
-				DurableTurns: true,
-				MessageItems: true,
-				ToolItems:    true,
+				Streaming:       true,
+				Permissions:     true,
+				Usage:           true,
+				Resume:          true,
+				Steering:        true,
+				DurableTurns:    true,
+				MessageItems:    true,
+				ToolItems:       true,
+				EnvironmentNone: true,
 			},
 		},
 		Pi: proto.SupportedAgentKind{

--- a/apps/parsar-daemon/internal/cli/connect_test.go
+++ b/apps/parsar-daemon/internal/cli/connect_test.go
@@ -174,7 +174,7 @@ func TestDiscoverAgentCLIsBothAvailable(t *testing.T) {
 	if !got.ClaudeCode.Capabilities.Permissions || !got.ClaudeCode.Capabilities.Resume {
 		t.Fatalf("ClaudeCode capabilities = %#v", got.ClaudeCode.Capabilities)
 	}
-	if !got.Codex.Capabilities.ToolItems || !got.Codex.Capabilities.MessageItems || !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
+	if !got.Codex.Capabilities.EnvironmentNone || !got.Codex.Capabilities.ToolItems || !got.Codex.Capabilities.MessageItems || !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
 		t.Fatalf("Codex capabilities = %#v (want Streaming+Permissions+Resume)", got.Codex.Capabilities)
 	}
 	if !got.Pi.Available || got.Pi.Version != "pi 0.1.0" {

--- a/apps/parsar-daemon/internal/dispatch/environment_test.go
+++ b/apps/parsar-daemon/internal/dispatch/environment_test.go
@@ -1,0 +1,27 @@
+package dispatch_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestNoEnvironmentRejectsOtherEngineBeforeFactory(t *testing.T) {
+	h := newHarness(t)
+	defer h.router.Shutdown(context.Background())
+	called := false
+	h.reg.Register("claude_code", func(context.Context, proto.PromptRequestPayload, chan<- proto.Envelope) (agent.Session, error) {
+		called = true
+		return nil, nil
+	})
+	err := h.router.Handle(context.Background(), mustEnv(t, proto.TypePromptRequest, "none", proto.PromptRequestPayload{AgentKind: "claude_code", DisableExecutionEnvironment: true}))
+	if err == nil || called {
+		t.Fatal("unsupported engine was started", err)
+	}
+	frames := h.sender.snapshot()
+	if len(frames) != 2 || frames[0].Type != proto.TypeError || frames[1].Type != proto.TypeDone {
+		t.Fatal(frames)
+	}
+}

--- a/apps/parsar-daemon/internal/dispatch/router.go
+++ b/apps/parsar-daemon/internal/dispatch/router.go
@@ -250,6 +250,11 @@ func (r *Router) handlePromptRequest(callerCtx context.Context, env proto.Envelo
 		r.log.ErrorContext(callerCtx, "handlePromptRequest: missing agent_kind", "run_id", runID)
 		return errors.New("dispatch: prompt_request missing agent_kind")
 	}
+	if req.DisableExecutionEnvironment && req.AgentKind != "codex" {
+		err := errors.New("execution environment none requires a supported Codex engine")
+		r.emitTerminalError(callerCtx, runID, err.Error())
+		return err
+	}
 	r.log.InfoContext(callerCtx, "handlePromptRequest: decoded",
 		"run_id", runID, "agent_kind", req.AgentKind,
 		"work_dir", req.WorkDir, "prompt_len", len(req.Prompt),

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -40,7 +40,7 @@ separate future dependency for Team orchestration in Parsar, not the HTTP contra
 | Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
 | Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, environment `none`, metadata and creation retry keys |
 | Internal Turn/input persistence | Tenant-scoped atomic input batches, steering, request-level retry identity, cancellation targets and terminal outcomes |
-| Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; no public event submission or execution worker yet |
+| Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; explicit Codex no-environment execution; no public event submission or execution worker yet |
 | Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items` and tool snapshots via `tool_items`; tenant-scoped paginated Store reads |
 | Public Turn recovery | Retrieve/list persisted states with scoped pagination; see limitations below |
 | Public Items recovery | Indexed message/command/MCP/function/web-search reads, scoped pagination and restart recovery; limitations below |
@@ -116,3 +116,21 @@ Pagination orders by first-observation timestamp, then position within that sour
 and stable public ID. Distinct observations sharing exactly the same timestamp
 may therefore differ from journal order; preserving source order for that tie is
 a tracked follow-up. Content updates do not move existing Items.
+
+### No-environment execution
+
+The internal dispatcher can execute a public `environment.type=none` snapshot
+on an authenticated, bound engine host advertising `environment_none`. It does
+not allocate a local execution environment: the daemon uses upstream Codex's
+`CODEX_EXEC_SERVER_URL=none` and verifies the native environment state before
+starting/resuming. A missing capability or unsupported native method fails rather
+than falling back to local execution. Private `daemon` snapshots remain distinct.
+This is an engine tool/environment boundary, not operating-system isolation.
+Public event submission/worker scheduling and the self-hosted registry/Noise
+transport are still pending.
+
+The native reference is Codex `rust-v0.153.4`, commit
+`3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`, especially
+`codex-rs/exec-server/src/environment_provider.rs`. The self-hosted registry
+requires executor registration, harness authorization and encrypted relay;
+a daemon WebSocket URL is not that protocol.

--- a/internal/agentdaemon/device/state.go
+++ b/internal/agentdaemon/device/state.go
@@ -67,6 +67,7 @@ type KindCapabilities struct {
 	Steering           bool `json:"steering,omitempty"`
 	MessageItems       bool `json:"message_items,omitempty"`
 	ToolItems          bool `json:"tool_items,omitempty"`
+	EnvironmentNone    bool `json:"environment_none,omitempty"`
 	DurableTurns       bool `json:"durable_turns,omitempty"`
 	WorkspaceAuthoring bool `json:"workspace_authoring,omitempty"`
 }

--- a/internal/agentdaemon/gateway/session.go
+++ b/internal/agentdaemon/gateway/session.go
@@ -533,6 +533,7 @@ func deviceKindsFromHeartbeat(p proto.HeartbeatPayload) []device.SupportedAgentK
 				DurableTurns:       info.Capabilities.DurableTurns,
 				MessageItems:       info.Capabilities.MessageItems,
 				ToolItems:          info.Capabilities.ToolItems,
+				EnvironmentNone:    info.Capabilities.EnvironmentNone,
 				WorkspaceAuthoring: info.Capabilities.WorkspaceAuthoring,
 			},
 		})

--- a/internal/agentdaemon/gateway/session_test.go
+++ b/internal/agentdaemon/gateway/session_test.go
@@ -405,7 +405,7 @@ func TestSession_HeartbeatPersistsSupportedAgentKinds(t *testing.T) {
 			{
 				Kind:         "codex",
 				Available:    true,
-				Capabilities: proto.AgentKindCapabilities{Steering: true, MessageItems: true, ToolItems: true},
+				Capabilities: proto.AgentKindCapabilities{Steering: true, MessageItems: true, ToolItems: true, EnvironmentNone: true},
 			},
 		},
 	})
@@ -431,7 +431,7 @@ func TestSession_HeartbeatPersistsSupportedAgentKinds(t *testing.T) {
 	if opencode.Available || opencode.Version != "missing" || !opencode.Capabilities.Streaming {
 		t.Fatalf("opencode descriptor not converted: %#v", opencode)
 	}
-	if !byKind["codex"].Capabilities.ToolItems || claude.Capabilities.ToolItems || opencode.Capabilities.ToolItems || !byKind["codex"].Capabilities.MessageItems || !byKind["codex"].Capabilities.Steering || claude.Capabilities.Steering || opencode.Capabilities.Steering {
+	if !byKind["codex"].Capabilities.EnvironmentNone || claude.Capabilities.EnvironmentNone || opencode.Capabilities.EnvironmentNone || !byKind["codex"].Capabilities.ToolItems || claude.Capabilities.ToolItems || opencode.Capabilities.ToolItems || !byKind["codex"].Capabilities.MessageItems || !byKind["codex"].Capabilities.Steering || claude.Capabilities.Steering || opencode.Capabilities.Steering {
 		t.Fatalf("steering capability not preserved: %#v", byKind)
 	}
 	codex, found, known := sess.AgentKindStatus("codex")

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -247,6 +247,7 @@ type AgentKindCapabilities struct {
 	Steering           bool `json:"steering,omitempty"`
 	MessageItems       bool `json:"message_items,omitempty"`
 	ToolItems          bool `json:"tool_items,omitempty"`
+	EnvironmentNone    bool `json:"environment_none,omitempty"`
 	// DurableTurns includes strict resume, completion release and cancellation snapshots.
 	DurableTurns bool `json:"durable_turns,omitempty"`
 }

--- a/internal/agentdaemon/proto/outbound.go
+++ b/internal/agentdaemon/proto/outbound.go
@@ -77,10 +77,11 @@ type PromptRequestPayload struct {
 	AgentStateKey      string `json:"agent_state_key,omitempty"`
 	WorkspaceAuthoring bool   `json:"workspace_authoring,omitempty"`
 	// ReleaseOnCompletion closes the native writer before acknowledging Done.
-	ReleaseOnCompletion bool `json:"release_on_completion,omitempty"`
-	StrictResume        bool `json:"strict_resume,omitempty"`
-	ObserveMessages     bool `json:"observe_messages,omitempty"`
-	ObserveTools        bool `json:"observe_tools,omitempty"`
+	ReleaseOnCompletion         bool `json:"release_on_completion,omitempty"`
+	StrictResume                bool `json:"strict_resume,omitempty"`
+	ObserveMessages             bool `json:"observe_messages,omitempty"`
+	ObserveTools                bool `json:"observe_tools,omitempty"`
+	DisableExecutionEnvironment bool `json:"disable_execution_environment,omitempty"`
 }
 
 // PromptAttachment is one piece of non-text user input the daemon-side

--- a/services/agents-api/internal/execution/dispatcher.go
+++ b/services/agents-api/internal/execution/dispatcher.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"maps"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -18,8 +17,9 @@ import (
 
 // Snapshot is resolved internally; Daemon is not a public environment wire type.
 type Snapshot struct {
-	Agent  v1.Agent      `json:"agent"`
-	Daemon *DaemonConfig `json:"daemon"`
+	Agent       v1.Agent        `json:"agent"`
+	Daemon      *DaemonConfig   `json:"daemon"`
+	Environment *v1.Environment `json:"environment"`
 }
 
 type DaemonConfig struct {
@@ -59,12 +59,15 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 		return store.Turn{}, errors.New("device must advertise streaming, steering and durable turns for this engine")
 	}
 	var snapshot Snapshot
-	if json.Unmarshal(session.Configuration, &snapshot) != nil || snapshot.Daemon == nil || strings.TrimSpace(snapshot.Agent.Model) == "" {
+	if json.Unmarshal(session.Configuration, &snapshot) != nil || strings.TrimSpace(snapshot.Agent.Model) == "" {
 		return store.Turn{}, store.ErrInvalidInput
 	}
-	workDir := snapshot.Daemon.WorkDir
-	if workDir != "" && !filepath.IsAbs(workDir) && !strings.HasPrefix(workDir, "~/") {
-		return store.Turn{}, store.ErrInvalidInput
+	workDir, noEnvironment, err := resolveExecutionEnvironment(snapshot)
+	if err != nil {
+		return store.Turn{}, err
+	}
+	if noEnvironment && (session.Engine != "codex" || !info.Capabilities.EnvironmentNone) {
+		return store.Turn{}, errors.New("device must advertise environment_none for Codex")
 	}
 	inputs, err := d.Store.ListTurnInputs(ctx, tenantID, sessionID, turnID, 0, 1)
 	if err != nil {
@@ -93,7 +96,7 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 	if _, err := d.Store.TransitionTurn(ctx, tenantID, sessionID, turnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
 		return store.Turn{}, err
 	}
-	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true, StrictResume: true, ObserveMessages: info.Capabilities.MessageItems, ObserveTools: info.Capabilities.ToolItems}
+	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true, StrictResume: true, ObserveMessages: info.Capabilities.MessageItems, ObserveTools: info.Capabilities.ToolItems, DisableExecutionEnvironment: noEnvironment}
 	result, status := d.deliver(ctx, tenantID, sessionID, peer, req, inputs[0].Sequence)
 	if result.Done.Usage.Model == "" {
 		result.Done.Usage.Model = snapshot.Agent.Model

--- a/services/agents-api/internal/execution/environment.go
+++ b/services/agents-api/internal/execution/environment.go
@@ -1,0 +1,25 @@
+package execution
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func resolveExecutionEnvironment(snapshot Snapshot) (string, bool, error) {
+	if snapshot.Environment != nil {
+		if snapshot.Environment.Type != "none" || snapshot.Daemon != nil {
+			return "", false, store.ErrInvalidInput
+		}
+		return "", true, nil
+	}
+	if snapshot.Daemon == nil {
+		return "", false, store.ErrInvalidInput
+	}
+	workDir := snapshot.Daemon.WorkDir
+	if workDir != "" && !filepath.IsAbs(workDir) && !strings.HasPrefix(workDir, "~/") {
+		return "", false, store.ErrInvalidInput
+	}
+	return workDir, false, nil
+}

--- a/services/agents-api/internal/execution/environment_test.go
+++ b/services/agents-api/internal/execution/environment_test.go
@@ -1,0 +1,30 @@
+package execution
+
+import (
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+	"testing"
+)
+
+func TestExecutionEnvironmentDoesNotDefaultToLocal(t *testing.T) {
+	cases := []struct {
+		name          string
+		snapshot      Snapshot
+		dir           string
+		none, invalid bool
+	}{
+		{"public none", Snapshot{Environment: &v1.Environment{Type: "none"}}, "", true, false},
+		{"legacy device", Snapshot{Daemon: &DaemonConfig{WorkDir: "/workspace"}}, "/workspace", false, false},
+		{"missing", Snapshot{}, "", false, true},
+		{"conflicting", Snapshot{Environment: &v1.Environment{Type: "none"}, Daemon: &DaemonConfig{}}, "", false, true},
+		{"unsupported", Snapshot{Environment: &v1.Environment{Type: "self_hosted"}}, "", false, true},
+		{"relative", Snapshot{Daemon: &DaemonConfig{WorkDir: "workspace"}}, "", false, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir, none, err := resolveExecutionEnvironment(c.snapshot)
+			if (err != nil) != c.invalid || dir != c.dir || none != c.none {
+				t.Fatal(dir, none, err)
+			}
+		})
+	}
+}

--- a/services/agents-api/internal/store/native_environment_test.go
+++ b/services/agents-api/internal/store/native_environment_test.go
@@ -1,0 +1,156 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func TestNativeNoExecutionEnvironment(t *testing.T) {
+	binary, root := os.Getenv("PARSAR_NATIVE_DAEMON_BIN"), os.Getenv("PARSAR_NATIVE_PROOF_DIR")
+	if binary == "" || root == "" {
+		t.Skip("explicit native daemon binary and evidence directory required")
+	}
+	h := newDispatchHarness(t)
+	oldPeer, _ := h.registry.LookupDevice(h.device.ID)
+	h.conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 65*time.Second)
+	defer cancel()
+	home, err := os.MkdirTemp(root, "no-environment-native-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := filepath.Join(home, "parsar-daemon", "execution")
+	if err = os.MkdirAll(profile, 0700); err != nil {
+		t.Fatal(err)
+	}
+	auth, _ := json.Marshal(map[string]string{"server_url": h.url + "/api/v1", "runtime_id": h.device.ID, "runner_credential": h.credential, "device_name": "native proof"})
+	if err = os.WriteFile(filepath.Join(profile, "auth.json"), auth, 0600); err != nil {
+		t.Fatal(err)
+	}
+	daemonLog, err := os.Create(filepath.Join(home, "daemon.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer daemonLog.Close()
+	cmd := exec.Command(binary, "connect", "--profile", "execution")
+	cmd.Env = append(os.Environ(), "PARSAR_HOME="+home)
+	cmd.Stdout, cmd.Stderr = daemonLog, daemonLog
+	if err = cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	stopped := make(chan error, 1)
+	go func() { stopped <- cmd.Wait() }()
+	defer func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		select {
+		case <-stopped:
+		case <-time.After(8 * time.Second):
+			_ = cmd.Process.Kill()
+			<-stopped
+		}
+	}()
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		peer, e := h.registry.LookupDevice(h.device.ID)
+		if e == nil && peer != oldPeer {
+			if info, found, known := peer.AgentKindStatus("codex"); known && found && info.Available && info.Capabilities.EnvironmentNone {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("native daemon not ready; logs %s", home)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	config, _ := json.Marshal(map[string]any{"agent": map[string]string{"model": "gpt-5.5", "instructions": "Keep this instruction."}, "environment": map[string]string{"type": "none"}})
+	h.session, err = h.s.CreateSession(ctx, h.tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "native-session", Configuration: config})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = h.s.BindSessionDevice(ctx, h.tenant, h.session.ID, h.device.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	var requests atomic.Int32
+	marker := filepath.Join(home, "must-not-exist")
+	model := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || !strings.HasSuffix(r.URL.Path, "/responses") {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+			return
+		}
+		n := requests.Add(1)
+		raw, _ := json.MarshalIndent(body, "", "  ")
+		_ = os.WriteFile(filepath.Join(home, fmt.Sprintf("model-request-%d.json", n)), raw, 0600)
+		var item map[string]any
+		if n == 1 {
+			args, _ := json.Marshal(map[string]string{"cmd": "touch " + marker})
+			item = map[string]any{"id": "fc_forbidden", "type": "function_call", "call_id": "call_forbidden", "name": "exec_command", "arguments": string(args), "status": "completed"}
+		} else {
+			item = map[string]any{"id": fmt.Sprintf("message_%d", n), "type": "message", "role": "assistant", "phase": "final_answer", "status": "completed", "content": []any{map[string]any{"type": "output_text", "text": "NO-ENVIRONMENT-OK", "annotations": []any{}}}}
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		send := func(kind string, data map[string]any) {
+			data["type"] = kind
+			b, _ := json.Marshal(data)
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", kind, b)
+			w.(http.Flusher).Flush()
+		}
+		send("response.created", map[string]any{"response": map[string]any{"id": fmt.Sprintf("response_%d", n), "status": "in_progress", "output": []any{}}})
+		send("response.output_item.added", map[string]any{"output_index": 0, "item": item})
+		send("response.output_item.done", map[string]any{"output_index": 0, "item": item})
+		send("response.completed", map[string]any{"response": map[string]any{"id": fmt.Sprintf("response_%d", n), "object": "response", "created_at": time.Now().Unix(), "status": "completed", "model": "gpt-5.5", "output": []any{item}, "usage": map[string]any{"input_tokens": 10, "output_tokens": 3, "total_tokens": 13}}})
+	}))
+	defer model.Close()
+	h.d.Options = func(context.Context, store.Session) (map[string]any, error) {
+		return map[string]any{"codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}, "env": map[string]any{"CODEX_EXEC_SERVER_URL": "ws://127.0.0.1:1"}}, nil
+	}
+	first := h.message("first", "Return an answer.")
+	h.finished(h.run(ctx, first.TurnID), store.TurnCompleted)
+	bound, err := h.s.GetSessionDevice(ctx, h.tenant, h.session.ID)
+	if err != nil || bound.NativeSessionID == "" {
+		t.Fatal(bound, err)
+	}
+	second := h.message("second", "Continue the same conversation.")
+	h.finished(h.run(ctx, second.TurnID), store.TurnCompleted)
+	again, err := h.s.GetSessionDevice(ctx, h.tenant, h.session.ID)
+	if err != nil || again.NativeSessionID != bound.NativeSessionID {
+		t.Fatal(again, err)
+	}
+	if requests.Load() != 3 {
+		t.Fatalf("expected rejected command and two answers; requests=%d; evidence %s", requests.Load(), home)
+	}
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("forbidden command may have executed: %v", err)
+	}
+	page, err := h.s.ListItems(ctx, h.tenant, h.session.ID, "", 100, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	answers := 0
+	for _, item := range page.Items {
+		if item.Role == "assistant" && item.Status == "completed" && len(item.Content) > 0 && item.Content[0].Text != nil && *item.Content[0].Text == "NO-ENVIRONMENT-OK" {
+			answers++
+		}
+	}
+	if answers != 2 {
+		t.Fatal(page)
+	}
+	t.Logf("Native environment none: command rejected, caller override ignored, two Turns resumed and recovered. Evidence: %s", home)
+}

--- a/services/agents-api/internal/store/no_environment_test.go
+++ b/services/agents-api/internal/store/no_environment_test.go
@@ -1,0 +1,29 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func TestNoEnvironmentRejectsUnadvertisedDeviceBeforeClaim(t *testing.T) {
+	h := newDispatchHarness(t)
+	ctx := context.Background()
+	var err error
+	h.session, err = h.s.CreateSession(ctx, h.tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "none", Configuration: []byte(`{"agent":{"model":"test-model"},"environment":{"type":"none"}}`)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = h.s.BindSessionDevice(ctx, h.tenant, h.session.ID, h.device.ID); err != nil {
+		t.Fatal(err)
+	}
+	input := h.message("first", "Answer")
+	if _, err = h.d.Run(ctx, h.tenant, h.session.ID, input.TurnID); err == nil {
+		t.Fatal("unsupported environment admitted")
+	}
+	turn, err := h.s.GetTurn(ctx, h.tenant, h.session.ID, input.TurnID)
+	if err != nil || turn.Status != store.TurnQueued {
+		t.Fatal(turn, err)
+	}
+}


### PR DESCRIPTION
Internal execution can now run a Session configured with `environment.type=none` without silently selecting the device's local execution environment. Supporting Codex hosts explicitly disable the native environment and verify that local/remote environments are absent before starting or resuming; unsupported engines and peers fail explicitly. Existing private daemon snapshots and ordinary product requests retain their defaults.

This is an engine environment boundary, not OS isolation. The device still hosts the engine and its state. Public event admission/worker scheduling, SSE, self-hosted registry/Noise transport and product cutover remain outside this PR.

Validation: `make check`, OpenAPI regeneration with no drift, full dedicated PostgreSQL race suite, and a real rebuilt daemon + Codex 0.153.4 proof. The native proof rejects a forced shell call, ignores a caller environment override, resumes two Turns and recovers their Items. Docker stayed stopped. Independent blind review completed with no actionable findings.
