### PR TITLE
fix(agents-api): enforce disabled native subagents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,10 @@ path until an explicit client cutover.
   each bounded task passes checks/review and merges, mark it done, reread the full
   board and choose the next task by value, dependencies, risk and effort. Agent API
   protocol and atomic execution work takes priority over product integration, UI
-  work and business Team orchestration.
+  work and business Team orchestration. Prioritize a sound architecture skeleton
+  and correct principal workflows with real API validation. Record and defer
+  low-frequency corner cases when risk and ROI permit; do not let minor details
+  delay the main work. Required checks and material correctness guarantees apply.
 
 - Parsar owns users, workspaces, business authorization, Agent/Team definitions,
   capabilities, product conversations, IM/sharing, approval decisions and billing.
@@ -301,6 +304,14 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   unsupported non-default levels remain an explicit implementation gap.
   Product requests that omit the native option retain their existing defaults.
   Structured output formats remain a separate protocol gap.
+- `subagent_control` advertises native subagent tool control. Agents API requires
+  it when resolved `multi_agent.enabled` is false and sends the typed internal
+  `disable_subagents` policy on both new and resumed Turns. Native translation
+  stays in the adapter: Codex disables both multi-agent feature generations,
+  overriding operator feature preferences. Product prompts that omit the policy
+  retain their defaults. Enabled multi-agent execution and public Subagent
+  resources remain separate implementation gaps; the Agent tools list is not
+  proven to enumerate every harness-internal utility.
 - `function_tools` advertises the optional native function-call bridge. Explicit
   prompt definitions become Codex dynamic tools; unchanged prompts carry none.
   Requests and ordered text/image results are scoped by Run and native call ID.

--- a/apps/parsar-daemon/internal/agent/codex/session.go
+++ b/apps/parsar-daemon/internal/agent/codex/session.go
@@ -126,6 +126,10 @@ func newSession(parent context.Context, req proto.PromptRequestPayload, out chan
 		return nil, fmt.Errorf("codex: build session plan: %w", err)
 	}
 
