### PR TITLE
feat(daemon): preserve text and image function results

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,7 +285,12 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   Structured output formats remain a separate protocol gap.
 - `function_tools` advertises the optional native function-call bridge. Explicit
   prompt definitions become Codex dynamic tools; unchanged prompts carry none.
-  Requests and textual results are scoped by Run and native call ID. Reuse
+  Requests and ordered text/image results are scoped by Run and native call ID.
+  Normalize string results into one text part at the public execution boundary;
+  the internal result carries a typed content array, and adapters translate it
+  to native content without fetching images or dropping parts. Validate content
+  before consuming a pending call. Retry identity includes the complete ordered
+  content and success flag. Reuse
   application receipts and conflict detection; a receipt confirms the native
   reply was written, not that an external side effect succeeded. Pending calls
   end with their Run; the execution service owns persistence and recovery, while

--- a/apps/parsar-daemon/internal/agent/codex/functions.go
+++ b/apps/parsar-daemon/internal/agent/codex/functions.go
@@ -107,12 +107,23 @@ func (s *Session) SubmitFunctionResult(ctx context.Context, result proto.Functio
 	if !exists || s.functions.closed || s.cancelled.Load() || s.terminal.Load() {
 		return agent.ErrUnknownFunctionCall
 	}
+	if err := result.ValidateContent(); err != nil {
+		return err
+	}
+	content := make([]functionContent, 0, len(result.Content))
+	for _, part := range result.Content {
+		kind := "inputText"
+		if part.Type == "input_image" {
+			kind = "inputImage"
+		}
+		content = append(content, functionContent{Type: kind, Text: part.Text, ImageURL: part.ImageURL})
+	}
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	reply := struct {
-		Success      bool           `json:"success"`
-		ContentItems []functionText `json:"contentItems"`
-	}{Success: result.Success, ContentItems: []functionText{{Type: "inputText", Text: result.Text}}}
+		Success      bool              `json:"success"`
+		ContentItems []functionContent `json:"contentItems"`
+	}{Success: result.Success, ContentItems: content}
 	if err := s.rpc.writeFrameContext(ctx, JsonRpcResponse{JsonRpc: JsonRpcVersion, ID: id, Result: reply}); err != nil {
 		return fmt.Errorf("write function result: %w", err)
 	}
@@ -120,9 +131,10 @@ func (s *Session) SubmitFunctionResult(ctx context.Context, result proto.Functio
 	return nil
 }
 
