### PR TITLE
test(codex): synchronize steering completion fixture

### DIFF
--- a/apps/parsar-daemon/internal/agent/codex/session_steering_lifecycle_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_steering_lifecycle_test.go
@@ -19,7 +19,11 @@ func TestSteeringReceiptTimeoutAndCompletionKeepProcessAlive(t *testing.T) {
 			s := &Session{rpc: client.JSONRPCClient, cancelCtx: context.Background(), out: out, cfg: sessionConfig{logger: obslog.Bg()}}
 			s.setThreadID("thread")
 			s.startSteering(json.RawMessage(`{"threadId":"thread","turn":{"id":"turn"}}`))
-			ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+			timeout := 50 * time.Millisecond
+			if complete {
+				timeout = time.Second
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 			done := make(chan error, 1)
 			go func() { done <- s.Steer(ctx, proto.PromptSteerPayload{InputID: "input", Text: "extra"}) }()
@@ -29,6 +33,21 @@ func TestSteeringReceiptTimeoutAndCompletionKeepProcessAlive(t *testing.T) {
 			}
 			// Withhold the response after reading the entire request frame.
 			if complete {
+				// Reading the pipe does not mean its writer has returned yet.
+				for {
+					client.pendingMu.Lock()
+					pending := client.pending[request.ID]
+					waiting := pending != nil && pending.timer != nil
+					client.pendingMu.Unlock()
+					if waiting {
+						break
+					}
+					select {
+					case <-ctx.Done():
+						t.Fatal("steering request did not reach response wait")
+					case <-time.After(time.Millisecond):
+					}
+				}
 				s.onTurnCompleted(json.RawMessage(`{"threadId":"thread","turn":{"id":"turn","status":"completed"}}`))
 			}
 			select {


### PR DESCRIPTION
The steering completion test could cancel while its asynchronous pipe write was still returning, even though the fake server had decoded the request. This exercised interrupted-write cleanup instead of response waiting and intermittently failed on Linux.

Wait for the pending request's response timer before simulating normal completion. Retain the receipt error, process-alive and single-terminal assertions; production code is unchanged.

Validation: reproduced the original failure with repeated runs; the corrected lifecycle test passed 100 iterations with `-race`, Linux amd64 also passed 100 iterations, the full Codex package passed with `-race`, and `make check` passed. Independent blind review found no issues and separately passed 100 iterations with the race detector. This is the prerequisite for the daemon test gate in #527.