+	if req.DisableSubagents {
+		disableSubagents(&plan)
+	}
+
 	if stringOpt(req.AgentOptions, "model_verbosity") != "" {
 		if err := prepareModelVerbosity(parent, cfg.codexBinary, &plan); err != nil {
 			plan.Cleanup()

--- a/apps/parsar-daemon/internal/agent/codex/subagents.go
+++ b/apps/parsar-daemon/internal/agent/codex/subagents.go
@@ -1,0 +1,13 @@
+package codex
+
+import "slices"
+
+func disableSubagents(plan *SessionPlan) {
+	// Native v1 and v2 controls must override operator feature preferences.
+	for _, feature := range []string{"multi_agent", "multi_agent_v2"} {
+		plan.EnableFeatures = slices.DeleteFunc(plan.EnableFeatures, func(value string) bool { return value == feature })
+		if !slices.Contains(plan.DisableFeatures, feature) {
+			plan.DisableFeatures = append(plan.DisableFeatures, feature)
+		}
+	}
+}

--- a/apps/parsar-daemon/internal/agent/codex/subagents_test.go
+++ b/apps/parsar-daemon/internal/agent/codex/subagents_test.go
@@ -1,0 +1,18 @@
+package codex
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDisableSubagentsOverridesNativeFeaturePreferences(t *testing.T) {
+	plan := SessionPlan{
+		EnableFeatures:  []string{"multi_agent", "unrelated", "multi_agent_v2"},
+		DisableFeatures: []string{"another", "multi_agent"},
+	}
+	disableSubagents(&plan)
+	if !reflect.DeepEqual(plan.EnableFeatures, []string{"unrelated"}) ||
+		!reflect.DeepEqual(plan.DisableFeatures, []string{"another", "multi_agent", "multi_agent_v2"}) {
+		t.Fatal(plan.EnableFeatures, plan.DisableFeatures)
+	}
+}

--- a/apps/parsar-daemon/internal/cli/connect.go
+++ b/apps/parsar-daemon/internal/cli/connect.go
@@ -267,6 +267,7 @@ func discoverAgentCLIs(rc *runContext, checks agentCLIChecks) (agentCLIDiscovery
 				EnvironmentNone:  true,
 				WebSearchControl: true,
 				TextVerbosity:    codex.SupportsTextVerbosity,
+				SubagentControl:  true,
 			},
 		},
 		Pi: proto.SupportedAgentKind{

--- a/apps/parsar-daemon/internal/cli/connect_test.go
+++ b/apps/parsar-daemon/internal/cli/connect_test.go
@@ -174,7 +174,7 @@ func TestDiscoverAgentCLIsBothAvailable(t *testing.T) {
 	if !got.ClaudeCode.Capabilities.Permissions || !got.ClaudeCode.Capabilities.Resume {
 		t.Fatalf("ClaudeCode capabilities = %#v", got.ClaudeCode.Capabilities)
 	}
-	if got.Codex.Capabilities.TextVerbosity != codex.SupportsTextVerbosity || !got.Codex.Capabilities.WebSearchControl || !got.Codex.Capabilities.EnvironmentNone || !got.Codex.Capabilities.ToolItems || !got.Codex.Capabilities.MessageItems || !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
+	if !got.Codex.Capabilities.SubagentControl || got.Codex.Capabilities.TextVerbosity != codex.SupportsTextVerbosity || !got.Codex.Capabilities.WebSearchControl || !got.Codex.Capabilities.EnvironmentNone || !got.Codex.Capabilities.ToolItems || !got.Codex.Capabilities.MessageItems || !got.Codex.Capabilities.Streaming || !got.Codex.Capabilities.Permissions || !got.Codex.Capabilities.Resume {
 		t.Fatalf("Codex capabilities = %#v (want Streaming+Permissions+Resume)", got.Codex.Capabilities)
 	}
 	if !got.Pi.Available || got.Pi.Version != "pi 0.1.0" {

--- a/contracts/agents-api/README.md
+++ b/contracts/agents-api/README.md
@@ -111,7 +111,7 @@ unsupported errors are implementation gaps, never evidence of full compatibility
 | Effective Session configuration persistence | Implemented; immutable JSON snapshot and retry identity |
 | Authenticated Session HTTP API | Create/retrieve/list and metadata-only update; inline model/instructions, ordinary text with low/medium/high verbosity (Unix daemon; non-default levels require native model support), non-deferred function tools, environment `none`, metadata and creation retry keys |
 | Internal Turn/input persistence | Tenant-scoped atomic message/cancel/function-result batches, steering, request-level retry identity, cancellation targets and terminal outcomes; public function-result decoding and mixed-batch admission supported |
-| Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; explicit Codex no-environment execution; public text/cancel submission with a bounded standalone worker |
+| Internal Turn execution | Bound daemon dispatch, strict native resume, receipt-based steering/cancellation; explicit Codex no-environment execution and disabled native subagent tools for the resolved false default; public text/cancel submission with a bounded standalone worker |
 | Internal execution observations | Ordered durable text/tool/usage journal and terminal outcome; partial cancellation output retained; optional native message IDs/phase/completion via `message_items` and tool snapshots via `tool_items`; tenant-scoped paginated Store reads |
 | Public Turn recovery | Retrieve/list persisted states with scoped pagination; see limitations below |
 | Public Items recovery | Indexed message/command/MCP/function/web-search reads, scoped pagination and restart recovery; limitations below |
@@ -143,6 +143,21 @@ Agent references/filtering, structured output, other agent options, vaults, init
 and execution/provider resources are not supported by this slice. Reject them
 explicitly. `AGENTS_API_ENGINE` selects the service's engine independently of the
 requested model; it does not add a competing field to the upstream request.
+
+### Native subagent control
+
+The pinned `types/beta/multi_agent_config.py` defines `enabled=false` as disabling
+subagent tools. The dispatcher enforces that effective value with a typed daemon
+policy and capability admission; the Codex adapter applies native feature controls
+on fresh and resumed Turns. Operator feature preferences cannot re-enable them.
+Controlled model-boundary tests check absence of direct/deferred subagent tools
+while the official function workflow continues to run.
+
+Explicit inline `multi_agent` input, enabled multi-agent execution and public
+Subagent resources are still unsupported. Do not infer that `Agent.tools` is the
+complete native tool registry: environment and subagent tools have separate
+configuration. The upstream behavior of internal Goal, Skills and user-input
+utilities needs further evidence; their presence alone is not proof of a mismatch.
 
 ### Turn recovery reads
 

--- a/internal/agentdaemon/device/state.go
+++ b/internal/agentdaemon/device/state.go
@@ -70,6 +70,7 @@ type KindCapabilities struct {
 	EnvironmentNone    bool `json:"environment_none,omitempty"`
 	WebSearchControl   bool `json:"web_search_control,omitempty"`
 	TextVerbosity      bool `json:"text_verbosity,omitempty"`
+	SubagentControl    bool `json:"subagent_control,omitempty"`
 	FunctionTools      bool `json:"function_tools,omitempty"`
 	DurableTurns       bool `json:"durable_turns,omitempty"`
 	WorkspaceAuthoring bool `json:"workspace_authoring,omitempty"`

--- a/internal/agentdaemon/gateway/session.go
+++ b/internal/agentdaemon/gateway/session.go
@@ -536,6 +536,7 @@ func deviceKindsFromHeartbeat(p proto.HeartbeatPayload) []device.SupportedAgentK
 				EnvironmentNone:    info.Capabilities.EnvironmentNone,
 				WebSearchControl:   info.Capabilities.WebSearchControl,
 				TextVerbosity:      info.Capabilities.TextVerbosity,
+				SubagentControl:    info.Capabilities.SubagentControl,
 				FunctionTools:      info.Capabilities.FunctionTools,
 				WorkspaceAuthoring: info.Capabilities.WorkspaceAuthoring,
 			},

--- a/internal/agentdaemon/gateway/session_test.go
+++ b/internal/agentdaemon/gateway/session_test.go
@@ -405,7 +405,7 @@ func TestSession_HeartbeatPersistsSupportedAgentKinds(t *testing.T) {
 			{
 				Kind:         "codex",
 				Available:    true,
-				Capabilities: proto.AgentKindCapabilities{Steering: true, MessageItems: true, ToolItems: true, EnvironmentNone: true, WebSearchControl: true, TextVerbosity: true},
+				Capabilities: proto.AgentKindCapabilities{Steering: true, MessageItems: true, ToolItems: true, EnvironmentNone: true, WebSearchControl: true, TextVerbosity: true, SubagentControl: true},
 			},
 		},
 	})
@@ -431,7 +431,7 @@ func TestSession_HeartbeatPersistsSupportedAgentKinds(t *testing.T) {
 	if opencode.Available || opencode.Version != "missing" || !opencode.Capabilities.Streaming {
 		t.Fatalf("opencode descriptor not converted: %#v", opencode)
 	}
-	if !byKind["codex"].Capabilities.TextVerbosity || claude.Capabilities.TextVerbosity || opencode.Capabilities.TextVerbosity || !byKind["codex"].Capabilities.WebSearchControl || claude.Capabilities.WebSearchControl || opencode.Capabilities.WebSearchControl || !byKind["codex"].Capabilities.EnvironmentNone || claude.Capabilities.EnvironmentNone || opencode.Capabilities.EnvironmentNone || !byKind["codex"].Capabilities.ToolItems || claude.Capabilities.ToolItems || opencode.Capabilities.ToolItems || !byKind["codex"].Capabilities.MessageItems || !byKind["codex"].Capabilities.Steering || claude.Capabilities.Steering || opencode.Capabilities.Steering {
+	if !byKind["codex"].Capabilities.SubagentControl || claude.Capabilities.SubagentControl || opencode.Capabilities.SubagentControl || !byKind["codex"].Capabilities.TextVerbosity || claude.Capabilities.TextVerbosity || opencode.Capabilities.TextVerbosity || !byKind["codex"].Capabilities.WebSearchControl || claude.Capabilities.WebSearchControl || opencode.Capabilities.WebSearchControl || !byKind["codex"].Capabilities.EnvironmentNone || claude.Capabilities.EnvironmentNone || opencode.Capabilities.EnvironmentNone || !byKind["codex"].Capabilities.ToolItems || claude.Capabilities.ToolItems || opencode.Capabilities.ToolItems || !byKind["codex"].Capabilities.MessageItems || !byKind["codex"].Capabilities.Steering || claude.Capabilities.Steering || opencode.Capabilities.Steering {
 		t.Fatalf("steering capability not preserved: %#v", byKind)
 	}
 	codex, found, known := sess.AgentKindStatus("codex")

--- a/internal/agentdaemon/proto/inbound.go
+++ b/internal/agentdaemon/proto/inbound.go
@@ -259,6 +259,7 @@ type AgentKindCapabilities struct {
 	EnvironmentNone    bool `json:"environment_none,omitempty"`
 	WebSearchControl   bool `json:"web_search_control,omitempty"`
 	TextVerbosity      bool `json:"text_verbosity,omitempty"`
+	SubagentControl    bool `json:"subagent_control,omitempty"`
 	// DurableTurns includes strict resume, completion release and cancellation snapshots.
 	DurableTurns  bool `json:"durable_turns,omitempty"`
 	FunctionTools bool `json:"function_tools,omitempty"`

--- a/internal/agentdaemon/proto/outbound.go
+++ b/internal/agentdaemon/proto/outbound.go
@@ -83,6 +83,7 @@ type PromptRequestPayload struct {
 	ObserveTools                bool           `json:"observe_tools,omitempty"`
 	FunctionTools               []FunctionTool `json:"function_tools,omitempty"`
 	DisableExecutionEnvironment bool           `json:"disable_execution_environment,omitempty"`
+	DisableSubagents            bool           `json:"disable_subagents,omitempty"`
 }
 
 // PromptAttachment is one piece of non-text user input the daemon-side

--- a/services/agents-api/internal/execution/dispatcher.go
+++ b/services/agents-api/internal/execution/dispatcher.go
@@ -68,6 +68,9 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 	if json.Unmarshal(session.Configuration, &snapshot) != nil || strings.TrimSpace(snapshot.Agent.Model) == "" {
 		return store.Turn{}, store.ErrInvalidInput
 	}
+	if !snapshot.Agent.MultiAgent.Enabled && !info.Capabilities.SubagentControl {
+		return store.Turn{}, errors.New("device must advertise subagent_control")
+	}
 	functions, err := functionTools(snapshot.Agent.Tools)
 	if err != nil {
 		return store.Turn{}, err
@@ -110,7 +113,7 @@ func (d *Dispatcher) Run(ctx context.Context, tenantID, sessionID, turnID string
 	if _, err := d.Store.TransitionTurn(ctx, tenantID, sessionID, turnID, store.TurnTransition{ExpectedStatus: store.TurnQueued, Status: store.TurnInProgress}); err != nil {
 		return store.Turn{}, err
 	}
-	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, FunctionTools: functions, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true, StrictResume: true, ObserveMessages: info.Capabilities.MessageItems, ObserveTools: info.Capabilities.ToolItems, DisableExecutionEnvironment: noEnvironment}
+	req := proto.PromptRequestPayload{AgentKind: session.Engine, ConversationID: sessionID, RunID: turnID, Prompt: text, WorkDir: workDir, FunctionTools: functions, AgentOptions: options, AgentStateKey: "agents-api-" + sessionID, AgentSessionID: bound.NativeSessionID, ReleaseOnCompletion: true, StrictResume: true, ObserveMessages: info.Capabilities.MessageItems, ObserveTools: info.Capabilities.ToolItems, DisableExecutionEnvironment: noEnvironment, DisableSubagents: !snapshot.Agent.MultiAgent.Enabled}
 	result, status := d.deliver(ctx, tenantID, sessionID, peer, req, through)
 	if result.Done.Usage.Model == "" {
 		result.Done.Usage.Model = snapshot.Agent.Model

--- a/services/agents-api/internal/execution/worker.go
+++ b/services/agents-api/internal/execution/worker.go
@@ -185,7 +185,7 @@ func (w *Worker) ready(deviceID string, functions bool) bool {
 		return false
 	}
 	info, found, known := peer.AgentKindStatus("codex")
-	return found && known && info.Available && info.Capabilities.Streaming && info.Capabilities.Steering && info.Capabilities.DurableTurns && info.Capabilities.EnvironmentNone && info.Capabilities.WebSearchControl && info.Capabilities.TextVerbosity && (!functions || info.Capabilities.FunctionTools)
+	return found && known && info.Available && info.Capabilities.Streaming && info.Capabilities.Steering && info.Capabilities.DurableTurns && info.Capabilities.EnvironmentNone && info.Capabilities.WebSearchControl && info.Capabilities.TextVerbosity && info.Capabilities.SubagentControl && (!functions || info.Capabilities.FunctionTools)
 }
 
 func (w *Worker) runClaim(ctx context.Context, item store.ExecutionWork) error {

--- a/services/agents-api/internal/store/dispatch_test.go
+++ b/services/agents-api/internal/store/dispatch_test.go
@@ -68,7 +68,7 @@ func newDispatchHarness(t *testing.T) *dispatchHarness {
 		t.Fatal("device connection failed")
 	}
 	t.Cleanup(func() { h.conn.Close() })
-	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true}}}})
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, SubagentControl: true}}}})
 	deadline := time.Now().Add(3 * time.Second)
 	for {
 		peer, e := h.registry.LookupDevice(h.device.ID)
@@ -336,16 +336,16 @@ func TestExecutionOutcomeAndNativeBindingCommitTogether(t *testing.T) {
 }
 
 func TestExecutionRejectsLegacyDaemonBeforeClaim(t *testing.T) {
-	for _, missing := range []string{"durable_turns", "web_search_control", "text_verbosity"} {
-		durable, search := missing != "durable_turns", missing == "text_verbosity"
+	for _, missing := range []string{"durable_turns", "web_search_control", "text_verbosity", "subagent_control"} {
+		durable, search := missing != "durable_turns", missing == "text_verbosity" || missing == "subagent_control"
 		t.Run(missing, func(t *testing.T) {
 			h := newDispatchHarness(t)
-			h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: durable, WebSearchControl: search}}}})
+			h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: durable, WebSearchControl: search, TextVerbosity: missing == "subagent_control"}}}})
 			deadline := time.Now().Add(3 * time.Second)
 			for {
 				peer, _ := h.registry.LookupDevice(h.device.ID)
 				info, _, _ := peer.AgentKindStatus("codex")
-				if info.Capabilities.DurableTurns == durable && info.Capabilities.WebSearchControl == search && !info.Capabilities.TextVerbosity {
+				if info.Capabilities.DurableTurns == durable && info.Capabilities.WebSearchControl == search && info.Capabilities.TextVerbosity == (missing == "subagent_control") && !info.Capabilities.SubagentControl {
 					break
 				}
 				if time.Now().After(deadline) {

--- a/services/agents-api/internal/store/execution_messages_test.go
+++ b/services/agents-api/internal/store/execution_messages_test.go
@@ -23,7 +23,7 @@ func TestExecutionNegotiatesAndPersistsMessageObservations(t *testing.T) {
 	}
 	h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
 	h.finished(result, store.TurnCompleted)
-	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, MessageItems: true}}}})
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, SubagentControl: true, MessageItems: true}}}})
 	deadline := time.Now().Add(3 * time.Second)
 	for {
 		peer, err := h.registry.LookupDevice(h.device.ID)

--- a/services/agents-api/internal/store/execution_tools_test.go
+++ b/services/agents-api/internal/store/execution_tools_test.go
@@ -25,7 +25,7 @@ func TestExecutionNegotiatesAndPersistsToolObservations(t *testing.T) {
 	}
 	h.write(first.TurnID, proto.TypeDone, proto.DonePayload{})
 	h.finished(result, store.TurnCompleted)
-	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, ToolItems: true}}}})
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, SubagentControl: true, ToolItems: true}}}})
 	deadline := time.Now().Add(3 * time.Second)
 	for {
 		peer, err := h.registry.LookupDevice(h.device.ID)

--- a/services/agents-api/internal/store/function_execution_test.go
+++ b/services/agents-api/internal/store/function_execution_test.go
@@ -26,7 +26,7 @@ func newFunctionHarness(t *testing.T) *dispatchHarness {
 	if err := h.s.BindSessionDevice(t.Context(), h.tenant, h.session.ID, h.device.ID); err != nil {
 		t.Fatal(err)
 	}
-	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, EnvironmentNone: true, FunctionTools: true}}}})
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, Resume: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, SubagentControl: true, EnvironmentNone: true, FunctionTools: true}}}})
 	deadline := time.Now().Add(time.Second)
 	for {
 		peer, _ := h.registry.LookupDevice(h.device.ID)

--- a/services/agents-api/internal/store/function_model_test.go
+++ b/services/agents-api/internal/store/function_model_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -43,6 +44,7 @@ func nativeFunctionResultsModel(t *testing.T, home string, results []any) (*http
 			t.Error(err)
 			return
 		}
+		assertNativeSubagentsDisabled(t, body)
 		n := requests.Add(1)
 		raw, _ := json.MarshalIndent(body, "", "  ")
 		_ = os.WriteFile(filepath.Join(home, fmt.Sprintf("functions-model-%d.json", n)), raw, 0600)
@@ -103,4 +105,17 @@ func nativeFunctionResultsModel(t *testing.T, home string, results []any) (*http
 		send("response.completed", map[string]any{"response": map[string]any{"id": fmt.Sprintf("r_%d", n), "object": "response", "created_at": 0, "status": "completed", "model": "gpt-5.5", "output": []any{entry}}})
 	}))
 	return model, &requests
