### PR TITLE
test(agents-api): exercise official stream tool handlers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,8 +122,13 @@ path until an explicit client cutover.
 - Pin upstream source and SDK versions in `contracts/agents-api/upstream.json`.
   Use official SDKs for clients and reuse upstream types or schemas where suitable.
   SDK deserialization alone is not server validation or proof of compatibility:
-  test raw HTTP payloads and observable workflows as well. Record unspecified or
-  unverified behavior explicitly; never invent official semantics. Track partial
+  test raw HTTP payloads and observable workflows as well. Synthetic data and mock
+  model responses may support controlled tests; live execution acceptance must
+  call a real model API through the service, daemon and harness. A real daemon
+  with a synthetic model does not constitute live model validation. Keep provider
+  credentials in private test configuration, outside source, logs and task records.
+  Record unspecified or unverified behavior explicitly; never invent official
+  semantics. Track partial
   coverage in `contracts/agents-api/README.md` until the complete target is verified.
 - No legacy Agents API compatibility requirement takes precedence over this
   design. Replace an unsuitable implementation instead of growing compatibility

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -322,3 +322,14 @@ If cancellation prevents native application (for example, a result followed by
 cancel in one admitted batch), the submission remains saved internally but has no
 public result Item or `item.added`. Admission-time result indexing and unapplied
 result recovery remain a separate compatibility gap; retries do not repair it.
+
+`TestNativePublicFunctionStreamHelper` runs `tests/official_function_stream.py`
+with the same native fixture and pinned SDK. `sessions.stream(tool_handlers=...)`
+submits a mapping returned by a handler and a generic failure when the handler
+raises. It verifies one invocation per call, retained output/error field presence,
+native application, and termination after the matching Turn completes and Session
+returns idle. These are controlled tests with synthetic model responses. Live
+execution acceptance additionally requires a real model API; provider connectivity
+alone does not prove the Agents API/daemon/harness workflow. Live MiniMax-M3
+execution currently fails the native verbosity capability check because the
+Session defaults to `medium`; this model-support gap remains open.

--- a/services/agents-api/internal/store/function_model_test.go
+++ b/services/agents-api/internal/store/function_model_test.go
@@ -26,6 +26,16 @@ func nativeFunctionModel(t *testing.T, home string) (*httptest.Server, []any, *a
 		t.Fatal(err)
 	}
 	output := []any{map[string]any{"type": "input_text", "text": "before"}, map[string]any{"type": "input_image", "image_url": "data:image/png;base64," + base64.StdEncoding.EncodeToString(encoded.Bytes())}, map[string]any{"type": "input_text", "text": "after"}}
+	expected := append([]any(nil), output...)
+	// Codex adds its default image detail at the model transport boundary.
+	expected[1] = map[string]any{"type": "input_image", "image_url": output[1].(map[string]any)["image_url"], "detail": "high"}
+	failure := append(append([]any(nil), expected...), map[string]any{"type": "input_text", "text": "synthetic failure"})
+	model, requests := nativeFunctionResultsModel(t, home, []any{expected, failure})
+	return model, output, requests
+}
+
+func nativeFunctionResultsModel(t *testing.T, home string, results []any) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
 	var requests atomic.Int32
 	model := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]any
@@ -66,12 +76,11 @@ func nativeFunctionModel(t *testing.T, home string) (*httptest.Server, []any, *a
 					continue
 				}
 				found = true
-				expected := append([]any(nil), output...)
-				// Codex adds its default image detail at the model transport boundary.
-				expected[1] = map[string]any{"type": "input_image", "image_url": output[1].(map[string]any)["image_url"], "detail": "high"}
-				if n == 4 {
-					expected = append(expected, map[string]any{"type": "input_text", "text": "synthetic failure"})
+				if int(n/2) > len(results) {
+					t.Error("unexpected native result continuation", n)
+					return
 				}
+				expected := results[n/2-1]
 				if !reflect.DeepEqual(item["output"], expected) {
 					t.Errorf("complete result changed: %v", item["output"])
 				}
@@ -93,5 +102,5 @@ func nativeFunctionModel(t *testing.T, home string) (*httptest.Server, []any, *a
 		send("response.output_item.done", map[string]any{"output_index": 0, "item": entry})
 		send("response.completed", map[string]any{"response": map[string]any{"id": fmt.Sprintf("r_%d", n), "object": "response", "created_at": 0, "status": "completed", "model": "gpt-5.5", "output": []any{entry}}})
 	}))
