### PR TITLE
fix(agents-api): preserve native default verbosity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,9 +285,13 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   through the Codex adapter for both new and resumed Turns. The adapter queries
   the native active catalog with `codex debug models`, checks model support and
   pins that catalog snapshot for execution. The probe requires Unix process-group
-  cancellation; other daemon hosts do not advertise this capability. Unknown/unsupported models or an
-  unreadable catalog fail before model execution instead of silently ignoring
-  verbosity. This is an explicit engine limitation until those models are supported.
+  cancellation; other daemon hosts do not advertise this capability. For models
+  without declared verbosity support, including the native unknown-model fallback,
+  `medium` selects native default text generation by omitting the override. The
+  pinned protocol defines `medium` as the default text amount. Supported models
+  still receive explicit `medium`, even when their catalog default differs.
+  Unsupported `low`/`high` and unreadable catalogs fail before model execution;
+  unsupported non-default levels remain an explicit implementation gap.
   Product requests that omit the native option retain their existing defaults.
   Structured output formats remain a separate protocol gap.
 - `function_tools` advertises the optional native function-call bridge. Explicit

--- a/apps/parsar-daemon/internal/agent/codex/model_verbosity.go
+++ b/apps/parsar-daemon/internal/agent/codex/model_verbosity.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -38,7 +39,11 @@ func prepareModelVerbosity(ctx context.Context, binary string, plan *SessionPlan
 		return fmt.Errorf("codex: cannot read model verbosity support: %w", err)
 	}
 	if !supported {
-		return fmt.Errorf("codex: model %q does not declare text verbosity support", plan.Model)
+		if !slices.Contains(plan.ExtraConfig, [2]string{"model_verbosity", `"medium"`}) {
+			return fmt.Errorf("codex: model %q does not declare text verbosity support", plan.Model)
+		}
+		// Protocol medium means the default text amount, which needs no native override.
+		plan.ExtraConfig = slices.DeleteFunc(plan.ExtraConfig, func(kv [2]string) bool { return kv[0] == "model_verbosity" })
 	}
 	codexHome := ""
 	for _, entry := range plan.Env {

--- a/apps/parsar-daemon/internal/agent/codex/model_verbosity_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/model_verbosity_test.go
@@ -64,3 +64,53 @@ func TestPrepareModelVerbosity(t *testing.T) {
 		t.Fatal("accepted unreadable catalog")
 	}
 }