+}
+
+func assertNativeSubagentsDisabled(t *testing.T, body map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(body["tools"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"Multi-agent tools:", "spawn_agent", "send_input", "wait_agent", "resume_agent", "close_agent", "send_message_to_agent"} {
+		if strings.Contains(string(raw), forbidden) {
+			t.Errorf("disabled subagent tool remains discoverable: %s", forbidden)
+		}
+	}
 }

--- a/services/agents-api/internal/store/function_public_native_test.go
+++ b/services/agents-api/internal/store/function_public_native_test.go
@@ -26,7 +26,7 @@ func TestNativePublicFunctionExecution(t *testing.T) {
 	model, output, requests := nativeFunctionModel(t, home)
 	defer model.Close()
 	h.d.Options = func(context.Context, store.Session) (map[string]any, error) {
-		return map[string]any{"codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}}, nil
+		return map[string]any{"enable_features": []any{"multi_agent", "multi_agent_v2"}, "codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}}, nil
 	}
 	serverURL, token := nativePublicFunctionServer(t, h, ctx)
 	outputPath, proofPath := filepath.Join(home, "function-output.json"), filepath.Join(home, "public-functions.json")

--- a/services/agents-api/internal/store/function_worker_test.go
+++ b/services/agents-api/internal/store/function_worker_test.go
@@ -22,7 +22,7 @@ func TestFunctionWorkerWaitsForCapableDevice(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			caps := proto.AgentKindCapabilities{Streaming: true, Steering: true, DurableTurns: true, EnvironmentNone: true, WebSearchControl: true, TextVerbosity: true}
+			caps := proto.AgentKindCapabilities{Streaming: true, Steering: true, DurableTurns: true, EnvironmentNone: true, WebSearchControl: true, TextVerbosity: true, SubagentControl: true}
 			heartbeat := func() {
 				h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: caps}}})
 			}

--- a/services/agents-api/internal/store/native_environment_test.go
+++ b/services/agents-api/internal/store/native_environment_test.go
@@ -43,6 +43,7 @@ func TestNativeNoExecutionEnvironment(t *testing.T) {
 		if body["model"] == "custom-provider-model" && !strings.Contains(fmt.Sprint(body["input"]), "DEFAULT-VERBOSITY") {
 			t.Error("unsupported verbosity reached model execution")
 		}
+		assertNativeSubagentsDisabled(t, body)
 		for _, value := range body["tools"].([]any) {
 			tool := value.(map[string]any)
 			if kind, _ := tool["type"].(string); strings.HasPrefix(kind, "web_search") {
@@ -104,7 +105,7 @@ func TestNativeNoExecutionEnvironment(t *testing.T) {
 	}))
 	defer model.Close()
 	h.d.Options = func(context.Context, store.Session) (map[string]any, error) {
-		return map[string]any{"model_verbosity": "high", "web_search": "live", "codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}, "env": map[string]any{"CODEX_EXEC_SERVER_URL": "ws://127.0.0.1:1"}}, nil
+		return map[string]any{"enable_features": []any{"multi_agent", "multi_agent_v2"}, "model_verbosity": "high", "web_search": "live", "codex_provider": map[string]any{"base_url": model.URL + "/v1", "bearer_token": "synthetic-test-token"}, "env": map[string]any{"CODEX_EXEC_SERVER_URL": "ws://127.0.0.1:1"}}, nil
 	}
 	first := h.message("first", "Return an answer.")
 	h.finished(h.run(ctx, first.TurnID), store.TurnCompleted)

--- a/services/agents-api/internal/store/public_execution_test.go
+++ b/services/agents-api/internal/store/public_execution_test.go
@@ -23,7 +23,7 @@ func publicSession(t *testing.T, h *dispatchHarness, key string) store.Session {
 
 func TestExecutionWorkerAdmissionBindingAndRecovery(t *testing.T) {
 	h := newDispatchHarness(t)
-	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, EnvironmentNone: true}}}})
+	h.write("", proto.TypeHeartbeat, proto.HeartbeatPayload{SupportedAgentKinds: []proto.SupportedAgentKind{{Kind: "codex", Available: true, Capabilities: proto.AgentKindCapabilities{Streaming: true, Steering: true, DurableTurns: true, WebSearchControl: true, TextVerbosity: true, SubagentControl: true, EnvironmentNone: true}}}})
 	h.session = publicSession(t, h, "public")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -63,7 +63,7 @@ func TestExecutionWorkerAdmissionBindingAndRecovery(t *testing.T) {
 	if err := request.DecodePayload(&prompt); err != nil {
 		t.Fatal(err)
 	}
-	if prompt.Prompt != "First\n\nSecond" || !prompt.DisableExecutionEnvironment || prompt.AgentOptions["web_search"] != "disabled" || prompt.AgentOptions["model_verbosity"] != "medium" {
+	if prompt.Prompt != "First\n\nSecond" || !prompt.DisableExecutionEnvironment || !prompt.DisableSubagents || prompt.AgentOptions["web_search"] != "disabled" || prompt.AgentOptions["model_verbosity"] != "medium" {
 		t.Fatal(prompt)
 	}
 	bound, err := h.s.GetSessionDevice(ctx, h.tenant, h.session.ID)


### PR DESCRIPTION
Sessions report `multi_agent.enabled=false`, but Codex previously advertised deferred tools for spawning and managing subagents. Enforce the resolved setting through a typed daemon policy and capability admission, translating it to native feature controls in the Codex adapter on new and resumed Turns. Operator feature preferences cannot override the policy; ordinary product prompts retain their defaults.

Validation: adapter and native workflow checks, captured model requests, the pinned official Python SDK, and real MiniMax-M3 execution across two Turns with function success/error and native history continuity. `make openapi` produces no drift. Full remote `make check` passed, including the isolated PostgreSQL integration tests. Fresh independent blind review of the full diff found no in-scope blockers; focused Codex/CLI/gateway tests and diff checks also passed.

Scope: this fixes the currently resolved false default. Explicit inline `multi_agent` input, enabled multi-agent execution, public Subagent resources and other harnesses remain separate gaps. Internal Goal/Skills/user-input tools are not treated as protocol violations solely because they appear.
