### PR TITLE
fix(agents-api): preserve Item observation order

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,8 +259,12 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
 - Public Items list reads a persisted execution-owned projection, updated in the
   same Session transaction as admitted messages and journal batches. IDs derive
   from the Turn and source identity; the first-observation timestamp and stable
-  tie breakers never change when content or status changes. Equal timestamps
-  use per-source position and public ID, not the original event ordinal. Cursors are scoped to the authenticated Session.
+  tie breakers never change when content or status changes. Allocate each new
+  Item's Session position under the Session lock, preserving observation order
+  for equal timestamps. Allocate a separate zero-based `output_index` per Turn;
+  inputs do not consume output indexes. Updates and retries retain both values.
+  Existing indexed history keeps its pre-upgrade deterministic order; missing
+  original ordering cannot be reconstructed. Cursors are scoped to the authenticated Session.
   Terminal Turns expose unfinished Items as `incomplete`, preserving completed
   message/tool states independently of the Turn outcome.
 - Pre-Items Turns rebuild their index once from paged persisted inputs/events,

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -111,10 +111,12 @@ Legacy Done frames alone do not complete assistant Items. Aggregate answer text
 is confirmed by successful Turn termination; failed Turns retain observed deltas
 instead of treating adapter diagnostics as assistant output.
 
-Pagination orders by first-observation timestamp, then position within that source
-and stable public ID. Distinct observations sharing exactly the same timestamp
-may therefore differ from journal order; preserving source order for that tie is
-a tracked follow-up. Content updates do not move existing Items.
+Pagination orders by first-observation timestamp, then the Item's immutable
+Session position and public ID. New Items retain observation order even when
+timestamps match. The index also stores a zero-based output index per Turn for
+future streaming; inputs do not consume it. Updates and retries do not move Items
+or change output indexes. Existing indexed history retains its pre-upgrade
+deterministic order rather than guessing an unavailable original source order.
 
 ### No-environment execution
 

--- a/services/agents-api/internal/db/queries/session_items.sql
+++ b/services/agents-api/internal/db/queries/session_items.sql
@@ -2,8 +2,12 @@
 SELECT * FROM session_items WHERE session_id = $1 AND id = $2;
 
 -- name: PutSessionItem :exec
-INSERT INTO session_items(id, session_id, turn_id, created_at, payload, position)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO session_items(id, session_id, turn_id, created_at, payload, position, output_index)
+VALUES (sqlc.arg(id), sqlc.arg(session_id), sqlc.arg(turn_id), sqlc.arg(created_at), sqlc.arg(payload),
+    (SELECT COALESCE(max(position), -1) + 1 FROM session_items WHERE session_id = sqlc.arg(session_id)),
+    CASE WHEN sqlc.arg(is_output)::boolean THEN
+        (SELECT COALESCE(max(output_index), -1) + 1 FROM session_items WHERE turn_id = sqlc.arg(turn_id))
+    END)
 ON CONFLICT (id) DO UPDATE SET payload = EXCLUDED.payload;
 
 -- name: ListSessionItems :many

--- a/services/agents-api/internal/db/sqlc/models.go
+++ b/services/agents-api/internal/db/sqlc/models.go
@@ -36,12 +36,13 @@ type SessionDevice struct {
 }
 
 type SessionItem struct {
-	ID        pgtype.UUID        `json:"id"`
-	SessionID pgtype.UUID        `json:"session_id"`
-	TurnID    pgtype.UUID        `json:"turn_id"`
-	CreatedAt pgtype.Timestamptz `json:"created_at"`
-	Position  int32              `json:"position"`
-	Payload   []byte             `json:"payload"`
+	ID          pgtype.UUID        `json:"id"`
+	SessionID   pgtype.UUID        `json:"session_id"`
+	TurnID      pgtype.UUID        `json:"turn_id"`
+	CreatedAt   pgtype.Timestamptz `json:"created_at"`
+	Position    int32              `json:"position"`
+	Payload     []byte             `json:"payload"`
+	OutputIndex pgtype.Int4        `json:"output_index"`
 }
 
 type Turn struct {

--- a/services/agents-api/internal/db/sqlc/session_items.sql.go
+++ b/services/agents-api/internal/db/sqlc/session_items.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getSessionItem = `-- name: GetSessionItem :one
-SELECT id, session_id, turn_id, created_at, position, payload FROM session_items WHERE session_id = $1 AND id = $2
+SELECT id, session_id, turn_id, created_at, position, payload, output_index FROM session_items WHERE session_id = $1 AND id = $2
 `
 
 type GetSessionItemParams struct {
@@ -30,6 +30,7 @@ func (q *Queries) GetSessionItem(ctx context.Context, arg GetSessionItemParams) 
 		&i.CreatedAt,
 		&i.Position,
 		&i.Payload,
+		&i.OutputIndex,
 	)
 	return i, err
 }