-	return model, output, &requests
+	return model, &requests
 }

--- a/services/agents-api/internal/store/function_public_native_test.go
+++ b/services/agents-api/internal/store/function_public_native_test.go
@@ -28,39 +28,13 @@ func TestNativePublicFunctionExecution(t *testing.T) {
 	h.d.Options = func(context.Context, store.Session) (map[string]any, error) {
 		return map[string]any{"codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}}, nil
 	}
-	worker, err := execution.StartWorker(ctx, h.d)
-	if err != nil {
-		t.Fatal(err)
-	}
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	done := make(chan error, 1)
-	go func() { done <- worker.Run(ctx) }()
-	defer func() {
-		cancel()
-		select {
-		case <-done:
-		case <-time.After(15 * time.Second):
-			t.Error("worker did not stop")
-		}
-	}()
-	token := uuid.NewString()
-	auth, err := api.NewAuthenticator([]api.APIKey{{TokenSHA256: device.HashCredential(token), TenantID: h.tenant}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	handler, err := api.NewHandler(h.s, auth, "codex", api.WithExecution(worker))
-	if err != nil {
-		t.Fatal(err)
-	}
-	server := httptest.NewServer(handler)
-	defer server.Close()
+	serverURL, token := nativePublicFunctionServer(t, h, ctx)
 	outputPath, proofPath := filepath.Join(home, "function-output.json"), filepath.Join(home, "public-functions.json")
 	raw, _ := json.Marshal(output)
 	if err := os.WriteFile(outputPath, raw, 0600); err != nil {
 		t.Fatal(err)
 	}
-	command := exec.CommandContext(ctx, python, "../../tests/official_functions.py", server.URL, token, outputPath, proofPath)
+	command := exec.CommandContext(ctx, python, "../../tests/official_functions.py", serverURL, token, outputPath, proofPath)
 	if log, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("official native functions: %v %s", err, log)
 	}
@@ -69,7 +43,7 @@ func TestNativePublicFunctionExecution(t *testing.T) {
 		Turns   []string `json:"turns"`
 		Calls   []string `json:"calls"`
 	}
-	raw, err = os.ReadFile(proofPath)
+	raw, err := os.ReadFile(proofPath)
 	if err != nil || json.Unmarshal(raw, &proof) != nil || len(proof.Turns) != 3 || len(proof.Calls) != 3 {
 		t.Fatal(proof, err)
 	}
@@ -87,4 +61,36 @@ func TestNativePublicFunctionExecution(t *testing.T) {
 		t.Fatal("unexpected replay or missing native continuation", requests.Load())
 	}
 	t.Logf("Official SDK configured functions, native text/image/error results, application receipts, next Turn and cancellation passed; evidence %s", home)
+}
+
+func nativePublicFunctionServer(t *testing.T, h *dispatchHarness, ctx context.Context) (string, string) {
+	t.Helper()
+	worker, err := execution.StartWorker(ctx, h.d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() { done <- worker.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(15 * time.Second):
+			t.Error("worker did not stop")
+		}
+	})
+	token := uuid.NewString()
+	auth, err := api.NewAuthenticator([]api.APIKey{{TokenSHA256: device.HashCredential(token), TenantID: h.tenant}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler, err := api.NewHandler(h.s, auth, "codex", api.WithExecution(worker))
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return server.URL, token
 }

--- a/services/agents-api/internal/store/function_stream_native_test.go
+++ b/services/agents-api/internal/store/function_stream_native_test.go
@@ -1,0 +1,57 @@
+package store_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+)
+
+func TestNativePublicFunctionStreamHelper(t *testing.T) {
+	python := os.Getenv("PARSAR_OFFICIAL_SDK_PYTHON")
+	if python == "" {
+		t.Skip("pinned official Python SDK required")
+	}
+	h, ctx, home := nativeDispatchHarness(t)
+	model, requests := nativeFunctionResultsModel(t, home, []any{
+		`{"ticket":"42","status":"open"}`,
+		"Tool handler failed.",
+	})
+	defer model.Close()
+	h.d.Options = func(context.Context, store.Session) (map[string]any, error) {
+		return map[string]any{"codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}}, nil
+	}
+	serverURL, token := nativePublicFunctionServer(t, h, ctx)
+	proofPath := filepath.Join(home, "public-function-stream.json")
+	command := exec.CommandContext(ctx, python, "../../tests/official_function_stream.py", serverURL, token, proofPath)
+	if log, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("official native stream helper: %v %s", err, log)
+	}
+	var proof struct {
+		Session string   `json:"session"`
+		Turns   []string `json:"turns"`
+		Calls   []string `json:"calls"`
+	}
+	raw, err := os.ReadFile(proofPath)
+	if err != nil || json.Unmarshal(raw, &proof) != nil || len(proof.Turns) != 2 || len(proof.Calls) != 2 {
+		t.Fatal(proof, err)
+	}
+	for i, callID := range proof.Calls {
+		call, err := h.s.GetFunctionCall(ctx, h.tenant, proof.Session, proof.Turns[i], callID)
+		if err != nil || !call.Applied {
+			t.Fatal(call, err)
+		}
+	}
+	bound, err := h.s.GetSessionDevice(ctx, h.tenant, proof.Session)
+	if err != nil || bound.NativeSessionID == "" || bound.ID != h.device.ID {
+		t.Fatal(bound, err)
+	}
+	if requests.Load() != 4 {
+		t.Fatal("unexpected replay or missing native continuation", requests.Load())
+	}
+	t.Logf("Official SDK stream tool handlers, error omission, public history and native application passed; evidence %s", home)
+}

--- a/services/agents-api/tests/official_function_stream.py
+++ b/services/agents-api/tests/official_function_stream.py
@@ -1,0 +1,78 @@
+"""Verify the pinned stream helper through the public API and native execution."""
+
+import importlib.metadata
+import json
+from pathlib import Path
+import sys
+
+import httpx2
+from openai import OpenAI
+
+base, token, evidence = sys.argv[1:]
+pin = json.loads((Path(__file__).resolve().parents[3] / "contracts/agents-api/upstream.json").read_text())
+source = json.loads(importlib.metadata.distribution("openai").read_text("direct_url.json") or "{}")
+assert source.get("vcs_info", {}).get("commit_id") == pin["commit"]
+assert importlib.metadata.version("openai") == pin["sdk_version"]
+agent = {"model": "gpt-5.5", "tools": [{
+    "type": "function", "name": "lookup_ticket", "description": "Read a synthetic ticket",
+    "parameters": {"type": "object", "properties": {"ticket": {"type": "string"}},
+                   "required": ["ticket"], "additionalProperties": False},
+}]}
+expected = [{"output": '{"ticket":"42","status":"open"}'}, {"error": "Tool handler failed."}]
+with OpenAI(base_url=base + "/v1", api_key=token, max_retries=0, _strict_response_validation=True,
+            http_client=httpx2.Client(trust_env=False, timeout=30)) as client:
+    sessions = client.beta.agents.sessions
+    session = sessions.create(agent=agent, environment={"type": "none"})
+    turns, calls, handler_calls, observed = [], [], [], []
+    for index in range(2):
+        def lookup_ticket(arguments):
+            assert arguments == {"ticket": "42"}, arguments
+            handler_calls.append(arguments)
+            if index == 1:
+                raise RuntimeError("private-handler-exception-must-not-be-exposed")
+            return {"ticket": arguments["ticket"], "status": "open"}
+
+        with sessions.stream(session.id, input="Look up ticket 42", timeout=30,
+                             tool_handlers={"lookup_ticket": lookup_ticket},
+                             idempotency_key="helper-" + str(index)) as stream:
+            events = [event.to_dict() for event in stream]
+        observed.append(events)
+        assert len(handler_calls) == index + 1, handler_calls
+        created = [event for event in events if event["type"] == "agent.session.turn.created"]
+        assert len(created) == 1, events
+        turn_id = created[0]["turn"]["id"]
+        turns.append(turn_id)
+        added = [event for event in events if event["type"] == "agent.session.turn.item.added"]
+        functions = [event for event in added if event["item"]["type"] == "function_call"]
+        assert len(functions) == 1 and functions[0]["turn_id"] == turn_id, events
+        call_id = functions[0]["item"]["call_id"]
+        calls.append(call_id)
+        results = [event for event in added if event["item"]["type"] == "function_call_output"]
+        assert len(results) == 1 and results[0]["turn_id"] == turn_id, events
+        assert results[0].get("output_index") is None
+        result = results[0]["item"]
+        assert result["call_id"] == call_id
+        assert {key: result[key] for key in ("output", "error") if key in result} == expected[index], result
+        assert not any(event["type"] == "agent.session.turn.item.done" and
+                       event["item"]["type"] == "function_call_output" for event in events)
+        terminal = [event for event in events if event["type"] in (
+            "agent.session.turn.completed", "agent.session.turn.failed", "agent.session.turn.cancelled")]
+        assert len(terminal) == 1 and terminal[0]["type"] == "agent.session.turn.completed", events
+        assert terminal[0]["turn"]["id"] == turn_id
+        assert events.index(functions[0]) < events.index(results[0]) < events.index(terminal[0]) < len(events) - 1
+        assert events[-1]["type"] == "agent.session.idle" and events[-1]["session"]["required_actions"] == []
+        assert not any(event["type"] == "agent.session.failed" for event in events)
+        assert sessions.turns.retrieve(turn_id, session_id=session.id).status == "completed"
+        current = sessions.retrieve(session.id)
+        assert current.status == "idle" and current.required_actions == []
+    items = sessions.items.list(session.id, limit=100, order="asc").data
+    results = {item.call_id: item.to_dict() for item in items if item.type == "function_call_output"}
+    assert len(results) == 2 and len(sessions.turns.list(session.id).data) == 2
+    for index, call_id in enumerate(calls):
+        assert {key: results[call_id][key] for key in ("output", "error") if key in results[call_id]} == expected[index]
+    answers = [item for item in items if item.type == "message" and item.role == "assistant"]
+    assert len(answers) == 2 and all(item.content[0].text == "FUNCTION-EXECUTION-OK" for item in answers)
+    proof = {"session": session.id, "turns": turns, "calls": calls, "handler_calls": handler_calls,
+             "events": observed, "results": results}
+    assert "private-handler-exception-must-not-be-exposed" not in json.dumps(proof)
+    Path(evidence).write_text(json.dumps(proof))


### PR DESCRIPTION
Exercise the pinned Python SDK's `sessions.stream(tool_handlers=...)` through the public HTTP API, PostgreSQL, worker, daemon and Codex. The regression covers automatic mapping results, handler exceptions without private error leakage, exact public output/error presence, one handler invocation per call, native application and stream termination after completion and idle.

Reuse the existing native model and service fixtures. This changes tests and verification documentation only; API behavior, queries, product execution and dependencies are unchanged.

Validation: the three native function suites and complete `make check` passed on `zju_a100_2`, with the fixed SDK and isolated PostgreSQL. Developer self-review checked the entire diff against the pinned helper and test scope. OpenAPI/sqlc regeneration is not applicable to this test/documentation change.

These controlled tests use synthetic model responses. A separate real MiniMax-M3 Responses request succeeded, but the public API/daemon/Codex probe failed before inference at the default-verbosity capability check. That live execution gap is recorded in ATOM-010 and remains open; this PR does not claim live model or complete protocol acceptance. Contributor guidance now explicitly requires a real model API for live execution acceptance.
