### PR TITLE
feat(agents-api): support Session metadata updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,10 +145,13 @@ path until an explicit client cutover.
   Parsar uses the same public contract as any other client, with no privileged
   endpoint or direct execution-table access. An OpenAI endpoint is a possible
   client target only where the requested capabilities and credentials support it.
-- Maintain tasks, priorities and evidence in the Feishu board. Complete each
-  bounded task and its required checks/review, then mark it done after merge and
-  choose the next dependency. Agent API protocol and atomic execution work takes
-  priority over product integration, UI work and business Team orchestration.
+- Maintain tasks, priorities and evidence in the Feishu board. Register issues
+  discovered during a task without switching work or automatically selecting them
+  next. Only a direct acceptance blocker justifies a minimal in-scope fix. After
+  each bounded task passes checks/review and merges, mark it done, reread the full
+  board and choose the next task by value, dependencies, risk and effort. Agent API
+  protocol and atomic execution work takes priority over product integration, UI
+  work and business Team orchestration.
 
 - Parsar owns users, workspaces, business authorization, Agent/Team definitions,
   capabilities, product conversations, IM/sharing, approval decisions and billing.
@@ -194,6 +197,10 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   Keep credentials and effective execution options out of Session metadata.
   Store resolved, non-secret Agent/environment configuration in the Session's
   immutable configuration snapshot, and include it in creation idempotency checks.
+  Session metadata updates replace only metadata under the authenticated tenant:
+  omission is a read, null/empty clears, and a nonempty object replaces all pairs.
+  Keep execution state, timestamps and the original creation request hash unchanged;
+  creation retries return the current resource without restoring its old metadata.
   Public schema validation belongs to the API; the Store validates JSON structure.
 - `make sqlc-generate` and the drift gate cover both services. Run
   `make check-agents-api` with `PARSAR_AGENTS_API_TEST_DATABASE_URL` pointing to a

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -36,7 +36,7 @@ separate. Each slice can use multiple small PRs tracked in the Feishu board.
 
 This inventory is based on the pinned Python source, not our generated OpenAPI.
 It contains 42 distinct HTTP operations in 15 resource classes, excluding async
-duplicates, overloads and client-side helpers. Eight operations currently have
+duplicates, overloads and client-side helpers. Nine operations currently have
 handlers; that count is not a compatibility score. Even those operations implement
 only part of the upstream input, configuration and event variants.
 
@@ -46,7 +46,7 @@ the Python SDK. Vault HTTP paths start at `/vaults`, not `/agents/vaults`.
 | Resource | Upstream operations | Current coverage |
 | --- | --- | --- |
 | Root reusable Agents | create, retrieve, update, list, delete | Missing |
-| sessions | create, retrieve, update, list, delete | Partial create/retrieve/list; update/delete missing |
+| sessions | create, retrieve, update, list, delete | Partial create/retrieve/list; metadata update implemented; delete missing |
 | sessions.events | create, stream | Text/cancel/function-result admission and live events; function-action state snapshots supported |
 | sessions.turns | retrieve, list | Implemented reads; lifecycle conformance still partial |
 | sessions.items | list | Partial Item variants |
@@ -81,6 +81,11 @@ unsupported errors are implementation gaps, never evidence of full compatibility
   `stream` nor `agent_id` permits null. Metadata omission/null defaults to an empty
   map; individual values must be strings, including valid empty strings. Validate
   these distinctions before persistence rather than coercing null to Go zero values.
+- `POST /agents/sessions/{id}` updates metadata only: omission preserves it,
+  null or `{}` clears it, and an object replaces all pairs. Apply the same string
+  and character limits as creation. Preserve execution state, effective configuration
+  and the original creation retry identity. Fixed SDK/raw HTTP checks cover these
+  distinctions, tenant isolation, active Session reads and restart persistence.
 - `AgentSession` includes the effective agent/environment, Unix-second timestamps,
   `object: agent.session`, metadata, required actions, status, usage and vault IDs.
   A Session remains reusable after its current Turn completes.
