### PR TITLE
feat(agents-api): configure public function tools

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,9 +267,8 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   isolation guarantee, and engine state still lives on that host. Ordinary product
   requests retain their existing environment. The public worker selects an authenticated same-tenant engine host for this mode.
 - `web_search_control` advertises the Codex adapter's explicit `web_search` option
-  (`disabled`, `cached`, or `live`). Agents API currently accepts no configured
-  tools and requires this capability before dispatch; it forces search off on
-  both new and resumed Turns. Native configuration translation stays in the
+  (`disabled`, `cached`, or `live`). Agents API requires this capability before dispatch;
+  it forces search off on both new and resumed Turns. Native configuration translation stays in the
   adapter. Product requests that omit the option inherit their existing defaults.
   This is tool selection, not a network isolation guarantee.
 - Inline Agent `text.verbosity` accepts `low`, `medium` and `high`; omitted or
@@ -310,8 +309,7 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   or results. Cancelling/terminal Turns expose no actionable calls. A waiting Turn
   can fail or cancel before a result arrives; successful execution requires resume.
   Actions remain visible until native application is acknowledged. This timing is
-  an implementation choice, not verified upstream event sequencing. Public tool
-  configuration remains pending.
+  an implementation choice, not verified upstream event sequencing.
 - Function results can join internal message/cancel input batches. Their explicit
   Turn/call identity selects an existing call; admission never creates a Turn for
   a result. Save the complete result and its input retry record in the same Session
@@ -320,8 +318,14 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   without applying them again. The execution input cursor skips function results;
   their separate native receipts still determine application. Public result events
   validate variant-specific fields and required values before admission; retain
-  omitted versus null error/output and ordered text/image parts. Public function
-  configuration remains pending.
+  omitted versus null error/output and ordered text/image parts. Inline function
+  tools resolve into the immutable configuration with explicit
+  `defer_loading=false`. Validate required strings and parameter objects before
+  persistence; reject unsupported deferred discovery. Omitted/null/empty tool
+  lists resolve to no tools. The public worker selects or waits for a same-tenant
+  device advertising `function_tools` when the Session has functions.
+  Function results are Session input Items: emit `item.added` without an output
+  index, and never emit `item.done`, whose upstream union only allows agent output.
 - Internal function execution requires an advertised `function_tools` capability
   before claiming a Turn. Translate resolved definitions in the execution adapter,
   persist declared callbacks before exposing actions, and deliver each saved result
@@ -331,8 +335,9 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   treat transport delivery as application or automatically replay an uncertain
   result. The adapter waits for outstanding application receipts even when Done
   arrives first. Waiting Turns still accept execution observations and cancellation.
-  Public `tools` configuration remains a separate protocol slice;
-  internal execution is not proof of full public function compatibility.
+  The public function workflow is verified with the pinned SDK and a real daemon
+  and Codex process against a synthetic model endpoint. This does not verify
+  other tool types, deferred discovery or upstream service timing.
 - `message_items` advertises native assistant-message observations. Agents API
   opts in with `observe_messages` only for advertised peers; ordinary product
   requests retain their existing frame sequence. Opted-in text deltas carry their

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -326,6 +326,8 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   device advertising `function_tools` when the Session has functions.
   Function results are Session input Items: emit `item.added` without an output
   index, and never emit `item.done`, whose upstream union only allows agent output.
+  Project their public output/error from the saved submission, including missing
+  versus null fields; native content normalization must not change public history.
 - Internal function execution requires an advertised `function_tools` capability
   before claiming a Turn. Translate resolved definitions in the execution adapter,
   persist declared callbacks before exposing actions, and deliver each saved result

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -27,7 +27,7 @@ Verify configuration against actual execution: response defaults must not merely
 describe values the adapter never applied.
 
 The next slices are contract conformance checks, effective configuration and the
-adapter boundary, complete function actions, then environment/file resources.
+adapter boundary, remaining function/tool variants, then environment/file resources.
 Reusable Agents, vaults and protocol subagents remain in the coverage backlog.
 Parsar cutover follows an independent client workflow; its business Team loop is
 separate. Each slice can use multiple small PRs tracked in the Feishu board.
@@ -100,15 +100,15 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Shared daemon connection layer | Implemented; existing product protocol retained |
 | Tenant-scoped Session persistence | Implemented; internal Store, not a public API |
 | Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
-| Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, ordinary text with low/medium/high verbosity (Unix daemon and native model support required), environment `none`, metadata and creation retry keys |
+| Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, ordinary text with low/medium/high verbosity (Unix daemon and native model support required), non-deferred function tools, environment `none`, metadata and creation retry keys |
 | Internal Turn/input persistence | Tenant-scoped atomic message/cancel/function-result batches, steering, request-level retry identity, cancellation targets and terminal outcomes; public function-result decoding and mixed-batch admission supported |
 | Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; explicit Codex no-environment execution; public text/cancel submission with a bounded standalone worker |
 | Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items` and tool snapshots via `tool_items`; tenant-scoped paginated Store reads |
 | Public Turn recovery | Retrieve/list persisted states with scoped pagination; see limitations below |
 | Public Items recovery | Indexed message/command/MCP/function/web-search reads, scoped pagination and restart recovery; limitations below |
 | Public SSE | Live Session/Turn lifecycle, supported Item and text events; bounded commit-before-publish buffering and recovery through saved reads |
-| Internal function bridge | Native Codex definitions and ordered text/image/error results, persisted callbacks and application receipts, cancellation and native resume; public function configuration pending |
-| Function-call persistence and reads | Immutable scoped calls/results/receipts; Session `required_actions`, `requires_action`, Turn `waiting` and live state snapshots; internal native dispatch integrated; public function configuration pending |
+| Internal function bridge | Native Codex definitions and ordered text/image/error results, persisted callbacks and application receipts, cancellation and native resume; public non-deferred function configuration supported |
+| Function-call persistence and reads | Immutable scoped calls/results/receipts; Session `required_actions`, `requires_action`, Turn `waiting` and live state snapshots; internal native dispatch integrated; public non-deferred function configuration supported |
 | Pending actions and environment lifecycle | Pending |
 | Official-client compatibility | Strict SDK checks for Session/Turn/Items reads and native text execution/cancellation/verbosity; pagination, retries, errors, tenant isolation and recovery |
 | Go product client | Official `openai-go` v3.61.0 with a thin service configuration; real HTTP integration tests |
@@ -169,7 +169,7 @@ Legacy tool results retain their content but have `incomplete` status when the
 source did not record a native outcome. Only recognized historical user text/image
 shapes become messages; arbitrary internal input objects remain in source storage.
 Unsupported native variants, reasoning, subagent Items and Items mutation
-are not covered. Public submission currently supports text messages and cancellation.
+are not covered. Public submission supports text messages, cancellation and function results.
 
 Legacy Done frames alone do not complete assistant Items. Aggregate answer text
 is confirmed by successful Turn termination; failed Turns retain observed deltas
@@ -191,7 +191,7 @@ not allocate a local execution environment: the daemon uses upstream Codex's
 starting/resuming. A missing capability or unsupported native method fails rather
 than falling back to local execution. Private `daemon` snapshots remain distinct.
 This is an engine tool/environment boundary, not operating-system isolation.
-The standalone worker uses this mode for public text execution. The self-hosted
+The standalone worker uses this mode for public text and function execution. The self-hosted
 registry/Noise transport remains pending.
 
 The native reference is Codex `rust-v0.153.4`, commit
@@ -203,7 +203,8 @@ a daemon WebSocket URL is not that protocol.
 ### Public execution admission
 
 `POST /v1/agents/sessions/{session_id}/events` accepts `agent.session.input.message`
-with user `input_text` content and `agent.session.input.cancel`. Successful atomic
+with user `input_text` content, `agent.session.input.cancel` and
+`agent.session.input.tool_result`. Successful atomic
 admission returns 204, as consumed by the official `events.create` method. A retry
 key identifies the entire ordered request; conflict does not partially admit it.
 Messages start queued work or steer the active Turn. Individual input messages
@@ -219,7 +220,7 @@ The service takes a database advisory lease, so a second execution service canno
 start on the same database. Startup marks previously claimed Turns failed without
 replaying them and retains queued work. This does not recover missing daemon frames
 or guarantee exactly-once external side effects. Session status reflects the latest
-persisted Turn; usage reports recorded measurements; public function configuration remains unimplemented.
+persisted Turn; usage reports recorded measurements.
 
 Native verification uses `PARSAR_NATIVE_DAEMON_BIN`, `PARSAR_NATIVE_PROOF_DIR` under
 `~/.parsar/`, and `PARSAR_OFFICIAL_SDK_PYTHON` pointing to the pinned SDK environment.
@@ -238,7 +239,8 @@ recorded measurements. Costs and prices are outside this execution contract.
 stream. Open it before submitting input. Session in-progress/idle/failed and Turn
 created/in-progress/completed/failed/cancelled events carry transition snapshots.
 Supported Items emit added/done events; assistant text emits content-part and
-text-delta/done events. Inputs have no output index. Completed text replaces
+text-delta/done events. Inputs, including function results, have no output index. Function results emit
+`item.added` and remain queryable; `item.done` only carries agent output. Completed text replaces
 accumulated deltas; cancelled unfinished Items retain their partial content and
 `incomplete` status. Tool snapshots are supported; native interim command-output
 and reasoning deltas remain outside the supported surface.
@@ -260,12 +262,11 @@ non-deferred definitions and Store result admission. It verifies ordered text/im
 results, error text, application receipts, matching action/Item call IDs, cancellation
 and native Session continuity. Codex supplies the model transport's default image
 detail. This proof uses a synthetic model responder and the real daemon/Codex;
-it does not exercise a public tool-result submission endpoint. Deferred functions,
+the public workflow below exercises the same native bridge through HTTP. Deferred functions,
 other tool kinds and the native 64-definition limit remain compatibility gaps.
 
 Function-action read coverage uses persisted-call fixtures with the real service
-handler, PostgreSQL and pinned official client. It does not yet demonstrate a
-publicly configured function executing end to end. Call insertion and application
+handler, PostgreSQL and pinned official client. Call insertion and application
 receipts update Turn/Session state atomically; duplicate notifications emit no new
 state. Actions remain visible until the execution adapter acknowledges application,
 or cancellation/terminal state removes them. This acknowledgement timing and the
@@ -277,8 +278,35 @@ Session state events contain `event_id`, `type` and `session`; Turn events retai
 Public function-result admission is verified with the pinned Python client and
 raw HTTP against a dedicated PostgreSQL fixture: required fields, nullable output
 and error, ordered text/image output, variant rejection, atomic batches, scoped
-access and retries after terminal state. This is admission verification; public
-function configuration and an end-to-end configured function remain separate gaps.
+access and retries after terminal state. This admission verification complements the native public workflow below.
 The generated Swagger 2.0 document leaves the output union unconstrained because
 it cannot express string-or-content-array unions; the pinned upstream types and
 server validation define the supported alternatives.
+
+### Public function configuration
+
+Inline `agent.tools` accepts non-deferred `function` definitions with the upstream
+required name, description and JSON Schema parameter object. Missing
+`defer_loading` resolves to `false`; null and other types are rejected. Omitted,
+null and empty tool lists resolve to an empty list. The resolved tools are part of
+the immutable Session configuration and creation retry identity. This slice does
+not implement saved-Agent inheritance or deferred tool discovery. The native
+64-definition cap, unique nonblank names of at most 512 bytes, other tool kinds
+and unrestricted JSON Schema execution remain compatibility gaps. Codex also
+exposes native planning/goal/skill/discovery tools; restricting those to the
+effective public tool set is an outstanding adapter gap, not implied here.
+
+The worker selects a same-tenant host advertising `function_tools` for configured
+Sessions. Work remains queued when no compatible host is available, including
+when a previously bound host no longer advertises that capability. It does not
+silently discard the definitions or move an existing native Session.
+
+`TestNativePublicFunctionExecution` runs `tests/official_functions.py` using the
+pinned official SDK against the actual HTTP handler, worker, PostgreSQL, daemon
+and Codex. A synthetic model requests a configured function; the client reads
+`required_actions`, submits ordered text/image results through public events,
+retries the same result, receives completion, and reuses the Session. A subsequent
+Turn verifies error output, and a third verifies cancellation while waiting.
+The test checks native result receipts, retained function Items and no duplicate
+native continuation. This proves the implemented workflow, not compatibility
+with every tool variant or the upstream service's exact event timing.

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -240,7 +240,9 @@ stream. Open it before submitting input. Session in-progress/idle/failed and Tur
 created/in-progress/completed/failed/cancelled events carry transition snapshots.
 Supported Items emit added/done events; assistant text emits content-part and
 text-delta/done events. Inputs, including function results, have no output index. Function results emit
-`item.added` and remain queryable; `item.done` only carries agent output. Completed text replaces
+`item.added` and remain queryable; `item.done` only carries agent output. Public
+function-result output/error retain the saved submission and field presence;
+native error-to-text translation does not rewrite those fields. Completed text replaces
 accumulated deltas; cancelled unfinished Items retain their partial content and
 `incomplete` status. Tool snapshots are supported; native interim command-output
 and reasoning deltas remain outside the supported surface.

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -312,3 +312,9 @@ Turn verifies error output, and a third verifies cancellation while waiting.
 The test checks native result receipts, retained function Items and no duplicate
 native continuation. This proves the implemented workflow, not compatibility
 with every tool variant or the upstream service's exact event timing.
+
+Accepted results currently enter public Items through native execution observations.
+If cancellation prevents native application (for example, a result followed by
+cancel in one admitted batch), the submission remains saved internally but has no
+public result Item or `item.added`. Admission-time result indexing and unapplied
+result recovery remain a separate compatibility gap; retries do not repair it.

--- a/contracts/agents-api/openapi.yaml
+++ b/contracts/agents-api/openapi.yaml
@@ -123,6 +123,26 @@ definitions:
     - turn_id
     - type
     type: object
+  v1.FunctionToolInput:
+    properties:
+      defer_loading:
+        type: boolean
+      description:
+        type: string
+      name:
+        type: string
+      parameters:
+        type: object
+      type:
+        enum:
+        - function
+        type: string
+    required:
+    - description
+    - name
+    - parameters
+    - type
+    type: object
   v1.InlineAgent:
     properties:
       instructions:
@@ -133,6 +153,11 @@ definitions:
       text:
         allOf:
         - $ref: '#/definitions/v1.TextConfigInput'
+        x-nullable: true
+      tools:
+        items:
+          $ref: '#/definitions/v1.FunctionToolInput'
+        type: array
         x-nullable: true
     required:
     - model
@@ -640,9 +665,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Supports inline model/instructions, text verbosity and environment
-        type none. Execution input and other options are explicitly unsupported in
-        this slice.
+      description: Supports inline model/instructions, text verbosity, non-deferred
+        function tools and environment type none. Execution input and other options
+        are explicitly unsupported in this slice.
       parameters:
       - description: agents=v1
         in: header

--- a/contracts/agents-api/v1/function_tools.go
+++ b/contracts/agents-api/v1/function_tools.go
@@ -1,0 +1,12 @@
+package v1
+
+import "encoding/json"
+
+// FunctionToolInput is the supported application-defined tool configuration.
+type FunctionToolInput struct {
+	Type         string          `json:"type" enums:"function" binding:"required"`
+	Name         *string         `json:"name" binding:"required"`
+	Description  *string         `json:"description" binding:"required"`
+	Parameters   json.RawMessage `json:"parameters" swaggertype:"object" binding:"required"`
+	DeferLoading json.RawMessage `json:"defer_loading,omitempty" swaggertype:"boolean"`
+}

--- a/contracts/agents-api/v1/items.go
+++ b/contracts/agents-api/v1/items.go
@@ -55,6 +55,21 @@ func (i *Item) UnmarshalJSON(raw []byte) error {
 	if err := decoder.Decode(&value); err != nil {
 		return err
 	}
+	if value.Type == "function_call_output" {
+		var fields struct {
+			Output json.RawMessage
+			Error  json.RawMessage
+		}
+		if err := json.Unmarshal(raw, &fields); err != nil {
+			return err
+		}
+		if value.Output == nil && len(fields.Output) > 0 {
+			value.Output = fields.Output
+		}
+		if value.Error == nil && len(fields.Error) > 0 {
+			value.Error = fields.Error
+		}
+	}
 	// MCP has required nullable output/error fields.
 	if value.Type == "mcp_call" {
 		if value.Output == nil {

--- a/contracts/agents-api/v1/sessions.go
+++ b/contracts/agents-api/v1/sessions.go
@@ -15,9 +15,10 @@ type CreateSessionRequest struct {
 }
 
 type InlineAgent struct {
-	Model        string           `json:"model" binding:"required"`
-	Instructions *string          `json:"instructions,omitempty" extensions:"x-nullable"`
-	Text         *TextConfigInput `json:"text,omitempty" extensions:"x-nullable"`
+	Tools        []FunctionToolInput `json:"tools,omitempty" extensions:"x-nullable"`
+	Model        string              `json:"model" binding:"required"`
+	Instructions *string             `json:"instructions,omitempty" extensions:"x-nullable"`
+	Text         *TextConfigInput    `json:"text,omitempty" extensions:"x-nullable"`
 }
 
 // Environment currently supports the upstream environment-free configuration.

--- a/services/agents-api/internal/api/configuration.go
+++ b/services/agents-api/internal/api/configuration.go
@@ -39,12 +39,16 @@ func resolve(input v1.CreateSessionRequest, tenant, key string) (json.RawMessage
 	if err != nil {
 		return nil, err
 	}
+	tools, err := resolveFunctions(input.Agent.Tools)
+	if err != nil {
+		return nil, err
+	}
 	// Inline execution configuration has its own stable identity for creation retries.
 	id := "agent_" + uuid.NewSHA1(uuid.NameSpaceOID, []byte(tenant+"\x00"+key)).String()
 	return json.Marshal(configuration{Agent: v1.Agent{
 		ID: id, Model: input.Agent.Model, Instructions: input.Agent.Instructions,
 		ServiceTier: "auto", Text: text,
-		Tools: []json.RawMessage{},
+		Tools: tools,
 	}, Environment: *input.Environment})
 }
 

--- a/services/agents-api/internal/api/function_configuration.go
+++ b/services/agents-api/internal/api/function_configuration.go
@@ -1,0 +1,50 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+)
+
+func resolveFunctions(input []v1.FunctionToolInput) ([]json.RawMessage, error) {
+	tools := make([]json.RawMessage, 0, len(input))
+	if len(input) > 64 {
+		return nil, errors.New("This service supports at most 64 function tools.")
+	}
+	names := make(map[string]bool, len(input))
+	for _, tool := range input {
+		if tool.Type != "function" || tool.Name == nil || tool.Description == nil {
+			return nil, errors.New("Function tools require type=function, name and description.")
+		}
+		if strings.TrimSpace(*tool.Name) == "" || len(*tool.Name) > 512 || names[*tool.Name] {
+			return nil, errors.New("Function names must be nonempty, unique and at most 512 bytes.")
+		}
+		var schema map[string]json.RawMessage
+		if json.Unmarshal(tool.Parameters, &schema) != nil || schema == nil {
+			return nil, errors.New("Function parameters must be a JSON Schema object.")
+		}
+		deferred := false
+		if len(tool.DeferLoading) > 0 && (bytes.Equal(bytes.TrimSpace(tool.DeferLoading), []byte("null")) || json.Unmarshal(tool.DeferLoading, &deferred) != nil) {
+			return nil, errors.New("defer_loading must be a boolean when supplied.")
+		}
+		if deferred {
+			return nil, errors.New("Deferred function discovery is not supported by this service yet.")
+		}
+		value, err := json.Marshal(struct {
+			Type         string          `json:"type"`
+			Name         string          `json:"name"`
+			Description  string          `json:"description"`
+			Parameters   json.RawMessage `json:"parameters"`
+			DeferLoading bool            `json:"defer_loading"`
+		}{"function", *tool.Name, *tool.Description, tool.Parameters, false})
+		if err != nil {
+			return nil, err
+		}
+		names[*tool.Name] = true
+		tools = append(tools, value)
+	}
+	return tools, nil
+}

--- a/services/agents-api/internal/api/function_configuration_test.go
+++ b/services/agents-api/internal/api/function_configuration_test.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+)
+
+func TestPublicFunctionConfiguration(t *testing.T) {
+	tool := `{"type":"function","name":"lookup","description":"","parameters":{"const":9007199254740993}}`
+	for _, suffix := range []string{"", `,"tools":null`, `,"tools":[]`, `,"tools":[` + tool + `]`, `,"tools":[` + strings.TrimSuffix(tool, "}") + `,"defer_loading":false}]`} {
+		h, s, _ := testHandler(t)
+		req := httptest.NewRequest(http.MethodPost, "/v1/agents/sessions", strings.NewReader(`{"agent":{"model":"model"`+suffix+`},"environment":{"type":"none"}}`))
+		req.Header.Set("Authorization", "Bearer test-api-key")
+		req.Header.Set("OpenAI-Beta", "agents=v1")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != 200 {
+			t.Fatal(suffix, w.Code, w.Body)
+		}
+		var response v1.Session
+		var saved configuration
+		if json.Unmarshal(w.Body.Bytes(), &response) != nil || json.Unmarshal(s.input.Configuration, &saved) != nil {
+			t.Fatal(w.Body)
+		}
+		if len(response.Agent.Tools) != len(saved.Agent.Tools) || response.Agent.Tools == nil {
+			t.Fatal(response.Agent.Tools, saved.Agent.Tools)
+		}
+		if strings.Contains(suffix, "lookup") {
+			if len(response.Agent.Tools) != 1 || !strings.Contains(string(saved.Agent.Tools[0]), `9007199254740993`) || !strings.Contains(string(saved.Agent.Tools[0]), `"defer_loading":false`) {
+				t.Fatal(saved.Agent.Tools)
+			}
+		} else if len(response.Agent.Tools) != 0 {
+			t.Fatal(response.Agent.Tools)
+		}
+	}
+}
+
+func TestPublicFunctionConfigurationRejectsInvalidOrUnsupported(t *testing.T) {
+	base := `"type":"function","name":"lookup","description":"","parameters":{}`
+	for _, raw := range []string{
+		`[null]`, `[{}]`, `[{"type":"web_search"}]`, `[{"type":"function","name":"lookup","parameters":{}}]`,
+		`[{"type":"function","name":null,"description":"","parameters":{}}]`,
+		`[{"type":"function","name":"lookup","description":null,"parameters":{}}]`,
+		`[{"type":"function","name":"lookup","description":""}]`,
+		`[{"type":"function","name":"lookup","description":"","parameters":null}]`,
+		`[{"type":"function","name":"lookup","description":"","parameters":[]}]`,
+		`[{` + base + `,"defer_loading":null}]`, `[{` + base + `,"defer_loading":true}]`, `[{` + base + `,"defer_loading":"false"}]`,
+		`[{` + base + `,"unexpected":true}]`, `[{` + base + `},{` + base + `}]`,
+	} {
+		h, s, _ := testHandler(t)
+		req := httptest.NewRequest(http.MethodPost, "/v1/agents/sessions", strings.NewReader(`{"agent":{"model":"model","tools":`+raw+`},"environment":{"type":"none"}}`))
+		req.Header.Set("Authorization", "Bearer test-api-key")
+		req.Header.Set("OpenAI-Beta", "agents=v1")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		if w.Code != 400 || s.tenant != "" {
+			t.Fatal(raw, w.Code, w.Body)
+		}
+	}
+}

--- a/services/agents-api/internal/api/handler.go
+++ b/services/agents-api/internal/api/handler.go
@@ -85,7 +85,7 @@ func tenantID(r *http.Request) string { return r.Context().Value(tenantContextKe
 
 // createSession creates an idle execution Session without submitting a Turn.
 // @Summary Create an execution Session
-// @Description Supports inline model/instructions, text verbosity and environment type none. Execution input and other options are explicitly unsupported in this slice.
+// @Description Supports inline model/instructions, text verbosity, non-deferred function tools and environment type none. Execution input and other options are explicitly unsupported in this slice.
 // @Tags Sessions
 // @Accept json
 // @Produce json

--- a/services/agents-api/internal/db/queries/functions.sql
+++ b/services/agents-api/internal/db/queries/functions.sql
@@ -28,3 +28,7 @@ UPDATE function_calls SET result = $4 WHERE session_id = $1 AND turn_id = $2 AND
 
 -- name: ApplyFunctionResult :exec
 UPDATE function_calls SET applied = true WHERE session_id = $1 AND turn_id = $2 AND call_id = $3;
+
+-- name: FunctionItemResult :one
+SELECT result FROM function_calls
+WHERE session_id = $1 AND turn_id = $2 AND call_id = $3;

--- a/services/agents-api/internal/db/sqlc/functions.sql.go
+++ b/services/agents-api/internal/db/sqlc/functions.sql.go
@@ -55,6 +55,24 @@ func (q *Queries) CreateFunctionCall(ctx context.Context, arg CreateFunctionCall
 	return result.RowsAffected(), nil
 }
 
+const functionItemResult = `-- name: FunctionItemResult :one
+SELECT result FROM function_calls
+WHERE session_id = $1 AND turn_id = $2 AND call_id = $3
+`
+
+type FunctionItemResultParams struct {
+	SessionID pgtype.UUID `json:"session_id"`
+	TurnID    pgtype.UUID `json:"turn_id"`
+	CallID    string      `json:"call_id"`
+}
+
+func (q *Queries) FunctionItemResult(ctx context.Context, arg FunctionItemResultParams) ([]byte, error) {
+	row := q.db.QueryRow(ctx, functionItemResult, arg.SessionID, arg.TurnID, arg.CallID)
+	var result []byte
+	err := row.Scan(&result)
+	return result, err
+}
+
 const getFunctionCall = `-- name: GetFunctionCall :one
 SELECT f.session_id, f.turn_id, f.call_id, f.executor_call_id, f.name, f.arguments, f.result, f.applied, f.created_at FROM function_calls f JOIN sessions s ON s.id = f.session_id
 WHERE s.tenant_id = $1 AND f.session_id = $2 AND f.turn_id = $3 AND f.call_id = $4

