### PR TITLE
feat(daemon): add owned process-group supervision

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -472,6 +472,23 @@ replaced; do not carry obsolete compatibility code forward to satisfy this secti
   use a safe public error. The worker does not replace product dispatch, business
   authorization, or the separate approval/environment lifecycle work.
 
+### SDK subprocess ownership
+
+The shared daemon `clirunner` offers opt-in Unix process-group ownership for
+adapters whose SDK launches a native child. Existing callers keep their current
+process policy. Explicit cancellation and parent-context cancellation share a
+TERM grace period and bounded KILL escalation. An internal reaper also cleans
+remaining group members when the direct process exits, even if a descendant
+still holds stdout open. Unsupported hosts reject this mode before launch.
+
+Owned output pipes remain readable after the leader exits. Consumers must drain
+stdout and stderr before calling `Wait`, which joins the cached process result
+and closes the readers. `Done` reports leader reaping and group cleanup signals;
+it is not a native execution receipt or proof of persisted history. SDK adapters
+must close their query, await their native child and drain observations before
+publishing completion. Process groups are lifecycle supervision, not OS isolation
+or containment of descendants that deliberately leave the group.
+
 ### Agent knowledge references
 
 - Unpublished knowledge retains only the bound version in other workspaces;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -479,7 +479,8 @@ adapters whose SDK launches a native child. Existing callers keep their current
 process policy. Explicit cancellation and parent-context cancellation share a
 TERM grace period and bounded KILL escalation. An internal reaper also cleans
 remaining group members when the direct process exits, even if a descendant
-still holds stdout open. Unsupported hosts reject this mode before launch.
+still holds stdout open. During cancellation, surviving descendants keep the
+remaining TERM grace after the leader exits. Unsupported hosts reject this mode before launch.
 
 Owned output pipes remain readable after the leader exits. Consumers must drain
 stdout and stderr before calling `Wait`, which joins the cached process result