@@ -250,8 +251,12 @@ func (q *Queries) MarkItemsIndexed(ctx context.Context, arg MarkItemsIndexedPara
 }
 
 const putSessionItem = `-- name: PutSessionItem :exec
-INSERT INTO session_items(id, session_id, turn_id, created_at, payload, position)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO session_items(id, session_id, turn_id, created_at, payload, position, output_index)
+VALUES ($1, $2, $3, $4, $5,
+    (SELECT COALESCE(max(position), -1) + 1 FROM session_items WHERE session_id = $2),
+    CASE WHEN $6::boolean THEN
+        (SELECT COALESCE(max(output_index), -1) + 1 FROM session_items WHERE turn_id = $3)
+    END)
 ON CONFLICT (id) DO UPDATE SET payload = EXCLUDED.payload
 `
 
@@ -261,7 +266,7 @@ type PutSessionItemParams struct {
 	TurnID    pgtype.UUID        `json:"turn_id"`
 	CreatedAt pgtype.Timestamptz `json:"created_at"`
 	Payload   []byte             `json:"payload"`
-	Position  int32              `json:"position"`
+	IsOutput  bool               `json:"is_output"`
 }
 
 func (q *Queries) PutSessionItem(ctx context.Context, arg PutSessionItemParams) error {
@@ -271,7 +276,7 @@ func (q *Queries) PutSessionItem(ctx context.Context, arg PutSessionItemParams) 
 		arg.TurnID,
 		arg.CreatedAt,
 		arg.Payload,
-		arg.Position,
+		arg.IsOutput,
 	)
 	return err
 }