--- a/services/agents-api/internal/execution/worker.go
+++ b/services/agents-api/internal/execution/worker.go
@@ -141,9 +141,19 @@ func (w *Worker) reconcile(ctx context.Context) error {
 }
 
 func (w *Worker) bind(ctx context.Context, item store.ExecutionWork) (bool, error) {
+	session, err := w.Dispatcher.Store.GetSession(ctx, item.TenantID, item.SessionID)
+	if err != nil {
+		return false, err
+	}
+	var snapshot Snapshot
+	if err := json.Unmarshal(session.Configuration, &snapshot); err != nil {
+		return false, err
+	}
+	functions := len(snapshot.Agent.Tools) > 0
+
 	bound, err := w.Dispatcher.Store.GetSessionDevice(ctx, item.TenantID, item.SessionID)
 	if err == nil {
-		return w.ready(bound.ID), nil
+		return w.ready(bound.ID, functions), nil
 	}
 	if !errors.Is(err, store.ErrNotFound) {
 		return false, err
@@ -153,7 +163,7 @@ func (w *Worker) bind(ctx context.Context, item store.ExecutionWork) (bool, erro
 		return false, err
 	}
 	for _, device := range devices {
-		if !w.ready(device.ID) {
+		if !w.ready(device.ID, functions) {
 			continue
 		}
 		err := w.Dispatcher.Store.BindSessionDevice(ctx, item.TenantID, item.SessionID, device.ID)
@@ -169,13 +179,13 @@ func (w *Worker) bind(ctx context.Context, item store.ExecutionWork) (bool, erro
 	return false, nil
 }
 
-func (w *Worker) ready(deviceID string) bool {
+func (w *Worker) ready(deviceID string, functions bool) bool {
 	peer, err := w.Dispatcher.Registry.LookupDevice(deviceID)
 	if err != nil {
 		return false
 	}
 	info, found, known := peer.AgentKindStatus("codex")
-	return found && known && info.Available && info.Capabilities.Streaming && info.Capabilities.Steering && info.Capabilities.DurableTurns && info.Capabilities.EnvironmentNone && info.Capabilities.WebSearchControl && info.Capabilities.TextVerbosity
+	return found && known && info.Available && info.Capabilities.Streaming && info.Capabilities.Steering && info.Capabilities.DurableTurns && info.Capabilities.EnvironmentNone && info.Capabilities.WebSearchControl && info.Capabilities.TextVerbosity && (!functions || info.Capabilities.FunctionTools)
 }
 
 func (w *Worker) runClaim(ctx context.Context, item store.ExecutionWork) error {

--- a/services/agents-api/internal/store/function_execution_native_test.go
+++ b/services/agents-api/internal/store/function_execution_native_test.go
@@ -1,21 +1,9 @@
 package store_test
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"image"
-	"image/color"
-	"image/png"
-	"net/http"
-	"net/http/httptest"
-	"os"
-	"path/filepath"
-	"reflect"
-	"strings"
-	"sync/atomic"
 	"testing"
 
 	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
@@ -31,64 +19,7 @@ func TestNativeFunctionExecutionPersistsCallsResultsAndContinuity(t *testing.T) 
 	if err := h.s.BindSessionDevice(ctx, h.tenant, h.session.ID, h.device.ID); err != nil {
 		t.Fatal(err)
 	}
-	picture := image.NewRGBA(image.Rect(0, 0, 1, 1))
-	picture.Set(0, 0, color.RGBA{R: 255, A: 255})
-	var encoded bytes.Buffer
-	if err := png.Encode(&encoded, picture); err != nil {
-		t.Fatal(err)
-	}
-	output := []any{map[string]any{"type": "input_text", "text": "before"}, map[string]any{"type": "input_image", "image_url": "data:image/png;base64," + base64.StdEncoding.EncodeToString(encoded.Bytes())}, map[string]any{"type": "input_text", "text": "after"}}
-	var requests atomic.Int32
-	model := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			t.Error(err)
-			return
-		}
-		n := requests.Add(1)
-		raw, _ := json.MarshalIndent(body, "", "  ")
-		_ = os.WriteFile(filepath.Join(home, fmt.Sprintf("functions-model-%d.json", n)), raw, 0600)
-		if !strings.Contains(string(raw), "lookup_ticket") {
-			t.Error("configured function missing")
-		}
-		var entry map[string]any
-		if n%2 == 1 {
-			entry = map[string]any{"id": fmt.Sprintf("fc_%d", n), "type": "function_call", "call_id": fmt.Sprintf("call_%d", n), "name": "lookup_ticket", "arguments": `{"ticket":"42"}`, "status": "completed"}
-		} else {
-			found := false
-			for _, value := range body["input"].([]any) {
-				item := value.(map[string]any)
-				if item["type"] != "function_call_output" || item["call_id"] != fmt.Sprintf("call_%d", n-1) {
-					continue
-				}
-				found = true
-				expected := append([]any(nil), output...)
-				// Codex adds its default image detail at the model transport boundary.
-				expected[1] = map[string]any{"type": "input_image", "image_url": output[1].(map[string]any)["image_url"], "detail": "high"}
-				if n == 4 {
-					expected = append(expected, map[string]any{"type": "input_text", "text": "synthetic failure"})
-				}
-				if !reflect.DeepEqual(item["output"], expected) {
-					t.Errorf("complete result changed: %v", item["output"])
-				}
-			}
-			if !found {
-				t.Error("native model did not receive stored result")
-			}
-			entry = map[string]any{"id": fmt.Sprintf("message_%d", n), "type": "message", "role": "assistant", "phase": "final_answer", "status": "completed", "content": []any{map[string]any{"type": "output_text", "text": "FUNCTION-EXECUTION-OK", "annotations": []any{}}}}
-		}
-		w.Header().Set("Content-Type", "text/event-stream")
-		send := func(kind string, data map[string]any) {
-			data["type"] = kind
-			raw, _ := json.Marshal(data)
-			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", kind, raw)
-			w.(http.Flusher).Flush()
-		}
-		send("response.created", map[string]any{"response": map[string]any{"id": fmt.Sprintf("r_%d", n), "status": "in_progress", "output": []any{}}})
-		send("response.output_item.added", map[string]any{"output_index": 0, "item": entry})
-		send("response.output_item.done", map[string]any{"output_index": 0, "item": entry})
-		send("response.completed", map[string]any{"response": map[string]any{"id": fmt.Sprintf("r_%d", n), "object": "response", "created_at": 0, "status": "completed", "model": "gpt-5.5", "output": []any{entry}}})
-	}))
+	model, output, requests := nativeFunctionModel(t, home)
 	defer model.Close()
 	h.d.Options = func(context.Context, store.Session) (map[string]any, error) {
 		return map[string]any{"codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}}, nil

--- a/services/agents-api/internal/store/function_item_events_test.go
+++ b/services/agents-api/internal/store/function_item_events_test.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"encoding/json"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/items"
+	"reflect"
 	"testing"
 )
 
@@ -49,5 +51,74 @@ func TestFunctionResultEventsAreInputs(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("function result missing from recovery items")
+	}
+}
+
+func TestFunctionResultItemsRetainSubmittedFields(t *testing.T) {
+	for _, raw := range []string{
+		`{"success":true}`,
+		`{"success":false,"output":null,"error":null}`,
+		`{"success":true,"output":"original"}`,
+		`{"success":false,"output":[{"type":"input_text","text":"before"},{"type":"input_image","image_url":"data:image/png;base64,AA=="}],"error":"failure"}`,
+	} {
+		t.Run(raw, func(t *testing.T) {
+			s, _ := testStore(t)
+			tenant, session := newTurnSession(t, s)
+			turn := submitMessage(t, s, tenant, session.ID, "start").TurnID
+			transition(t, s, tenant, session.ID, turn, TurnQueued, TurnInProgress)
+			call := functionCallFixture(items.Identity(turn, "tool:call"))
+			if err := s.RecordFunctionCall(t.Context(), tenant, session.ID, turn, call); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.SubmitFunctionResult(t.Context(), tenant, session.ID, turn, call.CallID, json.RawMessage(raw)); err != nil {
+				t.Fatal(err)
+			}
+			event := ExecutionEvent{Kind: "tool_call", Payload: json.RawMessage(`{"id":"call","stage":"after","native_item":{"type":"dynamicToolCall","id":"call","tool":"lookup","status":"completed","success":true,"arguments":{},"contentItems":[{"type":"inputText","text":"normalized"}]}}`)}
+			if err := s.AppendTurnEvents(t.Context(), tenant, session.ID, turn, 1, []ExecutionEvent{event}); err != nil {
+				t.Fatal(err)
+			}
+			assertFields := func(value any) {
+				t.Helper()
+				encoded, err := json.Marshal(value)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var expected, actual map[string]any
+				if json.Unmarshal([]byte(raw), &expected) != nil || json.Unmarshal(encoded, &actual) != nil {
+					t.Fatal(string(encoded))
+				}
+				for _, field := range []string{"output", "error"} {
+					wanted, present := expected[field]
+					got, exists := actual[field]
+					if present != exists || !reflect.DeepEqual(wanted, got) {
+						t.Fatalf("%s changed: %s", field, encoded)
+					}
+				}
+			}
+			page, err := s.ListItems(t.Context(), tenant, session.ID, "", 100, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			results := 0
+			for _, item := range page.Items {
+				if item.Type == "function_call_output" {
+					assertFields(item)
+					results++
+				}
+			}
+			changes, err := s.ListSessionEvents(t.Context(), tenant, session.ID, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, change := range changes {
+				if change.Event.Item != nil && change.Event.Item.Type == "function_call_output" {
+					assertFields(change.Event.Item)
+					results++
+				}
+			}
+			if results != 2 {
+				t.Fatal("missing saved or streamed result", results)
+			}
+		})
 	}
 }

--- a/services/agents-api/internal/store/function_item_events_test.go
+++ b/services/agents-api/internal/store/function_item_events_test.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestFunctionResultEventsAreInputs(t *testing.T) {
+	s, _ := testStore(t)
+	tenant, session := newTurnSession(t, s)
+	turn := submitMessage(t, s, tenant, session.ID, "start").TurnID
+	transition(t, s, tenant, session.ID, turn, TurnQueued, TurnInProgress)
+	events := []ExecutionEvent{
+		{Kind: "tool_call", Payload: json.RawMessage(`{"id":"call","stage":"after","native_item":{"type":"dynamicToolCall","id":"call","tool":"lookup","status":"completed","success":true,"arguments":{},"contentItems":[{"type":"inputText","text":"result"}]}}`)},
+		{Kind: "delta", Payload: json.RawMessage(`{"item_id":"answer","delta":"answer"}`)},
+	}
+	if err := s.AppendTurnEvents(t.Context(), tenant, session.ID, turn, 1, events); err != nil {
+		t.Fatal(err)
+	}
+	changes, err := s.ListSessionEvents(t.Context(), tenant, session.ID, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	results := 0
+	for _, change := range changes {
+		event := change.Event
+		if event.Item == nil {
+			continue
+		}
+		if event.Item.Type == "function_call_output" {
+			results++
+			if event.Type != "agent.session.turn.item.added" || event.OutputIndex != nil {
+				t.Fatal("function result is not agent output", event)
+			}
+		}
+		if event.Item.Type == "message" && event.Item.Role == "assistant" && (event.OutputIndex == nil || *event.OutputIndex != 1) {
+			t.Fatal("function result consumed an output index", event)
+		}
+	}
+	page, err := s.ListItems(t.Context(), tenant, session.ID, "", 100, true)
+	if err != nil || results != 1 {
+		t.Fatal(page, results, err)
+	}
+	found := false
+	for _, item := range page.Items {
+		if item.Type == "function_call_output" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("function result missing from recovery items")
+	}
+}

--- a/services/agents-api/internal/store/function_model_test.go
+++ b/services/agents-api/internal/store/function_model_test.go
@@ -1,0 +1,97 @@
+package store_test
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync/atomic"
+	"testing"
+)
+
+func nativeFunctionModel(t *testing.T, home string) (*httptest.Server, []any, *atomic.Int32) {
+	t.Helper()
+	picture := image.NewRGBA(image.Rect(0, 0, 1, 1))
+	picture.Set(0, 0, color.RGBA{R: 255, A: 255})
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, picture); err != nil {
+		t.Fatal(err)
+	}
+	output := []any{map[string]any{"type": "input_text", "text": "before"}, map[string]any{"type": "input_image", "image_url": "data:image/png;base64," + base64.StdEncoding.EncodeToString(encoded.Bytes())}, map[string]any{"type": "input_text", "text": "after"}}
+	var requests atomic.Int32
+	model := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Error(err)
+			return
+		}
+		n := requests.Add(1)
+		raw, _ := json.MarshalIndent(body, "", "  ")
+		_ = os.WriteFile(filepath.Join(home, fmt.Sprintf("functions-model-%d.json", n)), raw, 0600)
+		var config struct {
+			Agent struct{ Tools []map[string]any }
+		}
+		if err := json.Unmarshal([]byte(functionConfiguration), &config); err != nil {
+			t.Error(err)
+			return
+		}
+		expectedTool := config.Agent.Tools[0]
+		delete(expectedTool, "defer_loading")
+		expectedTool["strict"] = false
+		foundTool := false
+		for _, tool := range body["tools"].([]any) {
+			if reflect.DeepEqual(tool, expectedTool) {
+				foundTool = true
+			}
+		}
+		if !foundTool {
+			t.Error("configured function changed at the model boundary")
+		}
+		var entry map[string]any
+		if n%2 == 1 {
+			entry = map[string]any{"id": fmt.Sprintf("fc_%d", n), "type": "function_call", "call_id": fmt.Sprintf("call_%d", n), "name": "lookup_ticket", "arguments": `{"ticket":"42"}`, "status": "completed"}
+		} else {
+			found := false
+			for _, value := range body["input"].([]any) {
+				item := value.(map[string]any)
+				if item["type"] != "function_call_output" || item["call_id"] != fmt.Sprintf("call_%d", n-1) {
+					continue
+				}
+				found = true
+				expected := append([]any(nil), output...)
+				// Codex adds its default image detail at the model transport boundary.
+				expected[1] = map[string]any{"type": "input_image", "image_url": output[1].(map[string]any)["image_url"], "detail": "high"}
+				if n == 4 {
+					expected = append(expected, map[string]any{"type": "input_text", "text": "synthetic failure"})
+				}
+				if !reflect.DeepEqual(item["output"], expected) {
+					t.Errorf("complete result changed: %v", item["output"])
+				}
+			}
+			if !found {
+				t.Error("native model did not receive stored result")
+			}
+			entry = map[string]any{"id": fmt.Sprintf("message_%d", n), "type": "message", "role": "assistant", "phase": "final_answer", "status": "completed", "content": []any{map[string]any{"type": "output_text", "text": "FUNCTION-EXECUTION-OK", "annotations": []any{}}}}
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		send := func(kind string, data map[string]any) {
+			data["type"] = kind
+			raw, _ := json.Marshal(data)
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", kind, raw)
+			w.(http.Flusher).Flush()
+		}
+		send("response.created", map[string]any{"response": map[string]any{"id": fmt.Sprintf("r_%d", n), "status": "in_progress", "output": []any{}}})
+		send("response.output_item.added", map[string]any{"output_index": 0, "item": entry})
+		send("response.output_item.done", map[string]any{"output_index": 0, "item": entry})
+		send("response.completed", map[string]any{"response": map[string]any{"id": fmt.Sprintf("r_%d", n), "object": "response", "created_at": 0, "status": "completed", "model": "gpt-5.5", "output": []any{entry}}})
+	}))
+	return model, output, &requests
+}

