### PR TITLE
fix(agents-api): preserve session request null semantics

### DIFF
--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -77,6 +77,10 @@ unsupported errors are implementation gaps, never evidence of full compatibility
   and `OpenAI-Beta: agents=v1`. Do not introduce a competing `/sessions` surface.
 - Session creation takes an environment and inline agent configuration or a saved
   agent reference. A model name is not a daemon engine name.
+  In the pinned `session_create_params.py`, `stream` defaults to false and neither
+  `stream` nor `agent_id` permits null. Metadata omission/null defaults to an empty
+  map; individual values must be strings, including valid empty strings. Validate
+  these distinctions before persistence rather than coercing null to Go zero values.
 - `AgentSession` includes the effective agent/environment, Unix-second timestamps,
   `object: agent.session`, metadata, required actions, status, usage and vault IDs.
   A Session remains reusable after its current Turn completes.

--- a/contracts/agents-api/openapi.yaml
+++ b/contracts/agents-api/openapi.yaml
@@ -66,7 +66,6 @@ definitions:
         $ref: '#/definitions/v1.InlineAgent'
       agent_id:
         type: string
-        x-nullable: true
       environment:
         $ref: '#/definitions/v1.Environment'
       input:
@@ -78,6 +77,7 @@ definitions:
         type: object
         x-nullable: true
       stream:
+        default: false
         type: boolean
       vault_ids:
         items:
@@ -666,8 +666,10 @@ paths:
       consumes:
       - application/json
       description: Supports inline model/instructions, text verbosity, non-deferred
-        function tools and environment type none. Execution input and other options
-        are explicitly unsupported in this slice.
+        function tools and environment type none. Omitted stream defaults to false;
+        stream and agent_id cannot be null. Metadata may be null, but its values must
+        be strings. Execution input and other options are explicitly unsupported in
+        this slice.
       parameters:
       - description: agents=v1
         in: header

--- a/contracts/agents-api/v1/sessions.go
+++ b/contracts/agents-api/v1/sessions.go
@@ -6,11 +6,11 @@ import "encoding/json"
 // CreateSessionRequest currently supports inline agents without initial input.
 type CreateSessionRequest struct {
 	Agent       *InlineAgent      `json:"agent" binding:"required"`
-	AgentID     *string           `json:"agent_id,omitempty" extensions:"x-nullable"`
+	AgentID     *string           `json:"agent_id,omitempty"`
 	Environment *Environment      `json:"environment" binding:"required"`
 	Input       json.RawMessage   `json:"input,omitempty" swaggertype:"object" extensions:"x-nullable"`
 	Metadata    map[string]string `json:"metadata,omitempty" extensions:"x-nullable"`
-	Stream      bool              `json:"stream,omitempty"`
+	Stream      bool              `json:"stream,omitempty" default:"false"`
 	VaultIDs    []string          `json:"vault_ids,omitempty"`
 }
 

