### PR TITLE
fix(agents-api): admit function results in atomic input batches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,6 +312,14 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   Actions remain visible until native application is acknowledged. This timing is
   an implementation choice, not verified upstream event sequencing. Public tool
   configuration and result admission remain pending.
+- Function results can join internal message/cancel input batches. Their explicit
+  Turn/call identity selects an existing call; admission never creates a Turn for
+  a result. Save the complete result and its input retry record in the same Session
+  transaction. Any invalid target, conflicting result or later batch error rolls
+  back the whole request. Identical saved results remain retryable after termination
+  without applying them again. The execution input cursor skips function results;
+  their separate native receipts still determine application. Public event decoding
+  and function configuration remain pending.
 - Internal function execution requires an advertised `function_tools` capability
   before claiming a Turn. Translate resolved definitions in the execution adapter,
   persist declared callbacks before exposing actions, and deliver each saved result

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -101,7 +101,7 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Tenant-scoped Session persistence | Implemented; internal Store, not a public API |
 | Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
 | Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, ordinary text with low/medium/high verbosity (Unix daemon and native model support required), environment `none`, metadata and creation retry keys |
-| Internal Turn/input persistence | Tenant-scoped atomic input batches, steering, request-level retry identity, cancellation targets and terminal outcomes |
+| Internal Turn/input persistence | Tenant-scoped atomic message/cancel/function-result batches, steering, request-level retry identity, cancellation targets and terminal outcomes; public result decoding pending |
 | Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; explicit Codex no-environment execution; public text/cancel submission with a bounded standalone worker |
 | Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items` and tool snapshots via `tool_items`; tenant-scoped paginated Store reads |
 | Public Turn recovery | Retrieve/list persisted states with scoped pagination; see limitations below |

--- a/services/agents-api/internal/execution/delivery.go
+++ b/services/agents-api/internal/execution/delivery.go
@@ -225,6 +225,11 @@ func (d *Dispatcher) deliver(ctx context.Context, tenantID, sessionID string, pe
 				if len(inputs) == 0 {
 					continue
 				}
+				if inputs[0].Kind == "tool_result" {
+					// Function results use their own application receipts, not message steering.
+					result.AppliedThrough = inputs[0].Sequence
+					continue
+				}
 				if inputs[0].Kind == "cancel" {
 					continue
 				}

--- a/services/agents-api/internal/store/function_input_execution_test.go
+++ b/services/agents-api/internal/store/function_input_execution_test.go
@@ -1,0 +1,59 @@
+package store_test
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func TestExecutionFunctionInputBatchStillSteersMessages(t *testing.T) {
+	h := newFunctionHarness(t)
+	input := h.message("start", "Run")
+	running := h.run(t.Context(), input.TurnID)
+	h.read(proto.TypePromptRequest)
+	h.write(input.TurnID, proto.TypeFunctionCall, proto.FunctionCallPayload{CallID: "a", Name: "lookup_ticket", Arguments: json.RawMessage(`{}`)})
+	state := functionState(t, h, 1)
+	raw, _ := json.Marshal(store.FunctionResultInput{TurnID: input.TurnID, CallID: state.RequiredActions[0].CallID, Result: json.RawMessage(`{"success":true,"output":"answer"}`)})
+	batch := []store.Input{{Kind: "tool_result", Payload: raw}, {Kind: "message", Payload: json.RawMessage(`{"text":"Follow up"}`)}}
+	receipts, err := h.s.SubmitInputs(t.Context(), h.tenant, h.session.ID, "mixed", batch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.s.SubmitInputs(t.Context(), h.tenant, h.session.ID, "mixed", batch); err != nil {
+		t.Fatal(err)
+	}
+	resultSeen, messageSeen := false, false
+	_ = h.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	for !resultSeen || !messageSeen {
+		var env proto.Envelope
+		if err := h.conn.ReadJSON(&env); err != nil {
+			t.Fatal(err)
+		}
+		switch env.Type {
+		case proto.TypeFunctionResult:
+			var result proto.FunctionResultPayload
+			if env.DecodePayload(&result) != nil || resultSeen || result.CallID != "a" {
+				t.Fatal(result)
+			}
+			resultSeen = true
+			h.write(input.TurnID, proto.TypeInteractionDecisionAck, proto.InteractionDecisionAckPayload{DeliveryID: result.DeliveryID, Applied: true})
+		case proto.TypePromptSteer:
+			var steer proto.PromptSteerPayload
+			if env.DecodePayload(&steer) != nil || messageSeen || steer.Text != "Follow up" || steer.InputID != strconv.FormatInt(receipts[1].Sequence, 10) {
+				t.Fatal(steer)
+			}
+			messageSeen = true
+			h.write(input.TurnID, proto.TypePromptSteerAck, proto.PromptSteerAckPayload{InputID: steer.InputID, Accepted: true})
+		}
+	}
+	h.write(input.TurnID, proto.TypeDone, proto.DonePayload{Content: "done"})
+	h.finished(running, store.TurnCompleted)
+	saved, err := h.s.GetFunctionCall(t.Context(), h.tenant, h.session.ID, input.TurnID, state.RequiredActions[0].CallID)
+	if err != nil || !saved.Applied {
+		t.Fatal(saved, err)
+	}
+}

--- a/services/agents-api/internal/store/function_inputs.go
+++ b/services/agents-api/internal/store/function_inputs.go
@@ -21,7 +21,7 @@ type FunctionResultInput struct {
 
 func functionInput(raw json.RawMessage) (FunctionResultInput, error) {
 	var input FunctionResultInput
-	if json.Unmarshal(raw, &input) != nil || !validFunctionIdentity(input.CallID) {
+	if json.Unmarshal(raw, &input) != nil || !validFunctionIdentity(input.CallID) || len(input.Result) == 0 {
 		return input, ErrInvalidInput
 	}
 	if _, err := uuid.Parse(input.TurnID); err != nil {

--- a/services/agents-api/internal/store/function_inputs.go
+++ b/services/agents-api/internal/store/function_inputs.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/db/sqlc"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// FunctionResultInput identifies a persisted call; Result is validated by the API.
+// It is an internal command, not an upstream input event.
+type FunctionResultInput struct {
+	TurnID string          `json:"turn_id"`
+	CallID string          `json:"call_id"`
+	Result json.RawMessage `json:"result"`
+}
+
+func functionInput(raw json.RawMessage) (FunctionResultInput, error) {
+	var input FunctionResultInput
+	if json.Unmarshal(raw, &input) != nil || !validFunctionIdentity(input.CallID) {
+		return input, ErrInvalidInput
+	}
+	if _, err := uuid.Parse(input.TurnID); err != nil {
+		return input, ErrInvalidInput
+	}
+	result, err := canonicalJSONObject(input.Result)
+	if err != nil {
+		return input, err
+	}
+	input.Result = result
+	return input, nil
+}
+
+func admitFunctionResult(ctx context.Context, q *sqlc.Queries, tenantID string, session pgtype.UUID, key string, position int32, input Input) (InputReceipt, error) {
+	result, err := functionInput(input.Payload)
+	if err != nil {
+		return InputReceipt{}, err
+	}
+	lookup, err := turnLookup(tenantID, uuid.UUID(session.Bytes).String(), result.TurnID)
+	if err != nil {
+		return InputReceipt{}, err
+	}
+	turn, err := q.GetTurn(ctx, lookup)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return InputReceipt{}, ErrNotFound
+	}
+	if err != nil {
+		return InputReceipt{}, err
+	}
+	if err := storeFunctionResult(ctx, q, turn, result.CallID, result.Result); err != nil {
+		return InputReceipt{}, err
+	}
+	sequence, err := q.CreateTurnInput(ctx, sqlc.CreateTurnInputParams{
+		SessionID: session, TurnID: turn.ID, IdempotencyKey: key, Kind: input.Kind, Payload: input.Payload, BatchPosition: position,
+	})
+	if err != nil {
+		return InputReceipt{}, err
+	}
+	return inputReceipt(sequence, turn.ID, false), nil
+}

--- a/services/agents-api/internal/store/function_inputs_test.go
+++ b/services/agents-api/internal/store/function_inputs_test.go
@@ -193,7 +193,7 @@ func TestFunctionInputConcurrentBatchesSelectOneResult(t *testing.T) {
 func TestFunctionInputsRejectInvalidTargetsAndStorageObjects(t *testing.T) {
 	s, _ := testStore(t)
 	tenant, session, turn := functionInputFixture(t, s)
-	for _, raw := range []string{`{}`, `{"turn_id":"bad","call_id":"a","result":{}}`, fmt.Sprintf(`{"turn_id":%q,"call_id":"a","result":null}`, turn), fmt.Sprintf(`{"turn_id":%q,"call_id":"a","result":[]}`, turn)} {
+	for _, raw := range []string{`{}`, `{"turn_id":"bad","call_id":"a","result":{}}`, fmt.Sprintf(`{"turn_id":%q,"call_id":"a"}`, turn), fmt.Sprintf(`{"turn_id":%q,"call_id":"a","result":null}`, turn), fmt.Sprintf(`{"turn_id":%q,"call_id":"a","result":[]}`, turn)} {
 		_, err := s.SubmitInputs(t.Context(), tenant, session.ID, "invalid", []Input{{Kind: "tool_result", Payload: json.RawMessage(raw)}})
 		if !errors.Is(err, ErrInvalidInput) {
 			t.Fatal(err)

--- a/services/agents-api/internal/store/function_inputs_test.go
+++ b/services/agents-api/internal/store/function_inputs_test.go
@@ -1,0 +1,219 @@
+package store
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func resultInput(t *testing.T, turn, call, result string) Input {
+	t.Helper()
+	raw, err := json.Marshal(FunctionResultInput{TurnID: turn, CallID: call, Result: json.RawMessage(result)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return Input{Kind: "tool_result", Payload: raw}
+}
+
+func functionInputFixture(t *testing.T, s *Store) (string, Session, string) {
+	t.Helper()
+	tenant, session := newTurnSession(t, s)
+	turn := submitMessage(t, s, tenant, session.ID, "start").TurnID
+	transition(t, s, tenant, session.ID, turn, TurnQueued, TurnInProgress)
+	for _, id := range []string{"a", "b"} {
+		if err := s.RecordFunctionCall(t.Context(), tenant, session.ID, turn, functionCallFixture(id)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return tenant, session, turn
+}
+
+func TestFunctionInputBatchesPersistAndReplayWithoutRetargeting(t *testing.T) {
+	s, pool := testStore(t)
+	tenant, session, turn := functionInputFixture(t, s)
+	full := `{"success":false,"output":[{"type":"input_text","text":""},{"type":"input_image","image_url":"data:image/png;base64,AA=="},{"type":"input_text","text":"after"}],"error":"failed"}`
+	batch := []Input{resultInput(t, turn, "a", full), {Kind: "message", Payload: json.RawMessage(`{"text":"Follow up"}`)}, resultInput(t, turn, "b", `{"success":true,"output":null,"error":null}`), {Kind: "cancel", Payload: json.RawMessage(`{}`)}}
+	receipts, err := s.SubmitInputs(t.Context(), tenant, session.ID, "batch", batch)
+	if err != nil || len(receipts) != 4 {
+		t.Fatal(receipts, err)
+	}
+	for i, receipt := range receipts {
+		if receipt.Replayed || receipt.TurnID != turn || (i > 0 && receipt.Sequence <= receipts[i-1].Sequence) {
+			t.Fatal(receipts)
+		}
+	}
+	call, err := s.GetFunctionCall(t.Context(), tenant, session.ID, turn, "a")
+	got, _ := canonicalJSONObject(call.Result)
+	want, _ := canonicalJSONObject(json.RawMessage(full))
+	if err != nil || call.Applied || string(got) != string(want) {
+		t.Fatal(call, err)
+	}
+	// A result retry and its messages stay attached to their first Turn after restart.
+	transition(t, s, tenant, session.ID, turn, TurnWaiting, TurnFailed)
+	next := submitMessage(t, s, tenant, session.ID, "next").TurnID
+	pool.Close()
+	s, _ = testStore(t)
+	retry, err := s.SubmitInputs(t.Context(), tenant, session.ID, "batch", batch)
+	if err != nil || len(retry) != len(receipts) {
+		t.Fatal(retry, err)
+	}
+	for i := range retry {
+		if !retry[i].Replayed {
+			t.Fatal(retry)
+		}
+		retry[i].Replayed = false
+	}
+	if !reflect.DeepEqual(retry, receipts) {
+		t.Fatal(retry, receipts)
+	}
+	history, err := s.ListTurnInputs(t.Context(), tenant, session.ID, turn, 0, 100)
+	if err != nil || len(history) != 5 || history[1].Kind != "tool_result" || history[2].Kind != "message" {
+		t.Fatal(history, err)
+	}
+	future, err := s.ListTurnInputs(t.Context(), tenant, session.ID, next, 0, 100)
+	if err != nil || len(future) != 1 {
+		t.Fatal(future, err)
+	}
+	current, err := s.GetTurn(t.Context(), tenant, session.ID, next)
+	if err != nil || !current.CancelRequestedAt.IsZero() || current.Status != TurnQueued {
+		t.Fatal(current, err)
+	}
+	changed := []Input{batch[1], batch[0], batch[2], batch[3]}
+	if _, err := s.SubmitInputs(t.Context(), tenant, session.ID, "batch", changed); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatal(err)
+	}
+	// A new request identity can repeat an identical saved result, without native application.
+	if _, err := s.SubmitInputs(t.Context(), tenant, session.ID, "same-result", batch[:1]); err != nil {
+		t.Fatal(err)
+	}
+	call, err = s.GetFunctionCall(t.Context(), tenant, session.ID, turn, "a")
+	if err != nil || call.Applied {
+		t.Fatal(call, err)
+	}
+}
+
+func TestFunctionInputBatchFailureRollsBackEveryWrite(t *testing.T) {
+	for _, mode := range []string{"missing-call", "foreign-turn", "same-tenant-turn", "cancel-first", "changed-result"} {
+		t.Run(mode, func(t *testing.T) {
+			s, _ := testStore(t)
+			tenant, session, turn := functionInputFixture(t, s)
+			message := Input{Kind: "message", Payload: json.RawMessage(`{"text":"Must roll back"}`)}
+			cancel := Input{Kind: "cancel", Payload: json.RawMessage(`{}`)}
+			first := resultInput(t, turn, "a", `{"success":true}`)
+			batch := []Input{message, first, cancel}
+			expected := ErrNotFound
+			switch mode {
+			case "missing-call":
+				batch = append(batch, resultInput(t, turn, "missing", `{"success":true}`))
+			case "foreign-turn", "same-tenant-turn":
+				otherTenant := tenant
+				if mode == "foreign-turn" {
+					otherTenant = uuid.NewString()
+				}
+				other, err := s.CreateSession(t.Context(), otherTenant, CreateSessionInput{Engine: "codex", IdempotencyKey: "other"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				otherTurn := submitMessage(t, s, otherTenant, other.ID, "start").TurnID
+				transition(t, s, otherTenant, other.ID, otherTurn, TurnQueued, TurnInProgress)
+				if err := s.RecordFunctionCall(t.Context(), otherTenant, other.ID, otherTurn, functionCallFixture("a")); err != nil {
+					t.Fatal(err)
+				}
+				batch = append(batch, resultInput(t, otherTurn, "a", `{"success":true}`))
+			case "cancel-first":
+				batch = []Input{message, cancel, first}
+				expected = ErrTurnConflict
+			case "changed-result":
+				batch = append(batch, resultInput(t, turn, "a", `{"success":false}`))
+				expected = ErrIdempotencyConflict
+			}
+			if _, err := s.SubmitInputs(t.Context(), tenant, session.ID, "failed-batch", batch); !errors.Is(err, expected) {
+				t.Fatal(err)
+			}
+			call, err := s.GetFunctionCall(t.Context(), tenant, session.ID, turn, "a")
+			if err != nil || call.Result != nil || call.Applied {
+				t.Fatal(call, err)
+			}
+			state, err := s.GetTurn(t.Context(), tenant, session.ID, turn)
+			if err != nil || !state.CancelRequestedAt.IsZero() || state.Status != TurnWaiting {
+				t.Fatal(state, err)
+			}
+			history, err := s.ListTurnInputs(t.Context(), tenant, session.ID, turn, 0, 100)
+			if err != nil || len(history) != 1 {
+				t.Fatal(history, err)
+			}
+			if _, err := s.SubmitInputs(t.Context(), tenant, session.ID, "failed-batch", []Input{first, cancel}); err != nil {
+				t.Fatal("failed transaction retained retry identity", err)
+			}
+		})
+	}
+}
+
+func TestFunctionInputConcurrentBatchesSelectOneResult(t *testing.T) {
+	s, _ := testStore(t)
+	other, _ := testStore(t)
+	tenant, session, turn := functionInputFixture(t, s)
+	var wg sync.WaitGroup
+	results := make(chan error, 2)
+	for i := range 2 {
+		batch := []Input{{Kind: "message", Payload: json.RawMessage(fmt.Sprintf(`{"text":"message-%d"}`, i))}, resultInput(t, turn, "a", fmt.Sprintf(`{"success":true,"output":"%d"}`, i))}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := other.SubmitInputs(t.Context(), tenant, session.ID, fmt.Sprint(i), batch)
+			results <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+	wins, conflicts := 0, 0
+	for err := range results {
+		if err == nil {
+			wins++
+		} else if errors.Is(err, ErrIdempotencyConflict) {
+			conflicts++
+		} else {
+			t.Fatal(err)
+		}
+	}
+	if wins != 1 || conflicts != 1 {
+		t.Fatal(wins, conflicts)
+	}
+	history, err := s.ListTurnInputs(t.Context(), tenant, session.ID, turn, 0, 100)
+	if err != nil || len(history) != 3 {
+		t.Fatal(history, err)
+	}
+}
+
+func TestFunctionInputsRejectInvalidTargetsAndStorageObjects(t *testing.T) {
+	s, _ := testStore(t)
+	tenant, session, turn := functionInputFixture(t, s)
+	for _, raw := range []string{`{}`, `{"turn_id":"bad","call_id":"a","result":{}}`, fmt.Sprintf(`{"turn_id":%q,"call_id":"a","result":null}`, turn), fmt.Sprintf(`{"turn_id":%q,"call_id":"a","result":[]}`, turn)} {
+		_, err := s.SubmitInputs(t.Context(), tenant, session.ID, "invalid", []Input{{Kind: "tool_result", Payload: json.RawMessage(raw)}})
+		if !errors.Is(err, ErrInvalidInput) {
+			t.Fatal(err)
+		}
+	}
+	input := resultInput(t, turn, "a", `{"success":true}`)
+	for _, scope := range []struct{ tenant, session string }{{uuid.NewString(), session.ID}, {tenant, uuid.NewString()}} {
+		if _, err := s.SubmitInputs(t.Context(), scope.tenant, scope.session, "foreign", []Input{input}); !errors.Is(err, ErrNotFound) {
+			t.Fatal(err)
+		}
+	}
+	if _, err := s.SubmitInputs(t.Context(), tenant, session.ID, "missing-turn", []Input{resultInput(t, uuid.NewString(), "a", `{"success":true}`)}); !errors.Is(err, ErrNotFound) {
+		t.Fatal(err)
+	}
+	transition(t, s, tenant, session.ID, turn, TurnWaiting, TurnFailed)
+	if _, err := s.SubmitInputs(t.Context(), tenant, session.ID, "late", []Input{input}); !errors.Is(err, ErrTurnConflict) {
+		t.Fatal(err)
+	}
+	current, err := s.GetSession(t.Context(), tenant, session.ID)
+	if err != nil || current.LastTurn.ID != turn || current.LastTurn.Status != TurnFailed {
+		t.Fatal(current, err)
+	}
+}

--- a/services/agents-api/internal/store/function_results.go
+++ b/services/agents-api/internal/store/function_results.go
@@ -20,20 +20,7 @@ func (s *Store) SubmitFunctionResult(ctx context.Context, tenantID, sessionID, t
 		return err
 	}
 	return s.withFunctionCall(ctx, tenantID, sessionID, turnID, callID, func(q *sqlc.Queries, turn sqlc.Turn, call sqlc.FunctionCall) error {
-		match, err := q.MatchFunctionResult(ctx, sqlc.MatchFunctionResultParams{SessionID: turn.SessionID, TurnID: turn.ID, CallID: callID, Result: result})
-		if err != nil {
-			return err
-		}
-		if match.Submitted {
-			if !match.Matches {
-				return ErrIdempotencyConflict
-			}
-			return nil
-		}
-		if !acceptsFunctionResult(turn) {
-			return ErrTurnConflict
-		}
-		return q.SubmitFunctionResult(ctx, sqlc.SubmitFunctionResultParams{SessionID: turn.SessionID, TurnID: turn.ID, CallID: call.CallID, Result: result})
+		return storeFunctionResult(ctx, q, turn, call.CallID, result)
 	})
 }
 
@@ -78,4 +65,24 @@ func (s *Store) withFunctionCall(ctx context.Context, tenantID, sessionID, turnI
 		}
 		return fn(q, turn, call)
 	})
+}
+
+func storeFunctionResult(ctx context.Context, q *sqlc.Queries, turn sqlc.Turn, callID string, result json.RawMessage) error {
+	match, err := q.MatchFunctionResult(ctx, sqlc.MatchFunctionResultParams{SessionID: turn.SessionID, TurnID: turn.ID, CallID: callID, Result: result})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+	if match.Submitted {
+		if !match.Matches {
+			return ErrIdempotencyConflict
+		}
+		return nil
+	}
+	if !acceptsFunctionResult(turn) {
+		return ErrTurnConflict
+	}
+	return q.SubmitFunctionResult(ctx, sqlc.SubmitFunctionResultParams{SessionID: turn.SessionID, TurnID: turn.ID, CallID: callID, Result: result})
 }

--- a/services/agents-api/internal/store/turn_inputs.go
+++ b/services/agents-api/internal/store/turn_inputs.go
@@ -79,7 +79,7 @@ func (s *Store) SubmitInputs(ctx context.Context, tenantID, sessionID, key strin
 			return nil
 		}
 		for position, input := range batch {
-			receipt, err := admitInput(ctx, q, session, key, int32(position), input)
+			receipt, err := admitInput(ctx, q, tenantID, session, key, int32(position), input)
 			if err != nil {
 				return err
 			}
@@ -101,8 +101,8 @@ func validateInputs(inputs []Input) ([]Input, json.RawMessage, error) {
 	size := 0
 	for i, input := range inputs {
 		size += len(input.Payload)
-		if size > 512*1024 || len(input.Payload) == 0 || (input.Kind != "message" && input.Kind != "cancel") {
-			return nil, nil, fmt.Errorf("%w: message/cancel payloads must be nonempty and total at most 512 KiB", ErrInvalidInput)
+		if size > 512*1024 || len(input.Payload) == 0 || (input.Kind != "message" && input.Kind != "cancel" && input.Kind != "tool_result") {
+			return nil, nil, fmt.Errorf("%w: input payloads must be nonempty and total at most 512 KiB", ErrInvalidInput)
 		}
 		payload, err := canonicalJSONObject(input.Payload)
 		if err != nil {
@@ -111,13 +111,21 @@ func validateInputs(inputs []Input) ([]Input, json.RawMessage, error) {
 		if input.Kind == "cancel" && string(payload) != "{}" {
 			return nil, nil, fmt.Errorf("%w: cancel payload must be empty", ErrInvalidInput)
 		}
+		if input.Kind == "tool_result" {
+			if _, err := functionInput(payload); err != nil {
+				return nil, nil, err
+			}
+		}
 		batch[i] = Input{Kind: input.Kind, Payload: payload}
 	}
 	encoded, err := json.Marshal(batch)
 	return batch, encoded, err
 }
 
-func admitInput(ctx context.Context, q *sqlc.Queries, session pgtype.UUID, key string, position int32, input Input) (InputReceipt, error) {
+func admitInput(ctx context.Context, q *sqlc.Queries, tenantID string, session pgtype.UUID, key string, position int32, input Input) (InputReceipt, error) {
+	if input.Kind == "tool_result" {
+		return admitFunctionResult(ctx, q, tenantID, session, key, position, input)
+	}
 	turn, err := q.GetActiveTurn(ctx, session)
 	if errors.Is(err, pgx.ErrNoRows) {
 		if input.Kind == "message" {

--- a/services/agents-api/migrations/000014_function_inputs.sql
+++ b/services/agents-api/migrations/000014_function_inputs.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE turn_inputs DROP CONSTRAINT turn_inputs_kind_check;
+ALTER TABLE turn_inputs ADD CONSTRAINT turn_inputs_kind_check
+    CHECK (kind IN ('message', 'cancel', 'tool_result'));
+ALTER TABLE turn_inputs ADD CONSTRAINT turn_inputs_function_turn_check
+    CHECK (kind <> 'tool_result' OR turn_id IS NOT NULL);
+
+-- +goose Down
+-- Refuse a downgrade with saved function inputs rather than delete retry history.
+ALTER TABLE turn_inputs DROP CONSTRAINT turn_inputs_kind_check;
+ALTER TABLE turn_inputs ADD CONSTRAINT turn_inputs_kind_check
+    CHECK (kind IN ('message', 'cancel'));
+ALTER TABLE turn_inputs DROP CONSTRAINT turn_inputs_function_turn_check;


### PR DESCRIPTION
Internally admitted function results now participate in the same atomic input batches as messages and cancellation. Each result targets its original Session/Turn/call, retains request-level retry identity, and never starts or retargets a Turn. A conflicting or invalid event rolls back the entire batch. Execution skips result records while continuing to steer later messages; native application remains governed by separate receipts.

Scope is internal admission, the input-kind migration, and required execution cursor handling. Public `tool_result` decoding, public function configuration, product behavior, Team and environment features are separate work. This does not claim end-to-end public function compatibility.

Validation on `zju_a100_2`: dedicated PostgreSQL race tests repeated three times for mixed batches, rollback, concurrent conflicts, scope, terminal/restart retries and continued message steering; `make sqlc-generate`; required `make check`. Product Docker-only tests are excluded; the dedicated Agents API database suite runs.

Independent blind review identified a missing-result admission guard; the guard and omission regression are included. The local correction was self-reviewed, followed by three repeated focused race runs and another successful `make check`.

Tracked in Feishu ATOM-006.