-type functionText struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
+type functionContent struct {
+	Type     string  `json:"type"`
+	Text     *string `json:"text,omitempty"`
+	ImageURL *string `json:"imageUrl,omitempty"`
 }
 
 func (s *Session) stopFunctionCalls() {

--- a/apps/parsar-daemon/internal/agent/codex/functions_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/functions_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
@@ -36,9 +37,14 @@ func TestFunctionCallWaitsAndRepliesOnce(t *testing.T) {
 			case <-time.After(time.Second):
 				t.Fatal("missing function call")
 			}
+			text, image, empty := "answer", "https://example.com/result.png", ""
+			content := []proto.FunctionResultContent{{Type: "input_text", Text: &text}, {Type: "input_image", ImageURL: &image}, {Type: "input_text", Text: &empty}}
+			if err := s.SubmitFunctionResult(t.Context(), proto.FunctionResultPayload{CallID: "call", Content: []proto.FunctionResultContent{{Type: "input_audio"}}}); err == nil {
+				t.Fatal("invalid result consumed the pending call")
+			}
 			finished := make(chan error, 1)
 			go func() {
-				finished <- s.SubmitFunctionResult(t.Context(), proto.FunctionResultPayload{CallID: "call", Success: success, Text: "answer"})
+				finished <- s.SubmitFunctionResult(t.Context(), proto.FunctionResultPayload{CallID: "call", Success: success, Content: content})
 			}()
 			var reply struct {
 				ID     string          `json:"id"`
@@ -54,10 +60,10 @@ func TestFunctionCallWaitsAndRepliesOnce(t *testing.T) {
 				t.Fatal(err)
 			}
 			var result struct {
-				Success bool           `json:"success"`
-				Content []functionText `json:"contentItems"`
+				Success bool              `json:"success"`
+				Content []functionContent `json:"contentItems"`
 			}
-			if err := json.Unmarshal(reply.Result, &result); err != nil || result.Success != success || len(result.Content) != 1 || result.Content[0].Text != "answer" || result.Content[0].Type != "inputText" {
+			if err := json.Unmarshal(reply.Result, &result); err != nil || result.Success != success || !reflect.DeepEqual(result.Content, []functionContent{{Type: "inputText", Text: &text}, {Type: "inputImage", ImageURL: &image}, {Type: "inputText", Text: &empty}}) {
 				t.Fatal(string(reply.Result), err)
 			}
 			if err := s.SubmitFunctionResult(t.Context(), proto.FunctionResultPayload{CallID: "call"}); !errors.Is(err, agent.ErrUnknownFunctionCall) {

--- a/apps/parsar-daemon/internal/dispatch/functions.go
+++ b/apps/parsar-daemon/internal/dispatch/functions.go
@@ -27,6 +27,9 @@ func (r *Router) handleFunctionResult(ctx context.Context, env proto.Envelope) e
 	if env.ID == "" || result.CallID == "" || result.DeliveryID == "" {
 		return errors.New("function result requires run, call and delivery identities")
 	}
+	if err := result.ValidateContent(); err != nil {
+		return r.sendInteractionDecisionAck(ctx, env.ID, result.DeliveryID, false, "invalid_result", err.Error())
+	}
 	decision := result
 	decision.DeliveryID = ""
 	encoded, err := json.Marshal(decision)

--- a/apps/parsar-daemon/internal/dispatch/functions_native_test.go
+++ b/apps/parsar-daemon/internal/dispatch/functions_native_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -57,7 +58,34 @@ func TestNativeFunctionBridge(t *testing.T) {
 			}
 			item = map[string]any{"id": fmt.Sprintf("fc_%d", n), "type": "function_call", "call_id": fmt.Sprintf("call_%d", n), "name": "lookup_ticket", "arguments": `{"ticket":"42"}`, "status": "completed"}
 		} else {
-			if !strings.Contains(string(raw), "TICKET-RESULT") {
+
+			var request struct {
+				Input []struct {
+					Type   string          `json:"type"`
+					CallID string          `json:"call_id"`
+					Output json.RawMessage `json:"output"`
+				} `json:"input"`
+			}
+			if err := json.Unmarshal(raw, &request); err != nil {
+				t.Error(err)
+			}
+			found := false
+			for _, entry := range request.Input {
+				if entry.Type != "function_call_output" || entry.CallID != fmt.Sprintf("call_%d", n-1) {
+					continue
+				}
+				found = true
+				var parts []proto.FunctionResultContent
+				if err := json.Unmarshal(entry.Output, &parts); err != nil {
+					t.Error(err)
+					continue
+				}
+				expected := functionResultContent("TICKET-RESULT")
+				if !reflect.DeepEqual(parts, expected) {
+					t.Errorf("native result lost text/image content or order: %s", entry.Output)
+				}
+			}
+			if !found {
 				t.Error("native model did not receive function result")
 			}
 			item = map[string]any{"id": fmt.Sprintf("msg_%d", n), "type": "message", "role": "assistant", "phase": "final_answer", "status": "completed", "content": []any{map[string]any{"type": "output_text", "text": "FUNCTION-OK", "annotations": []any{}}}}
@@ -127,7 +155,7 @@ func TestNativeFunctionBridge(t *testing.T) {
 			if !receipt.Applied {
 				t.Fatal(receipt)
 			}
-			late, _ := proto.NewEnvelope(proto.TypeFunctionResult, run, proto.FunctionResultPayload{CallID: payload.CallID, Success: true, Text: "late", DeliveryID: "late"})
+			late, _ := proto.NewEnvelope(proto.TypeFunctionResult, run, proto.FunctionResultPayload{CallID: payload.CallID, Success: true, Content: functionResultContent("late"), DeliveryID: "late"})
 			if err := router.Handle(ctx, late); err != nil {
 				t.Fatal(err)
 			}
@@ -137,7 +165,7 @@ func TestNativeFunctionBridge(t *testing.T) {
 			}
 			break
 		}
-		result, _ := proto.NewEnvelope(proto.TypeFunctionResult, run, proto.FunctionResultPayload{CallID: payload.CallID, Success: index == 0, Text: "TICKET-RESULT", DeliveryID: "result"})
+		result, _ := proto.NewEnvelope(proto.TypeFunctionResult, run, proto.FunctionResultPayload{CallID: payload.CallID, Success: index == 0, Content: functionResultContent("TICKET-RESULT"), DeliveryID: "result"})
 		if err := router.Handle(ctx, result); err != nil {
 			t.Fatal(err)
 		}

--- a/apps/parsar-daemon/internal/dispatch/functions_test.go
+++ b/apps/parsar-daemon/internal/dispatch/functions_test.go
@@ -1,8 +1,13 @@
 package dispatch_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
 	"sync"
 	"testing"
 
@@ -48,7 +53,7 @@ func TestFunctionReceiptsScopeRetriesAndConflicts(t *testing.T) {
 	}
 	submit := func(run, call, text, delivery string) proto.InteractionDecisionAckPayload {
 		t.Helper()
-		env, _ := proto.NewEnvelope(proto.TypeFunctionResult, run, proto.FunctionResultPayload{CallID: call, Success: true, Text: text, DeliveryID: delivery})
+		env, _ := proto.NewEnvelope(proto.TypeFunctionResult, run, proto.FunctionResultPayload{CallID: call, Success: true, Content: functionResultContent(text), DeliveryID: delivery})
 		if err := router.Handle(t.Context(), env); err != nil {
 			t.Fatal(err)
 		}
@@ -66,11 +71,22 @@ func TestFunctionReceiptsScopeRetriesAndConflicts(t *testing.T) {
 	if a := submit("one", "missing", "answer", "b"); a.Applied || a.ErrorCode != "not_pending" {
 		t.Fatal(a)
 	}
+
+	invalid, _ := proto.NewEnvelope(proto.TypeFunctionResult, "one", proto.FunctionResultPayload{CallID: "call", DeliveryID: "invalid", Content: []proto.FunctionResultContent{{Type: "input_audio"}}})
+	if err := router.Handle(t.Context(), invalid); err != nil {
+		t.Fatal(err)
+	}
+	frames := sender.snapshot()
+	var invalidAck proto.InteractionDecisionAckPayload
+	_ = frames[len(frames)-1].DecodePayload(&invalidAck)
+	if invalidAck.Applied || invalidAck.ErrorCode != "invalid_result" {
+		t.Fatal(invalidAck)
+	}
 	// A lost receipt may be retried without writing the native result twice.
 	sender.mu.Lock()
 	sender.failNow = true
 	sender.mu.Unlock()
-	first, _ := proto.NewEnvelope(proto.TypeFunctionResult, "one", proto.FunctionResultPayload{CallID: "call", Success: true, Text: "answer", DeliveryID: "lost"})
+	first, _ := proto.NewEnvelope(proto.TypeFunctionResult, "one", proto.FunctionResultPayload{CallID: "call", Success: true, Content: functionResultContent("answer"), DeliveryID: "lost"})
 	if err := router.Handle(t.Context(), first); err == nil {
 		t.Fatal("receipt send failure was hidden")
 	}
@@ -79,6 +95,29 @@ func TestFunctionReceiptsScopeRetriesAndConflicts(t *testing.T) {
 	}
 	if a := submit("one", "call", "changed", "conflict"); a.Applied || a.ErrorCode != "decision_conflict" {
 		t.Fatal(a)
+	}
+
+	for _, mutation := range []string{"image", "order", "success"} {
+		result := proto.FunctionResultPayload{CallID: "call", Success: true, Content: functionResultContent("answer"), DeliveryID: mutation}
+		switch mutation {
+		case "image":
+			other := "https://example.com/other.png"
+			result.Content[1].ImageURL = &other
+		case "order":
+			result.Content[0], result.Content[1] = result.Content[1], result.Content[0]
+		case "success":
+			result.Success = false
+		}
+		env, _ := proto.NewEnvelope(proto.TypeFunctionResult, "one", result)
+		if err := router.Handle(t.Context(), env); err != nil {
+			t.Fatal(err)
+		}
+		frames := sender.snapshot()
+		var ack proto.InteractionDecisionAckPayload
+		_ = frames[len(frames)-1].DecodePayload(&ack)
+		if ack.Applied || ack.ErrorCode != "decision_conflict" {
+			t.Fatal(mutation, ack)
+		}
 	}
 	if a := submit("two", "call", "second answer", "other-run"); !a.Applied {
 		t.Fatal(a)
@@ -107,4 +146,16 @@ func TestFunctionToolsRequireAdvertisedSupport(t *testing.T) {
 	if err := router.Handle(t.Context(), env); err == nil || called {
 		t.Fatal("unsupported engine silently ignored tools", err)
 	}
+}
+
+func functionResultContent(text string) []proto.FunctionResultContent {
+	picture := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	picture.Set(0, 0, color.RGBA{R: 255, A: 255})
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, picture); err != nil {
+		panic(err)
+	}
+	imageURL := "data:image/png;base64," + base64.StdEncoding.EncodeToString(encoded.Bytes())
+	after := "AFTER-IMAGE"
+	return []proto.FunctionResultContent{{Type: "input_text", Text: &text}, {Type: "input_image", ImageURL: &imageURL}, {Type: "input_text", Text: &after}}
 }

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -107,6 +107,7 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Public Turn recovery | Retrieve/list persisted states with scoped pagination; see limitations below |
 | Public Items recovery | Indexed message/command/MCP/function/web-search reads, scoped pagination and restart recovery; limitations below |
 | Public SSE | Live Session/Turn lifecycle, supported Item and text events; bounded commit-before-publish buffering and recovery through saved reads |
+| Internal function bridge | Native Codex definitions and ordered text/image results, Run/call-scoped receipts, retries and cancellation; public function actions still pending |
 | Pending actions and environment lifecycle | Pending |
 | Official-client compatibility | Strict SDK checks for Session/Turn/Items reads and native text execution/cancellation/verbosity; pagination, retries, errors, tenant isolation and recovery |
 | Go product client | Official `openai-go` v3.61.0 with a thin service configuration; real HTTP integration tests |

--- a/internal/agentdaemon/proto/functions.go
+++ b/internal/agentdaemon/proto/functions.go
@@ -1,6 +1,9 @@
 package proto
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"errors"
+)
 
 const (
 	TypeFunctionCall   = "function_call"
@@ -21,8 +24,35 @@ type FunctionCallPayload struct {
 }
 
 type FunctionResultPayload struct {
-	DeliveryID string `json:"delivery_id"`
-	CallID     string `json:"call_id"`
-	Success    bool   `json:"success"`
-	Text       string `json:"text"`
+	DeliveryID string                  `json:"delivery_id"`
+	CallID     string                  `json:"call_id"`
+	Success    bool                    `json:"success"`
+	Content    []FunctionResultContent `json:"content"`
+}
+
+// FunctionResultContent is one ordered text or image part of a function result.
+type FunctionResultContent struct {
+	Type     string  `json:"type"`
+	Text     *string `json:"text,omitempty"`
+	ImageURL *string `json:"image_url,omitempty"`
+}
+
+func (r FunctionResultPayload) ValidateContent() error {
+	if r.Content == nil {
+		return errors.New("function result requires a content array")
+	}
+	for _, part := range r.Content {
+		switch part.Type {
+		case "input_text":
+			if part.Text != nil && part.ImageURL == nil {
+				continue
+			}
+		case "input_image":
+			if part.ImageURL != nil && part.Text == nil {
+				continue
+			}
+		}
+		return errors.New("function result requires text or image content")
+	}
+	return nil
 }

--- a/internal/agentdaemon/proto/functions_test.go
+++ b/internal/agentdaemon/proto/functions_test.go
@@ -1,0 +1,43 @@
+package proto
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFunctionResultContentWire(t *testing.T) {
+	for _, content := range []string{
+		`[]`,
+		`[{"type":"input_text","text":""}]`,
+		`[{"type":"input_text","text":"before"},{"type":"input_image","image_url":"data:image/png;base64,AA=="},{"type":"input_text","text":"after"}]`,
+	} {
+		raw := `{"delivery_id":"delivery","call_id":"call","success":false,"content":` + content + `}`
+		var result FunctionResultPayload
+		if err := json.Unmarshal([]byte(raw), &result); err != nil {
+			t.Fatal(err)
+		}
+		if err := result.ValidateContent(); err != nil {
+			t.Fatal(err)
+		}
+		encoded, err := json.Marshal(result)
+		if err != nil || string(encoded) != raw {
+			t.Fatalf("round trip: %s, %v", encoded, err)
+		}
+	}
+	for _, content := range []string{
+		`null`, `[null]`, `[{}]`,
+		`[{"type":"input_text"}]`, `[{"type":"input_text","text":null}]`,
+		`[{"type":"input_image"}]`, `[{"type":"input_image","image_url":null}]`,
+		`[{"type":"input_text","text":"before","image_url":"url"}]`,
+		`[{"type":"input_image","image_url":"url","text":"text"}]`,
+		`[{"type":"input_audio","text":"audio"}]`,
+	} {
+		var result FunctionResultPayload
+		if err := json.Unmarshal([]byte(`{"content":`+content+`}`), &result); err != nil {
+			t.Fatal(err)
+		}
+		if err := result.ValidateContent(); err == nil {
+			t.Fatalf("accepted %s", content)
+		}
+	}
+}


### PR DESCRIPTION
Function results could only carry text through the internal daemon bridge, although the pinned Agents API contract and native Codex support ordered text/image outputs. Preserve text, images, order and the success flag when replying to a pending native call, including empty text and empty content arrays. Invalid content is rejected before consuming the call; receipt replay compares all result content and still scopes it by Run and call.

This PR covers the internal execution bridge and its contract/tests only. Public function-action admission, persistence, business approvals, other content types and Team orchestration remain separate work. The unused private text-only result field is retired rather than kept as a compatibility branch.

Validation on `zju_a100_2`: focused race tests; native Codex 0.153.4 against a synthetic local Responses service checks the exact mixed result received by the model in successful and failed calls, resumed execution, cancellation and late-result rejection. No paid model calls are used. Full `make check` passed, including the dedicated Agents API database checks. Product Docker database checks were skipped because no product schema/store changed. A fresh independent reviewer inspected the entire diff against 266eb4733ae9a6f7f17629ff6eab2c1121fbf51b, with only requirements, acceptance criteria, scope and repository references; no actionable in-scope findings.

Feishu: ATOM-006.