--- a/services/agents-api/internal/store/function_public_native_test.go
+++ b/services/agents-api/internal/store/function_public_native_test.go
@@ -1,0 +1,90 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/device"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/api"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/execution"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+	"github.com/google/uuid"
+)
+
+func TestNativePublicFunctionExecution(t *testing.T) {
+	python := os.Getenv("PARSAR_OFFICIAL_SDK_PYTHON")
+	if python == "" {
+		t.Skip("pinned official Python SDK required")
+	}
+	h, ctx, home := nativeDispatchHarness(t)
+	model, output, requests := nativeFunctionModel(t, home)
+	defer model.Close()
+	h.d.Options = func(context.Context, store.Session) (map[string]any, error) {
+		return map[string]any{"codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}}, nil
+	}
+	worker, err := execution.StartWorker(ctx, h.d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- worker.Run(ctx) }()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(15 * time.Second):
+			t.Error("worker did not stop")
+		}
+	}()
+	token := uuid.NewString()
+	auth, err := api.NewAuthenticator([]api.APIKey{{TokenSHA256: device.HashCredential(token), TenantID: h.tenant}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler, err := api.NewHandler(h.s, auth, "codex", api.WithExecution(worker))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	outputPath, proofPath := filepath.Join(home, "function-output.json"), filepath.Join(home, "public-functions.json")
+	raw, _ := json.Marshal(output)
+	if err := os.WriteFile(outputPath, raw, 0600); err != nil {
+		t.Fatal(err)
+	}
+	command := exec.CommandContext(ctx, python, "../../tests/official_functions.py", server.URL, token, outputPath, proofPath)
+	if log, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("official native functions: %v %s", err, log)
+	}
+	var proof struct {
+		Session string   `json:"session"`
+		Turns   []string `json:"turns"`
+		Calls   []string `json:"calls"`
+	}
+	raw, err = os.ReadFile(proofPath)
+	if err != nil || json.Unmarshal(raw, &proof) != nil || len(proof.Turns) != 3 || len(proof.Calls) != 3 {
+		t.Fatal(proof, err)
+	}
+	for i, callID := range proof.Calls {
+		call, err := h.s.GetFunctionCall(ctx, h.tenant, proof.Session, proof.Turns[i], callID)
+		if err != nil || call.Applied != (i < 2) {
+			t.Fatal(call, err)
+		}
+	}
+	bound, err := h.s.GetSessionDevice(ctx, h.tenant, proof.Session)
+	if err != nil || bound.NativeSessionID == "" || bound.ID != h.device.ID {
+		t.Fatal(bound, err)
+	}
+	if requests.Load() != 5 {
+		t.Fatal("unexpected replay or missing native continuation", requests.Load())
+	}
+	t.Logf("Official SDK configured functions, native text/image/error results, application receipts, next Turn and cancellation passed; evidence %s", home)
+}

