### PR TITLE
feat(agents-api): accept public function result events

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,7 +331,7 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   treat transport delivery as application or automatically replay an uncertain
   result. The adapter waits for outstanding application receipts even when Done
   arrives first. Waiting Turns still accept execution observations and cancellation.
-  Public `tools` and `tool_result` admission remain a separate protocol slice;
+  Public `tools` configuration remains a separate protocol slice;
   internal execution is not proof of full public function compatibility.
 - `message_items` advertises native assistant-message observations. Agents API
   opts in with `observe_messages` only for advertised peers; ordinary product

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -311,15 +311,17 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   can fail or cancel before a result arrives; successful execution requires resume.
   Actions remain visible until native application is acknowledged. This timing is
   an implementation choice, not verified upstream event sequencing. Public tool
-  configuration and result admission remain pending.
+  configuration remains pending.
 - Function results can join internal message/cancel input batches. Their explicit
   Turn/call identity selects an existing call; admission never creates a Turn for
   a result. Save the complete result and its input retry record in the same Session
   transaction. Any invalid target, conflicting result or later batch error rolls
   back the whole request. Identical saved results remain retryable after termination
   without applying them again. The execution input cursor skips function results;
-  their separate native receipts still determine application. Public event decoding
-  and function configuration remain pending.
+  their separate native receipts still determine application. Public result events
+  validate variant-specific fields and required values before admission; retain
+  omitted versus null error/output and ordered text/image parts. Public function
+  configuration remains pending.
 - Internal function execution requires an advertised `function_tools` capability
   before claiming a Turn. Translate resolved definitions in the execution adapter,
   persist declared callbacks before exposing actions, and deliver each saved result

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -47,7 +47,7 @@ the Python SDK. Vault HTTP paths start at `/vaults`, not `/agents/vaults`.
 | --- | --- | --- |
 | Root reusable Agents | create, retrieve, update, list, delete | Missing |
 | sessions | create, retrieve, update, list, delete | Partial create/retrieve/list; update/delete missing |
-| sessions.events | create, stream | Partial text/cancel and live events; function-action state snapshots supported; tool-result admission pending |
+| sessions.events | create, stream | Text/cancel/function-result admission and live events; function-action state snapshots supported |
 | sessions.turns | retrieve, list | Implemented reads; lifecycle conformance still partial |
 | sessions.items | list | Partial Item variants |
 | sessions.artifacts | retrieve, list, delete, content | Missing |
@@ -101,13 +101,13 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Tenant-scoped Session persistence | Implemented; internal Store, not a public API |
 | Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
 | Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, ordinary text with low/medium/high verbosity (Unix daemon and native model support required), environment `none`, metadata and creation retry keys |