--- a/services/agents-api/internal/api/handler.go
+++ b/services/agents-api/internal/api/handler.go
@@ -85,7 +85,7 @@ func tenantID(r *http.Request) string { return r.Context().Value(tenantContextKe
 
 // createSession creates an idle execution Session without submitting a Turn.
 // @Summary Create an execution Session
-// @Description Supports inline model/instructions, text verbosity, non-deferred function tools and environment type none. Execution input and other options are explicitly unsupported in this slice.
+// @Description Supports inline model/instructions, text verbosity, non-deferred function tools and environment type none. Omitted stream defaults to false; stream and agent_id cannot be null. Metadata may be null, but its values must be strings. Execution input and other options are explicitly unsupported in this slice.
 // @Tags Sessions
 // @Accept json
 // @Produce json
@@ -101,10 +101,10 @@ func (h *Handler) createSession(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "unsupported_parameter", "Session creation does not accept query parameters.")
 		return
 	}
-	var input v1.CreateSessionRequest
+	var request decodedSessionRequest
 	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1024*1024))
 	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&input); err != nil {
+	if err := decoder.Decode(&request); err != nil {
 		var tooLarge *http.MaxBytesError
 		if errors.As(err, &tooLarge) {
 			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Request exceeds 1 MiB.")
@@ -115,6 +115,11 @@ func (h *Handler) createSession(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := decoder.Decode(new(any)); err != io.EOF {
 		writeError(w, http.StatusBadRequest, "invalid_request", "Request must contain exactly one JSON object.")
+		return
+	}
+	input, err := request.validated()
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "stream and agent_id cannot be null; metadata values must be strings.")
 		return
 	}
 	key := r.Header.Get("Idempotency-Key")

--- a/services/agents-api/internal/api/session_request.go
+++ b/services/agents-api/internal/api/session_request.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+// Keep explicit null until validation for fields whose Go zero values would
+// otherwise erase it. The embedded wire type retains strict nested decoding.
+type decodedSessionRequest struct {
+	v1.CreateSessionRequest
+	AgentID  json.RawMessage    `json:"agent_id"`
+	Stream   json.RawMessage    `json:"stream"`
+	Metadata map[string]*string `json:"metadata"`
+}
+
+func (request decodedSessionRequest) validated() (v1.CreateSessionRequest, error) {
+	input := request.CreateSessionRequest
+	if len(request.AgentID) > 0 {
+		var id string
+		if bytes.Equal(bytes.TrimSpace(request.AgentID), []byte("null")) || json.Unmarshal(request.AgentID, &id) != nil {
+			return input, store.ErrInvalidInput
+		}
+		input.AgentID = &id
+	}
+	if len(request.Stream) > 0 {
+		if bytes.Equal(bytes.TrimSpace(request.Stream), []byte("null")) || json.Unmarshal(request.Stream, &input.Stream) != nil {
+			return input, store.ErrInvalidInput
+		}
+	}
+	if request.Metadata != nil {
+		input.Metadata = make(map[string]string, len(request.Metadata))
+		for key, value := range request.Metadata {
+			if value == nil {
+				return input, store.ErrInvalidInput
+			}
+			input.Metadata[key] = *value
+		}
+	}
+	return input, nil
+}

--- a/services/agents-api/internal/api/session_request_test.go
+++ b/services/agents-api/internal/api/session_request_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"encoding/json"
+	"maps"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
+)
+
+func TestSessionCreateFieldPresence(t *testing.T) {
+	// Pinned SessionCreateParams: stream and agent_id are not nullable;
+	// metadata is nullable, but its values must be strings.
+	for _, tc := range []struct {
+		name, fields string
+		status       int
+		metadata     map[string]string
+	}{
+		{"omitted", ``, 200, nil},
+		{"false stream", `,"stream":false`, 200, nil},
+		{"null stream", `,"stream":null`, 400, nil},
+		{"whitespace null stream", `,"stream": null `, 400, nil},
+		{"string stream", `,"stream":"false"`, 400, nil},
+		{"numeric stream", `,"stream":0`, 400, nil},
+		{"null agent ID", `,"agent_id":null`, 400, nil},
+		{"numeric agent ID", `,"agent_id":0`, 400, nil},
+		{"null metadata", `,"metadata":null`, 200, nil},
+		{"empty metadata", `,"metadata":{}`, 200, nil},
+		{"string metadata", `,"metadata":{"empty":"","label":"中文🧪"}`, 200, map[string]string{"empty": "", "label": "中文🧪"}},
+		{"null metadata value", `,"metadata":{"label":null}`, 400, nil},
+		{"mixed metadata values", `,"metadata":{"empty":"","label":null}`, 400, nil},
+		{"numeric metadata value", `,"metadata":{"label":0}`, 400, nil},
+		{"array metadata", `,"metadata":[]`, 400, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, saved, _ := testHandler(t)
+			body := `{"agent":{"model":"example"},"environment":{"type":"none"}` + tc.fields + `}`
+			request := httptest.NewRequest(http.MethodPost, "/v1/agents/sessions", strings.NewReader(body))
+			request.Header.Set("Authorization", "Bearer test-api-key")
+			request.Header.Set("OpenAI-Beta", "agents=v1")
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, request)
+			if response.Code != tc.status {
+				t.Fatalf("status = %d, want %d: %s", response.Code, tc.status, response.Body)
+			}
+			if tc.status != http.StatusOK {
+				if saved.tenant != "" {
+					t.Fatal("invalid request reached persistence")
+				}
+				var failure v1.ErrorResponse
+				if json.Unmarshal(response.Body.Bytes(), &failure) != nil || failure.Error.Code != "invalid_request" {
+					t.Fatalf("invalid error response: %s", response.Body)
+				}
+				return
+			}
+			if saved.tenant == "" || !maps.Equal(saved.input.Metadata, tc.metadata) {
+				t.Fatalf("saved metadata = %#v, want %#v", saved.input.Metadata, tc.metadata)
+			}
+			var session v1.Session
+			if json.Unmarshal(response.Body.Bytes(), &session) != nil || !maps.Equal(session.Metadata, tc.metadata) {
+				t.Fatalf("metadata response changed: %s", response.Body)
+			}
+		})
+	}
+}

--- a/services/agents-api/tests/official_client.py
+++ b/services/agents-api/tests/official_client.py
@@ -19,6 +19,7 @@ sys.dont_write_bytecode = True
 import httpx2
 from jsonschema import Draft4Validator
 from official_items import verify_items