--- a/services/agents-api/internal/store/function_worker_test.go
+++ b/services/agents-api/internal/store/function_worker_test.go
@@ -1,0 +1,80 @@
+package store_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/MiniMax-AI-Dev/parsar/internal/agentdaemon/proto"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/execution"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func TestFunctionWorkerWaitsForCapableDevice(t *testing.T) {
+	for _, prebound := range []bool{false, true} {
+		t.Run(map[bool]string{false: "select", true: "bound"}[prebound], func(t *testing.T) {
+			h := newFunctionHarness(t)
+			if !prebound {
+				var err error
+				h.session, err = h.s.CreateSession(t.Context(), h.tenant, store.CreateSessionInput{Engine: "codex", IdempotencyKey: "unbound", Configuration: []byte(functionConfiguration)})
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			caps := proto.AgentKindCapabilities{Streaming: true, Steering: true, DurableTurns: true, EnvironmentNone: true, WebSearchControl: true, TextVerbosity: true}
+			heartbeat := func() {
+				h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: caps}}})
+			}
+			heartbeat()
+			deadline := time.Now().Add(3 * time.Second)
+			for {
+				peer, _ := h.registry.LookupDevice(h.device.ID)
+				info, _, _ := peer.AgentKindStatus("codex")
+				if !info.Capabilities.FunctionTools {
+					break
+				}
+				if time.Now().After(deadline) {
+					t.Fatal("heartbeat not applied")
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			input := h.message("queued", "Look up ticket")
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			worker, err := execution.StartWorker(ctx, h.d)
+			if err != nil {
+				t.Fatal(err)
+			}
+			done := make(chan error, 1)
+			go func() { done <- worker.Run(ctx) }()
+			defer func() {
+				cancel()
+				select {
+				case <-done:
+				case <-time.After(10 * time.Second):
+					t.Error("worker did not stop")
+				}
+			}()
+			time.Sleep(650 * time.Millisecond)
+			current, err := h.s.GetTurn(ctx, h.tenant, h.session.ID, input.TurnID)
+			if err != nil || current.Status != store.TurnQueued {
+				t.Fatal(current, err)
+			}
+			if !prebound {
+				if _, err := h.s.GetSessionDevice(ctx, h.tenant, h.session.ID); !errors.Is(err, store.ErrNotFound) {
+					t.Fatal("bound an incapable device", err)
+				}
+			}
+			caps.FunctionTools = true
+			heartbeat()
+			request := h.read(proto.TypePromptRequest)
+			var prompt proto.PromptRequestPayload
+			if request.DecodePayload(&prompt) != nil || len(prompt.FunctionTools) != 1 || prompt.FunctionTools[0].Name != "lookup_ticket" {
+				t.Fatal(prompt)
+			}
+			h.write(input.TurnID, proto.TypeDone, proto.DonePayload{Content: "done"})
+			waitTurn(t, h, input.TurnID, store.TurnCompleted)
+		})
+	}
+}

