### PR TITLE
docs(agents-api): prioritize independent protocol conformance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,9 +52,10 @@ Direct development on `main` is not allowed. Every session honours this rule.
 
 ## Independent blind review
 
-Fix one issue per PR. State the expected behavior, acceptance criteria, and
-explicit scope exclusions before implementation. Keep unrelated refactors,
-features, formatting, and dependency updates in separate PRs.
+Each PR should contain one independently verifiable change; a feature may span
+several small PRs. State the expected behavior, acceptance criteria, and explicit
+scope exclusions before implementation. Keep unrelated refactors, features,
+formatting, and dependency updates in separate PRs.
 
 Small, low-impact changes may use developer self-review and relevant
 verification without a subagent. Examples include isolated copy, spacing,
@@ -100,18 +101,53 @@ description and keep ownership on the side listed here.
 
 ### Product and execution service separation
 
-The target deployment has a Parsar product service and an independently usable
-Agents API, installed together by Compose. They may share a PostgreSQL instance,
-but own separate databases, credentials and migrations. Migrate incrementally;
-the existing server remains the execution owner until a flow is explicitly moved.
-Agents API is general infrastructure: third-party clients must be able to use
-the declared supported protocol through the official SDK with a different base
-URL, without creating Parsar business objects. Parsar is one client of that API.
+Agents API is the primary infrastructure deliverable. Parsar is an ordinary client
+and example application; its feature backlog must not dictate the execution
+service's public protocol or internal model. Agents API must build, deploy and run
+without the Parsar product service, frontend or database. An optional Compose
+deployment may install both services with one PostgreSQL instance, but separate
+databases, credentials and migrations. The existing product keeps its execution
+path until an explicit client cutover.
+
+#### Design and compatibility requirements
+
+- The complete pinned `openai/openai-python` `beta/agents` protocol is the target,
+  including its referenced resources and types. Match paths, methods, headers,
+  field presence, nullability, discriminators, defaults, status transitions,
+  pagination, errors and streaming behavior. Engine limitations are implementation
+  gaps to solve, not grounds for narrowing or redefining the upstream contract.
+- Pin upstream source and SDK versions in `contracts/agents-api/upstream.json`.
+  Use official SDKs for clients and reuse upstream types or schemas where suitable.
+  SDK deserialization alone is not server validation or proof of compatibility:
+  test raw HTTP payloads and observable workflows as well. Record unspecified or
+  unverified behavior explicitly; never invent official semantics. Track partial
+  coverage in `contracts/agents-api/README.md` until the complete target is verified.
+- No legacy Agents API compatibility requirement takes precedence over this
+  design. Replace an unsuitable implementation instead of growing compatibility
+  branches. Preserve reusable, verified infrastructure rather than rewriting it
+  merely for new names or directories. Replacements may retire obsolete private
+  interfaces and history backfills in bounded PRs; this does not authorize deleting
+  product data or changing unrelated product behavior.
+- Keep engine-specific types, process management and protocol translation inside
+  execution adapters. The public API and persistence/application core must not
+  interpret Parsar product payloads or depend on one engine's native item types.
+  Prefer maintained upstream SDKs and native execution protocols over a second
+  hand-written model/tool loop or a general-purpose compatibility framework.
+- Verify an independent official-client workflow before a Parsar integration.
+  Parsar uses the same public contract as any other client, with no privileged
+  endpoint or direct execution-table access. An OpenAI endpoint is a possible
+  client target only where the requested capabilities and credentials support it.
+- Maintain tasks, priorities and evidence in the Feishu board. Complete each
+  bounded task and its required checks/review, then mark it done after merge and
+  choose the next dependency. Agent API protocol and atomic execution work takes
+  priority over product integration, UI work and business Team orchestration.
 
 - Parsar owns users, workspaces, business authorization, Agent/Team definitions,
   capabilities, product conversations, IM/sharing, approval decisions and billing.
-- Agents API owns execution sessions, runs, effective configuration snapshots,
-  dispatch/cancel, environments, raw usage, pending interactions and durable events.
+- Agents API owns protocol saved Agents, execution sessions/turns, effective
+  configuration snapshots, dispatch/cancel, environments, vaults, raw usage,
+  pending interactions, protocol subagents and durable events. Protocol saved
+  Agents/vaults are execution resources, not Parsar marketplace or business roles.
   Neither service reads the other's tables. Parsar uses a versioned client contract.
 - A product conversation may map to several execution sessions. An execution
   session is distinct from a live daemon socket, process or sandbox. Native engine
@@ -121,11 +157,21 @@ URL, without creating Parsar business objects. Parsar is one client of that API.
   is live-only; recover through Session/Turn/Items reads. Any additional product
   cursor replay must be documented as an extension, not upstream semantics.
   Team definitions, management and orchestration belong to Parsar. Agents API
-  provides single-Agent execution primitives; Team loops are deferred. Future Team
-  orchestration directly depends on `openai/openai-agents-python` in Parsar.
+  establishes single-Agent execution first; business Team loops are deferred.
+  This does not exclude upstream `multi_agent` configuration or subagent resources
+  from protocol coverage. Future business Team orchestration directly depends on
+  `openai/openai-agents-python` in Parsar.
 - Daemon Skill/SP authoring remains a product operation: forward through a scoped
   product callback with the original requester and workspace checks. A runtime
   credential alone must not grant business write permissions.
