### PR TITLE
feat(daemon): bridge native function calls and results

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,6 +220,14 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   the engine process; it is not a user execution environment. This is not an OS
   isolation guarantee, and engine state still lives on that host. Ordinary product
   requests retain their existing environment. The public worker selects an authenticated same-tenant engine host for this mode.
+- `function_tools` advertises the optional native function-call bridge. Explicit
+  prompt definitions become Codex dynamic tools; unchanged prompts carry none.
+  Requests and textual results are scoped by Run and native call ID. Reuse
+  application receipts and conflict detection; a receipt confirms the native
+  reply was written, not that an external side effect succeeded. Pending calls
+  end with their Run; the execution service owns persistence and recovery, while
+  Parsar retains business approval and credential-owner authorization. Do not
+  map native approval requests to invented official protocol resources.
 - `message_items` advertises native assistant-message observations. Agents API
   opts in with `observe_messages` only for advertised peers; ordinary product
   requests retain their existing frame sequence. Opted-in text deltas carry their

--- a/apps/parsar-daemon/internal/agent/codex/functions.go
+++ b/apps/parsar-daemon/internal/agent/codex/functions.go
@@ -1,0 +1,135 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+type dynamicFunctionTool struct {
+	Type        string          `json:"type"`
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+type functionCalls struct {
+	mu          sync.Mutex
+	definitions []dynamicFunctionTool
+	names       map[string]bool
+	pending     map[string]any
+	closed      bool
+}
+
+func prepareFunctionTools(tools []proto.FunctionTool) (*functionCalls, error) {
+	state := &functionCalls{names: map[string]bool{}, pending: map[string]any{}}
+	if len(tools) > 64 {
+		return nil, errors.New("at most 64 function tools are supported")
+	}
+	for _, tool := range tools {
+		var schema map[string]any
+		if strings.TrimSpace(tool.Name) == "" || state.names[tool.Name] || json.Unmarshal(tool.Parameters, &schema) != nil || schema == nil {
+			return nil, errors.New("function tools require unique names and object schemas")
+		}
+		state.names[tool.Name] = true
+		state.definitions = append(state.definitions, dynamicFunctionTool{Type: "function", Name: tool.Name, Description: tool.Description, InputSchema: tool.Parameters})
+	}
+	return state, nil
+}
+
+func (s *Session) handleFunctionCall(raw json.RawMessage, rpcID any) (any, error) {
+	var call struct {
+		ThreadID  string          `json:"threadId"`
+		TurnID    string          `json:"turnId"`
+		CallID    string          `json:"callId"`
+		Namespace *string         `json:"namespace"`
+		Tool      string          `json:"tool"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.Unmarshal(raw, &call); err != nil {
+		return nil, err
+	}
+	if s.functions == nil || !s.functions.names[call.Tool] || call.Namespace != nil || call.CallID == "" || call.ThreadID != s.currentThreadID() || call.TurnID == "" || !json.Valid(call.Arguments) {
+		return nil, errors.New("unexpected function call")
+	}
+	s.functions.mu.Lock()
+	if s.functions.closed || s.cancelled.Load() || s.terminal.Load() || s.functions.pending[call.CallID] != nil || len(s.functions.pending) >= 64 {
+		s.functions.mu.Unlock()
+		return nil, errors.New("function call cannot be admitted")
+	}
+	s.functions.pending[call.CallID] = rpcID
+	s.functions.mu.Unlock()
+	env, err := proto.NewEnvelope(proto.TypeFunctionCall, s.runID, proto.FunctionCallPayload{CallID: call.CallID, Name: call.Tool, Arguments: call.Arguments})
+	if err == nil {
+		err = s.sendFunctionCall(env)
+	}
+	if err != nil {
+		s.functions.mu.Lock()
+		delete(s.functions.pending, call.CallID)
+		s.functions.mu.Unlock()
+		return nil, err
+	}
+	return DeferReply, nil
+}
+
+func (s *Session) sendFunctionCall(env proto.Envelope) error {
+	s.outMu.RLock()
+	defer s.outMu.RUnlock()
+	if s.outClosed {
+		return agent.ErrUnknownFunctionCall
+	}
+	timer := time.NewTimer(terminalSendTimeout)
+	defer timer.Stop()
+	select {
+	case s.out <- env:
+		return nil
+	case <-s.cancelCtx.Done():
+		return s.cancelCtx.Err()
+	case <-timer.C:
+		return errors.New("function call delivery timed out")
+	}
+}
+
+func (s *Session) SubmitFunctionResult(ctx context.Context, result proto.FunctionResultPayload) error {
+	if s.functions == nil {
+		return agent.ErrUnknownFunctionCall
+	}
+	s.functions.mu.Lock()
+	defer s.functions.mu.Unlock()
+	id, exists := s.functions.pending[result.CallID]
+	if !exists || s.functions.closed || s.cancelled.Load() || s.terminal.Load() {
+		return agent.ErrUnknownFunctionCall
+	}
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	reply := struct {
+		Success      bool           `json:"success"`
+		ContentItems []functionText `json:"contentItems"`
+	}{Success: result.Success, ContentItems: []functionText{{Type: "inputText", Text: result.Text}}}
+	if err := s.rpc.writeFrameContext(ctx, JsonRpcResponse{JsonRpc: JsonRpcVersion, ID: id, Result: reply}); err != nil {
+		return fmt.Errorf("write function result: %w", err)
+	}
+	delete(s.functions.pending, result.CallID)
+	return nil
+}
+
+type functionText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func (s *Session) stopFunctionCalls() {
+	if s.functions != nil {
+		s.functions.mu.Lock()
+		s.functions.closed = true
+		clear(s.functions.pending)
+		s.functions.mu.Unlock()
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/functions_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/functions_test.go
@@ -1,0 +1,105 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func TestFunctionCallWaitsAndRepliesOnce(t *testing.T) {
+	for _, success := range []bool{true, false} {
+		t.Run(map[bool]string{true: "success", false: "failure"}[success], func(t *testing.T) {
+			tc, srv, cleanup := NewTestClient()
+			defer cleanup()
+			s, out := newInteractionTestSession(tc.JSONRPCClient)
+			var err error
+			s.functions, err = prepareFunctionTools([]proto.FunctionTool{{Name: "lookup", Parameters: json.RawMessage(`{"type":"object"}`)}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			s.setThreadID("thread")
+			params := map[string]any{"threadId": "thread", "turnId": "turn", "callId": "call", "tool": "lookup", "arguments": map[string]string{"ticket": "42"}}
+			if err := SendServerRequest(srv, "rpc-call", "item/tool/call", params); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case env := <-out:
+				var call proto.FunctionCallPayload
+				if err := env.DecodePayload(&call); err != nil || env.Type != proto.TypeFunctionCall || env.ID != "run-test" || call.CallID != "call" || call.Name != "lookup" {
+					t.Fatal(env, err)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("missing function call")
+			}
+			finished := make(chan error, 1)
+			go func() {
+				finished <- s.SubmitFunctionResult(t.Context(), proto.FunctionResultPayload{CallID: "call", Success: success, Text: "answer"})
+			}()
+			var reply struct {
+				ID     string          `json:"id"`
+				Result json.RawMessage `json:"result"`
+			}
+			if err := json.NewDecoder(srv.FromClient).Decode(&reply); err != nil {
+				t.Fatal(err)
+			}
+			if reply.ID != "rpc-call" {
+				t.Fatal(reply.ID)
+			}
+			if err := <-finished; err != nil {
+				t.Fatal(err)
+			}
+			var result struct {
+				Success bool           `json:"success"`
+				Content []functionText `json:"contentItems"`
+			}
+			if err := json.Unmarshal(reply.Result, &result); err != nil || result.Success != success || len(result.Content) != 1 || result.Content[0].Text != "answer" || result.Content[0].Type != "inputText" {
+				t.Fatal(string(reply.Result), err)
+			}
+			if err := s.SubmitFunctionResult(t.Context(), proto.FunctionResultPayload{CallID: "call"}); !errors.Is(err, agent.ErrUnknownFunctionCall) {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestFunctionCallRejectsUnregisteredAndClosedRuns(t *testing.T) {
+	tc, _, cleanup := NewTestClient()
+	defer cleanup()
+	s, _ := newInteractionTestSession(tc.JSONRPCClient)
+	s.setThreadID("thread")
+	s.functions, _ = prepareFunctionTools([]proto.FunctionTool{{Name: "lookup", Parameters: json.RawMessage(`{}`)}})
+	for _, params := range []string{
+		`{"threadId":"other","turnId":"turn","callId":"a","tool":"lookup","arguments":{}}`,
+		`{"threadId":"thread","turnId":"turn","callId":"a","tool":"unknown","arguments":{}}`,
+		`{"threadId":"thread","turnId":"turn","callId":"a","tool":"lookup","namespace":"foreign","arguments":{}}`,
+	} {
+		if _, err := s.handleFunctionCall(json.RawMessage(params), "rpc"); err == nil {
+			t.Fatal("unexpected call accepted", params)
+		}
+	}
+	s.stopFunctionCalls()
+	if _, err := s.handleFunctionCall(json.RawMessage(`{"threadId":"thread","turnId":"turn","callId":"a","tool":"lookup","arguments":{}}`), "rpc"); err == nil {
+		t.Fatal("closed run accepted call")
+	}
+	if err := s.SubmitFunctionResult(context.Background(), proto.FunctionResultPayload{CallID: "a"}); !errors.Is(err, agent.ErrUnknownFunctionCall) {
+		t.Fatal(err)
+	}
+}
+
+func TestFunctionToolDefinitionsRejectAmbiguousInput(t *testing.T) {
+	for _, tools := range [][]proto.FunctionTool{
+		{{Name: "", Parameters: json.RawMessage(`{}`)}},
+		{{Name: "lookup", Parameters: json.RawMessage(`[]`)}},
+		{{Name: "lookup", Parameters: json.RawMessage(`null`)}},
+		{{Name: "lookup", Parameters: json.RawMessage(`{}`)}, {Name: "lookup", Parameters: json.RawMessage(`{}`)}},
+	} {
+		if _, err := prepareFunctionTools(tools); err == nil {
+			t.Fatal("invalid function accepted", tools)
+		}
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/protocol.go
+++ b/apps/parsar-daemon/internal/agent/codex/protocol.go
@@ -165,9 +165,10 @@ type ThreadStartParams struct {
 	// string: "read-only" / "workspace-write" / "danger-full-access".
 	// Sending the old object shape causes codex to silently default to
 	// read-only, which terminates the turn before the model can reply.
-	Sandbox               SandboxMode `json:"sandbox,omitempty"`
-	DeveloperInstructions string      `json:"developerInstructions,omitempty"`
-	RuntimeWorkspaceRoots []string    `json:"runtimeWorkspaceRoots,omitempty"`
+	Sandbox               SandboxMode           `json:"sandbox,omitempty"`
+	DeveloperInstructions string                `json:"developerInstructions,omitempty"`
+	RuntimeWorkspaceRoots []string              `json:"runtimeWorkspaceRoots,omitempty"`
+	DynamicTools          []dynamicFunctionTool `json:"dynamicTools,omitempty"`
 }
 
 type Thread struct {

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -56,6 +56,7 @@ func Factory(ctx context.Context, req proto.PromptRequestPayload, out chan<- pro
 //  5. turn/completed emits TypeDone + closes out. Cancel can short-cut
 //     this by killing the child early.
 type Session struct {
+	functions       *functionCalls
 	observeMessages bool
 	observeTools    bool
 	runID           string
@@ -114,6 +115,10 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 	if cfg.killTimeout <= 0 {
 		cfg.killTimeout = rpcKillTimeout
 	}
+	functions, err := prepareFunctionTools(req.FunctionTools)
+	if err != nil {
+		return nil, err
+	}
 	req.AgentStateKey = effectiveAgentStateKey(req)
 
 	plan, err := BuildSessionPlan(req.RunID, req.AgentStateKey, req.WorkDir, req.AgentOptions)
@@ -152,6 +157,7 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 
 	s := &Session{
 		runID:           req.RunID,
+		functions:       functions,
 		observeMessages: req.ObserveMessages,
 		observeTools:    req.ObserveTools,
 		cfg:             cfg,
@@ -240,6 +246,7 @@ func (s *Session) SubmitPromptForUserChoice(_ context.Context, askID string, dec
 func (s *Session) run(plan SessionPlan, req proto.PromptRequestPayload) {
 	defer close(s.waitDone)
 	defer s.stopCodexInteractionTimers()
+	defer s.stopFunctionCalls()
 	defer s.cleanup()
 	defer s.closeOut()
 
@@ -298,63 +305,6 @@ func (s *Session) run(plan SessionPlan, req proto.PromptRequestPayload) {
 	}
 }
 
-func (s *Session) startThread(plan SessionPlan) error {
-	params := ThreadStartParams{
-		Cwd:                   plan.Cwd,
-		Model:                 plan.Model,
-		ModelProvider:         plan.ModelProvider,
-		ApprovalPolicy:        plan.ApprovalPolicy,
-		Sandbox:               plan.Sandbox,
-		DeveloperInstructions: plan.SystemPrompt,
-	}
-	s.cfg.logger.Info("codex: thread/start request",
-		"run_id", s.runID,
-		"cwd", params.Cwd,
-		"model", params.Model,
-		"model_provider", params.ModelProvider,
-		"sandbox", string(params.Sandbox),
-		"approval_silent", IsSilent(&params.ApprovalPolicy),
-		"developer_instructions_len", len(params.DeveloperInstructions))
-	raw, err := s.rpc.Request(s.cancelCtx, "thread/start", params)
-	if err != nil {
-		return err
-	}
-	var res ThreadStartResult
-	if len(raw) > 0 {
-		_ = json.Unmarshal(raw, &res)
-	}
-	if res.Thread.ID != "" {
-		s.setThreadID(res.Thread.ID)
-	}
-	if res.Model != "" {
-		s.resolvedModel = res.Model
-	}
-	return nil
-}
-
-func (s *Session) resumeThread(threadID string, plan SessionPlan) error {
-	raw, err := s.rpc.Request(s.cancelCtx, "thread/resume", ThreadResumeParams{
-		ThreadID: threadID, ApprovalPolicy: plan.ApprovalPolicy, Sandbox: plan.Sandbox,
-		DeveloperInstructions: plan.SystemPrompt,
-	})
-	if err != nil {
-		return err
-	}
-	var res ThreadStartResult
-	if len(raw) > 0 {
-		_ = json.Unmarshal(raw, &res)
-	}
-	id := res.Thread.ID
-	if id == "" {
-		id = threadID
-	}
-	s.setThreadID(id)
-	if res.Model != "" {
-		s.resolvedModel = res.Model
-	}
-	return nil
-}
-
 // ---------------------------------------------------------------------------
 // notification handlers
 // ---------------------------------------------------------------------------
@@ -381,6 +331,7 @@ func (s *Session) registerHandlers() {
 	// Older app-server releases used this unseparated method name.
 	rpc.OnServerRequest("item/permissionsRequestApproval", s.handleCodexPermissionsApproval)
 	rpc.OnServerRequest("item/tool/requestUserInput", s.handleCodexUserInput)
+	rpc.OnServerRequest("item/tool/call", s.handleFunctionCall)
 	rpc.OnServerRequest("mcpServer/elicitation/request", s.handleCodexMCPElicitation)
 }
 

--- a/apps/parsar-daemon/internal/agent/codex/session_thread.go
+++ b/apps/parsar-daemon/internal/agent/codex/session_thread.go
@@ -1,0 +1,63 @@
+package codex
+
+import "encoding/json"
+
+func (s *Session) startThread(plan SessionPlan) error {
+	params := ThreadStartParams{
+		Cwd:                   plan.Cwd,
+		Model:                 plan.Model,
+		ModelProvider:         plan.ModelProvider,
+		ApprovalPolicy:        plan.ApprovalPolicy,
+		Sandbox:               plan.Sandbox,
+		DeveloperInstructions: plan.SystemPrompt,
+	}
+	if s.functions != nil {
+		params.DynamicTools = s.functions.definitions
+	}
+	s.cfg.logger.Info("codex: thread/start request",
+		"run_id", s.runID,
+		"cwd", params.Cwd,
+		"model", params.Model,
+		"model_provider", params.ModelProvider,
+		"sandbox", string(params.Sandbox),
+		"approval_silent", IsSilent(&params.ApprovalPolicy),
+		"developer_instructions_len", len(params.DeveloperInstructions))
+	raw, err := s.rpc.Request(s.cancelCtx, "thread/start", params)
+	if err != nil {
+		return err
+	}
+	var res ThreadStartResult
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &res)
+	}
+	if res.Thread.ID != "" {
+		s.setThreadID(res.Thread.ID)
+	}
+	if res.Model != "" {
+		s.resolvedModel = res.Model
+	}
+	return nil
+}
+
+func (s *Session) resumeThread(threadID string, plan SessionPlan) error {
+	raw, err := s.rpc.Request(s.cancelCtx, "thread/resume", ThreadResumeParams{
+		ThreadID: threadID, ApprovalPolicy: plan.ApprovalPolicy, Sandbox: plan.Sandbox,
+		DeveloperInstructions: plan.SystemPrompt,
+	})
+	if err != nil {
+		return err
+	}
+	var res ThreadStartResult
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &res)
+	}
+	id := res.Thread.ID
+	if id == "" {
+		id = threadID
+	}
+	s.setThreadID(id)
+	if res.Model != "" {
+		s.resolvedModel = res.Model
+	}
+	return nil
+}

--- a/apps/parsar-daemon/internal/agent/functions.go
+++ b/apps/parsar-daemon/internal/agent/functions.go
@@ -1,0 +1,14 @@
+package agent
+
+import (
+	"context"
+	"errors"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+var ErrUnknownFunctionCall = errors.New("agent: function call is no longer pending")
+
+type FunctionResultSubmitter interface {
+	SubmitFunctionResult(context.Context, proto.FunctionResultPayload) error
+}

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -261,6 +261,7 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 				Resume:          true,
 				Steering:        true,
 				DurableTurns:    true,
+				FunctionTools:   true,
 				MessageItems:    true,
 				ToolItems:       true,
 				EnvironmentNone: true,

--- a/apps/parsar-daemon/internal/dispatch/functions.go
+++ b/apps/parsar-daemon/internal/dispatch/functions.go
@@ -1,0 +1,61 @@
+package dispatch
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+func (r *Router) supportsFunctionTools(kind string) bool {
+	for _, info := range r.registry.SupportedAgentKinds() {
+		if info.Kind == kind {
+			return info.Available && info.Capabilities.FunctionTools
+		}
+	}
+	return false
+}
+
+func (r *Router) handleFunctionResult(ctx context.Context, env proto.Envelope) error {
+	var result proto.FunctionResultPayload
+	if err := env.DecodePayload(&result); err != nil {
+		return err
+	}
+	if env.ID == "" || result.CallID == "" || result.DeliveryID == "" {
+		return errors.New("function result requires run, call and delivery identities")
+	}
+	decision := result
+	decision.DeliveryID = ""
+	encoded, err := json.Marshal(decision)
+	if err != nil {
+		return err
+	}
+	fingerprint := sha256.Sum256(encoded)
+	// Scope receipt replay to both identities, even when native call IDs repeat across Runs.
+	kind := proto.TypeFunctionResult + "\x00" + result.CallID
+	if handled, err := r.replayAppliedInteractionDecision(ctx, env.ID, result.DeliveryID, kind, fingerprint); handled {
+		return err
+	}
+	r.mu.Lock()
+	state := r.sessions[env.ID]
+	var submitter agent.FunctionResultSubmitter
+	if state != nil {
+		submitter, _ = state.session.(agent.FunctionResultSubmitter)
+	}
+	r.mu.Unlock()
+	if submitter == nil {
+		return r.sendInteractionDecisionAck(ctx, env.ID, result.DeliveryID, false, "not_pending", "function call is no longer pending")
+	}
+	if err := submitter.SubmitFunctionResult(ctx, result); err != nil {
+		code := "runtime_error"
+		if errors.Is(err, agent.ErrUnknownFunctionCall) {
+			code = "not_pending"
+		}
+		return r.sendInteractionDecisionAck(ctx, env.ID, result.DeliveryID, false, code, "function result was not applied")
+	}
+	r.rememberAppliedInteractionDecision(env.ID, kind, fingerprint)
+	return r.sendInteractionDecisionAck(ctx, env.ID, result.DeliveryID, true, "", "")
+}

--- a/apps/parsar-daemon/internal/dispatch/functions_native_test.go
+++ b/apps/parsar-daemon/internal/dispatch/functions_native_test.go
@@ -1,0 +1,160 @@
+package dispatch_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent/codex"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/dispatch"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+type nativeFunctionSender chan proto.Envelope
+
+func (s nativeFunctionSender) Send(ctx context.Context, e proto.Envelope) error {
+	select {
+	case s <- e:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestNativeFunctionBridge(t *testing.T) {
+	root := os.Getenv("PARSAR_NATIVE_PROOF_DIR")
+	if root == "" {
+		t.Skip("explicit native Codex binary and proof directory required")
+	}
+	home, err := os.MkdirTemp(root, "daemon-functions-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PARSAR_HOME", home)
+	var count atomic.Int32
+	model := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+			return
+		}
+		n := count.Add(1)
+		raw, _ := json.MarshalIndent(body, "", "  ")
+		_ = os.WriteFile(filepath.Join(home, fmt.Sprintf("request-%d.json", n)), raw, 0600)
+		var item map[string]any
+		if n%2 == 1 {
+			if !strings.Contains(string(raw), "lookup_ticket") {
+				t.Error("tool was not registered")
+			}
+			item = map[string]any{"id": fmt.Sprintf("fc_%d", n), "type": "function_call", "call_id": fmt.Sprintf("call_%d", n), "name": "lookup_ticket", "arguments": `{"ticket":"42"}`, "status": "completed"}
+		} else {
+			if !strings.Contains(string(raw), "TICKET-RESULT") {
+				t.Error("native model did not receive function result")
+			}
+			item = map[string]any{"id": fmt.Sprintf("msg_%d", n), "type": "message", "role": "assistant", "phase": "final_answer", "status": "completed", "content": []any{map[string]any{"type": "output_text", "text": "FUNCTION-OK", "annotations": []any{}}}}
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		send := func(kind string, data map[string]any) {
+			data["type"] = kind
+			b, _ := json.Marshal(data)
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", kind, b)
+			w.(http.Flusher).Flush()
+		}
+		send("response.created", map[string]any{"response": map[string]any{"id": fmt.Sprintf("r_%d", n), "status": "in_progress", "output": []any{}}})
+		send("response.output_item.added", map[string]any{"output_index": 0, "item": item})
+		send("response.output_item.done", map[string]any{"output_index": 0, "item": item})
+		send("response.completed", map[string]any{"response": map[string]any{"id": fmt.Sprintf("r_%d", n), "object": "response", "created_at": time.Now().Unix(), "status": "completed", "model": "gpt-5.5", "output": []any{item}}})
+	}))
+	defer model.Close()
+	reg := agent.NewRegistry()
+	reg.RegisterKind(proto.SupportedAgentKind{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{FunctionTools: true}}, codex.Factory)
+	sender := make(nativeFunctionSender, 256)
+	router, err := dispatch.New(dispatch.Config{Registry: reg, Sender: sender})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer router.Shutdown(context.Background())
+	ctx, cancel := context.WithTimeout(t.Context(), 60*time.Second)
+	defer cancel()
+	await := func(kind string) proto.Envelope {
+		t.Helper()
+		for {
+			select {
+			case env := <-sender:
+				if env.Type == proto.TypeError {
+					t.Fatalf("native error: %s", env.Payload)
+				}
+				if env.Type == kind {
+					return env
+				}
+			case <-ctx.Done():
+				t.Fatalf("waiting for %s; evidence %s", kind, home)
+			}
+		}
+	}
+	nativeID := ""
+	for index := 0; index < 3; index++ {
+		run := fmt.Sprintf("run-%d", index)
+		request := proto.PromptRequestPayload{AgentKind: "codex", Prompt: "Look up ticket 42.", RunID: run, AgentStateKey: "native-functions", AgentSessionID: nativeID, StrictResume: true, ReleaseOnCompletion: true, DisableExecutionEnvironment: true, ObserveTools: true,
+			FunctionTools: []proto.FunctionTool{{Name: "lookup_ticket", Description: "Read a synthetic ticket", Parameters: json.RawMessage(`{"type":"object","properties":{"ticket":{"type":"string"}},"required":["ticket"],"additionalProperties":false}`)}},
+			AgentOptions:  map[string]any{"model": "gpt-5.5", "codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-local-token"}}}
+		env, _ := proto.NewEnvelope(proto.TypePromptRequest, run, request)
+		if err := router.Handle(ctx, env); err != nil {
+			t.Fatal(err)
+		}
+		call := await(proto.TypeFunctionCall)
+		var payload proto.FunctionCallPayload
+		if err := call.DecodePayload(&payload); err != nil || call.ID != run || payload.Name != "lookup_ticket" {
+			t.Fatal(call, err)
+		}
+		if index == 2 {
+			cancelFrame, _ := proto.NewEnvelope(proto.TypePromptCancel, run, proto.PromptCancelPayload{DeliveryID: "cancel"})
+			if err := router.Handle(ctx, cancelFrame); err != nil {
+				t.Fatal(err)
+			}
+			ack := await(proto.TypeInteractionDecisionAck)
+			var receipt proto.InteractionDecisionAckPayload
+			_ = ack.DecodePayload(&receipt)
+			if !receipt.Applied {
+				t.Fatal(receipt)
+			}
+			late, _ := proto.NewEnvelope(proto.TypeFunctionResult, run, proto.FunctionResultPayload{CallID: payload.CallID, Success: true, Text: "late", DeliveryID: "late"})
+			if err := router.Handle(ctx, late); err != nil {
+				t.Fatal(err)
+			}
+			_ = await(proto.TypeInteractionDecisionAck).DecodePayload(&receipt)
+			if receipt.Applied || receipt.ErrorCode != "not_pending" {
+				t.Fatal(receipt)
+			}
+			break
+		}
+		result, _ := proto.NewEnvelope(proto.TypeFunctionResult, run, proto.FunctionResultPayload{CallID: payload.CallID, Success: index == 0, Text: "TICKET-RESULT", DeliveryID: "result"})
+		if err := router.Handle(ctx, result); err != nil {
+			t.Fatal(err)
+		}
+		ack := await(proto.TypeInteractionDecisionAck)
+		var receipt proto.InteractionDecisionAckPayload
+		_ = ack.DecodePayload(&receipt)
+		if !receipt.Applied {
+			t.Fatal(receipt)
+		}
+		done := await(proto.TypeDone)
+		var output proto.DonePayload
+		_ = done.DecodePayload(&output)
+		id, _ := output.Metadata[proto.DoneMetaAgentSessionID].(string)
+		if output.Content != "FUNCTION-OK" || id == "" || (nativeID != "" && id != nativeID) {
+			t.Fatal(output)
+		}
+		nativeID = id
+	}
+	t.Logf("Native function success/failure, fresh-process resume, cancellation and late-result rejection passed; evidence %s", home)
+}

--- a/apps/parsar-daemon/internal/dispatch/functions_test.go
+++ b/apps/parsar-daemon/internal/dispatch/functions_test.go
@@ -1,0 +1,110 @@
+package dispatch_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/agent"
+	"github.com/MiniMax-AI-Dev/parsar/apps/parsar-daemon/internal/dispatch"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+)
+
+type functionSession struct {
+	*fakeSession
+	mu    sync.Mutex
+	calls int
+}
+
+func (s *functionSession) SubmitFunctionResult(_ context.Context, p proto.FunctionResultPayload) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if p.CallID != "call" || s.calls != 0 {
+		return agent.ErrUnknownFunctionCall
+	}
+	s.calls++
+	return nil
+}
+func TestFunctionReceiptsScopeRetriesAndConflicts(t *testing.T) {
+	reg := agent.NewRegistry()
+	sender := &recSender{}
+	sessions := map[string]*functionSession{}
+	reg.RegisterKind(proto.SupportedAgentKind{Kind: "function-test", Available: true, Capabilities: proto.AgentKindCapabilities{FunctionTools: true}}, func(ctx context.Context, p proto.PromptRequestPayload, out chan<- proto.Envelope) (agent.Session, error) {
+		s := &functionSession{fakeSession: &fakeSession{out: out, ctx: ctx, closeOutOnCancel: true}}
+		sessions[p.RunID] = s
+		return s, nil
+	})
+	router, err := dispatch.New(dispatch.Config{Registry: reg, Sender: sender})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer router.Shutdown(context.Background())
+	for _, id := range []string{"one", "two"} {
+		env, _ := proto.NewEnvelope(proto.TypePromptRequest, id, proto.PromptRequestPayload{AgentKind: "function-test", Prompt: "lookup", FunctionTools: []proto.FunctionTool{{Name: "lookup", Parameters: json.RawMessage(`{}`)}}})
+		if err := router.Handle(t.Context(), env); err != nil {
+			t.Fatal(err)
+		}
+	}
+	submit := func(run, call, text, delivery string) proto.InteractionDecisionAckPayload {
+		t.Helper()
+		env, _ := proto.NewEnvelope(proto.TypeFunctionResult, run, proto.FunctionResultPayload{CallID: call, Success: true, Text: text, DeliveryID: delivery})
+		if err := router.Handle(t.Context(), env); err != nil {
+			t.Fatal(err)
+		}
+		frames := sender.snapshot()
+		last := frames[len(frames)-1]
+		var ack proto.InteractionDecisionAckPayload
+		if err := last.DecodePayload(&ack); err != nil || last.Type != proto.TypeInteractionDecisionAck || last.ID != run || ack.DeliveryID != delivery {
+			t.Fatal(last, err)
+		}
+		return ack
+	}
+	if a := submit("missing", "call", "answer", "a"); a.Applied || a.ErrorCode != "not_pending" {
+		t.Fatal(a)
+	}
+	if a := submit("one", "missing", "answer", "b"); a.Applied || a.ErrorCode != "not_pending" {
+		t.Fatal(a)
+	}
+	// A lost receipt may be retried without writing the native result twice.
+	sender.mu.Lock()
+	sender.failNow = true
+	sender.mu.Unlock()
+	first, _ := proto.NewEnvelope(proto.TypeFunctionResult, "one", proto.FunctionResultPayload{CallID: "call", Success: true, Text: "answer", DeliveryID: "lost"})
+	if err := router.Handle(t.Context(), first); err == nil {
+		t.Fatal("receipt send failure was hidden")
+	}
+	if a := submit("one", "call", "answer", "retry"); !a.Applied {
+		t.Fatal(a)
+	}
+	if a := submit("one", "call", "changed", "conflict"); a.Applied || a.ErrorCode != "decision_conflict" {
+		t.Fatal(a)
+	}
+	if a := submit("two", "call", "second answer", "other-run"); !a.Applied {
+		t.Fatal(a)
+	}
+	for _, s := range sessions {
+		s.mu.Lock()
+		count := s.calls
+		s.mu.Unlock()
+		if count != 1 {
+			t.Fatal(count)
+		}
+	}
+}
+
+func TestFunctionToolsRequireAdvertisedSupport(t *testing.T) {
+	reg := agent.NewRegistry()
+	called := false
+	reg.Register("unsupported", func(context.Context, proto.PromptRequestPayload, chan<- proto.Envelope) (agent.Session, error) {
+		called = true
+		return nil, nil
+	})
+	sender := &recSender{}
+	router, _ := dispatch.New(dispatch.Config{Registry: reg, Sender: sender})
+	defer router.Shutdown(context.Background())
+	env, _ := proto.NewEnvelope(proto.TypePromptRequest, "run", proto.PromptRequestPayload{AgentKind: "unsupported", FunctionTools: []proto.FunctionTool{{Name: "lookup", Parameters: json.RawMessage(`{}`)}}})
+	if err := router.Handle(t.Context(), env); err == nil || called {
+		t.Fatal("unsupported engine silently ignored tools", err)
+	}
+}

--- a/apps/parsar-daemon/internal/dispatch/router.go
+++ b/apps/parsar-daemon/internal/dispatch/router.go
@@ -141,6 +141,8 @@ func (r *Router) Handle(ctx context.Context, env proto.Envelope) error {
 		return r.handlePromptRequest(ctx, env)
 	case proto.TypePromptCancel:
 		return r.handlePromptCancel(ctx, env)
+	case proto.TypeFunctionResult:
+		return r.handleFunctionResult(ctx, env)
 	case proto.TypePromptSteer:
 		return r.handlePromptSteer(ctx, env)
 	case proto.TypePermissionDecision:
@@ -249,6 +251,11 @@ func (r *Router) handlePromptRequest(callerCtx context.Context, env proto.Envelo
 	if req.AgentKind == "" {
 		r.log.ErrorContext(callerCtx, "handlePromptRequest: missing agent_kind", "run_id", runID)
 		return errors.New("dispatch: prompt_request missing agent_kind")
+	}
+	if len(req.FunctionTools) > 0 && !r.supportsFunctionTools(req.AgentKind) {
+		err := errors.New("engine does not support function tools")
+		r.emitTerminalError(callerCtx, runID, err.Error())
+		return err
 	}
 	if req.DisableExecutionEnvironment && req.AgentKind != "codex" {
 		err := errors.New("execution environment none requires a supported Codex engine")

--- a/internal/agentdaemon/device/state.go
+++ b/internal/agentdaemon/device/state.go
@@ -68,6 +68,7 @@ type KindCapabilities struct {
 	MessageItems       bool `json:"message_items,omitempty"`
 	ToolItems          bool `json:"tool_items,omitempty"`
 	EnvironmentNone    bool `json:"environment_none,omitempty"`
+	FunctionTools      bool `json:"function_tools,omitempty"`
 	DurableTurns       bool `json:"durable_turns,omitempty"`
 	WorkspaceAuthoring bool `json:"workspace_authoring,omitempty"`
 }

--- a/internal/agentdaemon/gateway/functions_test.go
+++ b/internal/agentdaemon/gateway/functions_test.go
@@ -1,0 +1,18 @@
+package gateway
+
+import (
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"testing"
+)
+
+func TestFunctionCapabilitySurvivesHeartbeatMapping(t *testing.T) {
+	for _, supported := range []bool{false, true} {
+		kinds := deviceKindsFromHeartbeat(proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{FunctionTools: supported}}}})
+		s := &Session{}
+		s.setSupportedAgentKinds(kinds)
+		info, found, known := s.AgentKindStatus("codex")
+		if !found || !known || info.Capabilities.FunctionTools != supported {
+			t.Fatal(info, found, known)
+		}
+	}
+}

--- a/internal/agentdaemon/gateway/session.go
+++ b/internal/agentdaemon/gateway/session.go
@@ -534,6 +534,7 @@ func deviceKindsFromHeartbeat(p proto.HeartbeatPayload) []device.SupportedAgentK
 				MessageItems:       info.Capabilities.MessageItems,
 				ToolItems:          info.Capabilities.ToolItems,
 				EnvironmentNone:    info.Capabilities.EnvironmentNone,
+				FunctionTools:      info.Capabilities.FunctionTools,
 				WorkspaceAuthoring: info.Capabilities.WorkspaceAuthoring,
 			},
 		})

--- a/internal/agentdaemon/proto/functions.go
+++ b/internal/agentdaemon/proto/functions.go
@@ -1,0 +1,28 @@
+package proto
+
+import "encoding/json"
+
+const (
+	TypeFunctionCall   = "function_call"
+	TypeFunctionResult = "function_result"
+)
+
+type FunctionTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+// FunctionCallPayload belongs to the Run identified by Envelope.ID.
+type FunctionCallPayload struct {
+	CallID    string          `json:"call_id"`
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+type FunctionResultPayload struct {
+	DeliveryID string `json:"delivery_id"`
+	CallID     string `json:"call_id"`
+	Success    bool   `json:"success"`
+	Text       string `json:"text"`
+}

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -258,7 +258,8 @@ type AgentKindCapabilities struct {
 	ToolItems          bool `json:"tool_items,omitempty"`
 	EnvironmentNone    bool `json:"environment_none,omitempty"`
 	// DurableTurns includes strict resume, completion release and cancellation snapshots.
-	DurableTurns bool `json:"durable_turns,omitempty"`
+	DurableTurns  bool `json:"durable_turns,omitempty"`
+	FunctionTools bool `json:"function_tools,omitempty"`
 }
 
 // SupportedAgentKind is one daemon-advertised agent engine. Daemons

--- a/internal/agentdaemon/proto/outbound.go
+++ b/internal/agentdaemon/proto/outbound.go
@@ -77,11 +77,12 @@ type PromptRequestPayload struct {
 	AgentStateKey      string `json:"agent_state_key,omitempty"`
 	WorkspaceAuthoring bool   `json:"workspace_authoring,omitempty"`
 	// ReleaseOnCompletion closes the native writer before acknowledging Done.
-	ReleaseOnCompletion         bool `json:"release_on_completion,omitempty"`
-	StrictResume                bool `json:"strict_resume,omitempty"`
-	ObserveMessages             bool `json:"observe_messages,omitempty"`
-	ObserveTools                bool `json:"observe_tools,omitempty"`
-	DisableExecutionEnvironment bool `json:"disable_execution_environment,omitempty"`
+	ReleaseOnCompletion         bool           `json:"release_on_completion,omitempty"`
+	StrictResume                bool           `json:"strict_resume,omitempty"`
+	ObserveMessages             bool           `json:"observe_messages,omitempty"`
+	ObserveTools                bool           `json:"observe_tools,omitempty"`
+	FunctionTools               []FunctionTool `json:"function_tools,omitempty"`
+	DisableExecutionEnvironment bool           `json:"disable_execution_environment,omitempty"`
 }
 
 // PromptAttachment is one piece of non-text user input the daemon-side


### PR DESCRIPTION
Explicit function tools can now pause a daemon Codex Run for an external text result. Calls and replies carry Run/call identities, reuse application receipts, reject conflicting retries and cancelled calls, and preserve native continuation. Prompts without functions and other engine adapters retain their existing behavior.

This is the daemon prerequisite for ATOM-006. Public Agents API required actions, durable result admission, product authorization and Team orchestration remain separate work. A delivery receipt confirms the native reply was written; it does not guarantee an external side effect or crash recovery.

Validation: `make check`, focused race tests, OpenAPI regeneration with no drift, and an opt-in test through the production Router/Codex adapter using the real Codex binary and a local synthetic model. Native success/failure results, fresh-process continuation, cancellation and late-result rejection passed. A fresh independent blind review found no blocking issues and independently reran focused race tests. Local Docker stayed stopped; DB integration checks requiring it were skipped (no database changes).