--- a/services/agents-api/internal/store/item_events.go
+++ b/services/agents-api/internal/store/item_events.go
@@ -13,6 +13,10 @@ func recordItemChange(ctx context.Context, q *sqlc.Queries, session pgtype.UUID,
 	if reflect.DeepEqual(previous, item) || ctx.Value(suppressSessionEvents{}) != nil {
 		return nil
 	}
+	// Function results are Session inputs, not AgentOutputItem variants.
+	if item.Type == "function_call_output" {
+		index.Valid = false
+	}
 	base := v1.SessionEvent{TurnID: item.TurnID}
 	if index.Valid {
 		base.OutputIndex = &index.Int32

--- a/services/agents-api/internal/store/item_projection.go
+++ b/services/agents-api/internal/store/item_projection.go
@@ -45,7 +45,7 @@ func projectItemSource(ctx context.Context, q *sqlc.Queries, session, turn pgtyp
 		if err != nil {
 			return err
 		}
-		stored, err := q.PutSessionItem(ctx, sqlc.PutSessionItemParams{ID: id, SessionID: session, TurnID: turn, CreatedAt: created, Payload: payload, IsOutput: kind != "message"})
+		stored, err := q.PutSessionItem(ctx, sqlc.PutSessionItemParams{ID: id, SessionID: session, TurnID: turn, CreatedAt: created, Payload: payload, IsOutput: kind != "message" && item.Type != "function_call_output"})
 		if err != nil {
 			return err
 		}

--- a/services/agents-api/internal/store/item_projection.go
+++ b/services/agents-api/internal/store/item_projection.go
@@ -41,6 +41,9 @@ func projectItemSource(ctx context.Context, q *sqlc.Queries, session, turn pgtyp
 			}
 		}
 		item := items.Merge(update, previous)
+		if err := restoreFunctionItemResult(ctx, q, session, turn, &item); err != nil {
+			return err
+		}
 		payload, err := json.Marshal(item)
 		if err != nil {
 			return err
@@ -124,4 +127,33 @@ func ensureSessionItems(ctx context.Context, q *sqlc.Queries, session pgtype.UUI
 			return err
 		}
 	}
+}
+
+func restoreFunctionItemResult(ctx context.Context, q *sqlc.Queries, session, turn pgtype.UUID, item *v1.Item) error {
+	if item.Type != "function_call_output" {
+		return nil
+	}
+	result, err := q.FunctionItemResult(ctx, sqlc.FunctionItemResultParams{SessionID: session, TurnID: turn, CallID: item.CallID})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(result, &fields); err != nil {
+		return err
+	}
+	// Native results may normalize content; public Items retain the saved submission.
+	item.Output, item.Error = nil, nil
+	if value, ok := fields["output"]; ok {
+		item.Output = value
+	}
+	if value, ok := fields["error"]; ok {
+		item.Error = value
+	}
+	return nil
 }

--- a/services/agents-api/tests/official_functions.py
+++ b/services/agents-api/tests/official_functions.py
@@ -1,0 +1,67 @@
+"""Verify public function configuration and execution against a real daemon/Codex."""
+
+import importlib.metadata
+import json
+from pathlib import Path
+import sys
+
+import httpx2
+from openai import ConflictError, OpenAI
+
+base, token, output_path, evidence = sys.argv[1:]
+pin = json.loads((Path(__file__).resolve().parents[3] / "contracts/agents-api/upstream.json").read_text())
+source = json.loads(importlib.metadata.distribution("openai").read_text("direct_url.json") or "{}")
+assert source.get("vcs_info", {}).get("commit_id") == pin["commit"]
+output = json.loads(Path(output_path).read_text())
+tool = {"type":"function","name":"lookup_ticket","description":"Read a synthetic ticket",
+        "parameters":{"type":"object","properties":{"ticket":{"type":"string"}},"required":["ticket"],"additionalProperties":False}}
+agent = {"model":"gpt-5.5","tools":[tool]}
+with OpenAI(base_url=base+"/v1", api_key=token, max_retries=0, _strict_response_validation=True,
+            http_client=httpx2.Client(trust_env=False, timeout=30)) as client:
+    sessions = client.beta.agents.sessions
+    session = sessions.create(agent=agent, environment={"type":"none"}, extra_headers={"Idempotency-Key":"functions"})
+    expected = dict(tool, defer_loading=False)
+    assert session.agent.tools[0].to_dict() == expected, session.agent.tools
+    tool["defer_loading"] = False
+    assert sessions.create(agent=agent, environment={"type":"none"}, extra_headers={"Idempotency-Key":"functions"}).id == session.id
+    tool["description"] = "changed"
+    try:
+        sessions.create(agent=agent, environment={"type":"none"}, extra_headers={"Idempotency-Key":"functions"})
+        raise AssertionError("changed tools reused a creation identity")
+    except ConflictError:
+        pass
+    turns, calls = [], []
+    for index in range(3):
+        handled = False
+        with sessions.events.stream(session.id, timeout=30) as stream:
+            message = {"type":"agent.session.input.message","input":[{"role":"user","content":[{"type":"input_text","text":"Look up ticket 42"}]}]}
+            sessions.events.create(session.id, events=[message], idempotency_key="message-"+str(index))
+            for event in stream:
+                if event.type in ("agent.session.turn.item.added", "agent.session.turn.item.done") and event.item.type == "function_call_output":
+                    assert event.type == "agent.session.turn.item.added" and event.output_index is None
+                if event.type == "agent.session.requires_action" and not handled:
+                    assert event.session.agent.tools[0].to_dict() == expected
+                    action = event.session.required_actions[0]
+                    assert action.name == "lookup_ticket" and action.arguments == {"ticket":"42"}
+                    assert sessions.turns.retrieve(action.turn_id, session_id=session.id).status == "waiting"
+                    turns.append(action.turn_id); calls.append(action.call_id); handled = True
+                    if index == 2:
+                        sessions.events.create(session.id, events=[{"type":"agent.session.input.cancel"}], idempotency_key="cancel")
+                    else:
+                        result = {"type":"agent.session.input.tool_result","turn_id":action.turn_id,"call_id":action.call_id,"success":index==0,"output":output}
+                        if index == 1:
+                            result["error"] = "synthetic failure"
+                        for _ in range(2):
+                            assert sessions.events.create(session.id, events=[result], idempotency_key="result-"+str(index)) is None
+                if event.type == "agent.session.idle":
+                    assert handled and event.session.required_actions == []
+                    break
+                assert event.type != "agent.session.failed", event.to_dict()
+        assert sessions.turns.retrieve(turns[-1], session_id=session.id).status == ("cancelled" if index==2 else "completed")
+        assert len(sessions.turns.list(session.id).data) == index+1
+    items = sessions.items.list(session.id, limit=100, order="asc").data
+    assert all(any(item.type=="function_call" and item.call_id==call for item in items) for call in calls)
+    answers = [item for item in items if item.type=="message" and item.role=="assistant"]
+    assert len(answers)==2 and all(item.content[0].text=="FUNCTION-EXECUTION-OK" for item in answers)
+    assert sessions.retrieve(session.id).agent.tools[0].to_dict() == expected
+    Path(evidence).write_text(json.dumps({"session":session.id,"turns":turns,"calls":calls,"configured_tool":expected}))

--- a/services/agents-api/tests/official_functions.py
+++ b/services/agents-api/tests/official_functions.py
@@ -39,6 +39,12 @@ with OpenAI(base_url=base+"/v1", api_key=token, max_retries=0, _strict_response_
             for event in stream:
                 if event.type in ("agent.session.turn.item.added", "agent.session.turn.item.done") and event.item.type == "function_call_output":
                     assert event.type == "agent.session.turn.item.added" and event.output_index is None
+                    submitted = event.item.to_dict()
+                    assert submitted["output"] == output
+                    if index == 1:
+                        assert submitted["error"] == "synthetic failure"
+                    else:
+                        assert "error" not in submitted
                 if event.type == "agent.session.requires_action" and not handled:
                     assert event.session.agent.tools[0].to_dict() == expected
                     action = event.session.required_actions[0]
@@ -61,6 +67,14 @@ with OpenAI(base_url=base+"/v1", api_key=token, max_retries=0, _strict_response_
         assert len(sessions.turns.list(session.id).data) == index+1
     items = sessions.items.list(session.id, limit=100, order="asc").data
     assert all(any(item.type=="function_call" and item.call_id==call for item in items) for call in calls)
+    results = {item.call_id: item.to_dict() for item in items if item.type=="function_call_output"}
+    assert len(results)==2
+    for index, call in enumerate(calls[:2]):
+        assert results[call]["output"] == output
+        if index == 1:
+            assert results[call]["error"] == "synthetic failure"
+        else:
+            assert "error" not in results[call]
     answers = [item for item in items if item.type=="message" and item.role=="assistant"]
     assert len(answers)==2 and all(item.content[0].text=="FUNCTION-EXECUTION-OK" for item in answers)
     assert sessions.retrieve(session.id).agent.tools[0].to_dict() == expected


### PR DESCRIPTION
Inline Agents can now declare non-deferred function tools and complete the public call/result workflow. Session creation validates required fields, resolves `defer_loading=false`, and retains the tools in the immutable configuration and retry identity. The worker waits for a compatible same-tenant host instead of dispatching functions to a host without support.

Function results remain readable Session Items and emit `item.added` without an output index. They no longer produce `item.done`, whose upstream union excludes function results; the pinned SDK rejected that event during native verification. Public result Items and events preserve the saved output/error, including omitted and null fields, without exposing the adapter's error-to-text normalization.

Validation on `zju_a100_2`:
- `make sqlc-generate`, `make openapi` and `make check` passed, with Agents API PostgreSQL integration enabled. The unrelated product migration smoke test skipped because Docker is disabled.
- Raw HTTP configuration checks, device capability selection and function-result event regression passed.
- Pinned official SDK with strict response validation → actual HTTP service/worker → daemon/Codex passed configured tools, ordered text/image/error results, retries, next-Turn continuity and waiting cancellation against a synthetic model provider. The existing internal native test also passed.

Deferred discovery, other tool kinds, native built-in tool restriction, product changes and Team/environment work remain outside this PR. Coverage limitations remain documented. Tracked under Feishu ATOM-006.

Independent blind review covered the complete diff. The submitted-result preservation finding was fixed and reverified. A further result-then-cancel batch case is explicitly deferred: its accepted result stays in internal storage but does not appear in public Items when cancellation prevents native observation. Normal result completion and independent waiting cancellation pass. Admission-time indexing is recorded in Feishu as a separate P2 follow-up, following the requested scope/ROI policy; this PR does not claim complete function compatibility.
