### PR TITLE
ci: cover daemon packages in required Go checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,6 +12,7 @@ on:
       - "contracts/agents-api/**"
       - "packages/agents-client/**"
       - "internal/**"
+      - "apps/parsar-daemon/**"
       - "apps/web/**"
       - "packages/cli/**"
       - "packages/opencode-plugin/**"
@@ -35,6 +36,7 @@ on:
       - "contracts/agents-api/**"
       - "packages/agents-client/**"
       - "internal/**"
+      - "apps/parsar-daemon/**"
       - "apps/web/**"
       - "packages/cli/**"
       - "packages/opencode-plugin/**"
@@ -106,7 +108,7 @@ jobs:
                 go=true
                 store=true
                 ;;
-              server/*|internal/*|services/agents-api/*|contracts/agents-api/*|packages/agents-client/*)
+              server/*|internal/*|apps/parsar-daemon/*|services/agents-api/*|contracts/agents-api/*|packages/agents-client/*)
                 go=true
                 ;;
               apps/web/*)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1255,12 +1255,14 @@ make check
 
 `make check` is the full local gate. It is composed of narrower targets that
 CI may run independently based on the changed paths: `make check-go` for sqlc
-drift plus non-store Go tests (including the shared daemon gateway and device packages), `make check-store` for migration/store
+drift plus non-store Go tests (including all daemon adapters and shared daemon
+protocol/gateway packages), `make check-store` for migration/store
 integration tests, `make check-web` for web typecheck plus design lint, and
 `make check-cli` for CLI/plugin typechecks, and `make check-installer` for
 Docker-free installer lifecycle checks, plus `make check-agents-api` for the
 execution service. Keep the subtargets aligned with
-the full gate whenever the required checks change.
+the full gate whenever the required checks change. Daemon-only changes must
+trigger the same Go checks in CI as server changes.
 
 Pin the CI vulnerability scanner to a version compatible with the workflow's
 Go toolchain; do not use `@latest` for that build-time tool.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-GO_TEST_PACKAGE ?= $(shell cd server && go list ./... ../internal/agentdaemon/gateway ../internal/agentdaemon/device ../services/agents-api/... ../packages/agents-client/... | grep -Ev '/server/internal/(store|seed)$$')
+GO_TEST_PACKAGE ?= $(shell cd server && go list ./... ../apps/parsar-daemon/... ../internal/agentdaemon/... ../services/agents-api/... ../packages/agents-client/... | grep -Ev '/server/internal/(store|seed)$$')
 GO_TEST_RUN ?=
 GO_TEST_ARGS ?=
 SQLC_VERSION ?= v1.29.0


### PR DESCRIPTION
Daemon-only changes could miss the Go test workflow, and the default local gate omitted daemon adapter and shared protocol tests. Include those packages in the existing Go gate and select it for daemon paths on pushes and pull requests.

Limited to Makefile, CI path selection and the contributor guide; production code is unchanged.

Validation: `make check` passed with daemon packages included. YAML parsing and eight path-classification cases passed; the default target contains all 22 daemon/shared packages, and a failing Go invocation propagates a failing Make status. Independent blind review found no issues and also ran the default Go test target successfully. Local Docker remained stopped.

The newly covered Linux run exposed a pre-existing steering test race, fixed separately in #528. This branch is rebased on that fix; its reviewed gate changes are unchanged, and the complete local gate passed again.