--- a/apps/parsar-daemon/internal/agent/clirunner/process.go
+++ b/apps/parsar-daemon/internal/agent/clirunner/process.go
@@ -18,6 +18,8 @@ type StartOptions struct {
 	Env         []string
 	NeedStdin   bool
 	KillTimeout time.Duration
+	// OwnProcessGroup bounds the lifetime of subprocess descendants on Unix.
+	OwnProcessGroup bool
 }
 
 type Process struct {
@@ -31,8 +33,10 @@ type Process struct {
 	done      chan struct{}
 	killAfter time.Duration
 
-	cancelOnce sync.Once
-	waitOnce   sync.Once
+	cancelOnce    sync.Once
+	waitOnce      sync.Once
+	cancelProcess func() error
+	waitProcess   func() error
 }
 
 func Start(opts StartOptions) (*Process, error) {
@@ -44,6 +48,10 @@ func Start(opts StartOptions) (*Process, error) {
 	}
 	if opts.KillTimeout <= 0 {
 		opts.KillTimeout = 3 * time.Second
+	}
+
+	if opts.OwnProcessGroup {
+		return startProcessGroup(opts)
 	}
 
 	ctx, cancel := context.WithCancel(opts.Parent)
@@ -113,6 +121,11 @@ func (p *Process) Cancel() {
 		return
 	}
 	p.cancelOnce.Do(func() {
+		if p.cancelProcess != nil {
+			_ = p.cancelProcess()
+			p.cancel()
+			return
+		}
 		if p.Cmd != nil && p.Cmd.Process != nil {
 			_ = p.Cmd.Process.Signal(syscall.SIGTERM)
 			go func() {
@@ -132,6 +145,9 @@ func (p *Process) Cancel() {
 func (p *Process) Wait() error {
 	if p == nil || p.Cmd == nil {
 		return nil
+	}
+	if p.waitProcess != nil {
+		return p.waitProcess()
 	}
 	err := p.Cmd.Wait()
 	p.waitOnce.Do(func() { close(p.done) })

--- a/apps/parsar-daemon/internal/agent/clirunner/process_group_linux_test.go
+++ b/apps/parsar-daemon/internal/agent/clirunner/process_group_linux_test.go
@@ -1,0 +1,236 @@
+//go:build linux
+
+package clirunner
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestOwnedGroupCancellation(t *testing.T) {
+	for _, mode := range []string{"graceful", "ignore-term", "leader-exits"} {
+		for _, parentCancel := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/parent=%t", mode, parentCancel), func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				dir := t.TempDir()
+				p := startOwnedHelper(t, ctx, mode, dir)
+				stdout, stderr := drainOwned(t, p)
+				child := waitChild(t, dir)
+				group, err := syscall.Getpgid(child)
+				if err != nil || group != p.Cmd.Process.Pid {
+					t.Fatalf("child group = %d, err = %v", group, err)
+				}
+				started := time.Now()
+				if parentCancel {
+					cancel()
+				} else {
+					p.Cancel()
+					p.Cancel()
+				}
+				<-p.Context().Done()
+				awaitOutput(t, stdout)
+				awaitOutput(t, stderr)
+				if mode == "ignore-term" && time.Since(started) < 300*time.Millisecond {
+					t.Fatal("TERM-ignoring processes exited before escalation")
+				}
+				if time.Since(started) > 3*time.Second {
+					t.Fatal("cancellation exceeded bound")
+				}
+				first := p.Wait()
+				if fmt.Sprint(p.Wait()) != fmt.Sprint(first) {
+					t.Fatal("Wait result changed")
+				}
+				p.Cancel()
+				waitExited(t, child)
+				if mode == "graceful" {
+					for _, name := range []string{"child-stopped", "leader-stopped"} {
+						if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+							t.Fatalf("graceful shutdown missing %s: %v", name, err)
+						}
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestOwnedGroupLeaderExitReleasesInheritedOutput(t *testing.T) {
+	dir := t.TempDir()
+	p := startOwnedHelper(t, context.Background(), "natural-exit", dir)
+	stdout, stderr := drainOwned(t, p)
+	child := waitChild(t, dir)
+	// Read to EOF before Wait, as the existing adapters do.
+	awaitOutput(t, stdout)
+	awaitOutput(t, stderr)
+	if err := p.Wait(); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	waitExited(t, child)
+}
+
+func TestOwnedGroupPreservesOutputAfterLeaderExit(t *testing.T) {
+	p := startOwnedHelper(t, context.Background(), "output", t.TempDir())
+	stdout, stderr := drainOwned(t, p)
+	for _, stream := range []<-chan []byte{stdout, stderr} {
+		actual := awaitOutput(t, stream)
+		if !bytes.Equal(actual, bytes.Repeat([]byte("x"), 512*1024)) {
+			t.Fatalf("truncated output: %d bytes", len(actual))
+		}
+	}
+	if err := p.Wait(); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	select {
+	case <-p.Done():
+	default:
+		t.Fatal("Done is not closed")
+	}
+}
+
+func startOwnedHelper(t *testing.T, ctx context.Context, mode, dir string) *Process {
+	t.Helper()
+	p, err := Start(StartOptions{
+		Parent: ctx, Binary: os.Args[0],
+		Args:            []string{"-test.run=^TestOwnedGroupHelper$", "--", "leader", mode, dir},
+		Env:             append(os.Environ(), "GO_WANT_OWNED_GROUP=1", "GORACE=atexit_sleep_ms=0"),
+		OwnProcessGroup: true, KillTimeout: 300 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { p.Cancel(); _ = p.Wait() })
+	return p
+}
+
+func drainOwned(t *testing.T, p *Process) (<-chan []byte, <-chan []byte) {
+	t.Helper()
+	read := func(r io.Reader) <-chan []byte {
+		ch := make(chan []byte, 1)
+		go func() {
+			value, err := io.ReadAll(r)
+			if err != nil {
+				t.Errorf("read output: %v", err)
+			}
+			ch <- value
+		}()
+		return ch
+	}
+	return read(p.Stdout), read(p.Stderr)
+}
+
+func awaitOutput(t *testing.T, ch <-chan []byte) []byte {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(5 * time.Second):
+		t.Fatal("output remained open")
+		return nil
+	}
+}
+
+func waitChild(t *testing.T, dir string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		value, err := os.ReadFile(filepath.Join(dir, "child-ready"))
+		if err == nil {
+			pid, err := strconv.Atoi(string(value))
+			if err == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("child did not start")
+	return 0
+}
+
+func waitExited(t *testing.T, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		value, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+		if os.IsNotExist(err) {
+			return
+		}
+		if err == nil {
+			fields := strings.Fields(string(value)[strings.LastIndex(string(value), ")")+1:])
+			if len(fields) > 0 && fields[0] == "Z" {
+				return
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("child %d is still running", pid)
+}
+
+func TestOwnedGroupHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_OWNED_GROUP") != "1" {
+		return
+	}
+	args := os.Args
+	for len(args) > 0 && args[0] != "--" {
+		args = args[1:]
+	}
+	if len(args) != 4 {
+		os.Exit(2)
+	}
+	role, mode, dir := args[1], args[2], args[3]
+	if mode == "output" {
+		data := bytes.Repeat([]byte("x"), 512*1024)
+		_, _ = os.Stdout.Write(data)
+		_, _ = os.Stderr.Write(data)
+		os.Exit(0)
+	}
+	terminated := make(chan os.Signal, 1)
+	if mode == "ignore-term" || role == "child" && mode != "graceful" {
+		signal.Ignore(syscall.SIGTERM)
+	} else {
+		signal.Notify(terminated, syscall.SIGTERM)
+	}
+	if role == "child" {
+		_ = os.WriteFile(filepath.Join(dir, "child-ready"), []byte(strconv.Itoa(os.Getpid())), 0o600)
+		if mode != "graceful" {
+			time.Sleep(time.Hour)
+		}
+		<-terminated
+		_ = os.WriteFile(filepath.Join(dir, "child-stopped"), nil, 0o600)
+		os.Exit(0)
+	}
+	child := exec.Command(os.Args[0], "-test.run=^TestOwnedGroupHelper$", "--", "child", mode, dir)
+	child.Env, child.Stdout, child.Stderr = os.Environ(), os.Stdout, os.Stderr
+	if err := child.Start(); err != nil {
+		os.Exit(3)
+	}
+	if mode == "natural-exit" {
+		for {
+			if _, err := os.Stat(filepath.Join(dir, "child-ready")); err == nil {
+				os.Exit(0)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if mode == "ignore-term" {
+		time.Sleep(time.Hour)
+	}
+	<-terminated
+	if mode == "leader-exits" {
+		os.Exit(0)
+	}
+	_ = child.Wait()
+	_ = os.WriteFile(filepath.Join(dir, "leader-stopped"), nil, 0o600)
+	os.Exit(0)
+}

--- a/apps/parsar-daemon/internal/agent/clirunner/process_group_linux_test.go
+++ b/apps/parsar-daemon/internal/agent/clirunner/process_group_linux_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestOwnedGroupCancellation(t *testing.T) {
-	for _, mode := range []string{"graceful", "ignore-term", "leader-exits"} {
+	for _, mode := range []string{"graceful", "ignore-term", "leader-exits", "child-cleanup"} {
 		for _, parentCancel := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s/parent=%t", mode, parentCancel), func(t *testing.T) {
 				ctx, cancel := context.WithCancel(context.Background())
@@ -54,6 +54,11 @@ func TestOwnedGroupCancellation(t *testing.T) {
 				}
 				p.Cancel()
 				waitExited(t, child)
+				if mode == "child-cleanup" {
+					if _, err := os.Stat(filepath.Join(dir, "child-stopped")); err != nil {
+						t.Fatalf("child lost its TERM cleanup grace: %v", err)
+					}
+				}
 				if mode == "graceful" {
 					for _, name := range []string{"child-stopped", "leader-stopped"} {
 						if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
@@ -196,17 +201,20 @@ func TestOwnedGroupHelper(t *testing.T) {
 		os.Exit(0)
 	}
 	terminated := make(chan os.Signal, 1)
-	if mode == "ignore-term" || role == "child" && mode != "graceful" {
+	if mode == "ignore-term" || role == "child" && mode != "graceful" && mode != "child-cleanup" {
 		signal.Ignore(syscall.SIGTERM)
 	} else {
 		signal.Notify(terminated, syscall.SIGTERM)
 	}
 	if role == "child" {
 		_ = os.WriteFile(filepath.Join(dir, "child-ready"), []byte(strconv.Itoa(os.Getpid())), 0o600)
-		if mode != "graceful" {
+		if mode != "graceful" && mode != "child-cleanup" {
 			time.Sleep(time.Hour)
 		}
 		<-terminated
+		if mode == "child-cleanup" {
+			time.Sleep(100 * time.Millisecond)
+		}
 		_ = os.WriteFile(filepath.Join(dir, "child-stopped"), nil, 0o600)
 		os.Exit(0)
 	}
@@ -217,7 +225,7 @@ func TestOwnedGroupHelper(t *testing.T) {
 	}
 	if mode == "natural-exit" {
 		for {
-			if _, err := os.Stat(filepath.Join(dir, "child-ready")); err == nil {
+			if value, err := os.ReadFile(filepath.Join(dir, "child-ready")); err == nil && len(value) > 0 {
 				os.Exit(0)
 			}
 			time.Sleep(time.Millisecond)
@@ -227,7 +235,7 @@ func TestOwnedGroupHelper(t *testing.T) {
 		time.Sleep(time.Hour)
 	}
 	<-terminated
-	if mode == "leader-exits" {
+	if mode == "leader-exits" || mode == "child-cleanup" {
 		os.Exit(0)
 	}
 	_ = child.Wait()

--- a/apps/parsar-daemon/internal/agent/clirunner/process_group_other.go
+++ b/apps/parsar-daemon/internal/agent/clirunner/process_group_other.go
@@ -1,0 +1,9 @@
+//go:build !unix
+
+package clirunner
+
+import "errors"
+
+func startProcessGroup(StartOptions) (*Process, error) {
+	return nil, errors.New("clirunner: process-group ownership requires Unix")
+}

--- a/apps/parsar-daemon/internal/agent/clirunner/process_group_unix.go
+++ b/apps/parsar-daemon/internal/agent/clirunner/process_group_unix.go
@@ -76,6 +76,7 @@ type ownedGroup struct {
 	killAfter time.Duration
 	mu        sync.Mutex
 	timer     *time.Timer
+	graceDone chan struct{}
 	cancelled bool
 	finished  bool
 }
@@ -94,18 +95,27 @@ func (g *ownedGroup) cancel() error {
 	if errors.Is(err, syscall.ESRCH) {
 		return os.ErrProcessDone
 	}
+	g.graceDone = make(chan struct{})
 	g.timer = time.AfterFunc(g.killAfter, func() {
 		g.mu.Lock()
 		defer g.mu.Unlock()
 		if !g.finished {
 			_ = syscall.Kill(-g.cmd.Process.Pid, syscall.SIGKILL)
 		}
+		close(g.graceDone)
 	})
 	return err
 }
 
 func (g *ownedGroup) finish() {
 	g.mu.Lock()
+	if g.graceDone != nil && !errors.Is(syscall.Kill(-g.cmd.Process.Pid, 0), syscall.ESRCH) {
+		// Descendants retain their TERM grace even when the leader has already exited.
+		graceDone := g.graceDone
+		g.mu.Unlock()
+		<-graceDone
+		g.mu.Lock()
+	}
 	defer g.mu.Unlock()
 	g.finished = true
 	if g.timer != nil {

--- a/apps/parsar-daemon/internal/agent/clirunner/process_group_unix.go
+++ b/apps/parsar-daemon/internal/agent/clirunner/process_group_unix.go
@@ -1,0 +1,116 @@
+//go:build unix
+
+package clirunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+)
+
+func startProcessGroup(opts StartOptions) (*Process, error) {
+	ctx, cancel := context.WithCancel(opts.Parent)
+	cmd := exec.CommandContext(ctx, opts.Binary, opts.Args...)
+	cmd.Dir = opts.Dir
+	if len(opts.Env) > 0 {
+		cmd.Env = append([]string{}, opts.Env...)
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	group := &ownedGroup{cmd: cmd, killAfter: opts.KillTimeout}
+	cmd.Cancel = group.cancel
+	p := &Process{Cmd: cmd, ctx: ctx, cancel: cancel, done: make(chan struct{}), cancelProcess: group.cancel}
+
+	// Cmd.Wait must reap the leader without closing output that consumers still need to drain.
+	stdout, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		cancel()
+		return nil, fmt.Errorf("clirunner: stdout pipe: %w", err)
+	}
+	stderr, stderrWriter, err := os.Pipe()
+	if err != nil {
+		cancel()
+		closePipe(stdout)
+		closePipe(stdoutWriter)
+		return nil, fmt.Errorf("clirunner: stderr pipe: %w", err)
+	}
+	p.Stdout, p.Stderr = stdout, stderr
+	cmd.Stdout, cmd.Stderr = stdoutWriter, stderrWriter
+	if opts.NeedStdin {
+		p.Stdin, err = cmd.StdinPipe()
+	}
+	if err == nil {
+		err = cmd.Start()
+	}
+	closePipe(stdoutWriter)
+	closePipe(stderrWriter)
+	if err != nil {
+		cancel()
+		closePipe(p.Stdin)
+		closePipe(stdout)
+		closePipe(stderr)
+		return nil, fmt.Errorf("clirunner: start %q: %w", opts.Binary, err)
+	}
+
+	var waitErr error
+	p.waitProcess = func() error {
+		<-p.done
+		closePipe(stdout)
+		closePipe(stderr)
+		return waitErr
+	}
+	go func() {
+		waitErr = cmd.Wait()
+		group.finish()
+		close(p.done)
+	}()
+	return p, nil
+}
+
+type ownedGroup struct {
+	cmd       *exec.Cmd
+	killAfter time.Duration
+	mu        sync.Mutex
+	timer     *time.Timer
+	cancelled bool
+	finished  bool
+}
+
+func (g *ownedGroup) cancel() error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.finished {
+		return os.ErrProcessDone
+	}
+	if g.cancelled {
+		return nil
+	}
+	g.cancelled = true
+	err := syscall.Kill(-g.cmd.Process.Pid, syscall.SIGTERM)
+	if errors.Is(err, syscall.ESRCH) {
+		return os.ErrProcessDone
+	}
+	g.timer = time.AfterFunc(g.killAfter, func() {
+		g.mu.Lock()
+		defer g.mu.Unlock()
+		if !g.finished {
+			_ = syscall.Kill(-g.cmd.Process.Pid, syscall.SIGKILL)
+		}
+	})
+	return err
+}
+
+func (g *ownedGroup) finish() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.finished = true
+	if g.timer != nil {
+		g.timer.Stop()
+	}
+	// A leader can exit while a descendant still holds the output pipes open.
+	_ = syscall.Kill(-g.cmd.Process.Pid, syscall.SIGKILL)
+}


### PR DESCRIPTION
SDK-backed adapters launch a native harness beneath their SDK process. Cancelling only the direct process can leave that harness running or keep an inherited output pipe open. Add opt-in Unix process-group ownership to the shared daemon runner, with TERM/KILL cancellation, direct-process reaping and cleanup of remaining descendants on exit. Output remains available to drain before `Wait`.

Existing adapters retain their process policy. This is a prerequisite for the Claude SDK adapter; it does not register an adapter, advertise capabilities or change public API, product execution, database or installation behavior. `CONTRIBUTING.md` defines the ownership and output-drain contract.

Validation:
- Real Linux parent/child processes cover both cancellation entry points, graceful exit, ignored TERM, early/natural leader exit, inherited pipes and complete 512 KiB stdout/stderr output.
- Race checks pass, including repeated cancellation and stable repeated waits.
- Full remote `make check` passed, including product DB, daemon/Go, web/CLI, installer and Agents API checks. Fresh independent review of the complete diff found no material issues; its repeated race checks passed.

Limits: other Unix hosts were not runtime-tested. Process groups do not contain descendants that deliberately leave their group; cleanup signals are not native execution receipts. No model call was repeated for this model-independent prerequisite. The SDK adapter still needs its own real API text and cold-resume acceptance.