@@ -104,7 +109,7 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Shared daemon connection layer | Implemented; existing product protocol retained |
 | Tenant-scoped Session persistence | Implemented; internal Store, not a public API |
 | Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
-| Authenticated Session HTTP API | Create/retrieve/list; inline model/instructions, ordinary text with low/medium/high verbosity (Unix daemon; non-default levels require native model support), non-deferred function tools, environment `none`, metadata and creation retry keys |
+| Authenticated Session HTTP API | Create/retrieve/list and metadata-only update; inline model/instructions, ordinary text with low/medium/high verbosity (Unix daemon; non-default levels require native model support), non-deferred function tools, environment `none`, metadata and creation retry keys |
 | Internal Turn/input persistence | Tenant-scoped atomic message/cancel/function-result batches, steering, request-level retry identity, cancellation targets and terminal outcomes; public function-result decoding and mixed-batch admission supported |
 | Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; explicit Codex no-environment execution; public text/cancel submission with a bounded standalone worker |
 | Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items` and tool snapshots via `tool_items`; tenant-scoped paginated Store reads |

--- a/contracts/agents-api/openapi.yaml
+++ b/contracts/agents-api/openapi.yaml
@@ -573,6 +573,14 @@ definitions:
     - data
     - has_more
     type: object
+  v1.UpdateSessionRequest:
+    properties:
+      metadata:
+        additionalProperties:
+          type: string
+        type: object
+        x-nullable: true
+    type: object
   v1.WebSearchAction:
     properties:
       pattern:
@@ -757,6 +765,62 @@ paths:
       security:
       - BearerAuth: []
       summary: Retrieve an execution Session
+      tags:
+      - Sessions
+    post:
+      consumes:
+      - application/json
+      description: Omit metadata to leave it unchanged, send null or {} to clear it,
+        or supply an object to replace all pairs. Up to 16 string pairs, with keys
+        at most 64 characters and values at most 512 characters. Execution configuration
+        and activity are unchanged.
+      parameters:
+      - description: agents=v1
+        in: header
+        name: OpenAI-Beta
+        required: true
+        type: string
+      - description: Session ID
+        in: path
+        name: session_id
+        required: true
+        type: string
+      - description: Session metadata
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/v1.UpdateSessionRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/v1.Session'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "413":
+          description: Request Entity Too Large
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/v1.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Update execution Session metadata
       tags:
       - Sessions
   /agents/sessions/{session_id}/events:

--- a/contracts/agents-api/v1/sessions.go
+++ b/contracts/agents-api/v1/sessions.go
@@ -14,6 +14,10 @@ type CreateSessionRequest struct {
 	VaultIDs    []string          `json:"vault_ids,omitempty"`
 }
 
+type UpdateSessionRequest struct {
+	Metadata map[string]string `json:"metadata,omitempty" extensions:"x-nullable"`
+}
+
 type InlineAgent struct {
 	Tools        []FunctionToolInput `json:"tools,omitempty" extensions:"x-nullable"`
 	Model        string              `json:"model" binding:"required"`

--- a/services/agents-api/internal/api/configuration.go
+++ b/services/agents-api/internal/api/configuration.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
-	"unicode/utf8"
 
 	v1 "github.com/MiniMax-AI-Dev/parsar/contracts/agents-api/v1"
 	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
@@ -27,13 +26,8 @@ func resolve(input v1.CreateSessionRequest, tenant, key string) (json.RawMessage
 	if input.Environment == nil || input.Environment.Type != "none" {
 		return nil, errors.New("This service currently requires environment.type=none.")
 	}
-	if len(input.Metadata) > 16 {
-		return nil, errors.New("metadata supports at most 16 pairs.")
-	}
-	for k, value := range input.Metadata {
-		if utf8.RuneCountInString(k) > 64 || utf8.RuneCountInString(value) > 512 {
-			return nil, errors.New("metadata keys must be at most 64 characters and values at most 512 characters.")
-		}
+	if err := validateMetadata(input.Metadata); err != nil {
+		return nil, err
 	}
 	text, err := resolveText(input.Agent.Text)
 	if err != nil {

--- a/services/agents-api/internal/api/handler.go
+++ b/services/agents-api/internal/api/handler.go
@@ -20,6 +20,7 @@ type SessionStore interface {
 	ListTurns(context.Context, string, string, string, int, bool) (store.TurnPage, error)
 	CreateSession(context.Context, string, store.CreateSessionInput) (store.Session, error)
 	GetSession(context.Context, string, string) (store.Session, error)
+	UpdateSessionMetadata(context.Context, string, string, map[string]string) (store.Session, error)
 	ListSessions(context.Context, string, string, int, bool) (store.SessionPage, error)
 }
 
@@ -48,6 +49,7 @@ func NewHandler(s SessionStore, auth *Authenticator, engine string, options ...O
 		r.Post("/agents/sessions", h.createSession)
 		r.Get("/agents/sessions", h.listSessions)
 		r.Get("/agents/sessions/{session_id}", h.getSession)
+		r.Post("/agents/sessions/{session_id}", h.updateSession)
 		r.Post("/agents/sessions/{session_id}/events", h.createEvents)
 		r.Get("/agents/sessions/{session_id}/events", h.streamEvents)
 		r.Get("/agents/sessions/{session_id}/items", h.listItems)

--- a/services/agents-api/internal/api/session_metadata.go
+++ b/services/agents-api/internal/api/session_metadata.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"unicode/utf8"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/store"
+	"github.com/go-chi/chi/v5"
+)
+
+// @Summary Update execution Session metadata
+// @Description Omit metadata to leave it unchanged, send null or {} to clear it, or supply an object to replace all pairs. Up to 16 string pairs, with keys at most 64 characters and values at most 512 characters. Execution configuration and activity are unchanged.
+// @Tags Sessions
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param OpenAI-Beta header string true "agents=v1"
+// @Param session_id path string true "Session ID"
+// @Param body body v1.UpdateSessionRequest true "Session metadata"
+// @Success 200 {object} v1.Session
+// @Failure 400,401,404,413,500 {object} v1.ErrorResponse
+// @Router /agents/sessions/{session_id} [post]
+func (h *Handler) updateSession(w http.ResponseWriter, r *http.Request) {
+	if len(r.URL.Query()) > 0 {
+		writeError(w, http.StatusBadRequest, "unsupported_parameter", "Session updates do not accept query parameters.")
+		return
+	}
+	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1024*1024))
+	if err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request_too_large", "Request exceeds 1 MiB.")
+		} else {
+			writeError(w, http.StatusBadRequest, "invalid_request", "Request must contain one JSON object.")
+		}
+		return
+	}
+	var request struct {
+		Metadata json.RawMessage `json:"metadata"`
+	}
+	if err := decodeInputObject(raw, &request, "metadata"); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request", "Request must be a JSON object containing supported fields.")
+		return
+	}
+	var session store.Session
+	if len(request.Metadata) == 0 {
+		session, err = h.store.GetSession(r.Context(), tenantID(r), chi.URLParam(r, "session_id"))
+	} else {
+		var values map[string]*string
+		if err := json.Unmarshal(request.Metadata, &values); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "metadata must be null or an object with string values.")
+			return
+		}
+		var metadata map[string]string
+		metadata, err = stringMetadata(values)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", "metadata values must be strings.")
+			return
+		}
+		if err := validateMetadata(metadata); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+			return
+		}
+		session, err = h.store.UpdateSessionMetadata(r.Context(), tenantID(r), chi.URLParam(r, "session_id"), metadata)
+	}
+	if err != nil {
+		writeStoreError(w, r, err)
+		return
+	}
+	h.respondSession(w, r, session)
+}
+
+func stringMetadata(values map[string]*string) (map[string]string, error) {
+	metadata := make(map[string]string, len(values))
+	for key, value := range values {
+		if value == nil {
+			return nil, store.ErrInvalidInput
+		}
+		metadata[key] = *value
+	}
+	return metadata, nil
+}
+
+func validateMetadata(metadata map[string]string) error {
+	if len(metadata) > 16 {
+		return errors.New("metadata supports at most 16 pairs.")
+	}
+	for key, value := range metadata {
+		if utf8.RuneCountInString(key) > 64 || utf8.RuneCountInString(value) > 512 {
+			return errors.New("metadata keys must be at most 64 characters and values at most 512 characters.")
+		}
+	}
+	return nil
+}

--- a/services/agents-api/internal/api/session_request.go
+++ b/services/agents-api/internal/api/session_request.go
@@ -31,14 +31,7 @@ func (request decodedSessionRequest) validated() (v1.CreateSessionRequest, error
 			return input, store.ErrInvalidInput
 		}
 	}
-	if request.Metadata != nil {
-		input.Metadata = make(map[string]string, len(request.Metadata))
-		for key, value := range request.Metadata {
-			if value == nil {
-				return input, store.ErrInvalidInput
-			}
-			input.Metadata[key] = *value
-		}
-	}
-	return input, nil
+	var err error
+	input.Metadata, err = stringMetadata(request.Metadata)
+	return input, err
 }

--- a/services/agents-api/internal/db/queries/sessions.sql
+++ b/services/agents-api/internal/db/queries/sessions.sql
@@ -21,3 +21,6 @@ ORDER BY
     CASE WHEN NOT sqlc.arg(ascending)::boolean THEN created_at END DESC,
     CASE WHEN NOT sqlc.arg(ascending)::boolean THEN id END DESC
 LIMIT sqlc.arg(page_limit);
+
+-- name: UpdateSessionMetadata :one
+UPDATE sessions SET metadata = $3 WHERE tenant_id = $1 AND id = $2 RETURNING *;

--- a/services/agents-api/internal/db/sqlc/sessions.sql.go
+++ b/services/agents-api/internal/db/sqlc/sessions.sql.go
@@ -138,3 +138,30 @@ func (q *Queries) ListSessions(ctx context.Context, arg ListSessionsParams) ([]S
 	}
 	return items, nil
 }
+
+const updateSessionMetadata = `-- name: UpdateSessionMetadata :one
+UPDATE sessions SET metadata = $3 WHERE tenant_id = $1 AND id = $2 RETURNING id, tenant_id, engine, metadata, idempotency_key, request_hash, created_at, configuration, event_sequence
+`
+
+type UpdateSessionMetadataParams struct {
+	TenantID pgtype.UUID `json:"tenant_id"`
+	ID       pgtype.UUID `json:"id"`
+	Metadata []byte      `json:"metadata"`
+}
+
+func (q *Queries) UpdateSessionMetadata(ctx context.Context, arg UpdateSessionMetadataParams) (Session, error) {
+	row := q.db.QueryRow(ctx, updateSessionMetadata, arg.TenantID, arg.ID, arg.Metadata)
+	var i Session
+	err := row.Scan(
+		&i.ID,
+		&i.TenantID,
+		&i.Engine,
+		&i.Metadata,
+		&i.IdempotencyKey,
+		&i.RequestHash,
+		&i.CreatedAt,
+		&i.Configuration,
+		&i.EventSequence,
+	)
+	return i, err
+}

--- a/services/agents-api/internal/store/session_metadata.go
+++ b/services/agents-api/internal/store/session_metadata.go
@@ -1,0 +1,49 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/MiniMax-AI-Dev/parsar/services/agents-api/internal/db/sqlc"
+	"github.com/jackc/pgx/v5"
+)
+
+func (s *Store) UpdateSessionMetadata(ctx context.Context, tenantID, sessionID string, metadata map[string]string) (Session, error) {
+	tenant, err := parseID(tenantID)
+	if err != nil {
+		return Session{}, err
+	}
+	id, err := parseID(sessionID)
+	if err != nil {
+		return Session{}, err
+	}
+	encoded, err := encodeSessionMetadata(metadata)
+	if err != nil {
+		return Session{}, err
+	}
+	row, err := s.queries.UpdateSessionMetadata(ctx, sqlc.UpdateSessionMetadataParams{TenantID: tenant, ID: id, Metadata: encoded})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Session{}, ErrNotFound
+	}
+	if err != nil {
+		return Session{}, fmt.Errorf("update session metadata: %w", err)
+	}
+	session, decodeErr := sessionFromRow(row)
+	return s.sessionActivity(ctx, session, decodeErr)
+}
+
+func encodeSessionMetadata(metadata map[string]string) ([]byte, error) {
+	if metadata == nil {
+		metadata = map[string]string{}
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("%w: metadata: %v", ErrInvalidInput, err)
+	}
+	if len(encoded) > 64*1024 {
+		return nil, fmt.Errorf("%w: metadata exceeds 64 KiB", ErrInvalidInput)
+	}
+	return encoded, nil
+}

--- a/services/agents-api/internal/store/session_metadata_test.go
+++ b/services/agents-api/internal/store/session_metadata_test.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestSessionMetadataPreservesCreationAndExecutionData(t *testing.T) {
+	s, pool := testStore(t)
+	ctx := context.Background()
+	tenant := uuid.NewString()
+	input := CreateSessionInput{Engine: "codex", IdempotencyKey: "metadata-update", Metadata: map[string]string{"old": "value"}, Configuration: []byte(`{"agent":{"model":"test-model"},"environment":{"type":"none"}}`)}
+	first, err := s.CreateSession(ctx, tenant, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := func() string {
+		t.Helper()
+		var row string
+		if err := pool.QueryRow(ctx, "SELECT (to_jsonb(s) - 'metadata')::text FROM sessions s WHERE tenant_id=$1 AND id=$2", tenant, first.ID).Scan(&row); err != nil {
+			t.Fatal(err)
+		}
+		return row
+	}
+	before := snapshot()
+	for _, metadata := range []map[string]string{{"new": "value"}, nil, {}, {"unicode": "中文🧪"}} {
+		updated, err := s.UpdateSessionMetadata(ctx, tenant, first.ID, metadata)
+		if metadata == nil {
+			metadata = map[string]string{}
+		}
+		if err != nil || !reflect.DeepEqual(updated.Metadata, metadata) {
+			t.Fatalf("update = %+v, %v", updated, err)
+		}
+		if snapshot() != before {
+			t.Fatal("metadata update changed other stored Session fields")
+		}
+		retry, err := s.CreateSession(ctx, tenant, input)
+		if err != nil || !reflect.DeepEqual(retry, updated) {
+			t.Fatalf("creation retry = %+v, %v", retry, err)
+		}
+		changed := input
+		changed.Metadata = metadata
+		if _, err := s.CreateSession(ctx, tenant, changed); !errors.Is(err, ErrIdempotencyConflict) {
+			t.Fatalf("changed creation request: %v", err)
+		}
+	}
+	current, err := s.GetSession(ctx, tenant, first.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		tenant, session string
+		metadata        map[string]string
+		want            error
+	}{
+		{uuid.NewString(), first.ID, nil, ErrNotFound},
+		{tenant, uuid.NewString(), nil, ErrNotFound},
+		{"invalid", first.ID, nil, ErrInvalidInput},
+		{tenant, "invalid", nil, ErrInvalidInput},
+		{tenant, first.ID, map[string]string{"large": strings.Repeat("x", 64*1024)}, ErrInvalidInput},
+	} {
+		if _, err := s.UpdateSessionMetadata(ctx, test.tenant, test.session, test.metadata); !errors.Is(err, test.want) {
+			t.Fatalf("rejected update error = %v, want %v", err, test.want)
+		}
+	}
+	got, err := s.GetSession(ctx, tenant, first.ID)
+	if err != nil || !reflect.DeepEqual(got, current) {
+		t.Fatalf("rejected update changed Session: %+v, %v", got, err)
+	}
+}
+
+func TestSessionMetadataConcurrentReplacement(t *testing.T) {
+	s, _ := testStore(t)
+	ctx := context.Background()
+	tenant := uuid.NewString()
+	first, err := s.CreateSession(ctx, tenant, CreateSessionInput{Engine: "codex", IdempotencyKey: "concurrent-metadata"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			key := fmt.Sprint(i)
+			got, err := s.UpdateSessionMetadata(ctx, tenant, first.ID, map[string]string{key: key})
+			if err != nil || len(got.Metadata) != 1 || got.Metadata[key] != key {
+				t.Errorf("concurrent update = %+v, %v", got, err)
+			}
+		}()
+	}
+	wg.Wait()
+	got, err := s.GetSession(ctx, tenant, first.ID)
+	if err != nil || len(got.Metadata) != 1 {
+		t.Fatalf("concurrent replacements merged or lost metadata: %+v, %v", got, err)
+	}
+}
+
+func TestSessionMetadataPreservesTerminalActivity(t *testing.T) {
+	s, _ := testStore(t)
+	ctx := context.Background()
+	tenant := uuid.NewString()
+	session, err := s.CreateSession(ctx, tenant, CreateSessionInput{Engine: "codex", IdempotencyKey: "terminal-metadata"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, status := range []string{TurnCompleted, TurnFailed, TurnCancelled} {
+		receipt, err := s.SubmitMessage(ctx, tenant, session.ID, uuid.NewString(), []byte(`{"text":"metadata fixture"}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.TransitionTurn(ctx, tenant, session.ID, receipt.TurnID, TurnTransition{ExpectedStatus: TurnQueued, Status: TurnInProgress}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.TransitionTurn(ctx, tenant, session.ID, receipt.TurnID, TurnTransition{ExpectedStatus: TurnInProgress, Status: status}); err != nil {
+			t.Fatal(err)
+		}
+		before, err := s.GetSession(ctx, tenant, session.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		before.Metadata = map[string]string{"label": status}
+		updated, err := s.UpdateSessionMetadata(ctx, tenant, session.ID, before.Metadata)
+		if err != nil || !reflect.DeepEqual(updated, before) {
+			t.Fatalf("metadata changed %s activity: %+v, %v", status, updated, err)
+		}
+	}
+}