+from official_session_requests import verify_session_create_requests
 from openai import AuthenticationError, BadRequestError, ConflictError, NotFoundError, OpenAI
 import yaml
 
@@ -143,6 +144,7 @@ def main():
                     metadata = {str(i): "🧪" * 512 for i in range(16)}
                     large = sessions.create(**spec, metadata=metadata)
                     assert sessions.retrieve(large.id).metadata == metadata
+                    request_sessions = verify_session_create_requests(a, spec)
                     turn_session = sessions.create(**spec)
                     fixture = Path(directory) / "turns.json"
                     fixture.write_text(json.dumps({"tenant": bindings[0]["tenant_id"], "session": turn_session.id}))
@@ -172,6 +174,7 @@ def main():
                     process.terminate()
                     process.wait(timeout=15)
                     process = start()
+                    assert [sessions.retrieve(item.id) for item in request_sessions] == request_sessions
                     assert list(sessions.items.list(turn_session.id, order="asc")) == saved_items
                     assert list(turns.list(turn_session.id, order="asc")) == recovered
                     assert sessions.retrieve(first.id) == first

--- a/services/agents-api/tests/official_session_requests.py
+++ b/services/agents-api/tests/official_session_requests.py
@@ -1,0 +1,50 @@
+"""Check Session-create field presence against the pinned SDK request types."""
+
+import uuid
+
+import httpx2
+from openai import BadRequestError
+
+
+def verify_session_create_requests(client, spec):
+    # SessionCreateParamsBase permits null metadata, not null string values;
+    # agent_id is str and stream is a boolean literal union without None.
+    sessions = client.beta.agents.sessions
+    before = {session.id for session in sessions.list()}
+    invalid = [
+        {"stream": None}, {"stream": "false"}, {"stream": 0},
+        {"agent_id": None}, {"agent_id": 0},
+        {"metadata": {"label": None}},
+        {"metadata": {"empty": "", "label": None}},
+        {"metadata": {"label": 0}}, {"metadata": []},
+    ]
+    headers = {"Authorization": f"Bearer {client.api_key}", "OpenAI-Beta": "agents=v1"}
+    with httpx2.Client(trust_env=False, timeout=10) as raw:
+        for fields in invalid:
+            response = raw.post(str(client.base_url).rstrip("/") + "/agents/sessions",
+                                headers=headers, json={**spec, **fields})
+            assert response.status_code == 400, (fields, response.status_code)
+            assert response.json()["error"]["code"] == "invalid_request"
+            try:
+                sessions.create(**spec, extra_body=fields)
+            except BadRequestError as error:
+                assert error.body["code"] == "invalid_request"
+            else:
+                raise AssertionError(f"Official client accepted invalid fields: {fields}")
+        assert {session.id for session in sessions.list()} == before
+
+        key = {"Idempotency-Key": str(uuid.uuid4())}
+        first = sessions.create(**spec, extra_headers=key)
+        assert first.metadata == {}
+        for fields in [{}, {"stream": False}, {"metadata": None}, {"metadata": {}},
+                       {"stream": False, "metadata": None}]:
+            assert sessions.create(**spec, extra_body=fields, extra_headers=key) == first
+            response = raw.post(str(client.base_url).rstrip("/") + "/agents/sessions",
+                                headers={**headers, **key}, json={**spec, **fields})
+            assert response.status_code == 200
+            assert response.json()["id"] == first.id and response.json()["metadata"] == {}
+        metadata = {"empty": "", "label": "中文🧪"}
+        preserved = sessions.create(**spec, metadata=metadata)
+        assert sessions.retrieve(preserved.id).metadata == metadata
+    print("Session create requests: raw HTTP and pinned SDK null rejection, no writes on rejection, default equivalence, idempotency and exact metadata passed.")
+    return [first, preserved]


### PR DESCRIPTION
Session creation accepted explicit `null` for `stream` and `agent_id`, and converted null metadata values to empty strings. Preserve those values until validation and reject them before persistence, while keeping omitted/false stream and omitted/null/empty metadata behavior intact. Align the generated request contract with the pinned SDK types.

Validation: `make openapi`, full `make check` (including isolated PostgreSQL and Docker store checks), API regressions, and fixed official Python/Go client tests on `zju_a100_2`. Raw HTTP and SDK checks cover rejection without writes, metadata fidelity, retry equivalence and restart reads. Baseline real HTTP reproduced `stream:null` returning 200.

Developer self-review covered the full diff against the pinned source. Scope is request admission only; no resource additions, execution changes or schema migrations. Full upstream error taxonomy and remaining protocol variants are still tracked under ATOM-014.

[Feishu task board](https://vrfi1sk8a0.feishu.cn/wiki/EA3CwVSRviqe1XkZ0tAcq7FqnFc)
