### PR TITLE
feat(agents-api): connect persisted functions to native execution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,7 +311,18 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   can fail or cancel before a result arrives; successful execution requires resume.
   Actions remain visible until native application is acknowledged. This timing is
   an implementation choice, not verified upstream event sequencing. Public tool
-  configuration, result admission and execution integration remain pending.
+  configuration and result admission remain pending.
+- Internal function execution requires an advertised `function_tools` capability
+  before claiming a Turn. Translate resolved definitions in the execution adapter,
+  persist declared callbacks before exposing actions, and deliver each saved result
+  once per live dispatch. Keep its success flag and ordered text/image output;
+  append a non-null error as a final text part because the native result has no
+  separate error field. Retain the original complete result in storage. Do not
+  treat transport delivery as application or automatically replay an uncertain
+  result. The adapter waits for outstanding application receipts even when Done
+  arrives first. Waiting Turns still accept execution observations and cancellation.
+  Public `tools` and `tool_result` admission remain a separate protocol slice;
+  internal execution is not proof of full public function compatibility.
 - `message_items` advertises native assistant-message observations. Agents API
   opts in with `observe_messages` only for advertised peers; ordinary product
   requests retain their existing frame sequence. Opted-in text deltas carry their

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -107,8 +107,8 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Public Turn recovery | Retrieve/list persisted states with scoped pagination; see limitations below |
 | Public Items recovery | Indexed message/command/MCP/function/web-search reads, scoped pagination and restart recovery; limitations below |
 | Public SSE | Live Session/Turn lifecycle, supported Item and text events; bounded commit-before-publish buffering and recovery through saved reads |
-| Internal function bridge | Native Codex definitions and ordered text/image results, Run/call-scoped receipts, retries and cancellation; public function actions still pending |
-| Function-call persistence and reads | Immutable scoped calls/results/receipts; Session `required_actions`, `requires_action`, Turn `waiting` and live state snapshots; public result admission and native dispatch integration pending |
+| Internal function bridge | Native Codex definitions and ordered text/image/error results, persisted callbacks and application receipts, cancellation and native resume; public function configuration/result admission pending |
+| Function-call persistence and reads | Immutable scoped calls/results/receipts; Session `required_actions`, `requires_action`, Turn `waiting` and live state snapshots; internal native dispatch integrated; public configuration/result admission pending |
 | Pending actions and environment lifecycle | Pending |
 | Official-client compatibility | Strict SDK checks for Session/Turn/Items reads and native text execution/cancellation/verbosity; pagination, retries, errors, tenant isolation and recovery |
 | Go product client | Official `openai-go` v3.61.0 with a thin service configuration; real HTTP integration tests |
@@ -219,7 +219,7 @@ The service takes a database advisory lease, so a second execution service canno
 start on the same database. Startup marks previously claimed Turns failed without
 replaying them and retains queued work. This does not recover missing daemon frames
 or guarantee exactly-once external side effects. Session status reflects the latest
-persisted Turn; usage reports recorded measurements; pending actions remain unimplemented.
+persisted Turn; usage reports recorded measurements; public function configuration and result admission remain unimplemented.
 
 Native verification uses `PARSAR_NATIVE_DAEMON_BIN`, `PARSAR_NATIVE_PROOF_DIR` under
 `~/.parsar/`, and `PARSAR_OFFICIAL_SDK_PYTHON` pointing to the pinned SDK environment.
@@ -254,6 +254,14 @@ oversized-event exception. A lagging reader receives a customer-safe `error` and
 disconnects rather than silently skipping output. Slow socket writes time out
 without blocking execution. Creation streaming and unsupported event variants
 are not implied by this endpoint.
+
+Internal function execution uses the same native daemon harness, with resolved
+non-deferred definitions and Store result admission. It verifies ordered text/image
+results, error text, application receipts, matching action/Item call IDs, cancellation
+and native Session continuity. Codex supplies the model transport's default image
+detail. This proof uses a synthetic model responder and the real daemon/Codex;
+it does not exercise a public tool-result submission endpoint. Deferred functions,
+other tool kinds and the native 64-definition limit remain compatibility gaps.
 
 Function-action read coverage uses persisted-call fixtures with the real service
 handler, PostgreSQL and pinned official client. It does not yet demonstrate a