--- a/services/agents-api/internal/store/sessions.go
+++ b/services/agents-api/internal/store/sessions.go
@@ -77,12 +77,9 @@ func (s *Store) CreateSession(ctx context.Context, tenantID string, input Create
 	if input.Metadata == nil {
 		input.Metadata = map[string]string{}
 	}
-	metadata, err := json.Marshal(input.Metadata)
+	metadata, err := encodeSessionMetadata(input.Metadata)
 	if err != nil {
-		return Session{}, fmt.Errorf("%w: metadata: %v", ErrInvalidInput, err)
-	}
-	if len(metadata) > 64*1024 {
-		return Session{}, fmt.Errorf("%w: metadata exceeds 64 KiB", ErrInvalidInput)
+		return Session{}, err
 	}
 	if len(input.Configuration) > 512*1024 {
 		return Session{}, fmt.Errorf("%w: configuration exceeds 512 KiB", ErrInvalidInput)

--- a/services/agents-api/tests/official_client.py
+++ b/services/agents-api/tests/official_client.py
@@ -20,6 +20,7 @@ import httpx2
 from jsonschema import Draft4Validator
 from official_items import verify_items
 from official_session_requests import verify_session_create_requests
+from official_session_metadata import verify_session_metadata, verify_active_session_metadata
 from openai import AuthenticationError, BadRequestError, ConflictError, NotFoundError, OpenAI
 import yaml
 
@@ -145,6 +146,7 @@ def main():
                     large = sessions.create(**spec, metadata=metadata)
                     assert sessions.retrieve(large.id).metadata == metadata
                     request_sessions = verify_session_create_requests(a, spec)
+                    request_sessions.append(verify_session_metadata(a, b, invalid, spec, expect_error))
                     turn_session = sessions.create(**spec)
                     fixture = Path(directory) / "turns.json"
                     fixture.write_text(json.dumps({"tenant": bindings[0]["tenant_id"], "session": turn_session.id}))
@@ -171,6 +173,7 @@ def main():
                     expect_error(NotFoundError, lambda: turns.list(first.id, after=turn_ids[0]))
                     expect_error(BadRequestError, lambda: turns.list(turn_session.id, limit=101))
                     saved_items = verify_items(a, b, invalid, turn_session.id, first.id, turn_ids, expect_error)
+                    request_sessions.append(verify_active_session_metadata(a, turn_session.id))
                     process.terminate()
                     process.wait(timeout=15)
                     process = start()

--- a/services/agents-api/tests/official_session_metadata.py
+++ b/services/agents-api/tests/official_session_metadata.py
@@ -1,0 +1,92 @@
+"Verify pinned Session metadata replacement through the actual HTTP service."
+
+import json
+import uuid
+
+import httpx2
+from openai import AuthenticationError, BadRequestError, ConflictError, NotFoundError
+
+
+def without_metadata(session):
+    return {key: value for key, value in session.to_dict().items() if key != "metadata"}
+
+
+def verify_session_metadata(client, other, invalid, spec, expect_error):
+    sessions = client.beta.agents.sessions
+    original = {"old": "remove", "keep": "replace"}
+    retry = {"Idempotency-Key": str(uuid.uuid4())}
+    first = sessions.create(**spec, metadata=original, extra_headers=retry)
+    fixed = without_metadata(first)
+    headers = {"Authorization": f"Bearer {client.api_key}", "OpenAI-Beta": "agents=v1"}
+    url = str(client.base_url).rstrip("/") + "/agents/sessions/" + first.id
+
+    def assert_metadata(session, expected):
+        assert session.metadata == expected
+        assert without_metadata(session) == fixed
+        assert sessions.retrieve(first.id) == session
+        assert next(item for item in sessions.list(limit=1) if item.id == first.id) == session
+        return session
+
+    assert_metadata(sessions.update(first.id), original)
+    with httpx2.Client(trust_env=False, timeout=10) as raw:
+        for metadata in [{"keep": "new", "empty": ""}, None, {},
+                         {"🧪" * 64: "界" * 512, **{str(i): "🧪" * 512 for i in range(15)}}]:
+            expected = metadata or {}
+            assert_metadata(sessions.update(first.id, metadata=metadata), expected)
+            # Reset between HTTP and SDK updates so both must actually replace values.
+            sessions.update(first.id, metadata=original)
+            response = raw.post(url, headers=headers, json={"metadata": metadata})
+            assert response.status_code == 200 and response.headers["cache-control"] == "no-store"
+            assert response.json()["metadata"] == expected
+            current = assert_metadata(sessions.retrieve(first.id), expected)
+            assert response.json() == current.to_dict()
+            assert sessions.update(first.id) == current
+            assert raw.post(url, headers=headers, json={}).json() == current.to_dict()
+            # Updating metadata must not rewrite or reapply the original creation request.
+            assert sessions.create(**spec, metadata=original, extra_headers=retry) == current
+            expect_error(ConflictError, lambda: sessions.create(**spec, metadata=metadata, extra_headers=retry))
+
+        invalid_fields = [
+            {"metadata": []}, {"metadata": "value"}, {"metadata": False},
+            {"metadata": {"key": None}}, {"metadata": {"key": 1}},
+            {"metadata": {"key": []}}, {"metadata": {"key": {}}},
+            {"metadata": {str(i): "value" for i in range(17)}},
+            {"metadata": {"界" * 65: "value"}}, {"metadata": {"key": "🧪" * 513}},
+            {"agent": spec["agent"]}, {"environment": spec["environment"]},
+            {"tenant_id": str(uuid.uuid4())}, {"Metadata": {}},
+        ]
+        for fields in invalid_fields:
+            response = raw.post(url, headers=headers, json=fields)
+            assert response.status_code == 400 and response.json()["error"]["code"] == "invalid_request"
+            expect_error(BadRequestError, lambda: sessions.update(first.id, extra_body=fields))
+            assert sessions.retrieve(first.id) == current
+        for body in ["", "null", "[]", "1", "{}{}", '{"metadata":']:
+            response = raw.post(url, headers=headers, content=body)
+            assert response.status_code == 400 and response.json()["error"]["code"] == "invalid_request"
+        oversized = json.dumps({"metadata": {"key": "x" * (1024 * 1024)}})
+        response = raw.post(url, headers=headers, content=oversized)
+        assert response.status_code == 413 and response.json()["error"]["code"] == "request_too_large"
+        assert raw.patch(url, headers=headers, json={"metadata": {}}).status_code == 405
+        for path in [url + "?tenant_id=other", url + "?unsupported=1"]:
+            assert raw.post(path, headers=headers, json={}).status_code == 400
+        for target in [other, invalid]:
+            expected_error = AuthenticationError if target is invalid else NotFoundError
+            for fields in [{}, {"metadata": None}, {"metadata": {"tenant_id": "untrusted"}}]:
+                expect_error(expected_error, lambda: target.beta.agents.sessions.update(first.id, **fields))
+        expect_error(NotFoundError, lambda: sessions.update(str(uuid.uuid4()), metadata={}))
+        expect_error(NotFoundError, lambda: sessions.update(str(uuid.uuid4())))
+        expect_error(BadRequestError, lambda: sessions.update("invalid-id", metadata={}))
+        expect_error(BadRequestError, lambda: sessions.update(first.id, extra_headers={"OpenAI-Beta": ""}))
+        assert sessions.retrieve(first.id) == current
+    print("Session metadata: pinned SDK and raw HTTP replacement, clearing, omission, limits, authentication, tenant isolation, unchanged configuration and creation retry identity passed.")
+    return current
+
+
+def verify_active_session_metadata(client, session_id):
+    sessions = client.beta.agents.sessions
+    before = sessions.retrieve(session_id)
+    assert before.status == "in_progress"
+    updated = sessions.update(session_id, metadata={"label": "active execution"})
+    assert updated.metadata == {"label": "active execution"}
+    assert without_metadata(updated) == without_metadata(before)
+    return updated


### PR DESCRIPTION
Add the pinned `POST /v1/agents/sessions/{session_id}` metadata update. Omitted metadata leaves the resource unchanged; null or an empty object clears it; a nonempty object replaces all pairs. Reuse create-time validation and existing Session/error projections, with tenant-scoped writes that preserve effective configuration, activity and the original creation retry identity.

The change is limited to metadata updates, generated OpenAPI/sqlc artifacts and relevant checks/documentation. Session delete, initial-input/stream creation, saved Agents and product cutover remain separate work. The contributor guide also records the user's clarified rule: newly found issues go into Feishu and do not automatically become the next task.

Validation:
- `make openapi`, `make sqlc-generate` and complete `make check` on `zju_a100_2`.
- Fixed Python SDK 3.13.0 at the upstream manifest commit plus raw HTTP: replacement/clear/omission, exact limits and Unicode, invalid requests, authentication/tenant isolation, unchanged configuration, creation retries, read/list and process restart.
- Real PostgreSQL: concurrent replacement, unchanged stored Session fields and completed/failed/cancelled Turn activity.
- Real MiniMax-M3 Responses API through the service, worker, daemon and native Codex: metadata updates before execution, while waiting for function results and after completion. Required actions, effective configuration, Usage, public results and native history continuity were preserved across two Turns. Synthetic tool data was used; model calls were real. The credential and paid-test proof stay outside the repository.

Review: a fresh independent-context subagent reviewed all 15 changed files against the pinned requirements, task boundaries and contributor rules. No blocking findings. It independently ran API Go tests, Python syntax checks and diff hygiene; it did not rerun the complete gate, database write regressions or paid model calls. Those results are from developer verification above.

Deferred finding: `API-JSON-001` is queued in Feishu as P3. Metadata containing U+0000 reaches PostgreSQL jsonb, which rejects it; HTTP 500 follows from the error mapping (SQL rejection was reproduced, HTTP behavior inferred). The same storage limitation already affects creation. Resolve its upstream semantics and storage/error strategy separately when board priority warrants it. No automatic follow-up is selected.

This does not establish complete Agents API compatibility or resolve the remaining Session/event/error variants. No product schema or execution-path change is included.