--- a/services/agents-api/internal/store/item_order_migration_test.go
+++ b/services/agents-api/internal/store/item_order_migration_test.go
@@ -1,0 +1,131 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/items"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/pressly/goose/v3"
+)
+
+func TestItemOrderMigrationPreservesIndexedHistory(t *testing.T) {
+	ctx := context.Background()
+	_, pool := store.NewTestStore(t)
+	schema := "item_order_" + uuid.New().String()[:8]
+	quoted := pgx.Identifier{schema}.Sanitize()
+	if _, err := pool.Exec(ctx, "CREATE SCHEMA "+quoted); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if _, err := pool.Exec(ctx, "DROP SCHEMA "+quoted+" CASCADE"); err != nil {
+			t.Error(err)
+		}
+	})
+	cfg := pool.Config().ConnConfig.Copy()
+	cfg.RuntimeParams["search_path"] = schema
+	db := sql.OpenDB(stdlib.GetConnector(*cfg))
+	t.Cleanup(func() { _ = db.Close() })
+	provider, err := goose.NewProvider(goose.DialectPostgres, db, os.DirFS("../../migrations"), goose.WithTableName("agents_api_schema_version"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = provider.UpTo(ctx, 10); err != nil {
+		t.Fatal(err)
+	}
+	session, turn, tenant := uuid.NewString(), uuid.NewString(), uuid.NewString()
+	if _, err = db.ExecContext(ctx, "INSERT INTO sessions(id,tenant_id,engine,idempotency_key,request_hash) VALUES ($1,$2,'codex','legacy','legacy')", session, tenant); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = db.ExecContext(ctx, "INSERT INTO turns(id,session_id) VALUES ($1,$2)", turn, session); err != nil {
+		t.Fatal(err)
+	}
+	for i, id := range []string{
+		"00000000-0000-0000-0000-000000000003",
+		"00000000-0000-0000-0000-000000000001",
+		"00000000-0000-0000-0000-000000000002",
+	} {
+		payload := `{"type":"function_call_output"}`
+		if i == 1 {
+			payload = `{"type":"message","role":"user"}`
+		}
+		if _, err = db.ExecContext(ctx, "INSERT INTO session_items(id,session_id,turn_id,created_at,position,payload) VALUES ($1,$2,$3,'2026-01-01',0,$4)", id, session, turn, payload); err != nil {
+			t.Fatal(err)
+		}
+	}
+	readIDs := func() []string {
+		t.Helper()
+		rows, err := db.QueryContext(ctx, "SELECT id FROM session_items ORDER BY created_at,position,id")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rows.Close()
+		var ids []string
+		for rows.Next() {
+			var id string
+			if err = rows.Scan(&id); err != nil {
+				t.Fatal(err)
+			}
+			ids = append(ids, id)
+		}
+		if err = rows.Err(); err != nil {
+			t.Fatal(err)
+		}
+		return ids
+	}
+	want := readIDs()
+	if _, err = provider.UpTo(ctx, 11); err != nil {
+		t.Fatal(err)
+	}
+	if got := readIDs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("migration reordered history: %v; want %v", got, want)
+	}
+	for i, id := range want {
+		var position int
+		var output pgtype.Int4
+		if err = db.QueryRowContext(ctx, "SELECT position,output_index FROM session_items WHERE id=$1", id).Scan(&position, &output); err != nil {
+			t.Fatal(err)
+		}
+		if position != i || output.Valid != (i > 0) || (output.Valid && int(output.Int32) != i-1) {
+			t.Fatalf("migrated item %d: position=%d output=%+v", i, position, output)
+		}
+	}
+	poolConfig := pool.Config()
+	poolConfig.ConnConfig = cfg
+	migratedPool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(migratedPool.Close)
+	s := store.New(migratedPool)
+	if _, err = s.TransitionTurn(ctx, tenant, session, turn, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
+		t.Fatal(err)
+	}
+	if err = s.AppendTurnEvents(ctx, tenant, session, turn, 1, []store.ExecutionEvent{{Kind: "delta", Payload: json.RawMessage(`{"item_id":"after-upgrade","delta":"continued"}`)}}); err != nil {
+		t.Fatal(err)
+	}
+	addedID := items.Identity(turn, "message:after-upgrade")
+	var position, output int
+	if err = db.QueryRowContext(ctx, "SELECT position,output_index FROM session_items WHERE id=$1", addedID).Scan(&position, &output); err != nil || position != 3 || output != 2 {
+		t.Fatalf("post-upgrade append: position=%d output=%d err=%v", position, output, err)
+	}
+	want = append(want, addedID)
+	if _, err = provider.Down(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if got := readIDs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("downgrade reordered history: %v", got)
+	}
+	if _, err = provider.UpTo(ctx, 11); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/services/agents-api/internal/store/item_order_test.go
+++ b/services/agents-api/internal/store/item_order_test.go
@@ -1,0 +1,147 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/items"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestItemObservationOrderSurvivesTiesUpdatesRetriesAndRecovery(t *testing.T) {
+	ctx := context.Background()
+	s, pool := store.NewTestStore(t)
+	tenant := uuid.NewString()
+	session, err := s.CreateSession(ctx, tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "ordered"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := s.SubmitMessage(ctx, tenant, session.ID, "first", json.RawMessage(`{"text":"question"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = s.TransitionTurn(ctx, tenant, session.ID, input.TurnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress})
+	if err != nil {
+		t.Fatal(err)
+	}
+	page, err := s.ListItems(ctx, tenant, session.ID, "", 100, true)
+	if err != nil || len(page.Items) != 1 {
+		t.Fatal(page, err)
+	}
+	want := []string{page.Items[0].ID}
+	keys := []string{"first", "second", "third"}
+	// Oppose UUID order so a timestamp tie cannot accidentally pass this check.
+	sort.Slice(keys, func(i, j int) bool {
+		return items.Identity(input.TurnID, "message:"+keys[i]) > items.Identity(input.TurnID, "message:"+keys[j])
+	})
+	var batch []store.ExecutionEvent
+	for _, key := range keys {
+		payload, _ := json.Marshal(map[string]string{"id": key, "status": "in_progress"})
+		batch = append(batch, store.ExecutionEvent{Kind: "output_message", Payload: payload})
+		want = append(want, items.Identity(input.TurnID, "message:"+key))
+	}
+	for range 2 {
+		if err = s.AppendTurnEvents(ctx, tenant, session.ID, input.TurnID, 1, batch); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err = s.SubmitMessage(ctx, tenant, session.ID, "steer", json.RawMessage(`{"text":"continue"}`)); err != nil {
+		t.Fatal(err)
+	}
+	page, err = s.ListItems(ctx, tenant, session.ID, "", 100, true)
+	if err != nil || len(page.Items) != 5 {
+		t.Fatal(page, err)
+	}
+	want = append(want, page.Items[4].ID)
+	completion, _ := json.Marshal(map[string]string{"id": keys[0], "status": "completed", "text": "final"})
+	batch = []store.ExecutionEvent{{Kind: "output_message", Payload: completion}, {Kind: "delta", Payload: json.RawMessage(`{"item_id":"last","delta":"partial"}`)}}
+	for range 2 {
+		if err = s.AppendTurnEvents(ctx, tenant, session.ID, input.TurnID, 4, batch); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want = append(want, items.Identity(input.TurnID, "message:last"))
+	bad := []store.ExecutionEvent{
+		{Kind: "delta", Payload: json.RawMessage(`{"item_id":"rollback","delta":"discard"}`)},
+		{Kind: "output_message", Payload: json.RawMessage(`{"id":"invalid","status":"invalid"}`)},
+	}
+	if err = s.AppendTurnEvents(ctx, tenant, session.ID, input.TurnID, 6, bad); err == nil {
+		t.Fatal("invalid batch accepted")
+	}
+	if err = s.AppendTurnEvents(ctx, tenant, session.ID, input.TurnID, 6, []store.ExecutionEvent{{Kind: "delta", Payload: json.RawMessage(`{"item_id":"after-rollback","delta":"retained"}`)}}); err != nil {
+		t.Fatal(err)
+	}
+	want = append(want, items.Identity(input.TurnID, "message:after-rollback"))
+	if _, err = pool.Exec(ctx, "UPDATE session_items SET created_at='2026-01-01' WHERE session_id=$1", session.ID); err != nil {
+		t.Fatal(err)
+	}
+	checkOrder := func() {
+		t.Helper()
+		for _, asc := range []bool{true, false} {
+			var got []string
+			cursor := ""
+			for {
+				page, err := store.New(pool).ListItems(ctx, tenant, session.ID, cursor, 2, asc)
+				if err != nil {
+					t.Fatal(err)
+				}
+				for _, item := range page.Items {
+					got = append(got, item.ID)
+				}
+				if !page.HasMore {
+					break
+				}
+				cursor = page.Items[len(page.Items)-1].ID
+			}
+			if !asc {
+				for i, j := 0, len(got)-1; i < j; i, j = i+1, j-1 {
+					got[i], got[j] = got[j], got[i]
+				}
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("observation order = %v; want %v", got, want)
+			}
+		}
+	}
+	checkOrder()
+	for position, id := range want {
+		var storedPosition int
+		var output pgtype.Int4
+		if err = pool.QueryRow(ctx, "SELECT position, output_index FROM session_items WHERE id=$1", id).Scan(&storedPosition, &output); err != nil {
+			t.Fatal(err)
+		}
+		if storedPosition != position || output.Valid != (position != 0 && position != 4) {
+			t.Fatalf("item %d: position=%d output=%+v", position, storedPosition, output)
+		}
+		index := position - 1
+		if position > 4 {
+			index--
+		}
+		if output.Valid && int(output.Int32) != index {
+			t.Fatalf("output index = %d, want %d", output.Int32, index)
+		}
+	}
+	if _, err = s.CompleteExecution(ctx, tenant, session.ID, input.TurnID, store.TurnCancelled, json.RawMessage(`{}`), "", input.Sequence); err != nil {
+		t.Fatal(err)
+	}
+	checkOrder()
+	next, err := s.SubmitMessage(ctx, tenant, session.ID, "next-turn", json.RawMessage(`{"text":"new turn"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = s.TransitionTurn(ctx, tenant, session.ID, next.TurnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
+		t.Fatal(err)
+	}
+	if err = s.AppendTurnEvents(ctx, tenant, session.ID, next.TurnID, 1, []store.ExecutionEvent{{Kind: "delta", Payload: json.RawMessage(`{"item_id":"new","delta":"new turn"}`)}}); err != nil {
+		t.Fatal(err)
+	}
+	var index int
+	if err = pool.QueryRow(ctx, "SELECT output_index FROM session_items WHERE id=$1", items.Identity(next.TurnID, "message:new")).Scan(&index); err != nil || index != 0 {
+		t.Fatalf("new Turn output index=%d: %v", index, err)
+	}
+}

--- a/services/agents-api/internal/store/item_projection.go
+++ b/services/agents-api/internal/store/item_projection.go
@@ -19,7 +19,7 @@ func projectItemSource(ctx context.Context, q *sqlc.Queries, session, turn pgtyp
 	if err != nil {
 		return fmt.Errorf("project execution item: %w", err)
 	}
-	for position, update := range updates {
+	for _, update := range updates {
 		id, _ := parseID(update.Item.ID)
 		if update.LegacyFinal {
 			native, err := q.HasNativeMessageItem(ctx, sqlc.HasNativeMessageItemParams{TurnID: turn, ID: id})
@@ -45,7 +45,7 @@ func projectItemSource(ctx context.Context, q *sqlc.Queries, session, turn pgtyp
 		if err != nil {
 			return err
 		}
-		if err = q.PutSessionItem(ctx, sqlc.PutSessionItemParams{ID: id, SessionID: session, TurnID: turn, CreatedAt: created, Payload: payload, Position: int32(position)}); err != nil {
+		if err = q.PutSessionItem(ctx, sqlc.PutSessionItemParams{ID: id, SessionID: session, TurnID: turn, CreatedAt: created, Payload: payload, IsOutput: kind != "message"}); err != nil {
 			return err
 		}
 	}

--- a/services/agents-api/migrations/000011_item_order.sql
+++ b/services/agents-api/migrations/000011_item_order.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+ALTER TABLE session_items ADD COLUMN output_index integer CHECK (output_index >= 0);
+
+WITH ordered AS (
+    SELECT id,
+        (row_number() OVER (PARTITION BY session_id ORDER BY created_at, position, id) - 1)::integer AS item_position,
+        CASE WHEN payload->>'role' IS DISTINCT FROM 'user' THEN
+            (count(*) FILTER (WHERE payload->>'role' IS DISTINCT FROM 'user') OVER (
+                PARTITION BY turn_id ORDER BY created_at, position, id ROWS UNBOUNDED PRECEDING
+            ) - 1)::integer
+        END AS output_index
+    FROM session_items
+)
+UPDATE session_items i SET position = ordered.item_position, output_index = ordered.output_index
+FROM ordered WHERE i.id = ordered.id;
+
+CREATE UNIQUE INDEX session_items_position_idx ON session_items(session_id, position);
+CREATE UNIQUE INDEX session_items_output_idx ON session_items(turn_id, output_index);
+
+-- +goose Down
+DROP INDEX session_items_output_idx;
+DROP INDEX session_items_position_idx;
+ALTER TABLE session_items DROP COLUMN output_index;


### PR DESCRIPTION
Items first observed at the same timestamp could be returned in UUID order instead of execution order. Allocate an immutable Session position and a zero-based output index per Turn under the existing Session lock. Input Items do not consume output indexes, and updates/retries retain both values. Existing indexed history preserves its previous deterministic order during migration.

This prepares Item ordering for the separately tracked live SSE work. It changes only the Agents API index, migration, generated queries, related tests and documentation; the public Item shape and Parsar product flows are unchanged.

Validation: required `make check`; dedicated PostgreSQL ordering, migration/continued writes/downgrade, pagination, retry, rollback and new-Turn checks; full Store/native execution regression; strict official Python and Go SDK checks. Independent blind review found no actionable issues. The reviewer ran Item projection tests; the dedicated database and native checks above were run by the author.
