### PR TITLE
feat(agents-api): apply effective text verbosity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,6 +272,16 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   both new and resumed Turns. Native configuration translation stays in the
   adapter. Product requests that omit the option inherit their existing defaults.
   This is tool selection, not a network isolation guarantee.
+- Inline Agent `text.verbosity` accepts `low`, `medium` and `high`; omitted or
+  null values resolve to `medium` in the immutable configuration snapshot. The
+  dispatcher requires `text_verbosity` support and passes the effective value
+  through the Codex adapter for both new and resumed Turns. The adapter queries
+  the native active catalog with `codex debug models`, checks model support and
+  pins that catalog snapshot for execution. Unknown/unsupported models or an
+  unreadable catalog fail before model execution instead of silently ignoring
+  verbosity. This is an explicit engine limitation until those models are supported.
+  Product requests that omit the native option retain their existing defaults.
+  Structured output formats remain a separate protocol gap.
 - `function_tools` advertises the optional native function-call bridge. Explicit
   prompt definitions become Codex dynamic tools; unchanged prompts carry none.
   Requests and textual results are scoped by Run and native call ID. Reuse

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,7 +277,8 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   dispatcher requires `text_verbosity` support and passes the effective value
   through the Codex adapter for both new and resumed Turns. The adapter queries
   the native active catalog with `codex debug models`, checks model support and
-  pins that catalog snapshot for execution. Unknown/unsupported models or an
+  pins that catalog snapshot for execution. The probe requires Unix process-group
+  cancellation; other daemon hosts do not advertise this capability. Unknown/unsupported models or an
   unreadable catalog fail before model execution instead of silently ignoring
   verbosity. This is an explicit engine limitation until those models are supported.
   Product requests that omit the native option retain their existing defaults.

--- a/apps/parsar-daemon/internal/agent/codex/generation_config.go
+++ b/apps/parsar-daemon/internal/agent/codex/generation_config.go
@@ -1,0 +1,17 @@
+package codex
+
+func extraConfigFromOpts(opts map[string]any) [][2]string {
+	var out [][2]string
+	if rs := stringOpt(opts, "reasoning_summary"); rs != "" {
+		// codex app-server has no per-call flag; route via -c override.
+		// TOML literal — quoted string keeps shell-safe special chars.
+		out = append(out, [2]string{"model_reasoning_summary", strconv(rs)})
+	}
+	if mode := stringOpt(opts, "web_search"); mode != "" {
+		out = append(out, [2]string{"web_search", strconv(mode)})
+	}
+	if verbosity := stringOpt(opts, "model_verbosity"); verbosity != "" {
+		out = append(out, [2]string{"model_verbosity", strconv(verbosity)})
+	}
+	return out
+}

--- a/apps/parsar-daemon/internal/agent/codex/model_catalog_command_other.go
+++ b/apps/parsar-daemon/internal/agent/codex/model_catalog_command_other.go
@@ -1,0 +1,16 @@
+//go:build !unix
+
+package codex
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+)
+
+// SupportsTextVerbosity requires bounded cancellation of the catalog probe.
+const SupportsTextVerbosity = false
+
+func modelCatalogCommand(context.Context, string, ...string) (*exec.Cmd, error) {
+	return nil, errors.New("codex: text verbosity requires Unix process-group cancellation support")
+}

--- a/apps/parsar-daemon/internal/agent/codex/model_catalog_command_unix.go
+++ b/apps/parsar-daemon/internal/agent/codex/model_catalog_command_unix.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package codex
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// SupportsTextVerbosity requires bounded cancellation of the catalog probe.
+const SupportsTextVerbosity = true
+
+func modelCatalogCommand(ctx context.Context, binary string, args ...string) (*exec.Cmd, error) {
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error { return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL) }
+	cmd.WaitDelay = time.Second
+	return cmd, nil
+}