-| Internal Turn/input persistence | Tenant-scoped atomic message/cancel/function-result batches, steering, request-level retry identity, cancellation targets and terminal outcomes; public result decoding pending |
+| Internal Turn/input persistence | Tenant-scoped atomic message/cancel/function-result batches, steering, request-level retry identity, cancellation targets and terminal outcomes; public function-result decoding and mixed-batch admission supported |
 | Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; explicit Codex no-environment execution; public text/cancel submission with a bounded standalone worker |
 | Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items` and tool snapshots via `tool_items`; tenant-scoped paginated Store reads |
 | Public Turn recovery | Retrieve/list persisted states with scoped pagination; see limitations below |
 | Public Items recovery | Indexed message/command/MCP/function/web-search reads, scoped pagination and restart recovery; limitations below |
 | Public SSE | Live Session/Turn lifecycle, supported Item and text events; bounded commit-before-publish buffering and recovery through saved reads |
-| Internal function bridge | Native Codex definitions and ordered text/image/error results, persisted callbacks and application receipts, cancellation and native resume; public function configuration/result admission pending |
+| Internal function bridge | Native Codex definitions and ordered text/image/error results, persisted callbacks and application receipts, cancellation and native resume; public function configuration pending |
 | Function-call persistence and reads | Immutable scoped calls/results/receipts; Session `required_actions`, `requires_action`, Turn `waiting` and live state snapshots; internal native dispatch integrated; public configuration/result admission pending |
 | Pending actions and environment lifecycle | Pending |
 | Official-client compatibility | Strict SDK checks for Session/Turn/Items reads and native text execution/cancellation/verbosity; pagination, retries, errors, tenant isolation and recovery |
@@ -219,7 +219,7 @@ The service takes a database advisory lease, so a second execution service canno
 start on the same database. Startup marks previously claimed Turns failed without
 replaying them and retains queued work. This does not recover missing daemon frames
 or guarantee exactly-once external side effects. Session status reflects the latest
-persisted Turn; usage reports recorded measurements; public function configuration and result admission remain unimplemented.
+persisted Turn; usage reports recorded measurements; public function configuration remains unimplemented.
 
 Native verification uses `PARSAR_NATIVE_DAEMON_BIN`, `PARSAR_NATIVE_PROOF_DIR` under
 `~/.parsar/`, and `PARSAR_OFFICIAL_SDK_PYTHON` pointing to the pinned SDK environment.
@@ -273,3 +273,12 @@ exact sequence of repeated `requires_action` notifications are implementation
 choices: the pinned source defines their shape but not that precise ordering.
 Session state events contain `event_id`, `type` and `session`; Turn events retain
 `session_id` and `turn_id`. There is no invented Turn `waiting` event.
+
+Public function-result admission is verified with the pinned Python client and
+raw HTTP against a dedicated PostgreSQL fixture: required fields, nullable output
+and error, ordered text/image output, variant rejection, atomic batches, scoped
+access and retries after terminal state. This is admission verification; public
+function configuration and an end-to-end configured function remain separate gaps.
+The generated Swagger 2.0 document leaves the output union unconstrained because
+it cannot express string-or-content-array unions; the pinned upstream types and
+server validation define the supported alternatives.

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -108,7 +108,7 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Public Items recovery | Indexed message/command/MCP/function/web-search reads, scoped pagination and restart recovery; limitations below |
 | Public SSE | Live Session/Turn lifecycle, supported Item and text events; bounded commit-before-publish buffering and recovery through saved reads |
 | Internal function bridge | Native Codex definitions and ordered text/image/error results, persisted callbacks and application receipts, cancellation and native resume; public function configuration pending |
-| Function-call persistence and reads | Immutable scoped calls/results/receipts; Session `required_actions`, `requires_action`, Turn `waiting` and live state snapshots; internal native dispatch integrated; public configuration/result admission pending |
+| Function-call persistence and reads | Immutable scoped calls/results/receipts; Session `required_actions`, `requires_action`, Turn `waiting` and live state snapshots; internal native dispatch integrated; public function configuration pending |
 | Pending actions and environment lifecycle | Pending |
 | Official-client compatibility | Strict SDK checks for Session/Turn/Items reads and native text execution/cancellation/verbosity; pagination, retries, errors, tenant isolation and recovery |
 | Go product client | Official `openai-go` v3.61.0 with a thin service configuration; real HTTP integration tests |

--- a/contracts/agents-api/openapi.yaml
+++ b/contracts/agents-api/openapi.yaml
@@ -378,14 +378,26 @@ definitions:
     type: object
   v1.SessionInput:
     properties:
+      call_id:
+        type: string
+      error:
+        type: string
+        x-nullable: true
       input:
         items:
           $ref: '#/definitions/v1.InputMessage'
         type: array
+      output:
+        x-nullable: true
+      success:
+        type: boolean
+      turn_id:
+        type: string
       type:
         enum:
         - agent.session.input.message
         - agent.session.input.cancel
+        - agent.session.input.tool_result
         type: string
     required:
     - type
@@ -771,9 +783,10 @@ paths:
     post:
       consumes:
       - application/json
-      description: Atomically accepts text messages and cancellation. Messages steer
-        active work or start a queued Turn. Retry keys identify the whole ordered
-        batch. Images and tool results are not supported yet.
+      description: Atomically accepts text messages, cancellation and function results.
+        Messages steer active work or start a queued Turn. Retry keys identify the
+        whole ordered batch. Function output accepts text or ordered text/image parts;
+        message images are not supported yet.
       parameters:
       - description: agents=v1
         in: header

--- a/contracts/agents-api/v1/inputs.go
+++ b/contracts/agents-api/v1/inputs.go
@@ -1,9 +1,16 @@
 package v1
 
-// SessionInput contains the supported message and cancellation event variants.
+import "encoding/json"
+
+// SessionInput contains the message, cancellation and function-result event variants.
 type SessionInput struct {
-	Type  string         `json:"type" enums:"agent.session.input.message,agent.session.input.cancel" binding:"required"`
-	Input []InputMessage `json:"input,omitempty"`
+	Type    string          `json:"type" enums:"agent.session.input.message,agent.session.input.cancel,agent.session.input.tool_result" binding:"required"`
+	Input   []InputMessage  `json:"input,omitempty"`
+	CallID  string          `json:"call_id,omitempty"`
+	TurnID  string          `json:"turn_id,omitempty"`
+	Success *bool           `json:"success,omitempty"`
+	Error   json.RawMessage `json:"error,omitempty" swaggertype:"string" extensions:"x-nullable"`
+	Output  any             `json:"output,omitempty" extensions:"x-nullable"`
 }
 
 type InputMessage struct {

--- a/services/agents-api/internal/api/errors.go
+++ b/services/agents-api/internal/api/errors.go
@@ -31,6 +31,8 @@ func writeStoreError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
 	case errors.Is(err, store.ErrNotFound):
 		writeError(w, http.StatusNotFound, "not_found", "Resource not found.")
+	case errors.Is(err, store.ErrTurnConflict):
+		writeError(w, http.StatusConflict, "turn_conflict", "The Turn cannot accept this input in its current state.")
 	case errors.Is(err, store.ErrIdempotencyConflict):
 		writeError(w, http.StatusConflict, "idempotency_conflict", "This idempotency key was used with different input.")
 	case errors.Is(err, store.ErrInvalidInput):

--- a/services/agents-api/internal/api/function_inputs.go
+++ b/services/agents-api/internal/api/function_inputs.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+type decodedInputEvent struct {
+	v1.SessionInput
+	Output json.RawMessage `json:"output,omitempty"`
+}
+
+func decodeInputEvent(raw json.RawMessage) (decodedInputEvent, error) {
+	var event decodedInputEvent
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return event, store.ErrInvalidInput
+	}
+	fields := []string{"type"}
+	switch event.Type {
+	case "agent.session.input.message":
+		fields = append(fields, "input")
+	case "agent.session.input.cancel":
+	case "agent.session.input.tool_result":
+		fields = append(fields, "call_id", "turn_id", "success", "error", "output")
+	default:
+		return event, store.ErrInvalidInput
+	}
+	return event, decodeInputObject(raw, &event, fields...)
+}
+
+func decodeInputObject(raw json.RawMessage, value any, allowed ...string) error {
+	var fields map[string]json.RawMessage
+	if json.Unmarshal(raw, &fields) != nil || fields == nil {
+		return store.ErrInvalidInput
+	}
+	for field := range fields {
+		if !slices.Contains(allowed, field) {
+			return store.ErrInvalidInput
+		}
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(value) != nil {
+		return store.ErrInvalidInput
+	}
+	return nil
+}
+
+func functionResultInput(event decodedInputEvent) (store.Input, error) {
+	if event.CallID == "" || event.TurnID == "" || event.Success == nil {
+		return store.Input{}, store.ErrInvalidInput
+	}
+	if len(event.Error) > 0 && !bytes.Equal(bytes.TrimSpace(event.Error), []byte("null")) {
+		var message string
+		if json.Unmarshal(event.Error, &message) != nil {
+			return store.Input{}, store.ErrInvalidInput
+		}
+	}
+	if err := validateFunctionOutput(event.Output); err != nil {
+		return store.Input{}, err
+	}
+	result, err := json.Marshal(struct {
+		Success bool            `json:"success"`
+		Error   json.RawMessage `json:"error,omitempty"`
+		Output  json.RawMessage `json:"output,omitempty"`
+	}{*event.Success, event.Error, event.Output})
+	if err != nil {
+		return store.Input{}, err
+	}
+	payload, err := json.Marshal(store.FunctionResultInput{TurnID: event.TurnID, CallID: event.CallID, Result: result})
+	return store.Input{Kind: "tool_result", Payload: payload}, err
+}
+
+func validateFunctionOutput(raw json.RawMessage) error {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return nil
+	}
+	var text string
+	if json.Unmarshal(raw, &text) == nil {
+		return nil
+	}
+	var parts []json.RawMessage
+	if json.Unmarshal(raw, &parts) != nil {
+		return store.ErrInvalidInput
+	}
+	for _, part := range parts {
+		var value struct {
+			Type     string  `json:"type"`
+			Text     *string `json:"text"`
+			ImageURL *string `json:"image_url"`
+		}
+		if json.Unmarshal(part, &value) != nil {
+			return store.ErrInvalidInput
+		}
+		field := "text"
+		switch value.Type {
+		case "input_text":
+			if value.Text == nil {
+				return store.ErrInvalidInput
+			}
+		case "input_image":
+			field = "image_url"
+			if value.ImageURL == nil {
+				return store.ErrInvalidInput
+			}
+		default:
+			return store.ErrInvalidInput
+		}
+		if err := decodeInputObject(part, &value, "type", field); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/services/agents-api/internal/api/function_inputs_test.go
+++ b/services/agents-api/internal/api/function_inputs_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func submitResultRequest(t *testing.T, body string, failure error) (*httptest.ResponseRecorder, *inputRecorder) {
+	t.Helper()
+	recorder := &inputRecorder{err: failure}
+	h, _, _ := testHandler(t, WithExecution(recorder))
+	r := httptest.NewRequest(http.MethodPost, "/v1/agents/sessions/session/events", strings.NewReader(body))
+	r.Header.Set("Authorization", "Bearer test-api-key")
+	r.Header.Set("OpenAI-Beta", "agents=v1")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w, recorder
+}
+
+func TestPublicFunctionResultsPreserveOptionalValues(t *testing.T) {
+	for _, fields := range []string{
+		`"success":false`, `"success":true,"error":null,"output":null`,
+		`"success":false,"error":"","output":""`, `"success":true,"output":[]`,
+		`"success":false,"error":"failure","output":[{"type":"input_text","text":""},{"type":"input_image","image_url":"data:image/png;base64,AA=="},{"type":"input_text","text":"last"}]`,
+	} {
+		body := `{"events":[{"type":"agent.session.input.tool_result","turn_id":"turn","call_id":"call",` + fields + `}]}`
+		w, recorder := submitResultRequest(t, body, nil)
+		if w.Code != 204 || w.Body.Len() != 0 || len(recorder.inputs) != 1 {
+			t.Fatal(w.Code, w.Body, recorder.inputs)
+		}
+		var input store.FunctionResultInput
+		if json.Unmarshal(recorder.inputs[0].Payload, &input) != nil || input.TurnID != "turn" || input.CallID != "call" {
+			t.Fatal(input)
+		}
+		var actual, expected map[string]any
+		_ = json.Unmarshal(input.Result, &actual)
+		_ = json.Unmarshal([]byte(`{`+fields+`}`), &expected)
+		a, _ := json.Marshal(actual)
+		b, _ := json.Marshal(expected)
+		if string(a) != string(b) {
+			t.Fatalf("got %s want %s", a, b)
+		}
+	}
+}
+
+func TestPublicFunctionResultsRejectMalformedVariantsBeforeAdmission(t *testing.T) {
+	prefix := `"type":"agent.session.input.tool_result","turn_id":"turn","call_id":"call"`
+	for _, event := range []string{
+		`{` + prefix + `}`, `{` + prefix + `,"success":null}`, `{` + prefix + `,"success":"true"}`,
+		`{` + prefix + `,"success":true,"input":null}`, `{` + prefix + `,"success":true,"error":{}}`,
+		`{` + prefix + `,"success":true,"output":{}}`, `{` + prefix + `,"success":true,"output":false}`,
+		`{` + prefix + `,"success":true,"output":[null]}`, `{` + prefix + `,"success":true,"output":[{"type":"input_text"}]}`,
+		`{` + prefix + `,"success":true,"output":[{"type":"input_text","text":null}]}`,
+		`{` + prefix + `,"success":true,"output":[{"type":"input_text","text":"x","image_url":null}]}`,
+		`{` + prefix + `,"success":true,"output":[{"type":"input_image"}]}`,
+		`{` + prefix + `,"success":true,"output":[{"type":"input_image","image_url":null}]}`,
+		`{` + prefix + `,"success":true,"output":[{"type":"input_image","image_url":"url","text":"x"}]}`,
+		`{"type":"agent.session.input.tool_result","turn_id":"turn","success":true}`,
+		`{"type":"agent.session.input.tool_result","call_id":"call","success":true}`,
+		`{"type":"agent.session.input.cancel","success":null}`, `{"type":"agent.session.input.cancel","input":null}`,
+		`{"type":"agent.session.input.message","input":[],"output":null}`,
+	} {
+		w, recorder := submitResultRequest(t, `{"events":[{"type":"agent.session.input.cancel"},`+event+`]}`, nil)
+		if w.Code != 400 || recorder.inputs != nil {
+			t.Fatal(event, w.Code, w.Body, recorder.inputs)
+		}
+	}
+}
+
+func TestPublicFunctionTurnConflictIsNotServerFailure(t *testing.T) {
+	w, _ := submitResultRequest(t, `{"events":[{"type":"agent.session.input.tool_result","turn_id":"turn","call_id":"call","success":true}]}`, store.ErrTurnConflict)
+	if w.Code != 409 || !strings.Contains(w.Body.String(), `"code":"turn_conflict"`) {
+		t.Fatal(w.Code, w.Body)
+	}
+}

--- a/services/agents-api/internal/api/inputs.go
+++ b/services/agents-api/internal/api/inputs.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
 	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -24,7 +23,7 @@ type Option func(*Handler)
 func WithExecution(s InputSubmitter) Option { return func(h *Handler) { h.inputs = s } }
 
 // @Summary Submit Session input events
-// @Description Atomically accepts text messages and cancellation. Messages steer active work or start a queued Turn. Retry keys identify the whole ordered batch. Images and tool results are not supported yet.
+// @Description Atomically accepts text messages, cancellation and function results. Messages steer active work or start a queued Turn. Retry keys identify the whole ordered batch. Function output accepts text or ordered text/image parts; message images are not supported yet.
 // @Tags Sessions
 // @Accept json
 // @Security BearerAuth
@@ -44,7 +43,9 @@ func (h *Handler) createEvents(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "unsupported_parameter", "Event submission does not accept query parameters.")
 		return
 	}
-	var request v1.CreateEventsRequest
+	var request struct {
+		Events []json.RawMessage `json:"events"`
+	}
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1024*1024))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(&request); err != nil {
@@ -52,7 +53,7 @@ func (h *Handler) createEvents(w http.ResponseWriter, r *http.Request) {
 		if errors.As(err, &large) {
 			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Request exceeds 1 MiB.")
 		} else {
-			writeError(w, http.StatusBadRequest, "invalid_request", "Only text message and cancellation events are supported.")
+			writeError(w, http.StatusBadRequest, "invalid_request", "Invalid Session input event request.")
 		}
 		return
 	}
@@ -60,7 +61,7 @@ func (h *Handler) createEvents(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid_request", "Request must contain exactly one JSON object.")
 		return
 	}
-	inputs, err := executionInputs(request)
+	inputs, err := executionInputs(request.Events)
 	if err != nil {
 		writeStoreError(w, r, err)
 		return
@@ -77,18 +78,28 @@ func (h *Handler) createEvents(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func executionInputs(request v1.CreateEventsRequest) ([]store.Input, error) {
-	if len(request.Events) == 0 || len(request.Events) > 64 {
+func executionInputs(events []json.RawMessage) ([]store.Input, error) {
+	if len(events) == 0 || len(events) > 64 {
 		return nil, store.ErrInvalidInput
 	}
-	inputs := make([]store.Input, 0, len(request.Events))
-	for _, event := range request.Events {
+	inputs := make([]store.Input, 0, len(events))
+	for _, raw := range events {
+		event, err := decodeInputEvent(raw)
+		if err != nil {
+			return nil, err
+		}
 		switch event.Type {
 		case "agent.session.input.cancel":
 			if event.Input != nil {
 				return nil, store.ErrInvalidInput
 			}
 			inputs = append(inputs, store.Input{Kind: "cancel", Payload: json.RawMessage(`{}`)})
+		case "agent.session.input.tool_result":
+			input, err := functionResultInput(event)
+			if err != nil {
+				return nil, err
+			}
+			inputs = append(inputs, input)
 		case "agent.session.input.message":
 			if len(event.Input) == 0 {
 				return nil, store.ErrInvalidInput

--- a/services/agents-api/internal/store/function_inputs_public_test.go
+++ b/services/agents-api/internal/store/function_inputs_public_test.go
@@ -1,0 +1,134 @@
+package store_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/device"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/api"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+	"github.com/google/uuid"
+)
+
+func TestFunctionInputsOfficialClientAtomicAdmission(t *testing.T) {
+	python := os.Getenv("PARSAR_OFFICIAL_SDK_PYTHON")
+	if python == "" {
+		t.Skip("PARSAR_OFFICIAL_SDK_PYTHON is required for official-client verification")
+	}
+	s, _ := store.NewTestStore(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	tenant, token, foreign := uuid.NewString(), uuid.NewString(), uuid.NewString()
+	session, err := s.CreateSession(ctx, tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "fixture"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := s.CreateSession(ctx, tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "other"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input, err := s.SubmitMessage(ctx, tenant, session.ID, "start", json.RawMessage(`{"text":"fixture"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.TransitionTurn(ctx, tenant, session.ID, input.TurnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"a", "b", "c", "rollback", "late"} {
+		if err := s.RecordFunctionCall(ctx, tenant, session.ID, input.TurnID, store.FunctionCall{CallID: id, ExecutorCallID: "native-" + id, Name: "lookup", Arguments: json.RawMessage(`{}`)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	auth, err := api.NewAuthenticator([]api.APIKey{{TokenSHA256: device.HashCredential(token), TenantID: tenant}, {TokenSHA256: device.HashCredential(foreign), TenantID: uuid.NewString()}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler, err := api.NewHandler(s, auth, "codex", api.WithExecution(s))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	command := exec.CommandContext(ctx, python, "../../tests/official_function_inputs.py", server.URL, token, foreign, session.ID, input.TurnID, other.ID)
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stdin, err := command.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { cancel(); _ = command.Wait() }()
+	if line, err := bufio.NewReader(stdout).ReadString('\n'); err != nil || line != "saved\n" {
+		t.Fatalf("SDK admission: %s %v %s", line, err, stderr.String())
+	}
+	for _, id := range []string{"a", "b", "c", "rollback", "late"} {
+		call, err := s.GetFunctionCall(ctx, tenant, session.ID, input.TurnID, id)
+		if err != nil || call.Applied {
+			t.Fatal(call, err)
+		}
+		var result map[string]json.RawMessage
+		if call.Result != nil {
+			if err := json.Unmarshal(call.Result, &result); err != nil {
+				t.Fatal(err)
+			}
+		}
+		switch id {
+		case "a":
+			var parts []map[string]any
+			_ = json.Unmarshal(result["output"], &parts)
+			if string(result["success"]) != "false" || string(result["error"]) != `"failure"` || len(parts) != 3 || parts[0]["text"] != "" || parts[1]["image_url"] != "data:image/png;base64,AA==" || parts[2]["text"] != "last" {
+				t.Fatal(result)
+			}
+		case "b":
+			if string(result["output"]) != "null" || string(result["error"]) != "null" {
+				t.Fatal(result)
+			}
+		case "c":
+			if len(result) != 1 || string(result["success"]) != "true" {
+				t.Fatal(result)
+			}
+		default:
+			if call.Result != nil {
+				t.Fatal("failed batch saved a result", call)
+			}
+		}
+	}
+	history, err := s.ListTurnInputs(ctx, tenant, session.ID, input.TurnID, 0, 100)
+	if err != nil || len(history) != 6 {
+		t.Fatal(history, err)
+	}
+	if _, err := s.TransitionTurn(ctx, tenant, session.ID, input.TurnID, store.TurnTransition{ExpectedStatus: store.TurnWaiting, Status: store.TurnFailed}); err != nil {
+		t.Fatal(err)
+	}
+	next, err := s.SubmitMessage(ctx, tenant, session.ID, "next", json.RawMessage(`{"text":"next"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stdin.Write([]byte("terminal\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := command.Wait(); err != nil {
+		t.Fatalf("SDK retry: %v %s", err, stderr.String())
+	}
+	history, err = s.ListTurnInputs(ctx, tenant, session.ID, next.TurnID, 0, 100)
+	if err != nil || len(history) != 1 {
+		t.Fatal(history, err)
+	}
+	current, err := s.GetTurn(ctx, tenant, session.ID, next.TurnID)
+	if err != nil || current.Status != store.TurnQueued || !current.CancelRequestedAt.IsZero() {
+		t.Fatal(current, err)
+	}
+}

--- a/services/agents-api/tests/official_function_inputs.py
+++ b/services/agents-api/tests/official_function_inputs.py
@@ -1,0 +1,49 @@
+"""Verify public result admission against storage fixtures, not native execution."""
+
+import importlib.metadata
+import json
+from pathlib import Path
+import sys
+
+import httpx2
+from openai import APIStatusError, OpenAI
+
+base, token, foreign, session, turn, other = sys.argv[1:]
+pin = json.loads((Path(__file__).resolve().parents[3] / "contracts/agents-api/upstream.json").read_text())
+source = json.loads(importlib.metadata.distribution("openai").read_text("direct_url.json") or "{}")
+assert source.get("vcs_info", {}).get("commit_id") == pin["commit"]
+
+
+def result(call, **values):
+    return {"type": "agent.session.input.tool_result", "turn_id": turn, "call_id": call, **values}
+
+
+def submit(api, events, key, expected=204, target=session):
+    try:
+        response = api.beta.agents.sessions.events.with_raw_response.create(
+            target, events=events, extra_headers={"Idempotency-Key": key})
+        assert response.status_code == expected == 204
+        assert response.content == b""
+    except APIStatusError as error:
+        assert error.status_code == expected, (error.status_code, expected, error.message)
+        assert error.body["code"] in {"not_found", "turn_conflict", "idempotency_conflict", "invalid_request"}
+
+
+with OpenAI(api_key=token, base_url=base+"/v1", max_retries=0,
+            _strict_response_validation=True, http_client=httpx2.Client(trust_env=False, timeout=10)) as api:
+    output = [{"type":"input_text","text":""}, {"type":"input_image","image_url":"data:image/png;base64,AA=="}, {"type":"input_text","text":"last"}]
+    message = {"type":"agent.session.input.message","input":[{"role":"user","content":[{"type":"input_text","text":"follow up"}]}]}
+    batch = [result("a", success=False, error="failure", output=output), result("b", success=True, output=None, error=None), result("c", success=True), message, {"type":"agent.session.input.cancel"}]
+    submit(api, [message, result("rollback", success=True), result("missing", success=True)], "rollback", 404)
+    submit(api, [result("a", success=True)], "other-session", 404, other)
+    submit(api, [message, result("rollback", success=None)], "malformed", 400)
+    stranger = api.with_options(api_key=foreign)
+    submit(stranger, [result("a", success=True)], "foreign", 404)
+    submit(api, batch, "batch")
+    submit(api, batch, "batch")
+    print("saved", flush=True)
+    assert sys.stdin.readline() == "terminal\n"
+    submit(api, batch, "batch")
+    submit(api, list(reversed(batch)), "batch", 409)
+    submit(api, [result("late", success=True)], "late", 409)
+    submit(api, [result("b", success=True)], "changed-null", 409)


### PR DESCRIPTION
Session event submission now accepts the pinned function-result variant alongside messages and cancellation. The API validates required fields and text/image output, preserves omitted versus null error/output, and admits the complete batch through existing transactional storage. Calls outside the tenant/Session are rejected; a terminal Turn conflict returns 409 instead of an internal error.

Scope is public result decoding/admission, wire documentation and verification. Function configuration and native execution through publicly configured tools are a separate PR. The pinned upstream protocol remains the compatibility source; Swagger 2.0 cannot fully express the output union.

Validation on `zju_a100_2`: focused API/PostgreSQL race tests, pinned Python SDK mixed-batch rollback/isolation/retry verification, `make openapi` and required `make check`. Docker-dependent product migration smoke tests are excluded; the dedicated Agents API database suite runs.

Independent blind review found no functional blockers. Two stale coverage statements were corrected and self-reviewed; the reviewer independently reran `make check` and confirmed the focused raw-handler and official-client tests did not skip.

Tracked in Feishu ATOM-006.
