### PR TITLE
feat(agents-api): expose durable function action state

### DIFF
--- a/.github/workflows/agents-api.yml
+++ b/.github/workflows/agents-api.yml
@@ -75,4 +75,7 @@ jobs:
         env:
           PARSAR_AGENTS_API_TEST_DATABASE_URL: postgres://agents_api:agents_api_test_only@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/parsar_agents_api_ci_tests?sslmode=disable
           AGENTS_API_SERVER_BIN: ${{ runner.temp }}/agents-api
-        run: python services/agents-api/tests/official_client.py
+          PARSAR_OFFICIAL_SDK_PYTHON: python
+        run: |
+          python services/agents-api/tests/official_client.py
+          go test ./services/agents-api/internal/store -run '^TestFunctionStateOfficialClientReadsAndLiveEvents$' -count=1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -304,7 +304,14 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   Identical retries return the saved decision; changed results conflict. Pending
   reads exclude applied calls and cancelling/terminal Turns while history remains
   readable. Persistence does not imply transparent native-process recovery.
-  Public actions, state/event projection and execution integration remain pending.
+  Recording a call moves the Turn to `waiting`; the last application receipt
+  resumes it. Session reads use one database snapshot for Turn, actions and usage.
+  Session state events retain their action snapshot, without private executor IDs
+  or results. Cancelling/terminal Turns expose no actionable calls. A waiting Turn
+  can fail or cancel before a result arrives; successful execution requires resume.
+  Actions remain visible until native application is acknowledged. This timing is
+  an implementation choice, not verified upstream event sequencing. Public tool
+  configuration, result admission and execution integration remain pending.
 - `message_items` advertises native assistant-message observations. Agents API
   opts in with `observe_messages` only for advertised peers; ordinary product
   requests retain their existing frame sequence. Opted-in text deltas carry their

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -47,7 +47,7 @@ the Python SDK. Vault HTTP paths start at `/vaults`, not `/agents/vaults`.
 | --- | --- | --- |
 | Root reusable Agents | create, retrieve, update, list, delete | Missing |
 | sessions | create, retrieve, update, list, delete | Partial create/retrieve/list; update/delete missing |
-| sessions.events | create, stream | Partial text/cancel and live events; function actions pending |
+| sessions.events | create, stream | Partial text/cancel and live events; function-action state snapshots supported; tool-result admission pending |
 | sessions.turns | retrieve, list | Implemented reads; lifecycle conformance still partial |
 | sessions.items | list | Partial Item variants |
 | sessions.artifacts | retrieve, list, delete, content | Missing |
@@ -108,7 +108,7 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Public Items recovery | Indexed message/command/MCP/function/web-search reads, scoped pagination and restart recovery; limitations below |
 | Public SSE | Live Session/Turn lifecycle, supported Item and text events; bounded commit-before-publish buffering and recovery through saved reads |
 | Internal function bridge | Native Codex definitions and ordered text/image results, Run/call-scoped receipts, retries and cancellation; public function actions still pending |
-| Internal function persistence | Immutable scoped calls, complete result objects, application receipts and recovery queries; public actions integration pending |
+| Function-call persistence and reads | Immutable scoped calls/results/receipts; Session `required_actions`, `requires_action`, Turn `waiting` and live state snapshots; public result admission and native dispatch integration pending |
 | Pending actions and environment lifecycle | Pending |
 | Official-client compatibility | Strict SDK checks for Session/Turn/Items reads and native text execution/cancellation/verbosity; pagination, retries, errors, tenant isolation and recovery |
 | Go product client | Official `openai-go` v3.61.0 with a thin service configuration; real HTTP integration tests |
@@ -254,3 +254,14 @@ oversized-event exception. A lagging reader receives a customer-safe `error` and
 disconnects rather than silently skipping output. Slow socket writes time out
 without blocking execution. Creation streaming and unsupported event variants
 are not implied by this endpoint.
+
+Function-action read coverage uses persisted-call fixtures with the real service
+handler, PostgreSQL and pinned official client. It does not yet demonstrate a
+publicly configured function executing end to end. Call insertion and application
+receipts update Turn/Session state atomically; duplicate notifications emit no new
+state. Actions remain visible until the execution adapter acknowledges application,
+or cancellation/terminal state removes them. This acknowledgement timing and the
+exact sequence of repeated `requires_action` notifications are implementation
+choices: the pinned source defines their shape but not that precise ordering.
+Session state events contain `event_id`, `type` and `session`; Turn events retain
+`session_id` and `turn_id`. There is no invented Turn `waiting` event.

--- a/contracts/agents-api/openapi.yaml
+++ b/contracts/agents-api/openapi.yaml
@@ -103,6 +103,26 @@ definitions:
     required:
     - error
     type: object
+  v1.FunctionCallAction:
+    properties:
+      arguments: {}
+      call_id:
+        type: string
+      name:
+        type: string
+      turn_id:
+        type: string
+      type:
+        enum:
+        - function_call
+        type: string
+    required:
+    - arguments
+    - call_id
+    - name
+    - turn_id
+    - type
+    type: object
   v1.InlineAgent:
     properties:
       instructions:
@@ -293,12 +313,13 @@ definitions:
         type: string
       required_actions:
         items:
-          type: object
+          $ref: '#/definitions/v1.FunctionCallAction'
         type: array
       status:
         enum:
         - idle
         - in_progress
+        - requires_action
         - failed
         type: string
       usage:
@@ -353,7 +374,6 @@ definitions:
         type: string
     required:
     - event_id
-    - session_id
     - type
     type: object
   v1.SessionInput:

--- a/contracts/agents-api/v1/events.go
+++ b/contracts/agents-api/v1/events.go
@@ -4,7 +4,7 @@ package v1
 type SessionEvent struct {
 	Type         string       `json:"type" binding:"required"`
 	EventID      string       `json:"event_id" binding:"required"`
-	SessionID    string       `json:"session_id" binding:"required"`
+	SessionID    string       `json:"session_id,omitempty"`
 	TurnID       string       `json:"turn_id,omitempty"`
 	Session      *Session     `json:"session,omitempty"`
 	Turn         *Turn        `json:"turn,omitempty"`

--- a/contracts/agents-api/v1/function_actions.go
+++ b/contracts/agents-api/v1/function_actions.go
@@ -1,0 +1,10 @@
+package v1
+
+// FunctionCallAction is the supported function-call variant of required_actions.
+type FunctionCallAction struct {
+	Arguments any    `json:"arguments" binding:"required"`
+	CallID    string `json:"call_id" binding:"required"`
+	Name      string `json:"name" binding:"required"`
+	TurnID    string `json:"turn_id" binding:"required"`
+	Type      string `json:"type" enums:"function_call" binding:"required"`
+}

--- a/contracts/agents-api/v1/sessions.go
+++ b/contracts/agents-api/v1/sessions.go
@@ -62,18 +62,18 @@ type TextFormat struct {
 }
 
 type Session struct {
-	ID              string            `json:"id" binding:"required"`
-	Agent           Agent             `json:"agent" binding:"required"`
-	CreatedAt       int64             `json:"created_at" binding:"required"`
-	Environment     Environment       `json:"environment" binding:"required"`
-	Error           *string           `json:"error" extensions:"x-nullable"`
-	LastActiveAt    int64             `json:"last_active_at" binding:"required"`
-	Metadata        map[string]string `json:"metadata" binding:"required"`
-	Object          string            `json:"object" enums:"agent.session" binding:"required"`
-	RequiredActions []json.RawMessage `json:"required_actions" swaggertype:"array,object" binding:"required"`
-	Status          string            `json:"status" enums:"idle,in_progress,failed" binding:"required"`
-	Usage           *TokenUsage       `json:"usage" extensions:"x-nullable"`
-	VaultIDs        []string          `json:"vault_ids" binding:"required"`
+	ID              string               `json:"id" binding:"required"`
+	Agent           Agent                `json:"agent" binding:"required"`
+	CreatedAt       int64                `json:"created_at" binding:"required"`
+	Environment     Environment          `json:"environment" binding:"required"`
+	Error           *string              `json:"error" extensions:"x-nullable"`
+	LastActiveAt    int64                `json:"last_active_at" binding:"required"`
+	Metadata        map[string]string    `json:"metadata" binding:"required"`
+	Object          string               `json:"object" enums:"agent.session" binding:"required"`
+	RequiredActions []FunctionCallAction `json:"required_actions" binding:"required"`
+	Status          string               `json:"status" enums:"idle,in_progress,requires_action,failed" binding:"required"`
+	Usage           *TokenUsage          `json:"usage" extensions:"x-nullable"`
+	VaultIDs        []string             `json:"vault_ids" binding:"required"`
 }
 
 type SessionList struct {

--- a/services/agents-api/internal/api/configuration.go
+++ b/services/agents-api/internal/api/configuration.go
@@ -57,7 +57,7 @@ func sessionResponse(session store.Session) (v1.Session, error) {
 		ID: session.ID, Agent: cfg.Agent, Environment: cfg.Environment, Usage: tokenUsage(session.Usage),
 		CreatedAt: session.CreatedAt.Unix(), LastActiveAt: session.CreatedAt.Unix(),
 		Metadata: session.Metadata, Object: "agent.session", Status: "idle",
-		RequiredActions: []json.RawMessage{}, VaultIDs: []string{},
+		RequiredActions: []v1.FunctionCallAction{}, VaultIDs: []string{},
 	}
 	if turn := session.LastTurn; turn != nil {
 		active := turn.CreatedAt
@@ -71,6 +71,10 @@ func sessionResponse(session store.Session) (v1.Session, error) {
 		switch turn.Status {
 		case store.TurnQueued, store.TurnInProgress, store.TurnWaiting:
 			response.Status = "in_progress"
+			if turn.CancelRequestedAt.IsZero() && len(session.RequiredActions) > 0 {
+				response.Status = "requires_action"
+				response.RequiredActions = session.RequiredActions
+			}
 		case store.TurnFailed:
 			response.Status = "failed"
 			message := "The execution could not complete."

--- a/services/agents-api/internal/api/function_state_test.go
+++ b/services/agents-api/internal/api/function_state_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func TestFunctionStateEventsUseTheirOwnSnapshot(t *testing.T) {
+	session := store.Session{ID: "session", CreatedAt: time.Now(), Metadata: map[string]string{},
+		Configuration:   json.RawMessage(`{"agent":{"id":"agent_test","model":"model","tools":[]},"environment":{"type":"none"}}`),
+		RequiredActions: []v1.FunctionCallAction{{CallID: "stale"}},
+	}
+	for _, arguments := range []string{`{"n":9007199254740993}`, `null`, `[1,"value"]`, `"value"`, `false`} {
+		action := v1.FunctionCallAction{Type: "function_call", CallID: "call", Name: "lookup", TurnID: "turn", Arguments: json.RawMessage(arguments)}
+		change := store.SessionChange{Event: v1.SessionEvent{Type: "agent.session.requires_action", EventID: "event", SessionID: "session"}, Turn: &store.Turn{ID: "turn", Status: store.TurnWaiting}, RequiredActions: []v1.FunctionCallAction{action}}
+		event, err := streamResponse(session, change)
+		if err != nil || event.Session.Status != "requires_action" || !reflect.DeepEqual(event.Session.RequiredActions, change.RequiredActions) {
+			t.Fatal(event, err)
+		}
+		raw, err := json.Marshal(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var wire map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &wire); err != nil {
+			t.Fatal(err)
+		}
+		if len(wire) != 3 || wire["session_id"] != nil || wire["turn_id"] != nil || wire["session"] == nil {
+			t.Fatal("unexpected public fields", string(raw))
+		}
+		change.RequiredActions = nil
+		change.Turn.Status = store.TurnInProgress
+		change.Event.Type = "agent.session.in_progress"
+		event, err = streamResponse(session, change)
+		if err != nil || event.Session.Status != "in_progress" || event.Session.RequiredActions == nil || len(event.Session.RequiredActions) != 0 {
+			t.Fatal("stale actions leaked", event, err)
+		}
+	}
+}

--- a/services/agents-api/internal/api/stream.go
+++ b/services/agents-api/internal/api/stream.go
@@ -121,6 +121,8 @@ func streamResponse(session store.Session, change store.SessionChange) (v1.Sessi
 		event.Turn = &turn
 		return event, err
 	}
+	event.SessionID = ""
+	session.RequiredActions = change.RequiredActions
 	session.LastTurn, session.Usage = change.Turn, change.SessionUsage
 	value, err := sessionResponse(session)
 	event.Session = &value

--- a/services/agents-api/internal/store/function_calls.go
+++ b/services/agents-api/internal/store/function_calls.go
@@ -19,7 +19,7 @@ type FunctionCall struct {
 	Applied                      bool
 }
 
-// RecordFunctionCall makes an execution callback durable without changing public state.
+// RecordFunctionCall commits an execution callback and its required-action state together.
 func (s *Store) RecordFunctionCall(ctx context.Context, tenantID, sessionID, turnID string, call FunctionCall) error {
 	p, err := turnLookup(tenantID, sessionID, turnID)
 	if err != nil {
@@ -56,7 +56,7 @@ func (s *Store) RecordFunctionCall(ctx context.Context, tenantID, sessionID, tur
 		if count != 1 {
 			return ErrIdempotencyConflict
 		}
-		return nil
+		return recordFunctionState(ctx, q, turn)
 	})
 }
 

--- a/services/agents-api/internal/store/function_calls_test.go
+++ b/services/agents-api/internal/store/function_calls_test.go
@@ -173,7 +173,7 @@ func TestFunctionResultsCannotApplyAfterCancellationOrCompletion(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			transition(t, s, tenant, session.ID, turn, TurnInProgress, terminal)
+			transition(t, s, tenant, session.ID, turn, TurnWaiting, terminal)
 			assertNoPendingFunctions(t, s, tenant, session.ID, turn)
 			if err := s.ConfirmFunctionResult(t.Context(), tenant, session.ID, turn, "submitted"); !errors.Is(err, ErrTurnConflict) {
 				t.Fatal(err)

--- a/services/agents-api/internal/store/function_results.go
+++ b/services/agents-api/internal/store/function_results.go
@@ -46,7 +46,10 @@ func (s *Store) ConfirmFunctionResult(ctx context.Context, tenantID, sessionID, 
 		if len(call.Result) == 0 || !acceptsFunctionResult(turn) {
 			return ErrTurnConflict
 		}
-		return q.ApplyFunctionResult(ctx, sqlc.ApplyFunctionResultParams{SessionID: turn.SessionID, TurnID: turn.ID, CallID: call.CallID})
+		if err := q.ApplyFunctionResult(ctx, sqlc.ApplyFunctionResultParams{SessionID: turn.SessionID, TurnID: turn.ID, CallID: call.CallID}); err != nil {
+			return err
+		}
+		return recordFunctionState(ctx, q, turn)
 	})
 }
 

--- a/services/agents-api/internal/store/function_state.go
+++ b/services/agents-api/internal/store/function_state.go
@@ -1,0 +1,68 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/db/sqlc"
+	"github.com/google/uuid"
+)
+
+func functionActions(ctx context.Context, q *sqlc.Queries, turn sqlc.Turn) ([]v1.FunctionCallAction, error) {
+	actions := make([]v1.FunctionCallAction, 0)
+	if !acceptsFunctionResult(turn) {
+		return actions, nil
+	}
+	calls, err := q.ListPendingFunctionCalls(ctx, sqlc.ListPendingFunctionCallsParams{SessionID: turn.SessionID, TurnID: turn.ID})
+	if err != nil {
+		return nil, err
+	}
+	for _, call := range calls {
+		actions = append(actions, v1.FunctionCallAction{Type: "function_call", CallID: call.CallID, Name: call.Name, TurnID: uuid.UUID(turn.ID.Bytes).String(), Arguments: json.RawMessage(call.Arguments)})
+	}
+	return actions, nil
+}
+
+func recordFunctionState(ctx context.Context, q *sqlc.Queries, turn sqlc.Turn) error {
+	actions, err := functionActions(ctx, q, turn)
+	if err != nil {
+		return err
+	}
+	status := TurnInProgress
+	if len(actions) > 0 {
+		status = TurnWaiting
+	}
+	if turn.Status != status {
+		turn, err = q.TransitionTurn(ctx, sqlc.TransitionTurnParams{ID: turn.ID, SessionID: turn.SessionID, ExpectedStatus: turn.Status, NewStatus: status, Outcome: []byte(`{}`)})
+		if err != nil {
+			return err
+		}
+		if err := recordTurnChange(ctx, q, turn, false); err != nil {
+			return err
+		}
+	}
+	return recordSessionActivity(ctx, q, turn, actions)
+}
+
+func recordSessionActivity(ctx context.Context, q *sqlc.Queries, row sqlc.Turn, actions []v1.FunctionCallAction) error {
+	turn := turnFromRow(row)
+	turn.Outcome = nil
+	status := "in_progress"
+	if terminalStatus(row.Status) {
+		status = "idle"
+		if row.Status == TurnFailed {
+			status = "failed"
+		}
+	} else if len(actions) > 0 {
+		status = "requires_action"
+	}
+	usage, err := q.SessionTokenUsage(ctx, row.SessionID)
+	if err != nil {
+		return err
+	}
+	return recordSessionChange(ctx, q, row.SessionID, SessionChange{
+		Event: v1.SessionEvent{Type: "agent.session." + status}, Turn: &turn,
+		SessionUsage: usage, RequiredActions: actions,
+	})
+}

--- a/services/agents-api/internal/store/function_state_public_test.go
+++ b/services/agents-api/internal/store/function_state_public_test.go
@@ -1,0 +1,91 @@
+package store_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/device"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/api"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+	"github.com/google/uuid"
+)
+
+func TestFunctionStateOfficialClientReadsAndLiveEvents(t *testing.T) {
+	python := os.Getenv("PARSAR_OFFICIAL_SDK_PYTHON")
+	if python == "" {
+		t.Skip("PARSAR_OFFICIAL_SDK_PYTHON is required for official-client verification")
+	}
+	s, _ := store.NewTestStore(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	tenant, token, foreign := uuid.NewString(), uuid.NewString(), uuid.NewString()
+	cfg := json.RawMessage(`{"agent":{"id":"agent_fixture","model":"fixture","tools":[],"multi_agent":{"enabled":false,"max_concurrent_subagents":null},"reasoning":{},"service_tier":"auto","text":{"format":{"type":"text"},"verbosity":"medium"}},"environment":{"type":"none"}}`)
+	session, err := s.CreateSession(ctx, tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "fixture", Configuration: cfg})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := s.SubmitMessage(ctx, tenant, session.ID, "start", json.RawMessage(`{"text":"fixture"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.TransitionTurn(ctx, tenant, session.ID, input.TurnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
+		t.Fatal(err)
+	}
+	record := func(id string) {
+		t.Helper()
+		if err := s.RecordFunctionCall(ctx, tenant, session.ID, input.TurnID, store.FunctionCall{CallID: id, ExecutorCallID: "private-" + id, Name: "lookup", Arguments: json.RawMessage(`{"ticket":9007199254740993}`)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	record("first")
+	auth, err := api.NewAuthenticator([]api.APIKey{{TokenSHA256: device.HashCredential(token), TenantID: tenant}, {TokenSHA256: device.HashCredential(foreign), TenantID: uuid.NewString()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler, err := api.NewHandler(s, auth, "codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	command := exec.CommandContext(ctx, python, "../../tests/official_function_state.py", server.URL, token, foreign, session.ID, input.TurnID)
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { cancel(); _ = command.Wait() }()
+	reader := bufio.NewReader(stdout)
+	if line, err := reader.ReadString('\n'); err != nil || line != "connected\n" {
+		cancel()
+		_ = command.Wait()
+		t.Fatalf("SDK readiness: %s %v %s", line, err, stderr.String())
+	}
+	record("second")
+	for _, id := range []string{"first", "second"} {
+		if err := s.SubmitFunctionResult(ctx, tenant, session.ID, input.TurnID, id, json.RawMessage(`{"success":true,"output":"private"}`)); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.ConfirmFunctionResult(ctx, tenant, session.ID, input.TurnID, id); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := s.CompleteExecution(ctx, tenant, session.ID, input.TurnID, store.TurnCompleted, nil, "", input.Sequence); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Wait(); err != nil {
+		t.Fatalf("official function-state verification: %v\n%s", err, stderr.String())
+	}
+	t.Log("Pinned official client verified persisted waiting reads, isolation, exact event fields and changing action snapshots")
+}

--- a/services/agents-api/internal/store/function_state_test.go
+++ b/services/agents-api/internal/store/function_state_test.go
@@ -1,0 +1,178 @@
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestFunctionStateSnapshotsRecoveryAndRetries(t *testing.T) {
+	s, pool := testStore(t)
+	tenant, session := newTurnSession(t, s)
+	turn := submitMessage(t, s, tenant, session.ID, "start").TurnID
+	transition(t, s, tenant, session.ID, turn, TurnQueued, TurnInProgress)
+	before, err := s.SessionEventCursor(t.Context(), tenant, session.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"first", "second"} {
+		for range 2 {
+			if err := s.RecordFunctionCall(t.Context(), tenant, session.ID, turn, functionCallFixture(id)); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	assertFunctionState(t, s, tenant, session.ID, TurnWaiting, 2)
+	for _, id := range []string{"first", "second"} {
+		if err := s.SubmitFunctionResult(t.Context(), tenant, session.ID, turn, id, json.RawMessage(`{"success":true,"output":"private result"}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	assertFunctionState(t, s, tenant, session.ID, TurnWaiting, 2)
+	pool.Close()
+	s, _ = testStore(t)
+	assertFunctionState(t, s, tenant, session.ID, TurnWaiting, 2)
+	if _, err := s.CompleteExecution(t.Context(), tenant, session.ID, turn, TurnCompleted, nil, "", 1); !errors.Is(err, ErrTurnConflict) {
+		t.Fatal("waiting execution completed", err)
+	}
+	for i, id := range []string{"first", "second"} {
+		for range 2 {
+			if err := s.ConfirmFunctionResult(t.Context(), tenant, session.ID, turn, id); err != nil {
+				t.Fatal(err)
+			}
+		}
+		status := TurnWaiting
+		if i == 1 {
+			status = TurnInProgress
+		}
+		assertFunctionState(t, s, tenant, session.ID, status, 1-i)
+	}
+	changes, err := s.ListSessionEvents(t.Context(), tenant, session.ID, before)
+	if err != nil {
+		t.Fatal(err)
+	}
+	counts := []int{1, 2, 1, 0, 0}
+	types := []string{"agent.session.requires_action", "agent.session.requires_action", "agent.session.requires_action", "agent.session.turn.in_progress", "agent.session.in_progress"}
+	if len(changes) != len(counts) {
+		t.Fatalf("duplicate or missing events: %+v", changes)
+	}
+	for i, change := range changes {
+		if change.Event.Type != types[i] || len(change.RequiredActions) != counts[i] {
+			t.Fatalf("snapshot %d: %+v", i, change)
+		}
+		if counts[i] > 0 {
+			raw, err := json.Marshal(change.RequiredActions[0].Arguments)
+			if err != nil || string(raw) != `{"ticket":9007199254740993}` {
+				t.Fatal("argument precision lost", string(raw), err)
+			}
+			if change.Turn.Status != TurnWaiting {
+				t.Fatal(change.Turn)
+			}
+		}
+	}
+	if _, err := s.GetSession(t.Context(), uuid.NewString(), session.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatal(err)
+	}
+	if _, err := s.ListSessionEvents(t.Context(), uuid.NewString(), session.ID, before); !errors.Is(err, ErrNotFound) {
+		t.Fatal(err)
+	}
+}
+
+func TestFunctionStateCancellationAndTerminalCleanup(t *testing.T) {
+	for _, status := range []string{TurnCancelled, TurnFailed, TurnCompleted} {
+		t.Run(status, func(t *testing.T) {
+			s, _ := testStore(t)
+			tenant, session := newTurnSession(t, s)
+			input := submitMessage(t, s, tenant, session.ID, "start")
+			transition(t, s, tenant, session.ID, input.TurnID, TurnQueued, TurnInProgress)
+			if err := s.RecordFunctionCall(t.Context(), tenant, session.ID, input.TurnID, functionCallFixture("call")); err != nil {
+				t.Fatal(err)
+			}
+			if status == TurnCancelled {
+				before, _ := s.SessionEventCursor(t.Context(), tenant, session.ID)
+				for _, key := range []string{"cancel", "cancel", "another-cancel"} {
+					if _, err := s.RequestCancel(t.Context(), tenant, session.ID, key); err != nil {
+						t.Fatal(err)
+					}
+				}
+				assertFunctionState(t, s, tenant, session.ID, TurnWaiting, 0)
+				changes, err := s.ListSessionEvents(t.Context(), tenant, session.ID, before)
+				if err != nil || len(changes) != 1 || changes[0].Event.Type != "agent.session.in_progress" || len(changes[0].RequiredActions) != 0 || changes[0].Turn.CancelRequestedAt.IsZero() {
+					t.Fatal(changes, err)
+				}
+			}
+			if status == TurnCompleted {
+				transition(t, s, tenant, session.ID, input.TurnID, TurnWaiting, status)
+			} else if _, err := s.CompleteExecution(t.Context(), tenant, session.ID, input.TurnID, status, nil, "", input.Sequence); err != nil {
+				t.Fatal(err)
+			}
+			assertFunctionState(t, s, tenant, session.ID, status, 0)
+			if _, err := s.GetFunctionCall(t.Context(), tenant, session.ID, input.TurnID, "call"); err != nil {
+				t.Fatal("history lost", err)
+			}
+			next := submitMessage(t, s, tenant, session.ID, "next")
+			if next.TurnID == input.TurnID {
+				t.Fatal("terminal turn reused")
+			}
+			assertFunctionState(t, s, tenant, session.ID, TurnQueued, 0)
+		})
+	}
+}
+
+func TestFunctionStateReadsRemainConsistentDuringReceipts(t *testing.T) {
+	s, _ := testStore(t)
+	tenant, session := newTurnSession(t, s)
+	turn := submitMessage(t, s, tenant, session.ID, "start").TurnID
+	transition(t, s, tenant, session.ID, turn, TurnQueued, TurnInProgress)
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+	wg.Go(func() {
+		defer close(done)
+		for i := range 30 {
+			id := fmt.Sprint(i)
+			if err := s.RecordFunctionCall(t.Context(), tenant, session.ID, turn, functionCallFixture(id)); err != nil {
+				t.Error(err)
+				return
+			}
+			if err := s.SubmitFunctionResult(t.Context(), tenant, session.ID, turn, id, json.RawMessage(`{"success":true}`)); err != nil {
+				t.Error(err)
+				return
+			}
+			if err := s.ConfirmFunctionResult(t.Context(), tenant, session.ID, turn, id); err != nil {
+				t.Error(err)
+				return
+			}
+		}
+	})
+	defer wg.Wait()
+	for {
+		current, err := s.GetSession(t.Context(), tenant, session.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if (current.LastTurn.Status == TurnWaiting) != (len(current.RequiredActions) > 0) {
+			t.Fatalf("torn activity snapshot: %+v", current)
+		}
+		select {
+		case <-done:
+			return
+		default:
+		}
+	}
+}
+
+func assertFunctionState(t *testing.T, s *Store, tenant, sessionID, status string, count int) {
+	t.Helper()
+	current, err := s.GetSession(t.Context(), tenant, sessionID)
+	if err != nil || current.LastTurn == nil || current.LastTurn.Status != status || len(current.RequiredActions) != count {
+		t.Fatalf("state: %+v; %v", current, err)
+	}
+	page, err := s.ListSessions(t.Context(), tenant, "", 10, true)
+	if err != nil || len(page.Sessions) != 1 || len(page.Sessions[0].RequiredActions) != count || page.Sessions[0].LastTurn.Status != status {
+		t.Fatal("list differs from retrieve", page, err)
+	}
+}

--- a/services/agents-api/internal/store/scheduling.go
+++ b/services/agents-api/internal/store/scheduling.go
@@ -84,15 +84,23 @@ func (s *Store) sessionActivity(ctx context.Context, session Session, err error)
 		return Session{}, err
 	}
 	id, _ := parseID(session.ID)
-	row, err := s.queries.GetLatestSessionTurn(ctx, id)
-	if errors.Is(err, pgx.ErrNoRows) {
-		return session, nil
-	}
-	if err != nil {
-		return Session{}, err
-	}
-	turn := turnFromRow(row)
-	session.LastTurn = &turn
-	session.Usage, err = s.queries.SessionTokenUsage(ctx, id)
+	err = pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly}, func(tx pgx.Tx) error {
+		q := s.queries.WithTx(tx)
+		row, err := q.GetLatestSessionTurn(ctx, id)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		turn := turnFromRow(row)
+		session.LastTurn = &turn
+		session.RequiredActions, err = functionActions(ctx, q, row)
+		if err != nil {
+			return err
+		}
+		session.Usage, err = q.SessionTokenUsage(ctx, id)
+		return err
+	})
 	return session, err
 }

--- a/services/agents-api/internal/store/session_events.go
+++ b/services/agents-api/internal/store/session_events.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -17,10 +18,11 @@ var ErrStreamGap = errors.New("live event buffer exceeded; recover through Sessi
 
 // SessionChange keeps transition snapshots separate from public response rendering.
 type SessionChange struct {
-	Sequence     int64           `json:"-"`
-	Event        v1.SessionEvent `json:"event"`
-	Turn         *Turn           `json:"turn,omitempty"`
-	SessionUsage json.RawMessage `json:"session_usage,omitempty"`
+	Sequence        int64                   `json:"-"`
+	Event           v1.SessionEvent         `json:"event"`
+	Turn            *Turn                   `json:"turn,omitempty"`
+	SessionUsage    json.RawMessage         `json:"session_usage,omitempty"`
+	RequiredActions []v1.FunctionCallAction `json:"required_actions,omitempty"`
 }
 
 type suppressSessionEvents struct{}
@@ -73,21 +75,7 @@ func recordTurnChange(ctx context.Context, q *sqlc.Queries, row sqlc.Turn, creat
 	if !created && !terminalStatus(row.Status) {
 		return nil
 	}
-	status := "in_progress"
-	if terminalStatus(row.Status) {
-		status = "idle"
-		if row.Status == TurnFailed {
-			status = "failed"
-		}
-	}
-	change.Event.Type = "agent.session." + status
-	change.Event.TurnID = ""
-	usage, err := q.SessionTokenUsage(ctx, row.SessionID)
-	if err != nil {
-		return err
-	}
-	change.SessionUsage = usage
-	return recordSessionChange(ctx, q, row.SessionID, change)
+	return recordSessionActivity(ctx, q, row, nil)
 }
 
 func (s *Store) SessionEventCursor(ctx context.Context, tenantID, sessionID string) (int64, error) {
@@ -135,7 +123,9 @@ func (s *Store) ListSessionEvents(ctx context.Context, tenantID, sessionID strin
 			return nil, ErrStreamGap
 		}
 		var change SessionChange
-		if err := json.Unmarshal(row.Payload, &change); err != nil {
+		decoder := json.NewDecoder(bytes.NewReader(row.Payload))
+		decoder.UseNumber()
+		if err := decoder.Decode(&change); err != nil {
 			return nil, err
 		}
 		change.Sequence = row.Sequence

--- a/services/agents-api/internal/store/sessions.go
+++ b/services/agents-api/internal/store/sessions.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
 	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/db/sqlc"
 )
 
@@ -30,14 +31,15 @@ var (
 // Session is a durable execution context, separate from product conversations
 // and from live daemon connections. Engine session IDs will be bound at execution.
 type Session struct {
-	ID            string
-	TenantID      string
-	Engine        string
-	Metadata      map[string]string
-	CreatedAt     time.Time
-	Configuration json.RawMessage
-	LastTurn      *Turn
-	Usage         json.RawMessage
+	ID              string
+	TenantID        string
+	Engine          string
+	Metadata        map[string]string
+	CreatedAt       time.Time
+	Configuration   json.RawMessage
+	LastTurn        *Turn
+	Usage           json.RawMessage
+	RequiredActions []v1.FunctionCallAction
 }
 
 type CreateSessionInput struct {
@@ -188,7 +190,7 @@ func parseID(value string) (pgtype.UUID, error) {
 }
 
 func sessionFromRow(row sqlc.Session) (Session, error) {
-	session := Session{ID: uuid.UUID(row.ID.Bytes).String(), TenantID: uuid.UUID(row.TenantID.Bytes).String(), Engine: row.Engine, CreatedAt: row.CreatedAt.Time}
+	session := Session{ID: uuid.UUID(row.ID.Bytes).String(), TenantID: uuid.UUID(row.TenantID.Bytes).String(), Engine: row.Engine, CreatedAt: row.CreatedAt.Time, RequiredActions: []v1.FunctionCallAction{}}
 	configuration, err := canonicalJSONObject(row.Configuration)
 	if err != nil {
 		return Session{}, fmt.Errorf("decode session configuration: %w", err)

--- a/services/agents-api/internal/store/turn_completion.go
+++ b/services/agents-api/internal/store/turn_completion.go
@@ -27,10 +27,14 @@ func (s *Store) CompleteExecution(ctx context.Context, tenantID, sessionID, turn
 	}
 	var row sqlc.Turn
 	err = s.withSession(ctx, tenantID, sessionID, func(q *sqlc.Queries, session pgtype.UUID) error {
-		if _, err := q.GetTurn(ctx, p); errors.Is(err, pgx.ErrNoRows) {
+		current, err := q.GetTurn(ctx, p)
+		if errors.Is(err, pgx.ErrNoRows) {
 			return ErrNotFound
 		} else if err != nil {
 			return err
+		}
+		if current.Status != TurnInProgress && (current.Status != TurnWaiting || status == TurnCompleted) {
+			return ErrTurnConflict
 		}
 		if status == TurnCompleted {
 			pending, err := q.HasUnappliedMessages(ctx, sqlc.HasUnappliedMessagesParams{SessionID: session, TurnID: p.ID, Sequence: appliedThrough})
@@ -41,8 +45,7 @@ func (s *Store) CompleteExecution(ctx context.Context, tenantID, sessionID, turn
 				return ErrUnappliedInputs
 			}
 		}
-		var err error
-		row, err = q.TransitionTurn(ctx, sqlc.TransitionTurnParams{ID: p.ID, SessionID: session, ExpectedStatus: TurnInProgress, NewStatus: status, Outcome: outcome})
+		row, err = q.TransitionTurn(ctx, sqlc.TransitionTurnParams{ID: p.ID, SessionID: session, ExpectedStatus: current.Status, NewStatus: status, Outcome: outcome})
 		if errors.Is(err, pgx.ErrNoRows) {
 			return ErrTurnConflict
 		}

--- a/services/agents-api/internal/store/turn_inputs.go
+++ b/services/agents-api/internal/store/turn_inputs.go
@@ -150,6 +150,14 @@ func admitInput(ctx context.Context, q *sqlc.Queries, session pgtype.UUID, key s
 			if err := recordTurnChange(ctx, q, cancelled, false); err != nil {
 				return InputReceipt{}, err
 			}
+		} else if turn.Status == TurnWaiting && !turn.CancelRequestedAt.Valid {
+			cancelling, err := q.SessionEventTurn(ctx, sqlc.SessionEventTurnParams{SessionID: session, ID: turn.ID})
+			if err != nil {
+				return InputReceipt{}, err
+			}
+			if err := recordSessionActivity(ctx, q, cancelling, nil); err != nil {
+				return InputReceipt{}, err
+			}
 		}
 	}
 	if err := indexInput(ctx, q, session, sequence); err != nil {

--- a/services/agents-api/tests/official_function_state.py
+++ b/services/agents-api/tests/official_function_state.py
@@ -1,0 +1,66 @@
+"""Verify function-action reads using real storage fixtures, without claiming execution coverage."""
+
+import importlib.metadata
+import json
+from pathlib import Path
+import sys
+
+import httpx2
+from openai import NotFoundError, OpenAI
+
+base, token, foreign, session_id, turn_id = sys.argv[1:]
+pin = json.loads((Path(__file__).resolve().parents[3] / "contracts/agents-api/upstream.json").read_text())
+source = json.loads(importlib.metadata.distribution("openai").read_text("direct_url.json") or "{}")
+assert source.get("vcs_info", {}).get("commit_id") == pin["commit"]
+
+
+def client(key):
+    return OpenAI(api_key=key, base_url=base + "/v1", max_retries=0,
+                  _strict_response_validation=True, http_client=httpx2.Client(trust_env=False, timeout=15))
+
+
+def verify_actions(session, ids):
+    assert session.status == ("requires_action" if ids else "in_progress")
+    assert [action.call_id for action in session.required_actions] == ids
+    for action in session.required_actions:
+        assert action.to_dict() == {"type": "function_call", "call_id": action.call_id,
+                                   "name": "lookup", "turn_id": turn_id,
+                                   "arguments": {"ticket": 9007199254740993}}, action.to_dict()
+
+
+with client(token) as api, client(foreign) as stranger:
+    sessions = api.beta.agents.sessions
+    verify_actions(sessions.retrieve(session_id), ["first"])
+    verify_actions(sessions.list().data[0], ["first"])
+    assert sessions.turns.retrieve(turn_id, session_id=session_id).status == "waiting"
+    assert sessions.turns.list(session_id).data[0].status == "waiting"
+    try:
+        stranger.beta.agents.sessions.retrieve(session_id)
+        raise AssertionError("foreign session was visible")
+    except NotFoundError:
+        pass
+    assert stranger.beta.agents.sessions.list().data == []
+    try:
+        stranger.beta.agents.sessions.events.stream(session_id)
+        raise AssertionError("foreign event stream was visible")
+    except NotFoundError:
+        pass
+    states = []
+    with sessions.events.stream(session_id) as stream:
+        print("connected", flush=True)
+        for event in stream:
+            if event.type.startswith("agent.session.turn."):
+                assert event.type != "agent.session.turn.waiting"
+                continue
+            wire = event.to_dict()
+            assert set(wire) == {"event_id", "session", "type"}, wire
+            states.append(event.type)
+            if event.type == "agent.session.idle":
+                assert event.session.status == "idle" and event.session.required_actions == []
+                break
+            verify_actions(event.session, [["first", "second"], ["second"], []][len(states)-1])
+    assert states == ["agent.session.requires_action", "agent.session.requires_action",
+                      "agent.session.in_progress", "agent.session.idle"]
+    restored = sessions.retrieve(session_id)
+    assert restored.status == "idle" and restored.required_actions == []
+    assert sessions.turns.retrieve(turn_id, session_id=session_id).status == "completed"


### PR DESCRIPTION
Persisted function calls now appear in Session `required_actions`, with `requires_action` Session status and `waiting` Turn status. Application receipts update the action set; the final receipt resumes the Turn, while cancellation and terminal outcomes clear actionable state and retain history. Reads use a consistent database snapshot, and live notifications preserve the action set at the time of each change.

This covers the read/state boundary only. Public function configuration, tool-result admission and native dispatch integration remain separate work. Receipt-based action removal and exact notification ordering are documented implementation choices, not claims of verified upstream timing. Session state event fields match the pinned SDK shape.

Validation on `zju_a100_2`: focused PostgreSQL race tests, strict pinned Python SDK reads and live events, tenant isolation, restart recovery, multiple calls, duplicate notifications, cancellation and terminal cleanup. Generated OpenAPI and full `make check`; the product Docker-store smoke test is skipped because Docker is disabled and this PR changes no product schema. The official-client read/event test is also wired into Agents API CI.

Tracks ATOM-006 in the [Feishu board](https://vrfi1sk8a0.feishu.cn/wiki/EA3CwVSRviqe1XkZ0tAcq7FqnFc).

Independent blind review covered the complete diff and reran the focused store/API/contract tests, including the official-client HTTP/SSE fixture: no actionable in-scope findings. All applicable CI checks passed.