--- a/apps/parsar-daemon/internal/agent/codex/model_catalog_command_unix_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/model_catalog_command_unix_test.go
@@ -11,9 +11,19 @@ import (
 )
 
 func TestModelCatalogCancellationStopsDescendants(t *testing.T) {
+	for _, finish := range []string{"wait", "exit 0"} {
+		t.Run(finish, func(t *testing.T) {
+			checkCatalogDescendantCancellation(t, finish)
+		})
+	}
+}
+
+func checkCatalogDescendantCancellation(t *testing.T, finish string) {
+	t.Helper()
+	started := time.Now()
 	dir := t.TempDir()
 	binary := filepath.Join(dir, "codex")
-	if err := os.WriteFile(binary, []byte("#!/bin/sh\n(sleep 1; printf leaked > leaked) &\nprintf ready > ready\nwait\n"), 0700); err != nil {
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\n(sleep 2; printf leaked > leaked) &\nprintf ready > ready\n"+finish+"\n"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
@@ -36,10 +46,10 @@ func TestModelCatalogCancellationStopsDescendants(t *testing.T) {
 		if err == nil {
 			t.Fatal("cancelled catalog probe succeeded")
 		}
-	case <-time.After(600 * time.Millisecond):
+	case <-time.After(1500 * time.Millisecond):
 		t.Fatal("catalog probe kept waiting on child output pipes")
 	}
-	time.Sleep(1100 * time.Millisecond)
+	time.Sleep(time.Until(started.Add(2200 * time.Millisecond)))
 	if _, err := os.Stat(filepath.Join(dir, "leaked")); !os.IsNotExist(err) {
 		t.Fatalf("catalog child survived cancellation: %v", err)
 	}

--- a/apps/parsar-daemon/internal/agent/codex/model_catalog_command_unix_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/model_catalog_command_unix_test.go
@@ -1,0 +1,46 @@
+//go:build unix
+
+package codex
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestModelCatalogCancellationStopsDescendants(t *testing.T) {
+	dir := t.TempDir()
+	binary := filepath.Join(dir, "codex")
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\n(sleep 1; printf leaked > leaked) &\nprintf ready > ready\nwait\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- prepareModelVerbosity(ctx, binary, &SessionPlan{Cwd: dir}) }()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "ready")); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("catalog launcher did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("cancelled catalog probe succeeded")
+		}
+	case <-time.After(600 * time.Millisecond):
+		t.Fatal("catalog probe kept waiting on child output pipes")
+	}
+	time.Sleep(1100 * time.Millisecond)
+	if _, err := os.Stat(filepath.Join(dir, "leaked")); !os.IsNotExist(err) {
+		t.Fatalf("catalog child survived cancellation: %v", err)
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/model_verbosity.go
+++ b/apps/parsar-daemon/internal/agent/codex/model_verbosity.go
@@ -26,6 +26,10 @@ func prepareModelVerbosity(ctx context.Context, binary string, plan *SessionPlan
 	cmd.Dir = plan.Cwd
 	cmd.Env = append(os.Environ(), plan.Env...)
 	catalog, err := cmd.Output()
+	// The launcher can exit before its children, ending the context watcher.
+	if cmd.Process != nil {
+		_ = cmd.Cancel()
+	}
 	if err != nil {
 		return fmt.Errorf("codex: cannot verify model verbosity support: %w", err)
 	}

--- a/apps/parsar-daemon/internal/agent/codex/model_verbosity.go
+++ b/apps/parsar-daemon/internal/agent/codex/model_verbosity.go
@@ -1,0 +1,100 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Validate against the binary's active catalog and use that same snapshot for
+// execution. A CLI override alone is silently ignored for unsupported models.
+func prepareModelVerbosity(ctx context.Context, binary string, plan *SessionPlan) error {
+	args := []string{}
+	for _, kv := range plan.ExtraConfig {
+		args = append(args, "-c", kv[0]+"="+kv[1])
+	}
+	args = append(args, "debug", "models")
+	ctx, cancel := context.WithTimeout(ctx, rpcDefaultRequestTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Dir = plan.Cwd
+	cmd.Env = append(os.Environ(), plan.Env...)
+	catalog, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("codex: cannot verify model verbosity support: %w", err)
+	}
+	supported, err := catalogSupportsVerbosity(catalog, plan.Model)
+	if err != nil {
+		return fmt.Errorf("codex: cannot read model verbosity support: %w", err)
+	}
+	if !supported {
+		return fmt.Errorf("codex: model %q does not declare text verbosity support", plan.Model)
+	}
+	codexHome := ""
+	for _, entry := range plan.Env {
+		if value, ok := strings.CutPrefix(entry, "CODEX_HOME="); ok {
+			codexHome = value
+		}
+	}
+	if !filepath.IsAbs(codexHome) {
+		return fmt.Errorf("codex: missing managed home for model catalog")
+	}
+	file, err := os.CreateTemp(codexHome, "model-catalog-*.json")
+	if err != nil {
+		return err
+	}
+	_, writeErr := file.Write(catalog)
+	closeErr := file.Close()
+	if writeErr != nil || closeErr != nil {
+		_ = os.Remove(file.Name())
+		if writeErr != nil {
+			return writeErr
+		}
+		return closeErr
+	}
+	cleanup := plan.Cleanup
+	plan.Cleanup = func() { _ = os.Remove(file.Name()); cleanup() }
+	plan.ExtraConfig = append(plan.ExtraConfig, [2]string{"model_catalog_json", strconv(file.Name())})
+	return nil
+}
+
+func catalogSupportsVerbosity(raw []byte, model string) (bool, error) {
+	var catalog struct {
+		Models []struct {
+			Slug             string `json:"slug"`
+			SupportVerbosity bool   `json:"support_verbosity"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(raw, &catalog); err != nil {
+		return false, err
+	}
+	// Match Codex models-manager's longest-prefix lookup, then its single,
+	// simple provider namespace fallback. Do not infer support from a model name.
+	match := func(name string) (bool, bool) {
+		longest, supported := 0, false
+		for _, candidate := range catalog.Models {
+			if len(candidate.Slug) > longest && strings.HasPrefix(name, candidate.Slug) {
+				longest, supported = len(candidate.Slug), candidate.SupportVerbosity
+			}
+		}
+		return supported, longest > 0
+	}
+	if supported, found := match(model); found {
+		return supported, nil
+	}
+	namespace, suffix, found := strings.Cut(model, "/")
+	if !found || namespace == "" || strings.Contains(suffix, "/") {
+		return false, nil
+	}
+	for _, c := range namespace {
+		if !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_' || c == '-') {
+			return false, nil
+		}
+	}
+	supported, _ := match(suffix)
+	return supported, nil
+}

--- a/apps/parsar-daemon/internal/agent/codex/model_verbosity.go
+++ b/apps/parsar-daemon/internal/agent/codex/model_verbosity.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -20,7 +19,10 @@ func prepareModelVerbosity(ctx context.Context, binary string, plan *SessionPlan
 	args = append(args, "debug", "models")
 	ctx, cancel := context.WithTimeout(ctx, rpcDefaultRequestTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd, err := modelCatalogCommand(ctx, binary, args...)
+	if err != nil {
+		return err
+	}
 	cmd.Dir = plan.Cwd
 	cmd.Env = append(os.Environ(), plan.Env...)
 	catalog, err := cmd.Output()

--- a/apps/parsar-daemon/internal/agent/codex/model_verbosity_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/model_verbosity_test.go
@@ -26,6 +26,9 @@ func TestCatalogVerbositySupport(t *testing.T) {
 }
 
 func TestPrepareModelVerbosity(t *testing.T) {
+	if !SupportsTextVerbosity {
+		t.Skip("catalog probe requires Unix")
+	}
 	t.Setenv("PARSAR_HOME", t.TempDir())
 	binary := filepath.Join(t.TempDir(), "codex")
 	catalog := `{"models":[{"slug":"known-model","support_verbosity":true,"native_extra":{"keep":true}}]}`

--- a/apps/parsar-daemon/internal/agent/codex/model_verbosity_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/model_verbosity_test.go
@@ -1,0 +1,63 @@
+package codex
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCatalogVerbositySupport(t *testing.T) {
+	catalog := []byte(`{"models":[{"slug":"gpt-5","support_verbosity":true},{"slug":"gpt-5-special","support_verbosity":false}]}`)
+	for model, want := range map[string]bool{
+		"gpt-5": true, "gpt-5.5": true, "provider/gpt-5.5": true,
+		"gpt-5-special": false, "provider/gpt-5-special": false,
+		"custom-provider-model": false, "": false, "a/b/gpt-5": false, "a b/gpt-5": false,
+	} {
+		got, err := catalogSupportsVerbosity(catalog, model)
+		if err != nil || got != want {
+			t.Errorf("%q: got %v, %v; want %v", model, got, err, want)
+		}
+	}
+	if _, err := catalogSupportsVerbosity([]byte(`{"models":false}`), "gpt-5"); err == nil {
+		t.Fatal("accepted malformed catalog")
+	}
+}
+
+func TestPrepareModelVerbosity(t *testing.T) {
+	t.Setenv("PARSAR_HOME", t.TempDir())
+	binary := filepath.Join(t.TempDir(), "codex")
+	catalog := `{"models":[{"slug":"known-model","support_verbosity":true,"native_extra":{"keep":true}}]}`
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nprintf '%s' '"+catalog+"'\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	plan, err := BuildSessionPlan("run", "state", "", map[string]any{"model": "known-model", "model_verbosity": "high"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer plan.Cleanup()
+	if err := prepareModelVerbosity(context.Background(), binary, &plan); err != nil {
+		t.Fatal(err)
+	}
+	kv := plan.ExtraConfig[len(plan.ExtraConfig)-1]
+	if kv[0] != "model_catalog_json" {
+		t.Fatal("catalog was not pinned")
+	}
+	name := strings.Trim(kv[1], `"`)
+	got, err := os.ReadFile(name)
+	if err != nil || string(got) != catalog {
+		t.Fatalf("catalog changed: %s, %v", got, err)
+	}
+	plan.Cleanup()
+	if _, err := os.Stat(name); !os.IsNotExist(err) {
+		t.Fatalf("catalog was not removed: %v", err)
+	}
+	plan.Model = "custom-provider-model"
+	if err := prepareModelVerbosity(context.Background(), binary, &plan); err == nil {
+		t.Fatal("accepted model that would ignore verbosity")
+	}
+	if err := prepareModelVerbosity(context.Background(), "/missing-codex", &plan); err == nil {
+		t.Fatal("accepted unreadable catalog")
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/options.go
+++ b/apps/parsar-daemon/internal/agent/codex/options.go
@@ -119,6 +119,14 @@ func BuildSessionPlan(runID, agentStateKey, workDir string, opts map[string]any)
 		}
 	}
 
+	if value, present := opts["model_verbosity"]; present {
+		switch value {
+		case "low", "medium", "high":
+		default:
+			return plan, fmt.Errorf("codex: model_verbosity must be low, medium or high")
+		}
+	}
+
 	resolvedCwd, err := resolveWorkDirCodex(workDir)
 	if err != nil {
 		return plan, err
@@ -301,19 +309,6 @@ func buildSessionEnv(opts map[string]any) ([]string, error) {
 		env = append(env, k+"="+s)
 	}
 	return env, nil
-}
-
-func extraConfigFromOpts(opts map[string]any) [][2]string {
-	var out [][2]string
-	if rs := stringOpt(opts, "reasoning_summary"); rs != "" {
-		// codex app-server has no per-call flag; route via -c override.
-		// TOML literal — quoted string keeps shell-safe special chars.
-		out = append(out, [2]string{"model_reasoning_summary", strconv(rs)})
-	}
-	if mode := stringOpt(opts, "web_search"); mode != "" {
-		out = append(out, [2]string{"web_search", strconv(mode)})
-	}
-	return out
 }
 
 func stringListOpt(opts map[string]any, key string) []string {

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -126,6 +126,13 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		return nil, fmt.Errorf("codex: build session plan: %w", err)
 	}
 
+	if stringOpt(req.AgentOptions, "model_verbosity") != "" {
+		if err := prepareModelVerbosity(parent, cfg.codexBinary, &plan); err != nil {
+			plan.Cleanup()
+			return nil, err
+		}
+	}
+
 	if req.DisableExecutionEnvironment {
 		plan.Env = append(plan.Env, "CODEX_EXEC_SERVER_URL=none")
 	}

--- a/apps/parsar-daemon/internal/agent/codex/verbosity_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/verbosity_test.go
@@ -1,0 +1,33 @@
+package codex
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestVerbosityConfiguration(t *testing.T) {
+	for _, mode := range []string{"", "low", "medium", "high"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Setenv("PARSAR_HOME", t.TempDir())
+			opts := map[string]any{}
+			var want [][2]string
+			if mode != "" {
+				opts["model_verbosity"] = mode
+				want = [][2]string{{"model_verbosity", `"` + mode + `"`}}
+			}
+			plan, err := BuildSessionPlan("run", "state", "", opts)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer plan.Cleanup()
+			if !reflect.DeepEqual(plan.ExtraConfig, want) {
+				t.Fatalf("config = %v, want %v", plan.ExtraConfig, want)
+			}
+		})
+	}
+	for _, value := range []any{nil, "", "enabled", true, 1, map[string]any{}, []any{}} {
+		if _, err := BuildSessionPlan("run", "state", "", map[string]any{"model_verbosity": value}); err == nil {
+			t.Fatalf("accepted invalid model_verbosity %T", value)
+		}
+	}
+}

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -266,6 +266,7 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 				ToolItems:        true,
 				EnvironmentNone:  true,
 				WebSearchControl: true,
+				TextVerbosity:    true,
 			},
 		},
 		Pi: proto.SupportedAgentKind{

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -266,7 +266,7 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 				ToolItems:        true,
 				EnvironmentNone:  true,
 				WebSearchControl: true,
-				TextVerbosity:    true,
+				TextVerbosity:    codex.SupportsTextVerbosity,
 			},
 		},
 		Pi: proto.SupportedAgentKind{

--- a/apps/parsar-daemon/internal/cli/connect_test.go
+++ b/apps/parsar-daemon/internal/cli/connect_test.go
@@ -174,7 +174,7 @@ func TestDiscoverAgentCLIsBothAvailable(t *testing.T) {
 	if !got.ClaudeCode.Capabilities.Permissions || !got.ClaudeCode.Capabilities.Resume {
 		t.Fatalf("ClaudeCode capabilities = %#v", got.ClaudeCode.Capabilities)
 	}
-	if !got.Codex.Capabilities.WebSearchControl || !got.Codex.Capabilities.EnvironmentNone || !got.Codex.Capabilities.ToolItems || !got.Codex.Capabilities.MessageItems || !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
+	if !got.Codex.Capabilities.TextVerbosity || !got.Codex.Capabilities.WebSearchControl || !got.Codex.Capabilities.EnvironmentNone || !got.Codex.Capabilities.ToolItems || !got.Codex.Capabilities.MessageItems || !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
 		t.Fatalf("Codex capabilities = %#v (want Streaming+Permissions+Resume)", got.Codex.Capabilities)
 	}
 	if !got.Pi.Available || got.Pi.Version != "pi 0.1.0" {

--- a/apps/parsar-daemon/internal/cli/connect_test.go
+++ b/apps/parsar-daemon/internal/cli/connect_test.go
@@ -174,7 +174,7 @@ func TestDiscoverAgentCLIsBothAvailable(t *testing.T) {
 	if !got.ClaudeCode.Capabilities.Permissions || !got.ClaudeCode.Capabilities.Resume {
 		t.Fatalf("ClaudeCode capabilities = %#v", got.ClaudeCode.Capabilities)
 	}
-	if !got.Codex.Capabilities.TextVerbosity || !got.Codex.Capabilities.WebSearchControl || !got.Codex.Capabilities.EnvironmentNone || !got.Codex.Capabilities.ToolItems || !got.Codex.Capabilities.MessageItems || !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
+	if got.Codex.Capabilities.TextVerbosity != codex.SupportsTextVerbosity || !got.Codex.Capabilities.WebSearchControl || !got.Codex.Capabilities.EnvironmentNone || !got.Codex.Capabilities.ToolItems || !got.Codex.Capabilities.MessageItems || !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
 		t.Fatalf("Codex capabilities = %#v (want Streaming+Permissions+Resume)", got.Codex.Capabilities)
 	}
 	if !got.Pi.Available || got.Pi.Version != "pi 0.1.0" {

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -100,7 +100,7 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Shared daemon connection layer | Implemented; existing product protocol retained |
 | Tenant-scoped Session persistence | Implemented; internal Store, not a public API |
 | Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
-| Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, environment `none`, metadata and creation retry keys |
+| Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, ordinary text with low/medium/high verbosity (native model support required), environment `none`, metadata and creation retry keys |
 | Internal Turn/input persistence | Tenant-scoped atomic input batches, steering, request-level retry identity, cancellation targets and terminal outcomes |
 | Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; explicit Codex no-environment execution; public text/cancel submission with a bounded standalone worker |
 | Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items` and tool snapshots via `tool_items`; tenant-scoped paginated Store reads |
@@ -108,7 +108,7 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Public Items recovery | Indexed message/command/MCP/function/web-search reads, scoped pagination and restart recovery; limitations below |
 | Public SSE | Live Session/Turn lifecycle, supported Item and text events; bounded commit-before-publish buffering and recovery through saved reads |
 | Pending actions and environment lifecycle | Pending |
-| Official-client compatibility | Strict SDK checks for Session/Turn/Items reads and native text execution/cancellation; pagination, retries, errors, tenant isolation and recovery |
+| Official-client compatibility | Strict SDK checks for Session/Turn/Items reads and native text execution/cancellation/verbosity; pagination, retries, errors, tenant isolation and recovery |
 | Go product client | Official `openai-go` v3.61.0 with a thin service configuration; real HTTP integration tests |
 | Product cutover | Pending |
 | Team orchestration | Deferred; Parsar-owned |
@@ -128,7 +128,7 @@ extension separately from upstream fields and document it here when implemented.
 
 `openapi.yaml` is our generated supported surface; it is not the full upstream
 specification. The shared Go wire types are in `v1`. Session update/delete, saved
-Agent references/filtering, other agent options, vaults, initial input, creation streaming
+Agent references/filtering, structured output, other agent options, vaults, initial input, creation streaming
 and execution/provider resources are not supported by this slice. Reject them
 explicitly. `AGENTS_API_ENGINE` selects the service's engine independently of the
 requested model; it does not add a competing field to the upstream request.

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -100,7 +100,7 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Shared daemon connection layer | Implemented; existing product protocol retained |
 | Tenant-scoped Session persistence | Implemented; internal Store, not a public API |
 | Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
-| Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, ordinary text with low/medium/high verbosity (native model support required), environment `none`, metadata and creation retry keys |
+| Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, ordinary text with low/medium/high verbosity (Unix daemon and native model support required), environment `none`, metadata and creation retry keys |
 | Internal Turn/input persistence | Tenant-scoped atomic input batches, steering, request-level retry identity, cancellation targets and terminal outcomes |
 | Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; explicit Codex no-environment execution; public text/cancel submission with a bounded standalone worker |
 | Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items` and tool snapshots via `tool_items`; tenant-scoped paginated Store reads |

--- a/contracts/agents-api/openapi.yaml
+++ b/contracts/agents-api/openapi.yaml
@@ -110,6 +110,10 @@ definitions:
         x-nullable: true
       model:
         type: string
+      text:
+        allOf:
+        - $ref: '#/definitions/v1.TextConfigInput'
+        x-nullable: true
     required:
     - model
     type: object
@@ -393,11 +397,27 @@ definitions:
         $ref: '#/definitions/v1.TextFormat'
       verbosity:
         enum:
+        - low
         - medium
+        - high
         type: string
     required:
     - format
     - verbosity
+    type: object
+  v1.TextConfigInput:
+    properties:
+      format:
+        allOf:
+        - $ref: '#/definitions/v1.TextFormat'
+        x-nullable: true
+      verbosity:
+        enum:
+        - low
+        - medium
+        - high
+        type: string
+        x-nullable: true
     type: object
   v1.TextFormat:
     properties:
@@ -588,8 +608,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Supports inline model/instructions and environment type none. Execution
-        input and other options are explicitly unsupported in this slice.
+      description: Supports inline model/instructions, text verbosity and environment
+        type none. Execution input and other options are explicitly unsupported in
+        this slice.
       parameters:
       - description: agents=v1
         in: header

--- a/contracts/agents-api/v1/sessions.go
+++ b/contracts/agents-api/v1/sessions.go
@@ -15,8 +15,9 @@ type CreateSessionRequest struct {
 }
 
 type InlineAgent struct {
-	Model        string  `json:"model" binding:"required"`
-	Instructions *string `json:"instructions,omitempty" extensions:"x-nullable"`
+	Model        string           `json:"model" binding:"required"`
+	Instructions *string          `json:"instructions,omitempty" extensions:"x-nullable"`
+	Text         *TextConfigInput `json:"text,omitempty" extensions:"x-nullable"`
 }
 
 // Environment currently supports the upstream environment-free configuration.
@@ -46,9 +47,14 @@ type Reasoning struct {
 	Summary *string `json:"summary,omitempty" extensions:"x-nullable"`
 }
 
+type TextConfigInput struct {
+	Format    *TextFormat `json:"format,omitempty" extensions:"x-nullable"`
+	Verbosity *string     `json:"verbosity,omitempty" enums:"low,medium,high" extensions:"x-nullable"`
+}
+
 type TextConfig struct {
 	Format    TextFormat `json:"format" binding:"required"`
-	Verbosity string     `json:"verbosity" enums:"medium" binding:"required"`
+	Verbosity string     `json:"verbosity" enums:"low,medium,high" binding:"required"`
 }
 
 type TextFormat struct {

--- a/internal/agentdaemon/device/state.go
+++ b/internal/agentdaemon/device/state.go
@@ -69,6 +69,7 @@ type KindCapabilities struct {
 	ToolItems          bool `json:"tool_items,omitempty"`
 	EnvironmentNone    bool `json:"environment_none,omitempty"`
 	WebSearchControl   bool `json:"web_search_control,omitempty"`
+	TextVerbosity      bool `json:"text_verbosity,omitempty"`
 	FunctionTools      bool `json:"function_tools,omitempty"`
 	DurableTurns       bool `json:"durable_turns,omitempty"`
 	WorkspaceAuthoring bool `json:"workspace_authoring,omitempty"`

--- a/internal/agentdaemon/gateway/session.go
+++ b/internal/agentdaemon/gateway/session.go
@@ -535,6 +535,7 @@ func deviceKindsFromHeartbeat(p proto.HeartbeatPayload) []device.SupportedAgentK
 				ToolItems:          info.Capabilities.ToolItems,
 				EnvironmentNone:    info.Capabilities.EnvironmentNone,
 				WebSearchControl:   info.Capabilities.WebSearchControl,
+				TextVerbosity:      info.Capabilities.TextVerbosity,
 				FunctionTools:      info.Capabilities.FunctionTools,
 				WorkspaceAuthoring: info.Capabilities.WorkspaceAuthoring,
 			},

--- a/internal/agentdaemon/gateway/session_test.go
+++ b/internal/agentdaemon/gateway/session_test.go
@@ -405,7 +405,7 @@ func TestSession_HeartbeatPersistsSupportedAgentKinds(t *testing.T) {
 			{
 				Kind:         "codex",
 				Available:    true,
-				Capabilities: proto.AgentKindCapabilities{Steering: true, MessageItems: true, ToolItems: true, EnvironmentNone: true, WebSearchControl: true},
+				Capabilities: proto.AgentKindCapabilities{Steering: true, MessageItems: true, ToolItems: true, EnvironmentNone: true, WebSearchControl: true, TextVerbosity: true},
 			},
 		},
 	})
@@ -431,7 +431,7 @@ func TestSession_HeartbeatPersistsSupportedAgentKinds(t *testing.T) {
 	if opencode.Available || opencode.Version != "missing" || !opencode.Capabilities.Streaming {
 		t.Fatalf("opencode descriptor not converted: %#v", opencode)
 	}
-	if !byKind["codex"].Capabilities.WebSearchControl || claude.Capabilities.WebSearchControl || opencode.Capabilities.WebSearchControl || !byKind["codex"].Capabilities.EnvironmentNone || claude.Capabilities.EnvironmentNone || opencode.Capabilities.EnvironmentNone || !byKind["codex"].Capabilities.ToolItems || claude.Capabilities.ToolItems || opencode.Capabilities.ToolItems || !byKind["codex"].Capabilities.MessageItems || !byKind["codex"].Capabilities.Steering || claude.Capabilities.Steering || opencode.Capabilities.Steering {
+	if !byKind["codex"].Capabilities.TextVerbosity || claude.Capabilities.TextVerbosity || opencode.Capabilities.TextVerbosity || !byKind["codex"].Capabilities.WebSearchControl || claude.Capabilities.WebSearchControl || opencode.Capabilities.WebSearchControl || !byKind["codex"].Capabilities.EnvironmentNone || claude.Capabilities.EnvironmentNone || opencode.Capabilities.EnvironmentNone || !byKind["codex"].Capabilities.ToolItems || claude.Capabilities.ToolItems || opencode.Capabilities.ToolItems || !byKind["codex"].Capabilities.MessageItems || !byKind["codex"].Capabilities.Steering || claude.Capabilities.Steering || opencode.Capabilities.Steering {
 		t.Fatalf("steering capability not preserved: %#v", byKind)
 	}
 	codex, found, known := sess.AgentKindStatus("codex")

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -258,6 +258,7 @@ type AgentKindCapabilities struct {
 	ToolItems          bool `json:"tool_items,omitempty"`
 	EnvironmentNone    bool `json:"environment_none,omitempty"`
 	WebSearchControl   bool `json:"web_search_control,omitempty"`
+	TextVerbosity      bool `json:"text_verbosity,omitempty"`
 	// DurableTurns includes strict resume, completion release and cancellation snapshots.
 	DurableTurns  bool `json:"durable_turns,omitempty"`
 	FunctionTools bool `json:"function_tools,omitempty"`

--- a/services/agents-api/internal/api/configuration.go
+++ b/services/agents-api/internal/api/configuration.go
@@ -35,11 +35,15 @@ func resolve(input v1.CreateSessionRequest, tenant, key string) (json.RawMessage
 			return nil, errors.New("metadata keys must be at most 64 characters and values at most 512 characters.")
 		}
 	}
+	text, err := resolveText(input.Agent.Text)
+	if err != nil {
+		return nil, err
+	}
 	// Inline execution configuration has its own stable identity for creation retries.
 	id := "agent_" + uuid.NewSHA1(uuid.NameSpaceOID, []byte(tenant+"\x00"+key)).String()
 	return json.Marshal(configuration{Agent: v1.Agent{
 		ID: id, Model: input.Agent.Model, Instructions: input.Agent.Instructions,
-		ServiceTier: "auto", Text: v1.TextConfig{Format: v1.TextFormat{Type: "text"}, Verbosity: "medium"},
+		ServiceTier: "auto", Text: text,
 		Tools: []json.RawMessage{},
 	}, Environment: *input.Environment})
 }

--- a/services/agents-api/internal/api/handler.go
+++ b/services/agents-api/internal/api/handler.go
@@ -85,7 +85,7 @@ func tenantID(r *http.Request) string { return r.Context().Value(tenantContextKe
 
 // createSession creates an idle execution Session without submitting a Turn.
 // @Summary Create an execution Session
-// @Description Supports inline model/instructions and environment type none. Execution input and other options are explicitly unsupported in this slice.
+// @Description Supports inline model/instructions, text verbosity and environment type none. Execution input and other options are explicitly unsupported in this slice.
 // @Tags Sessions
 // @Accept json
 // @Produce json

--- a/services/agents-api/internal/api/text_configuration.go
+++ b/services/agents-api/internal/api/text_configuration.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"errors"
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+)
+
+func resolveText(input *v1.TextConfigInput) (v1.TextConfig, error) {
+	text := v1.TextConfig{Format: v1.TextFormat{Type: "text"}, Verbosity: "medium"}
+	if input == nil {
+		return text, nil
+	}
+	if input.Format != nil && input.Format.Type != "text" {
+		return text, errors.New("This service currently supports text.format.type=text only.")
+	}
+	if input.Verbosity != nil {
+		switch *input.Verbosity {
+		case "low", "medium", "high":
+			text.Verbosity = *input.Verbosity
+		default:
+			return text, errors.New("text.verbosity must be low, medium or high.")
+		}
+	}
+	return text, nil
+}

--- a/services/agents-api/internal/api/text_configuration_test.go
+++ b/services/agents-api/internal/api/text_configuration_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+)
+
+func TestTextConfigurationHTTP(t *testing.T) {
+	for _, tc := range []struct{ text, want string }{
+		{``, "medium"}, {`,"text":null`, "medium"}, {`,"text":{}`, "medium"},
+		{`,"text":{"verbosity":null,"format":null}`, "medium"},
+		{`,"text":{"verbosity":"low"}`, "low"}, {`,"text":{"verbosity":"medium"}`, "medium"},
+		{`,"text":{"verbosity":"high","format":{"type":"text"}}`, "high"},
+	} {
+		t.Run(tc.text, func(t *testing.T) {
+			h, s, _ := testHandler(t)
+			req := httptest.NewRequest(http.MethodPost, "/v1/agents/sessions", strings.NewReader(`{"agent":{"model":"example"`+tc.text+`},"environment":{"type":"none"}}`))
+			req.Header.Set("Authorization", "Bearer test-api-key")
+			req.Header.Set("OpenAI-Beta", "agents=v1")
+			response := httptest.NewRecorder()
+			h.ServeHTTP(response, req)
+			if response.Code != 200 {
+				t.Fatal(response.Code, response.Body)
+			}
+			var got v1.Session
+			if err := json.Unmarshal(response.Body.Bytes(), &got); err != nil {
+				t.Fatal(err)
+			}
+			var saved configuration
+			if err := json.Unmarshal(s.input.Configuration, &saved); err != nil {
+				t.Fatal(err)
+			}
+			want := v1.TextConfig{Format: v1.TextFormat{Type: "text"}, Verbosity: tc.want}
+			if got.Agent.Text != want || saved.Agent.Text != want {
+				t.Fatal(got.Agent.Text, saved.Agent.Text)
+			}
+		})
+	}
+	for _, invalid := range []string{`{"verbosity":""}`, `{"verbosity":"verbose"}`, `{"verbosity":4}`, `{"format":{}}`, `{"format":{"type":"json_schema","schema":{}}}`, `{"format":{"type":"text","extra":true}}`, `{"unknown":true}`} {
+		h, s, _ := testHandler(t)
+		req := httptest.NewRequest(http.MethodPost, "/v1/agents/sessions", strings.NewReader(`{"agent":{"model":"example","text":`+invalid+`},"environment":{"type":"none"}}`))
+		req.Header.Set("Authorization", "Bearer test-api-key")
+		req.Header.Set("OpenAI-Beta", "agents=v1")
+		response := httptest.NewRecorder()
+		h.ServeHTTP(response, req)
+		if response.Code != 400 || s.tenant != "" {
+			t.Fatalf("accepted invalid config %s: %d", invalid, response.Code)
+		}
+	}
+}

--- a/services/agents-api/internal/execution/dispatcher.go
+++ b/services/agents-api/internal/execution/dispatcher.go
@@ -61,6 +61,9 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 	if session.Engine == "codex" && !info.Capabilities.WebSearchControl {
 		return store.Turn{}, errors.New("device must advertise web_search_control for Codex")
 	}
+	if session.Engine == "codex" && !info.Capabilities.TextVerbosity {
+		return store.Turn{}, errors.New("device must advertise text_verbosity for Codex")
+	}
 	var snapshot Snapshot
 	if json.Unmarshal(session.Configuration, &snapshot) != nil || strings.TrimSpace(snapshot.Agent.Model) == "" {
 		return store.Turn{}, store.ErrInvalidInput
@@ -91,6 +94,11 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 	delete(options, "override_system_prompt")
 	if session.Engine == "codex" {
 		options["web_search"] = "disabled"
+		verbosity := snapshot.Agent.Text.Verbosity
+		if verbosity == "" {
+			verbosity = "medium"
+		}
+		options["model_verbosity"] = verbosity
 	}
 	if _, err := d.Store.TransitionTurn(ctx, tenantID, sessionID, turnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
 		return store.Turn{}, err

--- a/services/agents-api/internal/execution/worker.go
+++ b/services/agents-api/internal/execution/worker.go
@@ -175,7 +175,7 @@ func (w *Worker) ready(deviceID string) bool {
 		return false
 	}
 	info, found, known := peer.AgentKindStatus("codex")
-	return found && known && info.Available && info.Capabilities.Streaming && info.Capabilities.Steering && info.Capabilities.DurableTurns && info.Capabilities.EnvironmentNone && info.Capabilities.WebSearchControl
+	return found && known && info.Available && info.Capabilities.Streaming && info.Capabilities.Steering && info.Capabilities.DurableTurns && info.Capabilities.EnvironmentNone && info.Capabilities.WebSearchControl && info.Capabilities.TextVerbosity
 }
 
 func (w *Worker) runClaim(ctx context.Context, item store.ExecutionWork) error {

--- a/services/agents-api/internal/store/dispatch_test.go
+++ b/services/agents-api/internal/store/dispatch_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http/httptest"
 	"net/url"
 	"sync"
@@ -69,7 +68,7 @@ func newDispatchHarness(t *testing.T) *dispatchHarness {
 		t.Fatal("device connection failed")
 	}
 	t.Cleanup(func() { h.conn.Close() })
-	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true}}}})
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true}}}})
 	deadline := time.Now().Add(3 * time.Second)
 	for {
 		peer, e := h.registry.LookupDevice(h.device.ID)
@@ -337,15 +336,16 @@ func TestExecutionOutcomeAndNativeBindingCommitTogether(t *testing.T) {
 }
 
 func TestExecutionRejectsLegacyDaemonBeforeClaim(t *testing.T) {
-	for _, durable := range []bool{false, true} {
-		t.Run(fmt.Sprintf("durable_%t", durable), func(t *testing.T) {
+	for _, missing := range []string{"durable_turns", "web_search_control", "text_verbosity"} {
+		durable, search := missing != "durable_turns", missing == "text_verbosity"
+		t.Run(missing, func(t *testing.T) {
 			h := newDispatchHarness(t)
-			h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: durable}}}})
+			h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: durable, WebSearchControl: search}}}})
 			deadline := time.Now().Add(3 * time.Second)
 			for {
 				peer, _ := h.registry.LookupDevice(h.device.ID)
 				info, _, _ := peer.AgentKindStatus("codex")
-				if info.Capabilities.DurableTurns == durable && !info.Capabilities.WebSearchControl {
+				if info.Capabilities.DurableTurns == durable && info.Capabilities.WebSearchControl == search && !info.Capabilities.TextVerbosity {
 					break
 				}
 				if time.Now().After(deadline) {

--- a/services/agents-api/internal/store/execution_messages_test.go
+++ b/services/agents-api/internal/store/execution_messages_test.go
@@ -23,7 +23,7 @@ func TestExecutionNegotiatesAndPersistsMessageObservations(t *testing.T) {
 	}
 	h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
 	h.finished(result, store.TurnCompleted)
-	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, MessageItems: true}}}})
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, MessageItems: true}}}})
 	deadline := time.Now().Add(3 * time.Second)
 	for {
 		peer, err := h.registry.LookupDevice(h.device.ID)

--- a/services/agents-api/internal/store/execution_tools_test.go
+++ b/services/agents-api/internal/store/execution_tools_test.go
@@ -25,7 +25,7 @@ func TestExecutionNegotiatesAndPersistsToolObservations(t *testing.T) {
 	}
 	h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
 	h.finished(result, store.TurnCompleted)
-	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, ToolItems: true}}}})
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, ToolItems: true}}}})
 	deadline := time.Now().Add(3 * time.Second)
 	for {
 		peer, err := h.registry.LookupDevice(h.device.ID)

--- a/services/agents-api/internal/store/native_environment_test.go
+++ b/services/agents-api/internal/store/native_environment_test.go
@@ -95,11 +95,26 @@ func TestNativeNoExecutionEnvironment(t *testing.T) {
 			t.Error(err)
 			return
 		}
+		if body["model"] == "custom-provider-model" {
+			t.Error("unsupported verbosity reached model execution")
+		}
 		for _, value := range body["tools"].([]any) {
 			tool := value.(map[string]any)
 			if kind, _ := tool["type"].(string); strings.HasPrefix(kind, "web_search") {
 				t.Error("undeclared web search reached the model")
 			}
+		}
+
+		encoded, _ := json.Marshal(body)
+		expected := "medium"
+		for _, level := range []string{"low", "high"} {
+			if strings.Contains(string(encoded), "TEXT-VERBOSITY:"+level) {
+				expected = level
+			}
+		}
+		textConfig, _ := body["text"].(map[string]any)
+		if textConfig["verbosity"] != expected {
+			t.Errorf("effective verbosity = %v, want %s", textConfig["verbosity"], expected)
 		}
 		n := requests.Add(1)
 		raw, _ := json.MarshalIndent(body, "", "  ")
@@ -140,7 +155,7 @@ func TestNativeNoExecutionEnvironment(t *testing.T) {
 	}))
 	defer model.Close()
 	h.d.Options = func(context.Context, store.Session) (map[string]any, error) {
-		return map[string]any{"web_search": "live", "codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}, "env": map[string]any{"CODEX_EXEC_SERVER_URL": "ws://127.0.0.1:1"}}, nil
+		return map[string]any{"model_verbosity": "high", "web_search": "live", "codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}, "env": map[string]any{"CODEX_EXEC_SERVER_URL": "ws://127.0.0.1:1"}}, nil
 	}
 	first := h.message("first", "Return an answer.")
 	h.finished(h.run(ctx, first.TurnID), store.TurnCompleted)

--- a/services/agents-api/internal/store/public_execution_test.go
+++ b/services/agents-api/internal/store/public_execution_test.go
@@ -23,7 +23,7 @@ func publicSession(t *testing.T, h *dispatchHarness, key string) store.Session {
 
 func TestExecutionWorkerAdmissionBindingAndRecovery(t *testing.T) {
 	h := newDispatchHarness(t)
-	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, DurableTurns: true, WebSearchControl: true, EnvironmentNone: true}}}})
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, EnvironmentNone: true}}}})
 	h.session = publicSession(t, h, "public")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -63,7 +63,7 @@ func TestExecutionWorkerAdmissionBindingAndRecovery(t *testing.T) {
 	if err := request.DecodePayload(&prompt); err != nil {
 		t.Fatal(err)
 	}
-	if prompt.Prompt != "First\n\nSecond" || !prompt.DisableExecutionEnvironment || prompt.AgentOptions["web_search"] != "disabled" {
+	if prompt.Prompt != "First\n\nSecond" || !prompt.DisableExecutionEnvironment || prompt.AgentOptions["web_search"] != "disabled" || prompt.AgentOptions["model_verbosity"] != "medium" {
 		t.Fatal(prompt)
 	}
 	bound, err := h.s.GetSessionDevice(ctx, h.tenant, h.session.ID)

--- a/services/agents-api/tests/official_execution.py
+++ b/services/agents-api/tests/official_execution.py
@@ -123,10 +123,35 @@ def main():
         assert not any(value.type == "agent.session.turn.created" for value in cancelled_events)
         assert {item.id for item in retained} <= {item.id for item in sessions.items.list(cancelled.id, limit=100).data}
         assert sessions.retrieve(cancelled.id).status == "idle"
+        for verbosity in ("low", "medium", "high"):
+            agent = {"model": "gpt-5.5", "text": {"verbosity": verbosity, "format": {"type": "text"}}}
+            key = "text-" + verbosity
+            configured = sessions.create(agent=agent, environment={"type": "none"}, extra_headers={"Idempotency-Key": key})
+            agent["text"]["format"] = None
+            assert sessions.create(agent=agent, environment={"type": "none"}, extra_headers={"Idempotency-Key": key}).id == configured.id
+            assert configured.agent.text.model_dump() == {"format": {"type": "text"}, "verbosity": verbosity}
+            for count in (1, 2):
+                sessions.events.create(configured.id, events=[message("TEXT-VERBOSITY:" + verbosity)])
+                wait_turn(configured.id, "completed", count)
+                assert sessions.retrieve(configured.id).agent.text == configured.agent.text
+            agent["text"]["verbosity"] = "high" if verbosity != "high" else "low"
+            try:
+                sessions.create(agent=agent, environment={"type": "none"}, extra_headers={"Idempotency-Key": key})
+                raise AssertionError("changed text configuration reused a retry key")
+            except ConflictError:
+                pass
+        unsupported = sessions.create(agent={"model": "custom-provider-model", "text": {"verbosity": "high"}},
+                                      environment={"type": "none"})
+        sessions.events.create(unsupported.id, events=[message("UNSUPPORTED-VERBOSITY")])
+        failed = wait_turn(unsupported.id, "failed")
+        assert failed.error is not None and failed.error.code == "internal_error", failed.error
+        assert sessions.retrieve(unsupported.id).status == "failed"
         Path(evidence).write_text(json.dumps({"session": session.id, "turns": [first.id, second.id],
                                               "cancelled_session": cancelled.id, "cancelled_turn": stopped.id,
                                               "stream_types": types, "reconnected_events": len(second_events),
-                                              "cancelled_events": [value.type for value in cancelled_events]}))
+                                              "cancelled_events": [value.type for value in cancelled_events],
+                                              "verbosity_new_and_resumed": ["low", "medium", "high"],
+                                              "unsupported_verbosity": failed.error.model_dump()}))
     finally:
         client.close()
         foreign.close()