+
+func TestPrepareDefaultModelVerbosity(t *testing.T) {
+	if !SupportsTextVerbosity {
+		t.Skip("catalog probe requires Unix")
+	}
+	t.Setenv("PARSAR_HOME", t.TempDir())
+	binary := filepath.Join(t.TempDir(), "codex")
+	catalog := `{"models":[{"slug":"supported","support_verbosity":true,"default_verbosity":"low"},{"slug":"unsupported","support_verbosity":false}]}`
+	if err := os.WriteFile(binary, []byte("#!/bin/sh\nprintf '%s' '"+catalog+"'\n"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	for _, model := range []string{"supported", "unsupported", "unknown-provider-model"} {
+		for _, level := range []string{"low", "medium", "high"} {
+			t.Run(model+"/"+level, func(t *testing.T) {
+				plan, err := BuildSessionPlan("run", "state", "", map[string]any{"model": model, "model_verbosity": level})
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer func() { plan.Cleanup() }()
+				err = prepareModelVerbosity(context.Background(), binary, &plan)
+				if model != "supported" && level != "medium" {
+					if err == nil {
+						t.Fatal("accepted unsupported non-default verbosity")
+					}
+					return
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				found := false
+				for _, kv := range plan.ExtraConfig {
+					if kv[0] == "model_verbosity" {
+						found = true
+						if kv[1] != `"`+level+`"` {
+							t.Fatal("configured verbosity changed", kv)
+						}
+					}
+				}
+				if found != (model == "supported") || plan.Model != model {
+					t.Fatal("native default or model identity changed", plan.ExtraConfig, plan.Model)
+				}
+				kv := plan.ExtraConfig[len(plan.ExtraConfig)-1]
+				raw, err := os.ReadFile(strings.Trim(kv[1], `"`))
+				if kv[0] != "model_catalog_json" || err != nil || string(raw) != catalog {
+					t.Fatal("native catalog snapshot changed", err)
+				}
+			})
+		}
+	}
+}

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -104,7 +104,7 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Shared daemon connection layer | Implemented; existing product protocol retained |
 | Tenant-scoped Session persistence | Implemented; internal Store, not a public API |
 | Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
-| Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, ordinary text with low/medium/high verbosity (Unix daemon and native model support required), non-deferred function tools, environment `none`, metadata and creation retry keys |
+| Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, ordinary text with low/medium/high verbosity (Unix daemon; non-default levels require native model support), non-deferred function tools, environment `none`, metadata and creation retry keys |
 | Internal Turn/input persistence | Tenant-scoped atomic message/cancel/function-result batches, steering, request-level retry identity, cancellation targets and terminal outcomes; public function-result decoding and mixed-batch admission supported |
 | Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; explicit Codex no-environment execution; public text/cancel submission with a bounded standalone worker |
 | Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items` and tool snapshots via `tool_items`; tenant-scoped paginated Store reads |
@@ -330,6 +330,27 @@ raises. It verifies one invocation per call, retained output/error field presenc
 native application, and termination after the matching Turn completes and Session
 returns idle. These are controlled tests with synthetic model responses. Live
 execution acceptance additionally requires a real model API; provider connectivity
-alone does not prove the Agents API/daemon/harness workflow. Live MiniMax-M3
-execution currently fails the native verbosity capability check because the
-Session defaults to `medium`; this model-support gap remains open.
+alone does not prove the Agents API/daemon/harness workflow.
+
+### Default verbosity on native models
+
+The pinned `AgentTextParam` defines `medium` as the default text amount. Omitted,
+null and explicit `medium` keep the same effective Session configuration and retry
+identity. Supported native models receive the explicit requested level. For
+unsupported or unknown models, the Codex adapter removes a `medium` override and
+uses native defaults while preserving the requested model and catalog snapshot.
+It still rejects unsupported `low`/`high` and unreadable catalogs.
+
+This follows [Codex 0.153.4 request selection](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/core/src/client.rs#L951)
+and its [unknown-model fallback](https://github.com/openai/codex/blob/rust-v0.153.4/codex-rs/models-manager/src/model_info.rs#L134).
+Controlled native verification checks explicit levels on supported models, absent
+verbosity on an unknown model, initial/resumed Turns, and default retry equivalence.
+This does not imply support for non-default verbosity on every model.
+
+Live MiniMax-M3 verification used the pinned SDK, actual service/worker/PostgreSQL,
+daemon and Codex with MiniMax's real Responses API. Two Turns verified a successful
+function result, handler failure, retained result fields, stream termination and
+native history continuity by recalling a random value returned only by the first
+tool invocation. Omitted, null and explicit medium reused the same creation
+identity. The tool data was synthetic; model responses were live. This does not
+establish non-default verbosity, tool-set enforcement or full protocol conformance.

--- a/services/agents-api/internal/store/native_environment_test.go
+++ b/services/agents-api/internal/store/native_environment_test.go
@@ -40,7 +40,7 @@ func TestNativeNoExecutionEnvironment(t *testing.T) {
 			t.Error(err)
 			return
 		}
-		if body["model"] == "custom-provider-model" {
+		if body["model"] == "custom-provider-model" && !strings.Contains(fmt.Sprint(body["input"]), "DEFAULT-VERBOSITY") {
 			t.Error("unsupported verbosity reached model execution")
 		}
 		for _, value := range body["tools"].([]any) {
@@ -58,7 +58,11 @@ func TestNativeNoExecutionEnvironment(t *testing.T) {
 			}
 		}
 		textConfig, _ := body["text"].(map[string]any)
-		if textConfig["verbosity"] != expected {
+		if body["model"] == "custom-provider-model" {
+			if _, present := textConfig["verbosity"]; present {
+				t.Error("native default sent an unsupported verbosity override")
+			}
+		} else if textConfig["verbosity"] != expected {
 			t.Errorf("effective verbosity = %v, want %s", textConfig["verbosity"], expected)
 		}
 		n := requests.Add(1)

--- a/services/agents-api/tests/official_execution.py
+++ b/services/agents-api/tests/official_execution.py
@@ -140,6 +140,17 @@ def main():
                 raise AssertionError("changed text configuration reused a retry key")
             except ConflictError:
                 pass
+        default_agent = {"model": "custom-provider-model"}
+        default = sessions.create(agent=default_agent, environment={"type": "none"},
+                                  extra_headers={"Idempotency-Key": "native-default"})
+        for text in (None, {"verbosity": None}, {"verbosity": "medium"}):
+            configured = sessions.create(agent=dict(default_agent, text=text), environment={"type": "none"},
+                                         extra_headers={"Idempotency-Key": "native-default"})
+            assert configured.id == default.id and configured.agent.text.verbosity == "medium"
+        for count in (1, 2):
+            sessions.events.create(default.id, events=[message("DEFAULT-VERBOSITY")])
+            wait_turn(default.id, "completed", count)
+            assert sessions.retrieve(default.id).agent.text.verbosity == "medium"
         unsupported = sessions.create(agent={"model": "custom-provider-model", "text": {"verbosity": "high"}},
                                       environment={"type": "none"})
         sessions.events.create(unsupported.id, events=[message("UNSUPPORTED-VERBOSITY")])
@@ -151,6 +162,7 @@ def main():
                                               "stream_types": types, "reconnected_events": len(second_events),
                                               "cancelled_events": [value.type for value in cancelled_events],
                                               "verbosity_new_and_resumed": ["low", "medium", "high"],
+                                              "native_default_session": default.id,
                                               "unsupported_verbosity": failed.error.model_dump()}))
     finally:
         client.close()


### PR DESCRIPTION
Sessions using a model without native verbosity support failed before inference even with the protocol default `medium`. Map that default to the model's native text generation while preserving the requested model and catalog snapshot. Supported models still receive explicit low/medium/high; unsupported low/high and unreadable catalogs still fail before execution.

The pinned SDK defines medium as the default text amount. Codex 0.153.4 omits verbosity for unsupported models and its unknown-model fallback. Public schema, effective Session configuration and retry identity remain unchanged. Product callers that omit the override retain their existing defaults.

Validation on `zju_a100_2`: baseline regression reproduced; all Codex adapter tests, controlled native initial/resume and default-equivalence checks, and complete `make check` passed. Real MiniMax-M3 API validation through fixed SDK -> Agents API -> PostgreSQL/worker -> daemon -> Codex completed two Turns with automatic function success/failure, persisted output/error fields, stream termination and recall of a random value from the previous tool result. Tool data was synthetic; model responses were real. OpenAPI/sqlc regeneration is not applicable because no API or query source changed.

Unsupported non-default verbosity, native tool-set enforcement and complete protocol conformance remain separate gaps.

A fresh independent-context subagent reviewed the full diff against the requirements, pinned SDK and native Codex behavior, with no blocking findings or requested changes. The reviewer did not rerun test suites or the live provider workflow; execution evidence above comes from developer-run validation.