+
+#### Current implementation
+
+The constraints below describe existing code, not requirements to preserve legacy
+design. The [protocol assessment](contracts/agents-api/README.md#implementation-direction)
+identifies replacements and gaps. Update these rules when their implementation is
+replaced; do not carry obsolete compatibility code forward to satisfy this section.
+
 - `internal/agentdaemon/gateway` is the shared daemon connection implementation.
   Its persistence interfaces use `internal/agentdaemon/device`, never product Store
   types. Product adapters live in `server/internal/agentdaemon`. Keep protocol

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -5,9 +5,71 @@ pinned in `upstream.json`. Its resource methods, corresponding types, pagination
 and streaming helpers define the compatibility target. This directory records
 the boundary; it does not imply that every upstream feature is implemented.
 
-Parsar owns product Agents and Teams. This service owns execution configuration
-snapshots and single-Agent sessions/turns. The OpenAI Agents Python **SDK** is a
-separate future dependency for Team orchestration in Parsar, not the HTTP contract.
+Parsar owns product Agents and Teams. This service owns upstream execution
+resources, including reusable Agents and protocol subagents. The OpenAI Agents
+Python **SDK** is a separate future dependency for business Team orchestration in
+Parsar, not the HTTP contract. Design rules live in
+[CONTRIBUTING.md](../../CONTRIBUTING.md#design-and-compatibility-requirements).
+
+## Implementation direction
+
+Keep the independent service, authentication, PostgreSQL/sqlc persistence,
+transactional admission and official-client test harness. Replace the parts that
+let legacy daemon representations define execution semantics. Starting over is
+permitted where a replacement is smaller and clearer; neither a wholesale rewrite
+nor compatibility with the old private implementation is a goal.
+
+Concentrate native configuration, structured input/output and Item translation
+in an execution adapter. The application core owns execution state and persistence;
+engine-specific shapes stay at the adapter boundary. Reuse the native Codex
+app-server and exec-server protocols before adding another orchestration layer.
+Verify configuration against actual execution: response defaults must not merely
+describe values the adapter never applied.
+
+The next slices are contract conformance checks, effective configuration and the
+adapter boundary, complete function actions, then environment/file resources.
+Reusable Agents, vaults and protocol subagents remain in the coverage backlog.
+Parsar cutover follows an independent client workflow; its business Team loop is
+separate. Each slice can use multiple small PRs tracked in the Feishu board.
+
+## Upstream resource inventory
+
+This inventory is based on the pinned Python source, not our generated OpenAPI.
+It contains 42 distinct HTTP operations in 15 resource classes, excluding async
+duplicates, overloads and client-side helpers. Eight operations currently have
+handlers; that count is not a compatibility score. Even those operations implement
+only part of the upstream input, configuration and event variants.
+
+Paths below are SDK resource paths beneath `client.beta.agents`. Method names use
+the Python SDK. Vault HTTP paths start at `/vaults`, not `/agents/vaults`.
+
+| Resource | Upstream operations | Current coverage |
+| --- | --- | --- |
+| Root reusable Agents | create, retrieve, update, list, delete | Missing |
+| sessions | create, retrieve, update, list, delete | Partial create/retrieve/list; update/delete missing |
+| sessions.events | create, stream | Partial text/cancel and live events; function actions pending |
+| sessions.turns | retrieve, list | Implemented reads; lifecycle conformance still partial |
+| sessions.items | list | Partial Item variants |
+| sessions.artifacts | retrieve, list, delete, content | Missing |
+| sessions.subagents | retrieve, list | Missing |
+| sessions.subagents.items | list | Missing |
+| sessions.subagents.turns | retrieve, list | Missing |
+| sessions.subagents.turns.items | list | Missing |
+| environments | retrieve | Missing |
+| environments.files | create, list | Missing |
+| environments.templates | create, retrieve, update, list, delete | Missing |
+| vaults | create, retrieve, list, delete | Missing |
+| vaults.credentials | create, retrieve, update, list, delete | Missing |
+
+For each resource, verify the referenced request/response unions and observable
+behavior, not just the route. Creation streaming/initial input, configuration
+options, text/image content, function results, environment variants, full Item/SSE
+variants, defaults, field omission/nullability and errors need their own cases.
+Use strict official-client tests plus raw HTTP assertions; SDKs can accept extra
+fields and cannot prove that reported configuration matches the running engine.
+Where SDK types or public documentation do not establish behavior, record the
+uncertainty and obtain upstream evidence before marking it conformant. Temporary
+unsupported errors are implementation gaps, never evidence of full compatibility.
 
 ## Public semantics
 


### PR DESCRIPTION
Agents API is the primary infrastructure deliverable; Parsar is an ordinary client/example. Clarify that the complete pinned OpenAI beta/agents protocol is the compatibility target and that legacy execution representations may be replaced rather than preserved. Distinguish protocol saved Agents, vaults and subagents from Parsar business objects.

Add an inventory of all 42 upstream HTTP operations across 15 resource classes, with current partial coverage. Keep reusable authentication, storage and transaction foundations; concentrate replacement work at protocol and engine boundaries. A feature may span several independently verifiable PRs.

Scope: documentation only (ATOM-009); no runtime, schema, data or product cutover changes.

Validation: `make check` passes on zju_a100_2 (Go 1.25.13, Node 22.22.2), and `git diff --check` passes. Docker-backed migration smoke and database-dependent tests were skipped in this documentation-only remote check; the separate CI Sessions database job passed. All required CI checks passed. Resource inventory cross-checked against pinned upstream Python source and current HTTP handlers. Independent architecture consultation informed the decision; this documentation-only diff was self-reviewed under the repository policy.