### PR DESCRIPTION
Agents API currently reports medium text verbosity while native Codex sends low, and rejects explicit verbosity settings. Support `agent.text.verbosity` values `low`, `medium` and `high`, resolve omitted/null configuration to medium, and apply the persisted selection to new and resumed Turns. Ordinary Parsar prompts that omit the native option keep their existing defaults.

The public field follows the pinned upstream `AgentText` types. The adapter verifies support using the native model catalog and pins the same catalog for execution; unsupported models fail before model execution instead of silently ignoring the setting. Catalog cancellation stops the process group and bounds pipe waiting; this capability currently requires a Unix daemon. Structured output, other Agent settings and additional model support remain separate protocol work.

Validation on `zju_a100_2`: required `make check`, regenerated Agents API OpenAPI, dedicated PostgreSQL execution regressions, and real Codex 0.153.4 plus daemon and the pinned official Python SDK using a synthetic model endpoint. Model-request capture verifies all three levels across new/resumed Turns, alongside persisted configuration, retry normalization/conflicts, cancellation and rejection of unsupported model configuration. Product Docker database checks are skipped; no product store or schema changes.

Review: independent blind reviews of the complete diff. The final local process-group cleanup correction was self-reviewed and tested for cancellation with both waiting and early-exiting launchers.