--- a/services/agents-api/internal/execution/delivery.go
+++ b/services/agents-api/internal/execution/delivery.go
@@ -88,10 +88,21 @@ func (d *Dispatcher) deliver(ctx context.Context, tenantID, sessionID string, pe
 	var pending *pendingInput
 	var cancelSent time.Time
 	var cancelReply <-chan cancellationResult
+	functions := &functionExchange{store: d.Store, tenant: tenantID, session: sessionID, turn: request.RunID, tools: request.FunctionTools}
+	done := false
 	cancelCtx, stopCancellation := context.WithCancel(ctx)
 	defer stopCancellation()
 	for {
+		if done && functions.reply == nil {
+			status = finishDelivery(ctx, journal, &result, cancelReply, pending != nil, functions)
+			return
+		}
 		select {
+		case reply := <-functions.reply:
+			if err := functions.confirm(ctx, reply); err != nil {
+				result.ErrorCode = "function_result_unconfirmed"
+				return
+			}
 		case <-flushTicker.C:
 			if journal.flush(ctx) != nil {
 				result.ErrorCode = "event_persistence_failed"
@@ -140,34 +151,17 @@ func (d *Dispatcher) deliver(ctx context.Context, tenantID, sessionID string, pe
 				}
 				result.ErrorCode, result.Error = "engine_failed", failure.Error
 			case proto.TypeDone:
-				if cancelReply != nil {
-					select {
-					case reply := <-cancelReply:
-						if recordCancellation(ctx, journal, reply, &result) != nil {
-							result.ErrorCode = "event_persistence_failed"
-							return
-						}
-						if reply.err == nil && reply.ack.Applied {
-							status = store.TurnCancelled
-							return
-						}
-						if reply.err != nil || reply.ack.ErrorCode != "run_inactive" {
-							result.ErrorCode = "cancel_unconfirmed"
-							return
-						}
-					case <-ctx.Done():
-						result.ErrorCode = "cancel_unconfirmed"
-						return
-					}
+				// Done closes the event subscription; application receipts have a separate waiter.
+				done, upstream = true, nil
+			case proto.TypeFunctionCall:
+				if err := journal.flush(ctx); err != nil {
+					result.ErrorCode = "event_persistence_failed"
+					return
 				}
-				if result.ErrorCode == "" {
-					if pending != nil {
-						result.ErrorCode = "input_outcome_unknown"
-					} else {
-						status = store.TurnCompleted
-					}
+				if err := functions.record(ctx, env); err != nil {
+					result.ErrorCode = "function_call_invalid"
+					return
 				}
-				return
 			case proto.TypePromptSteerAck:
 				var ack proto.PromptSteerAckPayload
 				if env.DecodePayload(&ack) != nil {
@@ -205,13 +199,20 @@ func (d *Dispatcher) deliver(ctx context.Context, tenantID, sessionID string, pe
 				result.ErrorCode = "execution_state_unavailable"
 				return
 			}
-			if turn.Status != store.TurnInProgress {
+			if turn.Status != store.TurnInProgress && turn.Status != store.TurnWaiting {
 				result.ErrorCode = "execution_state_changed"
 				return
 			}
 			if !turn.CancelRequestedAt.IsZero() {
 				cancelReply = requestCancellation(cancelCtx, peer, request.RunID)
 				cancelSent = time.Now()
+				continue
+			}
+			if err := functions.start(cancelCtx, peer); err != nil {
+				result.ErrorCode = "function_result_invalid"
+				return
+			}
+			if done {
 				continue
 			}
 			if pending == nil {

--- a/services/agents-api/internal/execution/delivery.go
+++ b/services/agents-api/internal/execution/delivery.go
@@ -99,7 +99,8 @@ func (d *Dispatcher) deliver(ctx context.Context, tenantID, sessionID string, pe
 		}
 		select {
 		case reply := <-functions.reply:
-			if err := functions.confirm(ctx, reply); err != nil {
+			// Once cancellation is sent, its receipt owns the terminal outcome.
+			if err := functions.confirm(ctx, reply); err != nil && cancelReply == nil {
 				result.ErrorCode = "function_result_unconfirmed"
 				return
 			}

--- a/services/agents-api/internal/execution/dispatcher.go
+++ b/services/agents-api/internal/execution/dispatcher.go
@@ -68,6 +68,13 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 	if json.Unmarshal(session.Configuration, &snapshot) != nil || strings.TrimSpace(snapshot.Agent.Model) == "" {
 		return store.Turn{}, store.ErrInvalidInput
 	}
+	functions, err := functionTools(snapshot.Agent.Tools)
+	if err != nil {
+		return store.Turn{}, err
+	}
+	if len(functions) > 0 && !info.Capabilities.FunctionTools {
+		return store.Turn{}, errors.New("device must advertise function_tools")
+	}
 	workDir, noEnvironment, err := resolveExecutionEnvironment(snapshot)
 	if err != nil {
 		return store.Turn{}, err
@@ -103,7 +110,7 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 	if _, err := d.Store.TransitionTurn(ctx, tenantID, sessionID, turnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
 		return store.Turn{}, err
 	}
-	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true, StrictResume: true, ObserveMessages: info.Capabilities.MessageItems, ObserveTools: info.Capabilities.ToolItems, DisableExecutionEnvironment: noEnvironment}
+	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, FunctionTools: functions, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true, StrictResume: true, ObserveMessages: info.Capabilities.MessageItems, ObserveTools: info.Capabilities.ToolItems, DisableExecutionEnvironment: noEnvironment}
 	result, status := d.deliver(ctx, tenantID, sessionID, peer, req, through)
 	if result.Done.Usage.Model == "" {
 		result.Done.Usage.Model = snapshot.Agent.Model

--- a/services/agents-api/internal/execution/finish.go
+++ b/services/agents-api/internal/execution/finish.go
@@ -1,0 +1,39 @@
+package execution
+
+import (
+	"context"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func finishDelivery(ctx context.Context, journal *journal, result *Result, cancelReply <-chan cancellationResult, pendingInput bool, functions *functionExchange) string {
+	if cancelReply != nil {
+		select {
+		case reply := <-cancelReply:
+			if recordCancellation(ctx, journal, reply, result) != nil {
+				result.ErrorCode = "event_persistence_failed"
+				return store.TurnFailed
+			}
+			if reply.err == nil && reply.ack.Applied {
+				return store.TurnCancelled
+			}
+			if reply.err != nil || reply.ack.ErrorCode != "run_inactive" {
+				result.ErrorCode = "cancel_unconfirmed"
+				return store.TurnFailed
+			}
+		case <-ctx.Done():
+			result.ErrorCode = "cancel_unconfirmed"
+			return store.TurnFailed
+		}
+	}
+	if result.ErrorCode == "" {
+		if pendingInput {
+			result.ErrorCode = "input_outcome_unknown"
+		} else if functions.complete(ctx) != nil {
+			result.ErrorCode = "function_result_unconfirmed"
+		} else {
+			return store.TurnCompleted
+		}
+	}
+	return store.TurnFailed
+}

--- a/services/agents-api/internal/execution/functions.go
+++ b/services/agents-api/internal/execution/functions.go
@@ -1,0 +1,180 @@
+package execution
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/gateway"
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/items"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func functionTools(raw []json.RawMessage) ([]proto.FunctionTool, error) {
+	tools := make([]proto.FunctionTool, 0, len(raw))
+	names := map[string]bool{}
+	if len(raw) > 64 {
+		return nil, errors.New("at most 64 function tools are supported")
+	}
+	for _, value := range raw {
+		var tool struct {
+			Type         string          `json:"type"`
+			Name         string          `json:"name"`
+			Description  string          `json:"description"`
+			Parameters   json.RawMessage `json:"parameters"`
+			DeferLoading bool            `json:"defer_loading"`
+		}
+		decoder := json.NewDecoder(bytes.NewReader(value))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&tool); err != nil {
+			return nil, err
+		}
+		var schema map[string]json.RawMessage
+		if tool.Type != "function" || tool.DeferLoading || strings.TrimSpace(tool.Name) == "" || len(tool.Name) > 512 || names[tool.Name] || json.Unmarshal(tool.Parameters, &schema) != nil || schema == nil {
+			return nil, errors.New("execution requires unique non-deferred functions with object schemas")
+		}
+		names[tool.Name] = true
+		tools = append(tools, proto.FunctionTool{Name: tool.Name, Description: tool.Description, Parameters: tool.Parameters})
+	}
+	return tools, nil
+}
+
+type functionReply struct {
+	ack proto.InteractionDecisionAckPayload
+	err error
+}
+
+type functionExchange struct {
+	store                 *store.Store
+	tenant, session, turn string
+	tools                 []proto.FunctionTool
+	callID                string
+	reply                 <-chan functionReply
+}
+
+func (f *functionExchange) record(ctx context.Context, env proto.Envelope) error {
+	var call proto.FunctionCallPayload
+	if env.ID != f.turn || env.DecodePayload(&call) != nil {
+		return errors.New("invalid function callback")
+	}
+	declared := false
+	for _, tool := range f.tools {
+		declared = declared || tool.Name == call.Name
+	}
+	if !declared {
+		return errors.New("undeclared function callback")
+	}
+	err := f.store.RecordFunctionCall(ctx, f.tenant, f.session, f.turn, store.FunctionCall{
+		CallID: items.Identity(f.turn, "tool:"+call.CallID), ExecutorCallID: call.CallID, Name: call.Name, Arguments: call.Arguments,
+	})
+	return f.unlessCancelling(ctx, err)
+}
+
+func (f *functionExchange) start(ctx context.Context, peer *gateway.Session) error {
+	if f.reply != nil || len(f.tools) == 0 {
+		return nil
+	}
+	calls, err := f.store.PendingFunctionCalls(ctx, f.tenant, f.session, f.turn)
+	if err != nil {
+		return err
+	}
+	for _, call := range calls {
+		if len(call.Result) == 0 {
+			continue
+		}
+		result, err := functionResult(call)
+		if err != nil {
+			return err
+		}
+		env, err := proto.NewEnvelope(proto.TypeFunctionResult, f.turn, result)
+		if err != nil {
+			return err
+		}
+		replies := make(chan functionReply, 1)
+		f.callID, f.reply = call.CallID, replies
+		go func() {
+			ack, err := peer.SendAndWaitInteractionAck(ctx, env, result.DeliveryID)
+			replies <- functionReply{ack: ack, err: err}
+		}()
+		return nil
+	}
+	return nil
+}
+
+func (f *functionExchange) confirm(ctx context.Context, reply functionReply) error {
+	id := f.callID
+	f.callID, f.reply = "", nil
+	if reply.err != nil {
+		return reply.err
+	}
+	if !reply.ack.Applied {
+		return fmt.Errorf("function result not applied: %s", reply.ack.ErrorCode)
+	}
+	return f.unlessCancelling(ctx, f.store.ConfirmFunctionResult(ctx, f.tenant, f.session, f.turn, id))
+}
+
+func (f *functionExchange) unlessCancelling(ctx context.Context, err error) error {
+	if errors.Is(err, store.ErrTurnConflict) {
+		turn, lookupErr := f.store.GetTurn(ctx, f.tenant, f.session, f.turn)
+		if lookupErr == nil && !turn.CancelRequestedAt.IsZero() {
+			return nil
+		}
+	}
+	return err
+}
+
+func (f *functionExchange) complete(ctx context.Context) error {
+	if len(f.tools) == 0 {
+		return nil
+	}
+	calls, err := f.store.PendingFunctionCalls(ctx, f.tenant, f.session, f.turn)
+	if err != nil {
+		return err
+	}
+	if len(calls) != 0 {
+		return errors.New("function calls remain unapplied")
+	}
+	turn, err := f.store.GetTurn(ctx, f.tenant, f.session, f.turn)
+	if err != nil {
+		return err
+	}
+	if turn.Status == store.TurnWaiting {
+		return errors.New("function turn has not resumed")
+	}
+	return nil
+}
+
+func functionResult(call store.FunctionCall) (proto.FunctionResultPayload, error) {
+	var value struct {
+		Success *bool           `json:"success"`
+		Output  json.RawMessage `json:"output"`
+		Error   *string         `json:"error"`
+	}
+	if err := json.Unmarshal(call.Result, &value); err != nil {
+		return proto.FunctionResultPayload{}, err
+	}
+	if value.Success == nil {
+		return proto.FunctionResultPayload{}, errors.New("function result requires success")
+	}
+	result := proto.FunctionResultPayload{DeliveryID: "function:" + call.CallID, CallID: call.ExecutorCallID, Success: *value.Success, Content: []proto.FunctionResultContent{}}
+	output := bytes.TrimSpace(value.Output)
+	if len(output) > 0 && !bytes.Equal(output, []byte("null")) {
+		if output[0] == '"' {
+			var text string
+			if err := json.Unmarshal(output, &text); err != nil {
+				return result, err
+			}
+			result.Content = append(result.Content, proto.FunctionResultContent{Type: "input_text", Text: &text})
+		} else if err := json.Unmarshal(output, &result.Content); err != nil {
+			return result, err
+		}
+	}
+	if value.Error != nil {
+		result.Content = append(result.Content, proto.FunctionResultContent{Type: "input_text", Text: value.Error})
+	}
+	return result, result.ValidateContent()
+}

--- a/services/agents-api/internal/execution/functions_test.go
+++ b/services/agents-api/internal/execution/functions_test.go
@@ -1,0 +1,53 @@
+package execution
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func TestFunctionDefinitionsRejectUnsupportedConfiguration(t *testing.T) {
+	valid := json.RawMessage(`{"type":"function","name":"lookup","description":"Find it","parameters":{"type":"object","properties":{}},"defer_loading":false}`)
+	tools, err := functionTools([]json.RawMessage{valid})
+	if err != nil || len(tools) != 1 || tools[0].Name != "lookup" || tools[0].Description != "Find it" {
+		t.Fatal(tools, err)
+	}
+	for _, raw := range []string{`{"type":"mcp"}`, `{"type":"function","name":"lookup","parameters":null}`, `{"type":"function","name":"lookup","parameters":{},"defer_loading":true}`, `{"type":"function","name":"lookup","parameters":{},"unknown":true}`} {
+		if _, err := functionTools([]json.RawMessage{json.RawMessage(raw)}); err == nil {
+			t.Fatal("unsupported configuration admitted", raw)
+		}
+	}
+	if _, err := functionTools([]json.RawMessage{valid, valid}); err == nil {
+		t.Fatal("duplicate function names")
+	}
+}
+
+func TestFunctionResultPreservesCompleteContent(t *testing.T) {
+	text := func(value string) proto.FunctionResultContent {
+		return proto.FunctionResultContent{Type: "input_text", Text: &value}
+	}
+	imageURL := "data:image/png;base64,test"
+	for _, test := range []struct {
+		raw     string
+		success bool
+		content []proto.FunctionResultContent
+	}{
+		{`{"success":true,"output":""}`, true, []proto.FunctionResultContent{text("")}},
+		{`{"success":true,"output":null,"error":null}`, true, []proto.FunctionResultContent{}},
+		{`{"success":false,"error":"failed"}`, false, []proto.FunctionResultContent{text("failed")}},
+		{`{"success":false,"output":[{"type":"input_text","text":"before"},{"type":"input_image","image_url":"data:image/png;base64,test"},{"type":"input_text","text":""}],"error":"failed"}`, false, []proto.FunctionResultContent{text("before"), {Type: "input_image", ImageURL: &imageURL}, text(""), text("failed")}},
+	} {
+		result, err := functionResult(store.FunctionCall{CallID: "public", ExecutorCallID: "native", Result: json.RawMessage(test.raw)})
+		if err != nil || result.CallID != "native" || result.DeliveryID != "function:public" || result.Success != test.success || !reflect.DeepEqual(result.Content, test.content) {
+			t.Fatal(result, err)
+		}
+	}
+	for _, raw := range []string{`{}`, `{"success":null}`, `{"success":true,"output":{}}`, `{"success":true,"output":[{"type":"input_text"}]}`, `{"success":true,"output":[{"type":"input_audio","audio_url":"a"}]}`} {
+		if _, err := functionResult(store.FunctionCall{Result: json.RawMessage(raw)}); err == nil {
+			t.Fatal("invalid stored result converted", raw)
+		}
+	}
+}

--- a/services/agents-api/internal/store/function_execution_native_test.go
+++ b/services/agents-api/internal/store/function_execution_native_test.go
@@ -1,0 +1,154 @@
+package store_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func TestNativeFunctionExecutionPersistsCallsResultsAndContinuity(t *testing.T) {
+	h, ctx, home := nativeDispatchHarness(t)
+	var err error
+	h.session, err = h.s.CreateSession(ctx, h.tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "native-functions", Configuration: json.RawMessage(functionConfiguration)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.s.BindSessionDevice(ctx, h.tenant, h.session.ID, h.device.ID); err != nil {
+		t.Fatal(err)
+	}
+	picture := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	picture.Set(0, 0, color.RGBA{R: 255, A: 255})
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, picture); err != nil {
+		t.Fatal(err)
+	}
+	output := []any{map[string]any{"type": "input_text", "text": "before"}, map[string]any{"type": "input_image", "image_url": "data:image/png;base64," + base64.StdEncoding.EncodeToString(encoded.Bytes())}, map[string]any{"type": "input_text", "text": "after"}}
+	var requests atomic.Int32
+	model := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+			return
+		}
+		n := requests.Add(1)
+		raw, _ := json.MarshalIndent(body, "", "  ")
+		_ = os.WriteFile(filepath.Join(home, fmt.Sprintf("functions-model-%d.json", n)), raw, 0600)
+		if !strings.Contains(string(raw), "lookup_ticket") {
+			t.Error("configured function missing")
+		}
+		var entry map[string]any
+		if n%2 == 1 {
+			entry = map[string]any{"id": fmt.Sprintf("fc_%d", n), "type": "function_call", "call_id": fmt.Sprintf("call_%d", n), "name": "lookup_ticket", "arguments": `{"ticket":"42"}`, "status": "completed"}
+		} else {
+			found := false
+			for _, value := range body["input"].([]any) {
+				item := value.(map[string]any)
+				if item["type"] != "function_call_output" || item["call_id"] != fmt.Sprintf("call_%d", n-1) {
+					continue
+				}
+				found = true
+				expected := append([]any(nil), output...)
+				// Codex adds its default image detail at the model transport boundary.
+				expected[1] = map[string]any{"type": "input_image", "image_url": output[1].(map[string]any)["image_url"], "detail": "high"}
+				if n == 4 {
+					expected = append(expected, map[string]any{"type": "input_text", "text": "synthetic failure"})
+				}
+				if !reflect.DeepEqual(item["output"], expected) {
+					t.Errorf("complete result changed: %v", item["output"])
+				}
+			}
+			if !found {
+				t.Error("native model did not receive stored result")
+			}
+			entry = map[string]any{"id": fmt.Sprintf("message_%d", n), "type": "message", "role": "assistant", "phase": "final_answer", "status": "completed", "content": []any{map[string]any{"type": "output_text", "text": "FUNCTION-EXECUTION-OK", "annotations": []any{}}}}
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		send := func(kind string, data map[string]any) {
+			data["type"] = kind
+			raw, _ := json.Marshal(data)
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", kind, raw)
+			w.(http.Flusher).Flush()
+		}
+		send("response.created", map[string]any{"response": map[string]any{"id": fmt.Sprintf("r_%d", n), "status": "in_progress", "output": []any{}}})
+		send("response.output_item.added", map[string]any{"output_index": 0, "item": entry})
+		send("response.output_item.done", map[string]any{"output_index": 0, "item": entry})
+		send("response.completed", map[string]any{"response": map[string]any{"id": fmt.Sprintf("r_%d", n), "object": "response", "created_at": 0, "status": "completed", "model": "gpt-5.5", "output": []any{entry}}})
+	}))
+	defer model.Close()
+	h.d.Options = func(context.Context, store.Session) (map[string]any, error) {
+		return map[string]any{"codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}}, nil
+	}
+	nativeID := ""
+	for index := range 3 {
+		input := h.message(fmt.Sprint(index), "Look up ticket 42")
+		running := h.run(ctx, input.TurnID)
+		state := functionState(t, h, 1)
+		action := state.RequiredActions[0]
+		if action.Name != "lookup_ticket" || action.TurnID != input.TurnID || state.LastTurn.Status != store.TurnWaiting {
+			t.Fatal(action, state.LastTurn)
+		}
+		if index == 2 {
+			if _, err := h.s.RequestCancel(ctx, h.tenant, h.session.ID, "native-cancel"); err != nil {
+				t.Fatal(err)
+			}
+			h.finished(running, store.TurnCancelled)
+			break
+		}
+		value := map[string]any{"success": index == 0, "output": output}
+		if index == 1 {
+			value["error"] = "synthetic failure"
+		}
+		raw, _ := json.Marshal(value)
+		for range 2 {
+			if err := h.s.SubmitFunctionResult(ctx, h.tenant, h.session.ID, input.TurnID, action.CallID, raw); err != nil {
+				t.Fatal(err)
+			}
+		}
+		h.finished(running, store.TurnCompleted)
+		saved, err := h.s.GetFunctionCall(ctx, h.tenant, h.session.ID, input.TurnID, action.CallID)
+		if err != nil || !saved.Applied {
+			t.Fatal(saved, err)
+		}
+		page, err := h.s.ListItems(ctx, h.tenant, h.session.ID, "", 100, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		found := false
+		for _, item := range page.Items {
+			if item.Type == "function_call" && item.CallID == action.CallID {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatal("required action identity differs from recovered function item")
+		}
+		bound, err := h.s.GetSessionDevice(ctx, h.tenant, h.session.ID)
+		if err != nil || bound.NativeSessionID == "" || (nativeID != "" && bound.NativeSessionID != nativeID) {
+			t.Fatal(bound, err)
+		}
+		nativeID = bound.NativeSessionID
+	}
+	functionState(t, h, 0)
+	if requests.Load() != 5 {
+		t.Fatal("function replay or missing model continuation", requests.Load())
+	}
+	if t.Failed() {
+		return
+	}
+	t.Logf("Native daemon/engine functions, complete text/image/error results, receipts, Items identity, resume and cancellation passed; evidence %s", home)
+}

--- a/services/agents-api/internal/store/function_execution_test.go
+++ b/services/agents-api/internal/store/function_execution_test.go
@@ -140,12 +140,24 @@ func TestExecutionFunctionsCancellationAndUnconfirmedResults(t *testing.T) {
 				}
 				var request proto.PromptCancelPayload
 				_ = h.read(proto.TypePromptCancel).DecodePayload(&request)
-				h.write(input.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: request.DeliveryID, Applied: true, Outcome: &proto.DonePayload{}})
+				h.write(input.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: reply.DeliveryID, ErrorCode: "not_pending"})
+				select {
+				case got := <-result:
+					t.Fatal("function rejection bypassed outstanding cancellation", got)
+				case <-time.After(40 * time.Millisecond):
+				}
+				h.write(input.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: request.DeliveryID, Applied: true, Outcome: &proto.DonePayload{Metadata: map[string]any{proto.DoneMetaAgentSessionID: "native-cancelled-functions"}}})
 				status = store.TurnCancelled
 			} else {
 				h.write(input.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: reply.DeliveryID, ErrorCode: "not_pending"})
 			}
 			h.finished(result, status)
+			if cancel {
+				bound, err := h.s.GetSessionDevice(t.Context(), h.tenant, h.session.ID)
+				if err != nil || bound.NativeSessionID != "native-cancelled-functions" {
+					t.Fatal(bound, err)
+				}
+			}
 			saved, err := h.s.GetFunctionCall(t.Context(), h.tenant, h.session.ID, input.TurnID, id)
 			if err != nil || saved.Applied || len(saved.Result) == 0 {
 				t.Fatal(saved, err)

--- a/services/agents-api/internal/store/function_execution_test.go
+++ b/services/agents-api/internal/store/function_execution_test.go
@@ -1,0 +1,196 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/items"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+const functionConfiguration = `{"agent":{"model":"gpt-5.5","tools":[{"type":"function","name":"lookup_ticket","description":"Read a synthetic ticket","parameters":{"type":"object","properties":{"ticket":{"type":"string"}},"required":["ticket"],"additionalProperties":false},"defer_loading":false}]},"environment":{"type":"none"}}`
+
+func newFunctionHarness(t *testing.T) *dispatchHarness {
+	t.Helper()
+	h := newDispatchHarness(t)
+	var err error
+	h.session, err = h.s.CreateSession(t.Context(), h.tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "functions", Configuration: json.RawMessage(functionConfiguration)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := h.s.BindSessionDevice(t.Context(), h.tenant, h.session.ID, h.device.ID); err != nil {
+		t.Fatal(err)
+	}
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, EnvironmentNone: true, FunctionTools: true}}}})
+	deadline := time.Now().Add(time.Second)
+	for {
+		peer, _ := h.registry.LookupDevice(h.device.ID)
+		info, _, _ := peer.AgentKindStatus("codex")
+		if info.Capabilities.FunctionTools {
+			return h
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("function heartbeat missing")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func functionState(t *testing.T, h *dispatchHarness, count int) store.Session {
+	t.Helper()
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		state, err := h.s.GetSession(t.Context(), h.tenant, h.session.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(state.RequiredActions) == count {
+			return state
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("waiting for %d function actions: %+v", count, state)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestExecutionFunctionsWaitForEveryApplicationReceipt(t *testing.T) {
+	h := newFunctionHarness(t)
+	input := h.message("start", "Run functions")
+	result := h.run(t.Context(), input.TurnID)
+	var prompt proto.PromptRequestPayload
+	_ = h.read(proto.TypePromptRequest).DecodePayload(&prompt)
+	if len(prompt.FunctionTools) != 1 || prompt.FunctionTools[0].Name != "lookup_ticket" {
+		t.Fatal(prompt.FunctionTools)
+	}
+	for _, id := range []string{"a", "b"} {
+		for range 2 {
+			h.write(input.TurnID, proto.TypeFunctionCall, proto.FunctionCallPayload{CallID: id, Name: "lookup_ticket", Arguments: json.RawMessage(`{"ticket":"42"}`)})
+		}
+	}
+	state := functionState(t, h, 2)
+	if state.LastTurn.Status != store.TurnWaiting {
+		t.Fatal(state.LastTurn)
+	}
+	for _, id := range []string{"a", "b"} {
+		public := items.Identity(input.TurnID, "tool:"+id)
+		if err := h.s.SubmitFunctionResult(t.Context(), h.tenant, h.session.ID, input.TurnID, public, json.RawMessage(`{"success":true,"output":"saved"}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for index := range 2 {
+		var reply proto.FunctionResultPayload
+		_ = h.read(proto.TypeFunctionResult).DecodePayload(&reply)
+		public := items.Identity(input.TurnID, "tool:"+reply.CallID)
+		saved, err := h.s.GetFunctionCall(t.Context(), h.tenant, h.session.ID, input.TurnID, public)
+		if err != nil || saved.Applied || reply.DeliveryID != "function:"+public || len(reply.Content) != 1 || *reply.Content[0].Text != "saved" {
+			t.Fatal(saved, reply, err)
+		}
+		if index == 1 {
+			h.write(input.TurnID, proto.TypeDone, proto.DonePayload{Content: "done", Metadata: map[string]any{proto.DoneMetaAgentSessionID: "native-functions"}})
+			select {
+			case got := <-result:
+				t.Fatal("Done bypassed outstanding receipt", got)
+			case <-time.After(40 * time.Millisecond):
+			}
+		}
+		for range 2 {
+			h.write(input.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: reply.DeliveryID, Applied: true})
+		}
+	}
+	h.finished(result, store.TurnCompleted)
+	functionState(t, h, 0)
+	next := h.message("next", "Resume")
+	result = h.run(t.Context(), next.TurnID)
+	_ = h.read(proto.TypePromptRequest).DecodePayload(&prompt)
+	if prompt.AgentSessionID != "native-functions" || len(prompt.FunctionTools) != 1 {
+		t.Fatal(prompt)
+	}
+	h.write(next.TurnID, proto.TypeDone, proto.DonePayload{Content: "resumed"})
+	h.finished(result, store.TurnCompleted)
+}
+
+func TestExecutionFunctionsCancellationAndUnconfirmedResults(t *testing.T) {
+	for _, cancel := range []bool{false, true} {
+		t.Run(map[bool]string{false: "unconfirmed", true: "cancel"}[cancel], func(t *testing.T) {
+			h := newFunctionHarness(t)
+			input := h.message("start", "Run")
+			result := h.run(t.Context(), input.TurnID)
+			h.read(proto.TypePromptRequest)
+			h.write(input.TurnID, proto.TypeFunctionCall, proto.FunctionCallPayload{CallID: "a", Name: "lookup_ticket", Arguments: json.RawMessage(`{}`)})
+			state := functionState(t, h, 1)
+			id := state.RequiredActions[0].CallID
+			if err := h.s.SubmitFunctionResult(t.Context(), h.tenant, h.session.ID, input.TurnID, id, json.RawMessage(`{"success":false,"error":"tool failed"}`)); err != nil {
+				t.Fatal(err)
+			}
+			var reply proto.FunctionResultPayload
+			_ = h.read(proto.TypeFunctionResult).DecodePayload(&reply)
+			if reply.Success || len(reply.Content) != 1 || *reply.Content[0].Text != "tool failed" {
+				t.Fatal(reply)
+			}
+			status := store.TurnFailed
+			if cancel {
+				if _, err := h.s.RequestCancel(t.Context(), h.tenant, h.session.ID, "cancel"); err != nil {
+					t.Fatal(err)
+				}
+				var request proto.PromptCancelPayload
+				_ = h.read(proto.TypePromptCancel).DecodePayload(&request)
+				h.write(input.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: request.DeliveryID, Applied: true, Outcome: &proto.DonePayload{}})
+				status = store.TurnCancelled
+			} else {
+				h.write(input.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: reply.DeliveryID, ErrorCode: "not_pending"})
+			}
+			h.finished(result, status)
+			saved, err := h.s.GetFunctionCall(t.Context(), h.tenant, h.session.ID, input.TurnID, id)
+			if err != nil || saved.Applied || len(saved.Result) == 0 {
+				t.Fatal(saved, err)
+			}
+			if err := h.s.ConfirmFunctionResult(t.Context(), h.tenant, h.session.ID, input.TurnID, id); !errors.Is(err, store.ErrTurnConflict) {
+				t.Fatal(err)
+			}
+			functionState(t, h, 0)
+		})
+	}
+}
+
+func TestExecutionFunctionsRejectUndeclaredCallsAndPrematureDone(t *testing.T) {
+	for _, name := range []string{"undeclared", "lookup_ticket"} {
+		t.Run(name, func(t *testing.T) {
+			h := newFunctionHarness(t)
+			input := h.message("start", "Run")
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			result := h.run(ctx, input.TurnID)
+			h.read(proto.TypePromptRequest)
+			h.write(input.TurnID, proto.TypeFunctionCall, proto.FunctionCallPayload{CallID: "a", Name: name, Arguments: json.RawMessage(`{}`)})
+			h.write(input.TurnID, proto.TypeDone, proto.DonePayload{})
+			h.finished(result, store.TurnFailed)
+		})
+	}
+}
+
+func TestExecutionFunctionsRequireAdvertisedCapability(t *testing.T) {
+	h := newDispatchHarness(t)
+	session, err := h.s.CreateSession(t.Context(), h.tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "functions", Configuration: json.RawMessage(functionConfiguration)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.session = session
+	if err := h.s.BindSessionDevice(t.Context(), h.tenant, session.ID, h.device.ID); err != nil {
+		t.Fatal(err)
+	}
+	input := h.message("start", "Run")
+	result := <-h.run(t.Context(), input.TurnID)
+	if result.err == nil || !strings.Contains(result.err.Error(), "function_tools") {
+		t.Fatal(result)
+	}
+	turn, err := h.s.GetTurn(t.Context(), h.tenant, session.ID, input.TurnID)
+	if err != nil || turn.Status != store.TurnQueued {
+		t.Fatal(turn, err)
+	}
+}

--- a/services/agents-api/internal/store/native_daemon_test.go
+++ b/services/agents-api/internal/store/native_daemon_test.go
@@ -1,0 +1,72 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func nativeDispatchHarness(t *testing.T) (*dispatchHarness, context.Context, string) {
+	t.Helper()
+	binary, root := os.Getenv("PARSAR_NATIVE_DAEMON_BIN"), os.Getenv("PARSAR_NATIVE_PROOF_DIR")
+	if binary == "" || root == "" {
+		t.Skip("explicit native daemon binary and evidence directory required")
+	}
+	h := newDispatchHarness(t)
+	oldPeer, _ := h.registry.LookupDevice(h.device.ID)
+	h.conn.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	t.Cleanup(cancel)
+	home, err := os.MkdirTemp(root, "execution-native-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := filepath.Join(home, "parsar-daemon", "execution")
+	if err = os.MkdirAll(profile, 0700); err != nil {
+		t.Fatal(err)
+	}
+	auth, _ := json.Marshal(map[string]string{"server_url": h.url + "/api/v1", "runtime_id": h.device.ID, "runner_credential": h.credential, "device_name": "native proof"})
+	if err = os.WriteFile(filepath.Join(profile, "auth.json"), auth, 0600); err != nil {
+		t.Fatal(err)
+	}
+	daemonLog, err := os.Create(filepath.Join(home, "daemon.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = daemonLog.Close() })
+	cmd := exec.Command(binary, "connect", "--profile", "execution")
+	cmd.Env = append(os.Environ(), "PARSAR_HOME="+home)
+	cmd.Stdout, cmd.Stderr = daemonLog, daemonLog
+	if err = cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	stopped := make(chan error, 1)
+	go func() { stopped <- cmd.Wait() }()
+	t.Cleanup(func() {
+		_ = cmd.Process.Signal(os.Interrupt)
+		select {
+		case <-stopped:
+		case <-time.After(8 * time.Second):
+			_ = cmd.Process.Kill()
+			<-stopped
+		}
+	})
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		peer, e := h.registry.LookupDevice(h.device.ID)
+		if e == nil && peer != oldPeer {
+			if info, found, known := peer.AgentKindStatus("codex"); known && found && info.Available && info.Capabilities.EnvironmentNone {
+				break
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("native daemon not ready; logs %s", home)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return h, ctx, home
+}

--- a/services/agents-api/internal/store/native_environment_test.go
+++ b/services/agents-api/internal/store/native_environment_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -18,62 +17,8 @@ import (
 )
 
 func TestNativeNoExecutionEnvironment(t *testing.T) {
-	binary, root := os.Getenv("PARSAR_NATIVE_DAEMON_BIN"), os.Getenv("PARSAR_NATIVE_PROOF_DIR")
-	if binary == "" || root == "" {
-		t.Skip("explicit native daemon binary and evidence directory required")
-	}
-	h := newDispatchHarness(t)
-	oldPeer, _ := h.registry.LookupDevice(h.device.ID)
-	h.conn.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
-	defer cancel()
-	home, err := os.MkdirTemp(root, "no-environment-native-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	profile := filepath.Join(home, "parsar-daemon", "execution")
-	if err = os.MkdirAll(profile, 0700); err != nil {
-		t.Fatal(err)
-	}
-	auth, _ := json.Marshal(map[string]string{"server_url": h.url + "/api/v1", "runtime_id": h.device.ID, "runner_credential": h.credential, "device_name": "native proof"})
-	if err = os.WriteFile(filepath.Join(profile, "auth.json"), auth, 0600); err != nil {
-		t.Fatal(err)
-	}
-	daemonLog, err := os.Create(filepath.Join(home, "daemon.log"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer daemonLog.Close()
-	cmd := exec.Command(binary, "connect", "--profile", "execution")
-	cmd.Env = append(os.Environ(), "PARSAR_HOME="+home)
-	cmd.Stdout, cmd.Stderr = daemonLog, daemonLog
-	if err = cmd.Start(); err != nil {
-		t.Fatal(err)
-	}
-	stopped := make(chan error, 1)
-	go func() { stopped <- cmd.Wait() }()
-	defer func() {
-		_ = cmd.Process.Signal(os.Interrupt)
-		select {
-		case <-stopped:
-		case <-time.After(8 * time.Second):
-			_ = cmd.Process.Kill()
-			<-stopped
-		}
-	}()
-	deadline := time.Now().Add(20 * time.Second)
-	for {
-		peer, e := h.registry.LookupDevice(h.device.ID)
-		if e == nil && peer != oldPeer {
-			if info, found, known := peer.AgentKindStatus("codex"); known && found && info.Available && info.Capabilities.EnvironmentNone {
-				break
-			}
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("native daemon not ready; logs %s", home)
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
+	h, ctx, home := nativeDispatchHarness(t)
+	var err error
 	config, _ := json.Marshal(map[string]any{"agent": map[string]string{"model": "gpt-5.5", "instructions": "Keep this instruction."}, "environment": map[string]string{"type": "none"}})
 	h.session, err = h.s.CreateSession(ctx, h.tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "native-session", Configuration: config})
 	if err != nil {

--- a/services/agents-api/internal/store/turn_events.go
+++ b/services/agents-api/internal/store/turn_events.go
@@ -72,7 +72,7 @@ func (s *Store) AppendTurnEvents(ctx context.Context, tenantID, sessionID, turnI
 			}
 			return nil
 		}
-		if turn.Status != TurnInProgress || first != turn.EventCount+1 {
+		if (turn.Status != TurnInProgress && turn.Status != TurnWaiting) || first != turn.EventCount+1 {
 			return ErrTurnConflict
 		}
 		if turn.EventCount+int32(len(events)) > 65536 || turn.EventBytes+int64(payloadBytes) > 32*1024*1024 {


### PR DESCRIPTION
Internally resolved function tools now execute through Agents API’s bound daemon. Declared callbacks are persisted as required actions, saved results retain ordered text/image content and failure details, and a Turn cannot complete until native application is acknowledged—even when Done arrives before the receipt. Cancellation and native Session continuity remain available while waiting.

Scope is the internal execution adapter and its persistence integration. Public `tools`/`tool_result` admission, product approvals, Team orchestration and environments are separate tasks; this is not full public function compatibility. No API schema, SQL migration, product or daemon behavior changes.

Validation on `zju_a100_2`:
- Focused PostgreSQL race tests for execution, callbacks, receipts, cancellation and completion ordering.
- Real daemon/Codex with a synthetic model responder: ordered text/image/error results, action/Item identity, native resume and pending-call cancellation.
- Existing native no-environment and official-client workflow regression.
- Required `make check`; dedicated Agents API PostgreSQL tests ran. Product Docker-only tests were skipped because no product behavior changed and shared Docker is excluded.

Tracked in Feishu ATOM-006.
